### PR TITLE
feat: show mutable ancestors in SCM view

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.refreshDebounceMillis` | `100` | Base debounce time (ms) for SCM refresh based on file events. |
 | `jj-view.refreshDebounceMaxMultiplier` | `4` | Maximum multiplier for the debounce timeout when events continue to occur. |
 | `jj-view.watcherIgnore` | `["node_modules", ".git"]` | Paths to ignore in the file watcher to prevent unnecessary refreshes. |
+| `jj-view.ancestorLimit` | `1` | Number of mutable ancestors to show in Source Control view. |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
                     "default": 100,
                     "description": "Base debounce time (ms) for SCM refresh based on file events."
                 },
+                "jj-view.ancestorLimit": {
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 0,
+                    "description": "Number of mutable ancestors to show in Source Control view."
+                },
                 "jj-view.refreshDebounceMaxMultiplier": {
                     "type": "number",
                     "default": 4,


### PR DESCRIPTION
- Display mutable ancestors as resource groups in Source Control view
- Add \`jj-view.ancestorLimit\` configuration (default: 1)