### PR TITLE
Use the snapshot for getLog

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -18,7 +18,7 @@ import { getErrorMessage } from './command-utils';
 
 export async function showCurrentChangeCommand(jj: JjService) {
     try {
-        const [logEntry] = await jj.getLog('@');
+        const [logEntry] = await jj.getLog({ revision: '@', useCachedSnapshot: true });
         if (logEntry) {
             vscode.window.showInformationMessage(`Current Change ID: ${logEntry.change_id}`);
         } else {

--- a/src/commands/squash.ts
+++ b/src/commands/squash.ts
@@ -26,7 +26,7 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
     let revision = extractRevision(args) || '@';
 
     // Check if we have multiple parents
-    const [currentEntry] = await jj.getLog(revision);
+    const [currentEntry] = await jj.getLog({ revision, useCachedSnapshot: true });
     if (!currentEntry) {
         return;
     }
@@ -41,7 +41,7 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
                 parentRef = (parentRef as { commit_id: string }).commit_id;
             }
 
-            const [parentEntry] = await jj.getLog(parentRef as string);
+            const [parentEntry] = await jj.getLog({ revision: parentRef as string, useCachedSnapshot: true });
             if (parentEntry) {
                 const shortId = parentEntry.change_id.substring(0, 8);
                 const desc = parentEntry.description?.trim() || '(no description)';
@@ -65,7 +65,7 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
 
         // Squash from working copy into selected parent
         const hasCurrentDesc = currentEntry.description && currentEntry.description.trim().length > 0;
-        const [parentEntry] = await jj.getLog(selected.detail!);
+        const [parentEntry] = await jj.getLog({ revision: selected.detail!, useCachedSnapshot: true });
         const hasParentDesc = parentEntry && parentEntry.description && parentEntry.description.trim().length > 0;
 
         // Only open editor if squashing ALL changes (paths empty) AND both have descriptions.
@@ -91,7 +91,7 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
         }
 
         const hasCurrentDesc = currentEntry && currentEntry.description && currentEntry.description.trim().length > 0;
-        const [parentEntry] = await jj.getLog(parentRev);
+        const [parentEntry] = await jj.getLog({ revision: parentRev, useCachedSnapshot: true });
         // Be safe with parent entry check (could be root)
         const hasParentDesc = parentEntry && parentEntry.description && parentEntry.description.trim().length > 0;
 
@@ -109,8 +109,8 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
 
 async function openSquashDescriptionEditor(jj: JjService, paths: string[], revision: string, parentRev: string) {
     // 1. Get descriptions
-    const [currentLog] = await jj.getLog(revision);
-    const [parentLog] = await jj.getLog(parentRev);
+    const [currentLog] = await jj.getLog({ revision, useCachedSnapshot: true });
+    const [parentLog] = await jj.getLog({ revision: parentRev, useCachedSnapshot: true });
 
     const currentDesc = currentLog.description || '';
     const parentDesc = parentLog.description || '';

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -142,7 +142,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         if (this._view) {
             try {
                 // Default jj log (usually local heads/roots)
-                const commits = await this._jj.getLog();
+                const commits = await this._jj.getLog({ useCachedSnapshot: true });
                 // Enrich with Gerrit status if enabled
                 if (this._gerrit.isEnabled) {
                     this._outputChannel?.appendLine('[JjLogWebviewProvider] Gerrit service is enabled. Fetching statuses...');

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -191,7 +191,7 @@ export class JjScmProvider implements vscode.Disposable {
                 await this.jj.status();
 
                 // 1. Calculate Context Keys & Get Log with Changes
-                const [logEntry] = await this.jj.getLog('@', /*limit=*/ undefined, /*useCachedSnapshot=*/ true);
+                const [logEntry] = await this.jj.getLog({ revision: '@', useCachedSnapshot: true });
                 // alias for clarity and scope access
                 const currentEntry = logEntry;
 
@@ -217,11 +217,10 @@ export class JjScmProvider implements vscode.Disposable {
                         } else {
                             // Fallback: Fetch parent log to check mutability
                             this.outputChannel.appendLine(`Checking parent mutability for: ${parentRev}`);
-                            const [parentLog] = await this.jj.getLog(
-                                parentRev as string,
-                                /*limit=*/ undefined,
-                                /*useCachedSnapshot=*/ true,
-                            );
+                            const [parentLog] = await this.jj.getLog({
+                                revision: parentRev as string,
+                                useCachedSnapshot: true,
+                            });
                             parentMutable = !parentLog.is_immutable;
                         }
                     }
@@ -299,11 +298,10 @@ export class JjScmProvider implements vscode.Disposable {
                         }
 
                         // Fetch parent log entry for description and file changes (parent list only provides IDs)
-                        const [parentEntry] = await this.jj.getLog(
-                            parentRef as string,
-                            /*limit=*/ undefined,
-                            /*useCachedSnapshot=*/ true,
-                        );
+                        const [parentEntry] = await this.jj.getLog({
+                            revision: parentRef as string,
+                            useCachedSnapshot: true,
+                        });
 
                         if (parentEntry) {
                             const shortId = parentEntry.change_id.substring(0, 8);

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -20,6 +20,12 @@ import { JjLogEntry, JjStatusEntry } from './jj-types';
 import { PatchHelper, SelectionRange } from './patch-helper';
 import { buildLogTemplate, LOG_ENTRY_SCHEMA } from './jj-template-builder';
 
+export interface JjLogOptions {
+    revision?: string;
+    limit?: number;
+    useCachedSnapshot?: boolean;
+}
+
 export class JjService {
     constructor(public readonly workspaceRoot: string) {}
 
@@ -67,7 +73,8 @@ export class JjService {
         return this.run('bookmark', ['set', name, '-r', toRevision, '--allow-backwards']);
     }
 
-    async getLog(revision?: string, limit?: number, useCachedSnapshot?: boolean): Promise<JjLogEntry[]> {
+    async getLog(options: JjLogOptions = {}): Promise<JjLogEntry[]> {
+        const { revision, limit, useCachedSnapshot } = options;
         const args = ['-T', buildLogTemplate(LOG_ENTRY_SCHEMA)];
         if (revision) {
             args.push('-r', revision);

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -642,7 +642,7 @@ suite('JJ SCM Provider Integration Test', function () {
         });
 
         // Verify Bookmark Moved
-        const [childLog] = await jj.getLog('@');
+        const [childLog] = await jj.getLog({ revision: '@' });
         assert.ok(
             childLog.bookmarks?.some((b) => b.name === 'integrated-bookmark'),
             'Bookmark should be on child now',

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -34,7 +34,7 @@ describe('JjService Unit Tests', () => {
     });
 
     test('getLog returns valid log entry', async () => {
-        const [log] = await jjService.getLog('@');
+        const [log] = await jjService.getLog({ revision: '@' });
         expect(log.change_id).toBeTruthy();
         expect(log.commit_id).toBeTruthy();
     });
@@ -368,7 +368,7 @@ describe('JjService Unit Tests', () => {
         repo.describe('parent');
         repo.new(['@'], 'child');
 
-        const [logEntry] = await jjService.getLog('@');
+        const [logEntry] = await jjService.getLog({ revision: '@' });
         expect(logEntry.parents).toBeDefined();
         expect(Array.isArray(logEntry.parents)).toBe(true);
         expect(logEntry.parents.length).toBeGreaterThan(0);
@@ -423,7 +423,7 @@ describe('JjService Unit Tests', () => {
 
     test('getLog parses extended fields', async () => {
         repo.describe('test fields');
-        const [log] = await jjService.getLog('@');
+        const [log] = await jjService.getLog({ revision: '@' });
 
         expect(log.change_id_shortest).toBeDefined();
         expect(log.is_immutable).toBeDefined();
@@ -442,24 +442,24 @@ describe('JjService Unit Tests', () => {
         fs.writeFileSync(filePath, 'content');
 
         repo.describe('not empty');
-        const [log] = await jjService.getLog('@');
+        const [log] = await jjService.getLog({ revision: '@' });
         expect(log.is_empty).toBe(false);
 
         repo.new(['@'], 'empty child');
-        const [emptyLog] = await jjService.getLog('@');
+        const [emptyLog] = await jjService.getLog({ revision: '@' });
         expect(emptyLog.is_empty).toBe(true);
     });
 
     test('getLog parses parents_immutable correctly', async () => {
         repo.describe('child of root');
-        const [child] = await jjService.getLog('@');
+        const [child] = await jjService.getLog({ revision: '@' });
 
         expect(child.parents_immutable).toBeDefined();
         expect(child.parents_immutable!.length).toBeGreaterThan(0);
         expect(child.parents_immutable![0]).toBe(true);
 
         repo.new(['@'], 'grandchild');
-        const [grandchild] = await jjService.getLog('@');
+        const [grandchild] = await jjService.getLog({ revision: '@' });
 
         expect(grandchild.parents_immutable).toBeDefined();
         expect(grandchild.parents_immutable![0]).toBe(false);
@@ -467,7 +467,7 @@ describe('JjService Unit Tests', () => {
 
     test('getLog parses author and committer with full details', async () => {
         repo.describe('author test');
-        const [log] = await jjService.getLog('@');
+        const [log] = await jjService.getLog({ revision: '@' });
 
         // Verify author structure (values may come from global jj config, not repo-local)
         expect(typeof log.author).toBe('object');
@@ -901,7 +901,7 @@ describe('JjService Unit Tests', () => {
         repo.writeFile('modified.txt', 'modified'); // Modified
         fs.rmSync(file3); // Deleted
 
-        const [log] = await jjService.getLog('@');
+        const [log] = await jjService.getLog({ revision: '@' });
         expect(log.changes).toBeDefined();
         const changes = log.changes!;
 
@@ -925,13 +925,13 @@ describe('JjService Unit Tests', () => {
 
         // Create a new commit (child)
         await jjService.new('child');
-        const [child] = await jjService.getLog('@');
+        const [child] = await jjService.getLog({ revision: '@' });
 
         // Move bookmark to child
         await jjService.moveBookmark('test-bookmark', child.change_id);
 
         // Verify bookmark moved
-        const [childLog] = await jjService.getLog('@');
+        const [childLog] = await jjService.getLog({ revision: '@' });
         expect(childLog.bookmarks).toEqual(
             expect.arrayContaining([expect.objectContaining({ name: 'test-bookmark' })]),
         );
@@ -958,10 +958,10 @@ describe('JjService Unit Tests', () => {
 
         await jjService.rebase(parentId, targetId, 'revision');
 
-        const [parentLog] = await jjService.getLog(parentId);
-        const [targetLog] = await jjService.getLog(targetId);
-        const [childLog] = await jjService.getLog(childId);
-        const [grandparentLog] = await jjService.getLog(grantparentId);
+        const [parentLog] = await jjService.getLog({ revision: parentId });
+        const [targetLog] = await jjService.getLog({ revision: targetId });
+        const [childLog] = await jjService.getLog({ revision: childId });
+        const [grandparentLog] = await jjService.getLog({ revision: grantparentId });
 
         // Parent is child of Target
         expect(parentLog.parents[0]).toBe(targetLog.commit_id);
@@ -974,9 +974,9 @@ describe('JjService Unit Tests', () => {
 
         await jjService.rebase(grantparentId, rootId, 'source');
 
-        const [grandparentLogAfter] = await jjService.getLog(grantparentId);
-        const [childLogAfter] = await jjService.getLog(childId);
-        const [rootLog] = await jjService.getLog(rootId);
+        const [grandparentLogAfter] = await jjService.getLog({ revision: grantparentId });
+        const [childLogAfter] = await jjService.getLog({ revision: childId });
+        const [rootLog] = await jjService.getLog({ revision: rootId });
 
         // Grandparent is child of Root
         expect(grandparentLogAfter.parents[0]).toBe(rootLog.commit_id);
@@ -1040,7 +1040,7 @@ describe('JjService Unit Tests', () => {
         await jjService.new();
         fs.renameSync(path.join(repo.path, oldFile), path.join(repo.path, newFile));
         
-        const [logEntry] = await jjService.getLog('@');
+        const [logEntry] = await jjService.getLog({ revision: '@' });
         expect(logEntry).toBeDefined();
         
         const changes = logEntry.changes || [];


### PR DESCRIPTION
This avoids the huge performance cost we were incurring by calling getLog with snapshotting in a bunch of places. It was called repeatedly on every refresh.