### PR TITLE
Add absorb support

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,7 +31,12 @@ This document outlines the coding standards, testing strategies, and architectur
 
 ## Testing Strategy
 
-This project employs a split testing strategy to ensure both logic correctness and integration validity. Tests should never mock JjService. They should use TestRepo to create a temporary repository on disk and JjService to interact with it. Test verifications should use TestRepo and not try to verify using JjService.
+This project employs a split testing strategy to ensure both logic correctness and integration validity. 
+
+**CRITICAL RULE**: Tests should **NEVER** mock `JjService` methods. 
+- Always use `TestRepo` to set up a real temporary repository on disk.
+- Use a real `JjService` instance to operate on it. 
+- Use `TestRepo` methods to verify outcomes (e.g. file content, log history), rather than spying on `JjService` calls.
 
 ### 1. Unit Tests
 
@@ -42,6 +47,7 @@ This project employs a split testing strategy to ensure both logic correctness a
 - **Scope**:
     - Test individual classes and functions in isolation.
     - **Mock all external dependencies**, especially the `vscode` module and file system operations.
+    - **EXCEPTION**: Do NOT mock `JjService` methods (e.g. `jj.absorb`). Instead, use `TestRepo` to create a real temporary repo and use a real `JjService` instance to interact with it.
     - Fast feedback loop, run frequently.
 - **Example**: Testing `JjService` log parsing logic or `JjScmProvider` state calculations without starting VS Code.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Support for common and advanced `jj` operations:
 - **Navigation**: Move to parent or child revisions easily.
 - **Undo**: Quickly undo `jj` operations.
 - **Squashing**: Squash changes into the parent revision.
+- **Absorbing**: Automatically move changes into the mutable ancestor where they were introduced.
 - **Rebasing**: Rebase changes onto other revisions.
 
 ## Commands
@@ -64,6 +65,7 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 
 ### History & Merging
 - `JJ View: Squash into Parent`: Squash the current change into its parent.
+- `JJ View: Absorb`: Move changes into the mutable ancestor where they belong.
 - `JJ View: Complete Squash`: Finish a squash operation (e.g., from the editor title).
 - `JJ View: New Merge Change`: Create a merge commit.
 - `JJ View: Open Merge Editor`: Open the merge editor for conflicted files.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"
@@ -192,6 +192,12 @@
                 "title": "Set Bookmark",
                 "category": "JJ View",
                 "icon": "$(bookmark)"
+            },
+            {
+                "command": "jj-view.absorb",
+                "title": "Absorb",
+                "category": "JJ View",
+                "icon": "$(magnet)"
             }
         ],
         "keybindings": [
@@ -261,6 +267,11 @@
                     "command": "jj-view.setBookmark",
                     "when": "webviewSection == 'commit'",
                     "group": "navigation"
+                },
+                {
+                    "command": "jj-view.absorb",
+                    "when": "webviewSection == 'commit' && canAbsorb",
+                    "group": "navigation"
                 }
             ],
             "scm/title": [
@@ -283,23 +294,28 @@
             ],
             "scm/resourceGroup/context": [
                 {
-                    "command": "jj-view.squash",
+                    "command": "jj-view.absorb",
                     "group": "inline",
                     "when": "scmResourceGroup == 'working-copy' && jj.parentMutable"
                 },
                 {
                     "command": "jj-view.abandon",
-                    "group": "inline",
+                    "group": "inline@1",
                     "when": "scmResourceGroup == 'working-copy'"
                 },
                 {
+                    "command": "jj-view.squash",
+                    "group": "inline@2",
+                    "when": "scmResourceGroup == 'working-copy' && jj.parentMutable"
+                },
+                {
                     "command": "jj-view.showDetails",
-                    "group": "inline@1",
+                    "group": "inline@3",
                     "when": "scmResourceGroupState =~ /^jjParentGroup/"
                 },
                 {
                     "command": "jj-view.edit",
-                    "group": "inline@2",
+                    "group": "inline@4",
                     "when": "scmResourceGroupState == 'jjParentGroup:mutable'"
                 }
             ],

--- a/src/commands/absorb.ts
+++ b/src/commands/absorb.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import { JjService } from '../jj-service';
+import { JjScmProvider } from '../jj-scm-provider';
+import { collectResourceStates, extractRevision, withDelayedProgress } from './command-utils';
+
+export async function absorbCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    const resourceStates = collectResourceStates(args);
+    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+
+    const fromRevision = extractRevision(args);
+
+    try {
+        await withDelayedProgress('Absorbing changes...', jj.absorb({ paths, fromRevision }));
+        await scmProvider.refresh({ reason: 'after absorb' });
+        vscode.window.setStatusBarMessage('Absorb completed.', 3000);
+    } catch (e: unknown) {
+        vscode.window.showErrorMessage(`Absorb failed: ${(e as Error).message}`);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { uploadCommand } from './commands/upload';
 import { discardChangeCommand } from './commands/discard-change';
 import { squashChangeCommand } from './commands/squash-change';
 import { setBookmarkCommand } from './commands/bookmark';
+import { absorbCommand } from './commands/absorb';
 
 export interface Api {
     scmProvider: JjScmProvider;
@@ -252,6 +253,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.openMergeEditor', async (arg: unknown, ...rest: unknown[]) => {
             await openMergeEditorCommand(scmProvider, arg, ...rest);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.absorb', async (...args: unknown[]) => {
+            await absorbCommand(scmProvider, jj, args);
         }),
     );
 

--- a/src/jj-context-keys.ts
+++ b/src/jj-context-keys.ts
@@ -19,4 +19,7 @@ export enum JjContextKey {
 
     /** True when log selection allows merge (2+ items selected) */
     SelectionAllowMerge = 'jj.selection.allowMerge',
+
+    /** True when selected commit(s) have at least one mutable parent */
+    SelectionParentMutable = 'jj.selection.parentMutable',
 }

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -602,4 +602,19 @@ export class JjService {
             await fs.rm(tmpDir, { recursive: true, force: true });
         }
     }
+    async absorb(options: { paths?: string[]; fromRevision?: string } = {}): Promise<string> {
+        const { paths, fromRevision } = options;
+        const args: string[] = ['--no-pager'];
+
+        if (fromRevision) {
+            args.push('--from', fromRevision);
+        }
+        if (paths && paths.length > 0) {
+            // Check if paths are relative or absolute, assume toRelative handles it
+            const relativePaths = paths.map((p) => this.toRelative(p));
+            args.push(...relativePaths);
+        }
+
+        return this.run('absorb', args, { isMutation: true });
+    }
 }

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo, buildGraph } from '../test-repo';
+import { absorbCommand } from '../../commands/absorb';
+
+suite('Absorb Integration Test', function () {
+    this.timeout(60000);
+    let repo: TestRepo;
+    let jj: JjService;
+    let scmProvider: JjScmProvider;
+    let outputChannel: vscode.OutputChannel;
+
+    setup(async () => {
+        repo = new TestRepo();
+        await repo.init();
+        jj = new JjService(repo.path);
+
+        outputChannel = vscode.window.createOutputChannel('JJ Test');
+
+        const context = {
+            subscriptions: [],
+            extensionUri: vscode.Uri.file(__dirname),
+        } as unknown as vscode.ExtensionContext;
+
+        scmProvider = new JjScmProvider(context, jj, repo.path, outputChannel);
+    });
+
+    teardown(async () => {
+        scmProvider.dispose();
+        await repo.dispose();
+    });
+
+    test('absorb working copy changes into parent', async () => {
+        await buildGraph(repo, [
+            { label: 'parent', description: 'parent', files: { 'file.txt': 'line 1\nline 2\nline 3\n' } },
+            {
+                label: 'child',
+                parents: ['parent'],
+                description: 'child',
+                files: { 'file.txt': 'line 1\nline 2 changed\nline 3\n' },
+                isWorkingCopy: true,
+            },
+        ]);
+
+        await absorbCommand(scmProvider, jj, []);
+
+        const parentContent = repo.getFileContent('@-', 'file.txt');
+        assert.ok(parentContent.includes('line 2 changed'), 'Parent should have absorbed the change');
+    });
+
+    test('absorb from specific revision', async () => {
+        // root -> A (introduces lineA) -> B (modifies lineA) -> C (working copy)
+        const ids = await buildGraph(repo, [
+            { label: 'root', description: 'root', files: { 'file.txt': 'base\n' } },
+            { label: 'A', parents: ['root'], description: 'A', files: { 'file.txt': 'base\nlineA\n' } },
+            { label: 'B', parents: ['A'], description: 'B', files: { 'file.txt': 'base\nlineA modified\n' } },
+            { label: 'C', parents: ['B'], description: 'C', isWorkingCopy: true },
+        ]);
+
+        await absorbCommand(scmProvider, jj, [{ commitId: ids['B'].changeId }]);
+
+        const contentA = repo.getFileContent(ids['A'].changeId, 'file.txt');
+        assert.equal(contentA, 'base\nlineA modified\n');
+    });
+});

--- a/src/test/commands/absorb.test.ts
+++ b/src/test/commands/absorb.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+import * as vscode from 'vscode';
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import { absorbCommand } from '../../commands/absorb';
+import { JjService } from '../../jj-service';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { TestRepo, buildGraph } from '../test-repo';
+import { createMock } from '../test-utils';
+
+// Mock vscode
+vi.mock('vscode', () => {
+    return {
+        ProgressLocation: { Notification: 15 },
+        window: {
+            showErrorMessage: vi.fn(),
+            withProgress: vi.fn((_options, task) => task()),
+            setStatusBarMessage: vi.fn(),
+        },
+        Uri: {
+            file: (path: string) => ({ fsPath: path }),
+        },
+        workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/root' } }],
+        },
+    };
+});
+
+describe('absorbCommand', () => {
+    let jj: JjService;
+    let repo: TestRepo;
+    let scmProvider: JjScmProvider;
+
+    beforeEach(() => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path);
+
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn(),
+        });
+    });
+
+    afterEach(() => {
+        repo.dispose();
+        vi.clearAllMocks();
+    });
+
+    it('should absorb working copy changes', async () => {
+        const fileName = 'file.txt';
+        await buildGraph(repo, [
+            { label: 'parent', description: 'parent', files: { [fileName]: 'line1\nline2\n' } },
+            {
+                label: 'child',
+                parents: ['parent'],
+                description: 'child',
+                files: { [fileName]: 'line1\nline2 modified\n' },
+                isWorkingCopy: true,
+            },
+        ]);
+
+        await absorbCommand(scmProvider, jj, []);
+
+        // Verify parent has the change
+        const parentContent = repo.getFileContent('@-', fileName);
+        expect(parentContent).toBe('line1\nline2 modified\n');
+        
+        expect(scmProvider.refresh).toHaveBeenCalled();
+        expect(vscode.window.setStatusBarMessage).toHaveBeenCalledWith('Absorb completed.', 3000);
+    }, 20000);
+
+    it('should absorb from specific revision', async () => {
+        const fileName = 'rev-absorb.txt';
+        const ids = await buildGraph(repo, [
+            { label: 'root', description: 'root', files: { [fileName]: 'base\n' } },
+            {
+                label: 'A',
+                parents: ['root'],
+                description: 'A',
+                files: { [fileName]: 'base\nlineA\n' },
+            },
+            {
+                label: 'B',
+                parents: ['A'],
+                description: 'B',
+                files: { [fileName]: 'base\nlineA modified\n' },
+                isWorkingCopy: true,
+            },
+        ]);
+
+        const commitBId = ids['B'].commitId;
+        const arg = { commitId: commitBId };
+
+        await absorbCommand(scmProvider, jj, [arg]);
+
+        // Verify A has the change
+        const contentA = repo.getFileContent(ids['A'].changeId, fileName);
+        expect(contentA).toBe('base\nlineA modified\n');
+        
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    }, 20000);
+});

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -172,7 +172,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         if (p1Node!.y === p2Node!.y) {
             expect(p1Node!.x).not.toBe(p2Node!.x);
         }
-    });
+    }, 20000);
 
     test('Complex Replay (Reproduce User Scenario)', async () => {
         // Reproduce:

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -142,6 +142,9 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 // Merge requires multiple items selected
                 canMerge: isSelected && selectionCount > 1,
 
+                // Absorb requires at least one mutable parent and single-item context
+                canAbsorb: commit.parents_immutable?.some((immutable: boolean) => !immutable) && (!isSelected || selectionCount <= 1),
+
                 preventDefaultContextMenuItems: true,
             })}
             onClick={(e) => {


### PR DESCRIPTION
This shows up as a commend, in the working copy header, and in the context menu on jj log webview commits