### PR TITLE
Apply a global 20s test timeout to stabilize windows CI

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -2,4 +2,7 @@ import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
     files: 'out/test/**/*.integration.test.js',
+    mocha: {
+        timeout: 20000,
+    },
 });

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -12,8 +12,6 @@ import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
 
 suite('Button Visibility Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let scmProvider: JjScmProvider;
     let executeCommandStub: sinon.SinonStub;

--- a/src/test/commands/absorb.test.ts
+++ b/src/test/commands/absorb.test.ts
@@ -58,7 +58,7 @@ describe('absorbCommand', () => {
         
         expect(scmProvider.refresh).toHaveBeenCalled();
         expect(vscode.window.setStatusBarMessage).toHaveBeenCalledWith('Absorb completed.', 3000);
-    }, 20000);
+    });
 
     it('should absorb from specific revision', async () => {
         const fileName = 'rev-absorb.txt';
@@ -89,5 +89,5 @@ describe('absorbCommand', () => {
         expect(contentA).toBe('base\nlineA modified\n');
         
         expect(scmProvider.refresh).toHaveBeenCalled();
-    }, 20000);
+    });
 });

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -172,7 +172,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         if (p1Node!.y === p2Node!.y) {
             expect(p1Node!.x).not.toBe(p2Node!.x);
         }
-    }, 20000);
+    });
 
     test('Complex Replay (Reproduce User Scenario)', async () => {
         // Reproduce:

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -12,9 +12,6 @@ import { TestRepo } from './test-repo';
 import { createMock, accessPrivate } from './test-utils';
 
 suite('JJ Decoration Integration Test', function () {
-    // Use function to allow this.timeout
-    this.timeout(20000);
-
     let scmProvider: JjScmProvider;
     let jjService: JjService;
     let repo: TestRepo;

--- a/src/test/jj-merge-provider.integration.test.ts
+++ b/src/test/jj-merge-provider.integration.test.ts
@@ -11,8 +11,6 @@ import { JjMergeContentProvider } from '../jj-merge-provider';
 import { TestRepo } from './test-repo';
 
 suite('JJ Merge Provider Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let provider: JjMergeContentProvider;
     let registration: vscode.Disposable;

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -15,8 +15,6 @@ import { TestRepo, buildGraph } from './test-repo';
 import { createMock, accessPrivate } from './test-utils';
 
 suite('JJ SCM Provider Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let scmProvider: JjScmProvider;
 

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -11,8 +11,6 @@ import { TestRepo } from './test-repo';
 import { createMock, accessPrivate } from './test-utils';
 
 suite('JJ SCM Visibility Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let scmProvider: JjScmProvider;
     let outputChannel: vscode.OutputChannel;

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -16,8 +16,6 @@ import { TestRepo, buildGraph } from './test-repo';
 import { createMock } from './test-utils';
 
 suite('Quick Diff Commands Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let scmProvider: JjScmProvider;
     let repo: TestRepo;

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -20,8 +20,6 @@ import { TestRepo } from './test-repo';
 import { createMock, asSinonStub } from './test-utils';
 
 suite('Webview Commands End-to-End Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let scm: JjScmProvider;
     let provider: JjLogWebviewProvider;

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -13,8 +13,6 @@ import { TestRepo } from './test-repo';
 import { createMock, asSinonStub } from './test-utils';
 
 suite('Webview Selection Integration Test', function () {
-    this.timeout(20000);
-
     let jj: JjService;
     let provider: JjLogWebviewProvider;
     let messageHandler: (m: unknown) => Promise<void>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
         include: ['src/test/**/*.test.ts'],
         exclude: ['src/test/**/*.integration.test.ts'], // Exclude integration tests
         globals: true,
+        testTimeout: 20000,
     },
 });


### PR DESCRIPTION
Windows filesystem is slow and a lot of tests are intermittently timing out