### PR TITLE
Use vscode font instead of editor font

### DIFF
--- a/media/main.css
+++ b/media/main.css
@@ -10,6 +10,7 @@ body {
     /* Pane background */
     color: var(--vscode-editor-foreground);
     font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
     overflow-x: hidden;
 }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -160,8 +160,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 alignItems: 'stretch',
                 flexDirection: 'row',
                 justifyContent: 'flex-start',
-                fontFamily: 'var(--vscode-editor-font-family)',
-                fontSize: 'var(--vscode-editor-font-size)',
+                paddingBottom: '0',
                 cursor: 'default',
                 width: '100%',
                 backgroundColor: backgroundColor,
@@ -171,7 +170,6 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 minWidth: 0,
                 paddingLeft: '6px',
                 paddingTop: '0',
-                paddingBottom: '0',
             }}
         >
             {/* Left Column: ID and Actions */}
@@ -347,8 +345,6 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                     <div
                         className="gerrit-row"
                         style={{
-                            fontSize: 'var(--vscode-editor-font-size)',
-                            fontFamily: 'var(--vscode-editor-font-family)',
                             display: 'flex',
                             alignItems: 'center',
                             gap: '6px',


### PR DESCRIPTION
This addresses the desire for a smaller font as requested in #25. I might follow this up with the ability to configure the font, since the vscode font feels a little small to me.