### PR TITLE
Be more careful in integration test teardown

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,8 +1,28 @@
 import { defineConfig } from '@vscode/test-cli';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-user-data-'));
+const userDir = path.join(tmpDir, 'User');
+fs.mkdirSync(userDir, { recursive: true });
+
+// Write settings to disable git
+fs.writeFileSync(path.join(userDir, 'settings.json'), JSON.stringify({
+    "git.enabled": false,
+    "git.path": null,
+    "git.autoRepositoryDetection": false
+}, null, 4));
 
 export default defineConfig({
     files: 'out/test/**/*.integration.test.js',
     mocha: {
         timeout: 20000,
+        require: ['./out/test/global-teardown.js'],
     },
+    launchArgs: [
+        '--disable-extensions',
+        '--disable-extension', 'vscode.git',
+        '--user-data-dir', tmpDir
+    ],
 });

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -23,6 +23,7 @@ export interface JjResourceState extends vscode.SourceControlResourceState {
 }
 
 export class JjScmProvider implements vscode.Disposable {
+    private _disposed = false;
     private disposables: vscode.Disposable[] = [];
     private _sourceControl: vscode.SourceControl;
     private _workingCopyGroup: vscode.SourceControlResourceGroup;
@@ -195,6 +196,9 @@ export class JjScmProvider implements vscode.Disposable {
     async refresh(options: { forceSnapshot?: boolean; reason?: string } = {}): Promise<void> {
         // Chain the refresh execution to ensure serial execution
         this._refreshMutex = this._refreshMutex.then(async () => {
+            if (this._disposed) {
+                return;
+            }
             const { forceSnapshot, reason } = options;
             const reasonStr = reason ? ` (reason: ${reason})` : '';
             this.outputChannel.appendLine(`Refreshing JJ SCM (snapshot: ${!!forceSnapshot})${reasonStr}...`);
@@ -517,6 +521,7 @@ export class JjScmProvider implements vscode.Disposable {
     }
 
     dispose() {
+        this._disposed = true;
         if (this._pollTimer) {
             clearTimeout(this._pollTimer);
         }

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -46,13 +46,13 @@ suite('Button Visibility Integration Test', function () {
         executeCommandStub.callThrough(); // Call original for other commands
     });
 
-    teardown(() => {
+    teardown(async () => {
         // Cleanup
         scmProvider.dispose();
         if (executeCommandStub) {
             executeCommandStub.restore();
         }
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Sets jj.parentMutable to true when parent is mutable', async () => {

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -34,7 +34,7 @@ suite('Absorb Integration Test', function () {
 
     teardown(async () => {
         scmProvider.dispose();
-        await repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('absorb working copy changes into parent', async () => {

--- a/src/test/global-teardown.ts
+++ b/src/test/global-teardown.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// Mocha Root Hook Plugin.
+// afterAll runs once after ALL suites finish, cleaning up test repos by prefix.
+// This avoids race conditions where VS Code file watchers are still active
+// when individual test teardowns delete their repos.
+export const mochaHooks = {
+    afterAll() {
+        const tmpDir = os.tmpdir();
+        const entries = fs.readdirSync(tmpDir);
+        for (const entry of entries) {
+            if (entry.startsWith('jj-view-test-')) {
+                const fullPath = path.join(tmpDir, entry);
+                try {
+                    fs.rmSync(fullPath, { recursive: true, force: true });
+                } catch {
+                    // Ignore cleanup errors
+                }
+            }
+        }
+    },
+};

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -43,11 +43,11 @@ suite('JJ Decoration Integration Test', function () {
         scmProvider = new JjScmProvider(context, jjService, repo.path, outputChannel);
     });
 
-    teardown(() => {
+    teardown(async () => {
         if (scmProvider) {
             scmProvider.dispose();
         }
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Decorations show Correct Status for Working Copy', async () => {

--- a/src/test/jj-merge-provider.integration.test.ts
+++ b/src/test/jj-merge-provider.integration.test.ts
@@ -25,10 +25,10 @@ suite('JJ Merge Provider Integration Test', function () {
         registration = vscode.workspace.registerTextDocumentContentProvider('jj-merge-output', provider);
     });
 
-    teardown(() => {
+    teardown(async () => {
         registration.dispose();
         provider.clearCache();
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Provider resolves conflict content', async () => {

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -54,7 +54,7 @@ suite('JJ SCM Provider Integration Test', function () {
         if (scmProvider) {
             scmProvider.dispose();
         }
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Detects added file in working copy', async () => {

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -40,9 +40,9 @@ suite('JJ SCM Visibility Integration Test', function () {
         scmProvider = new JjScmProvider(context, jj, repo.path, outputChannel);
     });
 
-    teardown(() => {
+    teardown(async () => {
         scmProvider.dispose();
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Buttons visibility conditions', async () => {

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -58,7 +58,7 @@ suite('Quick Diff Commands Integration Test', function () {
         if (scmProvider) {
             scmProvider.dispose();
         }
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Discard Change reverts file content on disk', async () => {

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -129,7 +129,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
         }
         disposables.forEach((d) => d.dispose());
         disposables = [];
-        await repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Abandon command flows from Webview -> Command -> JJ CLI', async () => {

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -82,11 +82,11 @@ suite('Webview Selection Integration Test', function () {
         await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
-    teardown(() => {
+    teardown(async () => {
         if (executeCommandStub) {
             executeCommandStub.restore();
         }
-        repo.dispose();
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Selection Change updates Context Keys', async () => {


### PR DESCRIPTION
This avoids extra error logs from deleting the test repo before the extension is stopped.