### PR TITLE
Make change id display in log more minimal

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"

--- a/src/test/layout-utils.test.ts
+++ b/src/test/layout-utils.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeGap, computeMaxShortestIdLength, computeGraphAreaWidth } from '../webview/layout-utils';
+
+describe('Layout Utils', () => {
+    describe('computeGap', () => {
+        it('should return half of the font size rounded', () => {
+            expect(computeGap(10)).toBe(5);
+            expect(computeGap(13)).toBe(7);
+            expect(computeGap(16)).toBe(8);
+        });
+    });
+
+    describe('computeMaxShortestIdLength', () => {
+        it('should return 8 for empty commit list', () => {
+            expect(computeMaxShortestIdLength([])).toBe(8);
+        });
+
+        it('should return 8 if no shortest IDs are present', () => {
+            const commits = [{ change_id_shortest: undefined }, {}];
+            expect(computeMaxShortestIdLength(commits)).toBe(8);
+        });
+
+        it('should return the maximum length of shortest IDs', () => {
+            const commits = [
+                { change_id_shortest: 'abc' },
+                { change_id_shortest: 'abcde' },
+                { change_id_shortest: 'ab' },
+            ];
+            expect(computeMaxShortestIdLength(commits)).toBe(5);
+        });
+
+        it('should ignore undefined shortest IDs', () => {
+             const commits = [
+                { change_id_shortest: 'abc' },
+                { change_id_shortest: undefined },
+            ];
+            expect(computeMaxShortestIdLength(commits)).toBe(3);
+        });
+    });
+
+    describe('computeGraphAreaWidth', () => {
+        it('should calculate correct width', () => {
+            // graphWidth * laneWidth + leftMargin + gap
+            // 2 * 16 + 12 + 10 = 32 + 12 + 10 = 54
+            expect(computeGraphAreaWidth(2, 16, 12, 10)).toBe(54);
+        });
+    });
+});

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { computeGraphLayout } from '../graph-compute';
 import { GraphRail } from './GraphRail';
 import { CommitNode, ActionPayload } from './CommitNode';
+import { computeGap, computeMaxShortestIdLength, computeGraphAreaWidth } from '../layout-utils';
 
 interface CommitGraphProps {
     commits: any[];
@@ -45,10 +46,17 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
 
     // Total graph width calculation
     const LEFT_MARGIN = 12; // Match GraphRail
-    const GAP = 10; // Space between graph and text
+
+    // Dynamic sizing based on font
+    // Fallback to 13px if not available
+    const fontSize = typeof document !== 'undefined' ? parseInt(getComputedStyle(document.body).fontSize) || 13 : 13;
+    const GAP = computeGap(fontSize);
+    
+    // Determine the max shortest ID length to display
+    const maxShortestIdLength = React.useMemo(() => computeMaxShortestIdLength(commits), [commits]);
 
     // Padding-left for the text area
-    const graphAreaWidth = layout.width * LANE_WIDTH + LEFT_MARGIN + GAP;
+    const graphAreaWidth = computeGraphAreaWidth(layout.width, LANE_WIDTH, LEFT_MARGIN, GAP);
 
     return (
         <div className="commit-graph" style={{ position: 'relative' }}>
@@ -94,6 +102,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
                                 isSelected={isSelected}
                                 selectionCount={selectedCommitIds?.size || 0}
                                 hasImmutableSelection={hasImmutableSelection}
+                                idDisplayLength={maxShortestIdLength}
                             />
                         </div>
                     );

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -27,6 +27,7 @@ interface CommitNodeProps {
     isSelected?: boolean;
     selectionCount: number;
     hasImmutableSelection: boolean;
+    idDisplayLength?: number;
 }
 
 export const CommitNode: React.FC<CommitNodeProps> = ({
@@ -36,6 +37,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
     isSelected,
     selectionCount,
     hasImmutableSelection,
+    idDisplayLength = 8, // Default fallback
 }) => {
     const isWorkingCopy = commit.is_working_copy;
     const isImmutable = commit.is_immutable;
@@ -178,7 +180,8 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 style={{
                     marginRight: '8px',
                     flexShrink: 0,
-                    minWidth: '60px',
+                    width: `${idDisplayLength}ch`,
+                    minWidth: `${idDisplayLength}ch`,
                     position: 'relative',
                     display: 'flex',
                     alignItems: 'center',
@@ -195,17 +198,18 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                         display: 'flex',
                         alignItems: 'center',
                         opacity: 1,
+                        fontFamily: 'monospace', // Ensure ch units align with text
                     }}
                 >
                     {commit.change_id_shortest ? (
                         <>
                             <span style={{ fontWeight: 'bold' }}>{commit.change_id_shortest}</span>
                             <span style={{ opacity: 0.5 }}>
-                                {commit.change_id.substring(commit.change_id_shortest.length, 8)}
+                                {commit.change_id.substring(commit.change_id_shortest.length, idDisplayLength)}
                             </span>
                         </>
                     ) : (
-                        commit.change_id.substring(0, 8)
+                        commit.change_id.substring(0, idDisplayLength)
                     )}
                 </span>
 

--- a/src/webview/layout-utils.ts
+++ b/src/webview/layout-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Calculates the gap between the commit graph and the text content based on font size.
+ * Currently set to 0.5 * fontSize.
+ */
+export function computeGap(fontSize: number): number {
+    return Math.round(fontSize * 0.5);
+}
+
+/**
+ * Interface for minimal commit structure needed for ID length calculation.
+ */
+export interface ShortestIdCommit {
+    change_id_shortest?: string;
+}
+
+/**
+ * Determines the maximum length of the shortest unique change ID prefix in the given list of commits.
+ * Returns 8 as a fallback if no shortest IDs are available.
+ */
+export function computeMaxShortestIdLength(commits: ShortestIdCommit[]): number {
+    let max = 0;
+    for (const commit of commits) {
+        if (commit.change_id_shortest) {
+            max = Math.max(max, commit.change_id_shortest.length);
+        }
+    }
+    return max > 0 ? max : 8;
+}
+
+/**
+ * Calculates the total width of the graph area (including margin and gap).
+ */
+export function computeGraphAreaWidth(
+    graphWidth: number,
+    laneWidth: number,
+    leftMargin: number,
+    gap: number,
+): number {
+    return graphWidth * laneWidth + leftMargin + gap;
+}


### PR DESCRIPTION
This makes the change id length only as long
as the longest short change id.

This addresses the request in #25 