### PR TITLE
Fix mutability context for parent resource groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.12.3",
+    "version": "1.12.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -278,16 +278,17 @@ export class JjScmProvider implements vscode.Disposable {
 
                             // Reuse existing group or create new one
                             let group: vscode.SourceControlResourceGroup;
+                            const contextValue = parentEntry.is_immutable ? 'jjParentGroup' : 'jjParentGroup:mutable';
+
                             if (i < this._parentGroups.length) {
                                 group = this._parentGroups[i];
                                 group.label = label;
+                                group.contextValue = contextValue;
                             } else {
                                 const groupId = `parent-${i}`;
                                 group = this._sourceControl.createResourceGroup(groupId, label);
                                 group.hideWhenEmpty = true;
-                                group.contextValue = parentEntry.is_immutable
-                                    ? 'jjParentGroup'
-                                    : 'jjParentGroup:mutable';
+                                group.contextValue = contextValue;
                                 this._parentGroups.push(group);
                             }
 


### PR DESCRIPTION
This wasn't getting updated when groups were re-used so it could get stuck as immutable if the original parent was immutable