### PR TITLE
bug: Metaedit update-author must happen after signing.backend is set to none for it to apply.

### DIFF
--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -72,13 +72,16 @@ export class TestRepo {
         // Use suppressStderr to the user settings to hide "future commits" warnings.
         this.config('user.name', 'Test User', /*suppressStderr=*/ true);
         this.config('user.email', 'test@example.com', /*suppressStderr=*/ true);
-        this.exec(['metaedit', '--update-author']);
-
-        this.config('ui.merge-editor', 'builtin');
         
         // Ensure that tests don't fail if the user has configured signing globally (e.g.
         // signing.sign-all = true). Background processes in tests can't prompt for passphrases.
         this.config('signing.backend', 'none');
+        
+        // Metaedit to update author after signing is disabled
+        this.exec(['metaedit', '--update-author']);
+
+        this.config('ui.merge-editor', 'builtin');
+        
     }
 
     new(parents?: string[], message?: string) {


### PR DESCRIPTION
Quick fix for #35 since metaedit needs to happen after setting backend signing to none.