### PR TITLE
Improve graph layout to match jj log

### DIFF
--- a/src/cli-renderer.ts
+++ b/src/cli-renderer.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphLayout } from './webview/graph-model';
+
+/**
+ * Renders a GraphLayout as ASCII text matching the `jj log` format.
+ *
+ * Each commit produces two lines:
+ *   1. Node line: graph characters + node symbol + separator + commit info
+ *   2. Description line: connector or continuation + separator + description
+ *
+ * Angled edges bend right before their target (matching jj log behavior).
+ */
+export function renderGraphToAscii(layout: GraphLayout): string {
+    const { nodes, edges, rows } = layout;
+    const nodesById = new Map(nodes.map((n) => [n.commitId, n]));
+
+    /**
+     * Check if a lane has a vertical pass-through at a given row.
+     * For the "bend before target" model:
+     * - Straight edges (x1==x2): vertical at lane x1 for y1 <= y <= y2
+     * - Angled edges (x1!=x2): vertical at source lane x1 for y1 <= y <= y2-1
+     *   (stays at source lane until bending just before target)
+     */
+    function hasVerticalAt(lane: number, y: number): boolean {
+        return edges.some((e) => {
+            const minY = Math.min(e.y1, e.y2);
+            const maxY = Math.max(e.y1, e.y2);
+            if (e.x1 === e.x2 && e.x1 === lane) {
+                return minY <= y && y <= maxY;
+            }
+            if (e.x1 === lane && e.x1 !== e.x2) {
+                return minY <= y && y <= maxY - 1;
+            }
+            return false;
+        });
+    }
+
+    /**
+     * Compute the active width at a row for text alignment.
+     * Uses the same lifetime model as hasVerticalAt, plus accounts for
+     * connector lines that extend to wider lanes.
+     */
+    function activeWidthAt(y: number): number {
+        let w = 0;
+        const node = nodes.find((n) => n.y === y);
+        if (node) w = Math.max(w, node.x + 1);
+
+        for (const e of edges) {
+            const minY = Math.min(e.y1, e.y2);
+            const maxY = Math.max(e.y1, e.y2);
+            if (e.x1 === e.x2) {
+                // Straight edge
+                if (minY <= y && y <= maxY) {
+                    w = Math.max(w, e.x1 + 1);
+                }
+            } else {
+                // Angled edge: active at source lane x1 for y1 <= y <= y2-1
+                if (minY <= y && y <= maxY - 1) {
+                    w = Math.max(w, Math.max(e.x1, e.x2) + 1);
+                }
+            }
+        }
+
+        // Account for connector width: if there's a bend at boundary y→y+1,
+        // the connector line spans both lanes.
+        for (const e of edges) {
+            if (e.y2 === y + 1 && e.x1 !== e.x2) {
+                w = Math.max(w, Math.max(e.x1, e.x2) + 1);
+            }
+        }
+
+        return w;
+    }
+
+    /**
+     * Find connector edges that bend at the boundary between rows y and y+1.
+     */
+    function findConnectors(y: number): Array<{ x1: number; x2: number }> {
+        const connectors: Array<{ x1: number; x2: number }> = [];
+        for (const e of edges) {
+            if (e.y2 === y + 1 && e.x1 !== e.x2) {
+                connectors.push({ x1: e.x1, x2: e.x2 });
+            }
+        }
+        return connectors;
+    }
+
+    /**
+     * Build graph characters for a line.
+     */
+    function buildGraphChars(
+        y: number,
+        aw: number,
+        nodeSymbol?: string,
+        connectors?: Array<{ x1: number; x2: number }>,
+    ): string {
+        const node = nodesById.get(rows[y]?.commit_id || '');
+        const nodeLane = node?.x ?? -1;
+        let line = '';
+
+        if (connectors && connectors.length > 0) {
+            const conn = connectors[0];
+            const narrowLane = Math.min(conn.x1, conn.x2);
+            const wideLane = Math.max(conn.x1, conn.x2);
+            const isJoin = conn.x2 < conn.x1;
+
+            for (let lane = 0; lane < aw; lane++) {
+                if (lane === narrowLane) {
+                    const continuesDown = hasVerticalAt(narrowLane, y + 1) ||
+                        nodes.some((n) => n.y === y + 1 && n.x === narrowLane);
+                    line += continuesDown ? '├' : (isJoin ? '╰' : '╭');
+                } else if (lane === wideLane) {
+                    line += isJoin ? '╯' : '╮';
+                } else if (lane > narrowLane && lane < wideLane) {
+                    if (hasVerticalAt(lane, y)) {
+                        line += '┼';
+                    } else {
+                        line += '─';
+                    }
+                } else {
+                    if (hasVerticalAt(lane, y)) {
+                        line += '│';
+                    } else {
+                        line += ' ';
+                    }
+                }
+
+                if (lane < aw - 1) {
+                    if (lane >= narrowLane && lane < wideLane) {
+                        line += '─';
+                    } else {
+                        line += ' ';
+                    }
+                }
+            }
+        } else if (nodeSymbol) {
+            for (let lane = 0; lane < aw; lane++) {
+                if (lane === nodeLane) {
+                    line += nodeSymbol;
+                } else if (hasVerticalAt(lane, y)) {
+                    line += '│';
+                } else {
+                    line += ' ';
+                }
+                if (lane < aw - 1) {
+                    line += ' ';
+                }
+            }
+        } else {
+            for (let lane = 0; lane < aw; lane++) {
+                if (hasVerticalAt(lane, y)) {
+                    line += '│';
+                } else {
+                    line += ' ';
+                }
+                if (lane < aw - 1) {
+                    line += ' ';
+                }
+            }
+        }
+
+        return line;
+    }
+
+    const output: string[] = [];
+
+    for (let i = 0; i < rows.length; i++) {
+        const commit = rows[i];
+        const node = nodesById.get(commit.commit_id);
+        if (!node) continue;
+
+        const aw = activeWidthAt(i);
+
+        let symbol: string;
+        if (commit.is_working_copy) {
+            symbol = '@';
+        } else if (commit.is_immutable && commit.parents.length === 0) {
+            symbol = '◆';
+        } else {
+            symbol = '○';
+        }
+
+        // Line 1: Node line with metadata
+        const changeIdShort = commit.change_id_shortest || commit.change_id.substring(0, 8);
+        const changeIdRest = commit.change_id.substring(changeIdShort.length, 8);
+        const commitIdShort = commit.commit_id.substring(0, 8);
+        const metaText = `${changeIdShort}${changeIdRest} ${commitIdShort}`;
+
+        const nodeLine = buildGraphChars(i, aw, symbol);
+        output.push(`${nodeLine}  ${metaText}`.trimEnd());
+
+        // Line 2: Description/connector line
+        const desc = commit.description.split('\n')[0] || '(no description set)';
+        const connectors = findConnectors(i);
+
+        if (connectors.length > 0) {
+            const connLine = buildGraphChars(i, aw, undefined, connectors);
+            output.push(`${connLine}  ${desc}`.trimEnd());
+        } else if (i < rows.length - 1) {
+            const contLine = buildGraphChars(i, aw);
+            output.push(`${contLine}  ${desc}`.trimEnd());
+        }
+    }
+
+    return output.map((line) => line.trimEnd()).join('\n');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * CLI tool to render jj-view's graph in ASCII, matching `jj log` format.
+ *
+ * Usage:
+ *   npx ts-node src/cli.ts [repo-path]
+ *
+ * If repo-path is omitted, uses the current directory.
+ * Requires `jj` to be installed and the target directory to be a jj repository.
+ */
+
+import * as cp from 'child_process';
+import { JjLogEntry } from './jj-types';
+import { computeGraphLayout } from './webview/graph-compute';
+import { renderGraphToAscii } from './cli-renderer';
+import { buildLogTemplate, LOG_ENTRY_SCHEMA } from './jj-template-builder';
+
+function main() {
+    const repoPath = process.argv[2] || process.cwd();
+
+    // Build the same template used by jj-view
+    const template = buildLogTemplate(LOG_ENTRY_SCHEMA);
+
+    // Run jj log to get JSON data
+    let output: string;
+    try {
+        output = cp.execFileSync('jj', ['log', '--no-pager', '-T', template], {
+            cwd: repoPath,
+            encoding: 'utf-8',
+            maxBuffer: 10 * 1024 * 1024,
+        });
+    } catch (e: unknown) {
+        const err = e as { stderr?: string; message?: string };
+        console.error('Failed to run jj log:', err.stderr || err.message);
+        process.exit(1);
+    }
+
+    // Parse entries
+    const entries: JjLogEntry[] = [];
+    for (const line of output.trim().split('\n')) {
+        if (!line) continue;
+        const jsonStart = line.indexOf('{');
+        if (jsonStart === -1) continue;
+        const jsonPart = line.substring(jsonStart);
+        try {
+            entries.push(JSON.parse(jsonPart) as JjLogEntry);
+        } catch (e) {
+            console.error('Failed to parse:', line);
+        }
+    }
+
+    if (entries.length === 0) {
+        console.log('No commits found.');
+        return;
+    }
+
+    // Compute layout using the same algorithm as the webview
+    const layout = computeGraphLayout(entries);
+
+    // Render as ASCII
+    const ascii = renderGraphToAscii(layout);
+    console.log(ascii);
+}
+
+main();

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -55,7 +55,12 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
     // Determine the max shortest ID length to display
     const maxShortestIdLength = React.useMemo(() => computeMaxShortestIdLength(commits), [commits]);
 
-    // Padding-left for the text area
+    // Per-row padding-left for the text area (aligns text next to each node)
+    const rowGraphAreaWidths = React.useMemo(
+        () => (layout.rowWidths || []).map((rw) => computeGraphAreaWidth(rw, LANE_WIDTH, LEFT_MARGIN, GAP)),
+        [layout.rowWidths, LANE_WIDTH, LEFT_MARGIN, GAP],
+    );
+    // Fallback for the overall graph
     const graphAreaWidth = computeGraphAreaWidth(layout.width, LANE_WIDTH, LEFT_MARGIN, GAP);
 
     return (
@@ -72,7 +77,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
 
             {/* Commit List (Text) */}
             <div style={{ position: 'relative', zIndex: 1 }}>
-                {displayRows.map((commit) => {
+                {displayRows.map((commit, rowIndex) => {
                     const isSelected = selectedCommitIds?.has(commit.change_id);
                     const hasImmutableSelection =
                         selectedCommitIds && selectedCommitIds.size > 0
@@ -80,13 +85,14 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
                             : false;
 
                     const height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
+                    const rowPaddingLeft = rowGraphAreaWidths[rowIndex] ?? graphAreaWidth;
 
                     return (
                         <div
                             key={commit.commit_id}
                             style={{
                                 height: height,
-                                paddingLeft: graphAreaWidth,
+                                paddingLeft: rowPaddingLeft,
                                 display: 'flex',
                                 whiteSpace: 'nowrap',
                                 overflow: 'hidden',

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -51,37 +51,26 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
             // Straight Vertical
             d = `M ${sx} ${sy} L ${ex} ${ey}`;
         } else {
-            // Rail Routing: Bend at the row boundary to keep the structure clean.
-            // We use the top of the next row as the midpoint for the S-curve.
-            const nextRowY = rowOffsets[y1 + 1] || (sy + ROW_HEADER_HEIGHT);
-            const midY = nextRowY;
+            // Rail Routing: Bend right BEFORE the target row to match jj log.
+            // The edge stays vertical at the source lane, then bends at the
+            // boundary just before the target row.
+            const targetRowY = rowOffsets[y2] || ey;
+            const midY = targetRowY;
 
             // Direction for horizontal
             const dirX = x2 > x1 ? 1 : -1;
 
-            // Start -> Vertical to Turn
+            // Start -> Vertical down at source lane
             d += `M ${sx} ${sy}`;
             d += ` L ${sx} ${midY - R}`;
 
             // Curve 1 (Vertical to Horizontal)
-
-            // Quadratic Bezier (Q): Q control-point-x control-point-y end-x end-y
-            // Start: (sx, midY - R)
-            // Control: (sx, midY) - Corner
-            // End: (sx + R*dirX, midY)
             d += ` Q ${sx} ${midY} ${sx + R * dirX} ${midY}`;
 
             // Horizontal Line
-            // If adjacent lanes (delta=1), len = W = 2*R.
-            // start + 2*R*dirX = start + W*dirX = ex.
-            // So horizontal segment is length 0. Perfect S.
-            // If delta > 1, straight line exists.
             d += ` L ${ex - R * dirX} ${midY}`;
 
             // Curve 2 (Horizontal to Vertical)
-            // Start: (ex - R*dirX, midY)
-            // Control: (ex, midY)
-            // End: (ex, midY + R)
             d += ` Q ${ex} ${midY} ${ex} ${midY + R}`;
 
             // Vertical to End

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -84,6 +84,14 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
             if (p0Lane === -1) {
                 p0Lane = nodeLane;
                 lanes[nodeLane] = p0;
+            } else if (p0Lane > nodeLane) {
+                // Parent was reserved at a wider lane by another child.
+                // Move it to the current (narrower) lane to match jj's layout:
+                // this creates a ├─╯ join connector instead of keeping the
+                // parent at the wider lane.
+                lanes[p0Lane] = null;
+                lanes[nodeLane] = p0;
+                p0Lane = nodeLane;
             }
             pendingEdges.push({
                 x1: nodeLane,
@@ -159,5 +167,30 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
         nodes.reduce((max, n) => Math.max(max, n.x + 1), 0),
     );
 
-    return { nodes, edges, width, height: sortedRows.length, rows: sortedRows };
+    // Compute per-row active widths for text alignment.
+    // Uses the "bend before target" model:
+    // - Straight edges occupy their lane for all rows between source and target
+    // - Angled edges stay at source lane until bending just before the target
+    const rowWidths: number[] = new Array(sortedRows.length).fill(0);
+    for (const node of nodes) {
+        rowWidths[node.y] = Math.max(rowWidths[node.y], node.x + 1);
+    }
+    for (const edge of edges) {
+        const minY = Math.min(edge.y1, edge.y2);
+        const maxY = Math.max(edge.y1, edge.y2);
+        const maxLane = Math.max(edge.x1, edge.x2) + 1;
+        if (edge.x1 === edge.x2) {
+            // Straight edge: active for all rows
+            for (let y = minY; y <= maxY && y < sortedRows.length; y++) {
+                rowWidths[y] = Math.max(rowWidths[y], maxLane);
+            }
+        } else {
+            // Angled edge: active at source lane until y2-1
+            for (let y = minY; y <= maxY - 1 && y < sortedRows.length; y++) {
+                rowWidths[y] = Math.max(rowWidths[y], maxLane);
+            }
+        }
+    }
+
+    return { nodes, edges, width, height: sortedRows.length, rows: sortedRows, rowWidths };
 }

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -31,4 +31,5 @@ export interface GraphLayout {
     width: number;
     height: number;
     rows: JjLogEntry[]; // The commits in display order
+    rowWidths: number[]; // Per-row active width (in lanes) for text alignment
 }


### PR DESCRIPTION
## Summary

Improves jj-view's graph rendering to more closely match the output of `jj log`.

### Changes

1. **Per-row text alignment**: Commit text (hash, description, etc.) is now positioned immediately next to each node, matching how `jj log` aligns text per-row rather than in a fixed column.
2. **First-parent lane reassignment**: When a parent commit is already assigned to a wider lane by another child, it is reassigned to the narrower lane of the current node, matching `jj log`'s lane compaction behavior.
3. **SVG edge routing - bend before target**: Graph edges now bend horizontally right before reaching their target node instead of right after leaving the source. This matches `jj log`'s connector layout.
4. **CLI renderer and entry point**: Added `src/cli-renderer.ts` and `src/cli.ts` for rendering the graph as ASCII art, enabling side-by-side comparison with `jj log` output.
### Testing

- All 260 existing unit tests pass
- - TypeScript type checking passes
- - CLI tool: `npx ts-node src/cli.ts [repo-path]`