### PR TITLE
fix(gerrit): detect changes to commit description for CL upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.16.1
+
+### Fixes
+- **Gerrit**: The Upload button now correctly appears when you modify a commit's description. Previously, it only detected changes to file contents.
+
 ## 1.16.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.16.0",
+    "version": "1.16.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"

--- a/src/gerrit-service.ts
+++ b/src/gerrit-service.ts
@@ -18,6 +18,9 @@ interface GerritFile {
 
 interface GerritRevision {
     files?: Record<string, GerritFile>;
+    commit?: {
+        message: string;
+    };
 }
 
 export interface GerritChange {
@@ -337,7 +340,7 @@ export class GerritService implements vscode.Disposable {
 
         const info = await this._fetchFromNetwork(cacheKey);
         if (info) {
-            await this._verifySyncForCommit(commitId, info);
+            await this._verifySyncForCommit(commitId, description, info);
             this.cache.set(cacheKey, info);
         }
         return info;
@@ -390,9 +393,9 @@ export class GerritService implements vscode.Disposable {
     private async _fetchFromNetwork(cacheKey: string): Promise<GerritClInfo | undefined> {
         if (!this._gerritHost) return undefined;
         
-        const searchQ = `change:${cacheKey}`;
+            const searchQ = `change:${cacheKey}`;
         try {
-            const url = `${this._gerritHost}/changes/?q=${searchQ}&o=LABELS&o=SUBMITTABLE&o=CURRENT_REVISION&o=CURRENT_FILES`;
+            const url = `${this._gerritHost}/changes/?q=${searchQ}&o=LABELS&o=SUBMITTABLE&o=CURRENT_REVISION&o=CURRENT_FILES&o=CURRENT_COMMIT`;
             
             const response = await fetch(url);
             if (!response.ok) {
@@ -415,19 +418,19 @@ export class GerritService implements vscode.Disposable {
             const currentRev = change.current_revision;
             
             let files: Record<string, { newSha?: string; status?: string }> | undefined;
-            if (currentRev && change.revisions && change.revisions[currentRev] && change.revisions[currentRev].files) {
-                files = {};
-                const rawFiles = change.revisions[currentRev].files;
-                if (rawFiles) {
-                    for (const [path, fileInfo] of Object.entries(rawFiles)) {
-                        // Skip magic files like /COMMIT_MSG
-                        if (path.startsWith('/')) continue;
-                        
-                        files[path] = {
-                            newSha: fileInfo.new_sha,
-                            status: fileInfo.status
-                        };
-                    }
+            let remoteDescription: string | undefined;
+
+            const rev = (currentRev && change.revisions) ? change.revisions[currentRev] : undefined;
+            if (rev) {
+                remoteDescription = rev.commit?.message;
+
+                if (rev.files) {
+                    files = Object.entries(rev.files).reduce((acc, [path, fileInfo]) => {
+                        if (!path.startsWith('/')) {
+                            acc[path] = { newSha: fileInfo.new_sha, status: fileInfo.status };
+                        }
+                        return acc;
+                    }, {} as Record<string, { newSha?: string; status?: string }>);
                 }
             }
 
@@ -439,7 +442,8 @@ export class GerritService implements vscode.Disposable {
                 url: `${this._gerritHost}/c/${change._number}`,
                 unresolvedComments: change.unresolved_comment_count || 0,
                 currentRevision: change.current_revision,
-                files
+                files,
+                remoteDescription
             };
             return info;
         } catch (error) {
@@ -452,11 +456,24 @@ export class GerritService implements vscode.Disposable {
      * Verify whether a local commit's content matches its Gerrit revision
      * by comparing per-file blob SHA-1 hashes. Sets `synced = true` if matching.
      */
-    private async _verifySyncForCommit(commitId: string, info: GerritClInfo): Promise<void> {
+    private async _verifySyncForCommit(commitId: string, description: string | undefined, info: GerritClInfo): Promise<void> {
         if (info.status !== 'NEW' ||
             info.currentRevision === commitId ||
             !info.files) {
             return;
+        }
+
+        // Verify description matches
+        if (info.remoteDescription && description) {
+            const normalize = (desc: string) => {
+                // Gerrit appends the Change-Id footer to the description.
+                // Since our local description might not have this, we strip it out before comparing
+                // to avoid false positive sync failures.
+                return desc.replace(/^Change-Id: I[0-9a-fA-F]{40}\s*$/gm, '').trim();
+            };
+            if (normalize(description) !== normalize(info.remoteDescription)) {
+                return;
+            }
         }
 
         const gerritFiles = info.files;
@@ -471,7 +488,7 @@ export class GerritService implements vscode.Disposable {
 
             const gerritPaths = Object.keys(gerritFiles).filter(p => gerritFiles[p].status !== 'D');
             const gerritPathSet = new Set(gerritPaths);
-
+            
             // 2. Compare sets using ES2024 Set.difference
             // Check for strict equality of sets: A.difference(B) must be empty AND B.difference(A) must be empty
             if (localPaths.difference(gerritPathSet).size > 0 || gerritPathSet.difference(localPaths).size > 0) {

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -18,6 +18,7 @@ export interface GerritClInfo {
     currentRevision?: string;
     files?: Record<string, { newSha?: string; status?: string }>;
     synced?: boolean;
+    remoteDescription?: string;
 }
 
 export interface JjLogEntry {

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -208,6 +208,7 @@ describe('GerritService Detection', () => {
         expect(fetchSpy).not.toHaveBeenCalled();
         expect(result).toBeUndefined();
     });
+
     test('fetchAndCacheStatus handles invalid JJ Change-Id gracefully', async () => {
         mockConfig.get.mockReturnValue('https://host.com');
         service = new GerritService(repo.path, jjService);
@@ -224,6 +225,7 @@ describe('GerritService Detection', () => {
         expect(fetchSpy).not.toHaveBeenCalled();
         expect(result).toBeUndefined();
     });
+
     test('fetchAndCacheStatus caches by Change-Id', async () => {
         mockConfig.get.mockReturnValue('https://host.com');
         service = new GerritService(repo.path, jjService);
@@ -474,6 +476,111 @@ describe('GerritService Detection', () => {
         expect(result).toBeDefined();
         // Should be not synced because file2.txt is extra locally
         expect(result?.synced).toBeFalsy();
+    });
+
+    test('forceFetchAndCacheStatus detects description mismatch as not synced', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        const changeId = 'I1234567890abcdef1234567890abcdef12345678'; 
+        const currentRev = 'commit-sha-on-gerrit';
+        
+        // Match files exactly but change description
+        repo.writeFile('file1.txt', 'content1');
+        await jjService.describe('Local Description\n\nChange-Id: ' + changeId);
+        const localHashes = await jjService.getGitBlobHashes(repo.getCommitId('@'), ['file1.txt']);
+        
+        fakeGerritServer.addChange({
+            change_id: changeId,
+            _number: 123,
+            status: 'NEW',
+            current_revision: currentRev,
+            revisions: {
+                [currentRev]: {
+                    commit: { message: 'Remote Description\n\nChange-Id: ' + changeId },
+                    files: {
+                        'file1.txt': { status: 'A', new_sha: localHashes.get('file1.txt') }
+                    }
+                }
+            }
+        });
+
+        const commitId = repo.getCommitId('@').trim();
+
+        // Pass a DIFFERENT local description
+        const resultNoSync = await service.forceFetchAndCacheStatus(commitId, changeId, `Local Description\n\nChange-Id: ${changeId}`);
+        expect(resultNoSync?.synced).toBeFalsy();
+    });
+
+    test('forceFetchAndCacheStatus accepts matching description regardless of whitespace', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        const changeId = 'I1234567890abcdef1234567890abcdef12345678'; 
+        const currentRev = 'commit-sha-on-gerrit';
+        
+        const baseDescription = `Same Description\n\nChange-Id: ${changeId}`;
+        
+        repo.writeFile('file1.txt', 'content1');
+        await jjService.describe(baseDescription);
+        const localHashes = await jjService.getGitBlobHashes(repo.getCommitId('@'), ['file1.txt']);
+
+        fakeGerritServer.addChange({
+            change_id: changeId,
+            _number: 123,
+            status: 'NEW',
+            current_revision: currentRev,
+            revisions: {
+                [currentRev]: {
+                    commit: { message: baseDescription + '\n\n' }, // Extra newlines remotely
+                    files: {
+                        'file1.txt': { status: 'A', new_sha: localHashes.get('file1.txt') }
+                    }
+                }
+            }
+        });
+
+        const commitId = repo.getCommitId('@').trim();
+
+        // Pass exactly the base description (different whitespace/trimming)
+        const resultSynced = await service.forceFetchAndCacheStatus(commitId, changeId, baseDescription);
+        expect(resultSynced?.synced).toBeTruthy();
+    });
+
+    test('forceFetchAndCacheStatus ignores Change-Id footer differences', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        const jjId = 'zzzzzzzzzzzzkkkkkkkkkkkkkkkkkkkkkkkkkkkk'; 
+        const gerritId = 'I000000000000ffffffffffffffffffffffffffff';
+        const currentRev = 'commit-sha-on-gerrit';
+        
+        repo.writeFile('file1.txt', 'content1');
+        await jjService.describe('Local description has no Change-Id');
+        const localHashes = await jjService.getGitBlobHashes(repo.getCommitId('@'), ['file1.txt']);
+
+        fakeGerritServer.addChange({
+            change_id: gerritId,
+            _number: 123,
+            status: 'NEW',
+            current_revision: currentRev,
+            revisions: {
+                [currentRev]: {
+                    commit: { message: 'Local description has no Change-Id\n\nChange-Id: ' + gerritId }, // Gerrit has it
+                    files: {
+                        'file1.txt': { status: 'A', new_sha: localHashes.get('file1.txt') }
+                    }
+                }
+            }
+        });
+
+        const commitId = repo.getCommitId('@').trim();
+
+        const resultSynced = await service.forceFetchAndCacheStatus(commitId, jjId, 'Local description has no Change-Id');
+        expect(resultSynced?.synced).toBeTruthy();
     });
 
     test('requestRefreshWithBackoffs schedules multiple refreshes', async () => {


### PR DESCRIPTION
Previously, the Gerrit sync check only verified if the file contents (blob hashes) matched between the local working copy and the remote Gerrit revision. If a user only amended the commit message, the UI would incorrectly report that the CL was fully synced and not prompt for an upload.

This change extracts the commit message from the Gerrit API response and compares it with the local `jj` commit description. To avoid false positives, the comparison automatically strips out the `Change-Id:` footer, which is dynamically appended by Gerrit or `jj git push` and often absent from the local description.