### PR TITLE
Implement E2E testing framework and refactor commands for multi-select

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
               if: runner.os != 'Linux'
               run: npm run test:integration
 
+            - name: Install Playwright Browsers & Dependencies
+              if: runner.os == 'Linux'
+              run: npx playwright install --with-deps chromium
+
+            - name: Run E2E Tests (Linux)
+              if: runner.os == 'Linux'
+              run: xvfb-run -a npm run test:e2e
+
             - name: Package Extension
               if: runner.os == 'Linux'
               run: npx @vscode/vsce package

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.vsix
 .DS_Store
 codicons/
+test-results/

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
                 {
                     "command": "jj-view.newBefore",
                     "group": "navigation",
-                    "when": "view == jj-view.logView && jj.selection.allowAbandon"
+                    "when": "view == jj-view.logView && jj.selection.allowNewBefore"
                 }
             ],
             "webview/context": [
@@ -278,7 +278,7 @@
                 },
                 {
                     "command": "jj-view.newBefore",
-                    "when": "webviewSection == 'commit' && canEdit",
+                    "when": "webviewSection == 'commit' && canNewBefore",
                     "group": "navigation"
                 },
                 {
@@ -456,6 +456,7 @@
         "test:activation": "node esbuild.js && npm run build:tests && vscode-test --config .vscode-test-activation.mjs",
         "test:integration:all": "node esbuild.js && npm run build:tests && vscode-test --config .vscode-test.mjs && vscode-test --config .vscode-test-activation.mjs",
         "test:screenshots": "playwright test",
+        "test:e2e": "node esbuild.js && npm run build:tests && playwright test -c playwright.e2e.config.ts",
         "test:unit": "vitest run",
         "release:encode": "ts-node .agents/scripts/encode-release-notes.ts"
     },

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/test/e2e',
+  timeout: 60000,
+  expect: {
+    timeout: 10000,
+  },
+  reporter: 'line',
+  use: {
+    trace: 'on-first-retry',
+  },
+});

--- a/src/commands/abandon.ts
+++ b/src/commands/abandon.ts
@@ -12,7 +12,7 @@ export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, 
     let revisions: string[] = [];
 
     // 1. Check if triggered from Working Copy header (ignore selection)
-    if (args.some(isWorkingCopyResourceGroup)) {
+    if (args.some(arg => isWorkingCopyResourceGroup(arg))) {
         revisions = ['@'];
     } else {
         // 2. Check explicit argument (e.g. context menu click)
@@ -54,7 +54,6 @@ export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, 
         await scmProvider.refresh();
         vscode.window.showInformationMessage(`Abandoned ${revisions.length} change(s).`);
     } catch (e: unknown) {
-        // const errorMessage = e instanceof Error ? e.message : String(e);
         showJjError(e, 'Error abandoning commit', scmProvider.outputChannel);
     }
 }

--- a/src/commands/absorb.ts
+++ b/src/commands/absorb.ts
@@ -6,13 +6,13 @@
 import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
-import { collectResourceStates, extractRevision, showJjError, withDelayedProgress } from './command-utils';
+import { collectResourceStates, extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 
 export async function absorbCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
     const paths = resourceStates.map((r) => r.resourceUri.fsPath);
 
-    const fromRevision = extractRevision(args);
+    const fromRevision = extractRevisions(args)[0];
 
     try {
         await withDelayedProgress('Absorbing changes...', jj.absorb({ paths, fromRevision }));

--- a/src/commands/bookmark.ts
+++ b/src/commands/bookmark.ts
@@ -8,11 +8,11 @@ import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 import { JjScmProvider } from '../jj-scm-provider';
 
-export async function setBookmarkCommand(scmProvider: JjScmProvider, jj: JjService, context: { commitId: string }) {
-    if (!context || !context.commitId) {
+export async function setBookmarkCommand(scmProvider: JjScmProvider, jj: JjService, context: { changeId?: string; commitId?: string }) {
+    const revision = context?.changeId || context?.commitId;
+    if (!revision) {
         return;
     }
-    const commitId = context.commitId;
 
     try {
         const bookmarks = await withDelayedProgress('Fetching bookmarks...', jj.getBookmarks());
@@ -30,7 +30,7 @@ export async function setBookmarkCommand(scmProvider: JjScmProvider, jj: JjServi
             if (name) {
                 quickPick.hide();
                 try {
-                    await withDelayedProgress(`Setting bookmark ${name}...`, jj.moveBookmark(name, commitId));
+                    await withDelayedProgress(`Setting bookmark ${name}...`, jj.moveBookmark(name, revision));
                     await scmProvider.refresh({ reason: 'after bookmark set' });
                 } catch (e: unknown) {
                     showJjError(e, 'Error setting bookmark', scmProvider.outputChannel);

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { JjResourceState } from '../jj-scm-provider';
+import { ScmContextValue } from '../jj-context-keys';
 import * as vscode from 'vscode';
 
 // Internal type guards to keep the messy VS Code argument matching encapsulated
@@ -34,6 +35,14 @@ function hasCommitId(arg: unknown): arg is { commitId: string } {
     }
     const obj = arg as { commitId: unknown };
     return typeof obj.commitId === 'string';
+}
+
+function hasChangeId(arg: unknown): arg is { changeId: string } {
+    if (typeof arg !== 'object' || arg === null || !('changeId' in arg)) {
+        return false;
+    }
+    const obj = arg as { changeId: unknown };
+    return typeof obj.changeId === 'string';
 }
 
 /**
@@ -78,7 +87,7 @@ function isSourceControlResourceGroup(arg: unknown): arg is vscode.SourceControl
 }
 
 export function isWorkingCopyResourceGroup(arg: unknown): arg is vscode.SourceControlResourceGroup {
-    return isSourceControlResourceGroup(arg) && arg.id === 'working-copy';
+    return isSourceControlResourceGroup(arg) && arg.id === ScmContextValue.WorkingCopyGroup;
 }
 
 export function isParentResourceGroup(arg: unknown): arg is vscode.SourceControlResourceGroup {
@@ -86,39 +95,64 @@ export function isParentResourceGroup(arg: unknown): arg is vscode.SourceControl
 }
 
 /**
- * Helper to check if a specific revision was passed as a string argument
- * (often from the command palette or explicit tool calls)
+ * Helper to extract revisions from various VS Code argument types.
+ * Supports strings, objects with revision/commitId, and resource groups.
  */
-export function extractRevision(args: unknown[]): string | undefined {
+export function extractRevisions(args: unknown[]): string[] {
+    const revisions: string[] = [];
+
     for (const arg of args) {
+        if (!arg) continue;
+
         if (typeof arg === 'string' && arg.trim().length > 0) {
-            return arg;
+            revisions.push(arg);
+            continue;
         }
 
         if (hasRevision(arg)) {
-            return arg.revision;
+            revisions.push(arg.revision);
+            continue;
+        }
+
+        if (hasChangeId(arg)) {
+            revisions.push(arg.changeId);
+            continue;
         }
 
         if (hasCommitId(arg)) {
-            return arg.commitId;
+            revisions.push(arg.commitId);
+            continue;
         }
 
         if (isWorkingCopyResourceGroup(arg)) {
-            return '@';
+            revisions.push('@');
+            continue;
         }
 
         if (isParentResourceGroup(arg) && arg.resourceStates.length > 0) {
-            const firstState = arg.resourceStates[0] as JjResourceState;
-            return firstState.revision;
+            // Revisions for all files in this group (they should all be the same commit)
+            const groupRevisions = (arg.resourceStates as JjResourceState[])
+                .map(s => s.revision)
+                .filter((v, i, a) => a.indexOf(v) === i);
+            revisions.push(...groupRevisions);
+            continue;
+        }
+        
+        if (Array.isArray(arg)) {
+            revisions.push(...extractRevisions(arg));
         }
     }
-    // 5. Webview Context (generic object with commitId)
-    const arg0 = args[0];
-    if (hasCommitId(arg0)) {
-        return arg0.commitId;
-    }
 
-    return undefined;
+    return Array.from(new Set(revisions));
+}
+
+/**
+ * Helper to check if a specific revision was passed (singular).
+ * Re-added for backward compatibility to keep independent command diffs small.
+ */
+export function extractRevision(args: unknown[]): string | undefined {
+    const revs = extractRevisions(args);
+    return revs.length > 0 ? revs[0] : undefined;
 }
 
 export function getErrorMessage(error: unknown): string {

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -4,7 +4,7 @@
  */
 
 import { JjService } from '../jj-service';
-import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 import { JjScmProvider } from '../jj-scm-provider';
 
 export async function setDescriptionCommand(
@@ -16,7 +16,7 @@ export async function setDescriptionCommand(
     const revisionArgs = message ? args.slice(1) : args;
     const revision =
         (message && typeof args[1] === 'string' ? args[1] : undefined) ??
-        extractRevision(revisionArgs) ??
+        extractRevisions(revisionArgs)[0] ??
         '@';
 
     const description = message ?? scmProvider.sourceControl.inputBox.value;

--- a/src/commands/duplicate.ts
+++ b/src/commands/duplicate.ts
@@ -4,18 +4,18 @@
  */
 
 import { JjService } from '../jj-service';
-import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 import { JjScmProvider } from '../jj-scm-provider';
 
 export async function duplicateCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
-    const revision = extractRevision(args);
+    const revision = extractRevisions(args)[0];
     if (!revision) {
         return;
     }
 
     try {
-        await withDelayedProgress('Duplicating revision...', jj.duplicate(revision));
-        await scmProvider.refresh();
+        await withDelayedProgress('Duplicating...', jj.duplicate(revision));
+        await scmProvider.refresh({ reason: 'after duplicate' });
     } catch (e: unknown) {
         showJjError(e, 'Error duplicating commit', scmProvider.outputChannel);
     }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -14,8 +14,8 @@ export async function editCommand(scmProvider: JjScmProvider, jj: JjService, arg
     }
 
     try {
-        await withDelayedProgress('Editing revision...', jj.edit(revision));
-        await scmProvider.refresh();
+        await withDelayedProgress('Editing...', jj.edit(revision));
+        await scmProvider.refresh({ reason: 'after edit' });
     } catch (e: unknown) {
         showJjError(e, 'Error editing commit', scmProvider.outputChannel);
     }

--- a/src/commands/new-before.ts
+++ b/src/commands/new-before.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
-import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 import { JjScmProvider } from '../jj-scm-provider';
 
 export async function newBeforeCommand(
@@ -13,25 +13,28 @@ export async function newBeforeCommand(
     jj: JjService,
     args: unknown[],
 ) {
-    let targetRevision: string | undefined;
+    let revisions: string[] = [];
 
-    // Check for arguments (context menu, etc)
-    if (args && args.length > 0) {
-        targetRevision = extractRevision(args);
-    }
+    // 1. Revisions from arguments (context menu, etc)
+    const argRevisions = extractRevisions(args);
+    
+    // 2. Selection from provider
+    const selectedIds = scmProvider.getSelectedCommitIds();
 
-    // Fallback: Check for selection in webview
-    const revisions: string[] = [];
-    if (targetRevision) {
-        revisions.push(targetRevision);
-    } else {
-        const selectedIds = scmProvider.getSelectedCommitIds();
-        if (selectedIds.length > 0) {
-            revisions.push(...selectedIds);
+    if (argRevisions.length > 0) {
+        // If the right-clicked commit is part of the selection, use the full selection.
+        // This allows "New Before" to apply to multiple selected commits if you right-click one of them.
+        const target = argRevisions[0];
+        if (selectedIds.includes(target)) {
+            revisions = selectedIds;
         } else {
-             // Fallback: Default to working copy parent (which is essentially "insert before working copy")
-             revisions.push('@');
+            revisions = argRevisions;
         }
+    } else if (selectedIds.length > 0) {
+        revisions = selectedIds;
+    } else {
+        // Fallback: Default to working copy (insert before working copy)
+        revisions = ['@'];
     }
 
     if (revisions.length === 0) {

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -72,19 +72,19 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     break;
                 case 'newChild':
                     // new(message?, parent?)
-                    await vscode.commands.executeCommand('jj-view.new', data.payload.commitId);
+                    await vscode.commands.executeCommand('jj-view.new', data.payload);
                     break;
                 case 'squash':
                     // Route through extension command to reuse safe squash logic (editor, etc.)
-                    // Pass the commitId string to the squash command
-                    await vscode.commands.executeCommand('jj-view.squash', data.payload.commitId);
+                    // Pass the whole payload
+                    await vscode.commands.executeCommand('jj-view.squash', data.payload);
                     // Refresh is handled by the command event listener
                     break;
                 case 'edit':
-                    await vscode.commands.executeCommand('jj-view.edit', data.payload.commitId);
+                    await vscode.commands.executeCommand('jj-view.edit', data.payload);
                     break;
                 case 'select':
-                    const details = await this._jj.showDetails(data.payload.commitId);
+                    const details = await this._jj.showDetails(data.payload.changeId);
                     const cleanDetails = details.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
                     vscode.workspace.openTextDocument({ content: cleanDetails, language: 'plaintext' }).then((doc) =>
                         vscode.window.showTextDocument(doc, {
@@ -100,28 +100,28 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     await vscode.commands.executeCommand('jj-view.abandon', data.payload);
                     break;
                 case 'getDetails':
-                    await this.createCommitDetailsPanel(data.payload.commitId);
+                    await this.createCommitDetailsPanel(data.payload.changeId);
                     break;
                 case 'new':
                     await vscode.commands.executeCommand('jj-view.new');
                     break;
                 case 'newBefore':
-                    await vscode.commands.executeCommand('jj-view.newBefore', ...(data.payload.commitIds || []));
+                    await vscode.commands.executeCommand('jj-view.newBefore', ...(data.payload.changeIds || []));
                     break;
                 case 'resolve':
                     await this._jj.resolve(data.payload);
                     await vscode.commands.executeCommand('jj-view.refresh');
                     break;
                 case 'moveBookmark':
-                    await this._jj.moveBookmark(data.payload.bookmark, data.payload.targetCommitId);
+                    await this._jj.moveBookmark(data.payload.bookmark, data.payload.targetChangeId);
                     await vscode.commands.executeCommand('jj-view.refresh');
                     break;
                 case 'rebaseCommit':
-                    await this._jj.rebase(data.payload.sourceCommitId, data.payload.targetCommitId, data.payload.mode);
+                    await this._jj.rebase(data.payload.sourceChangeId, data.payload.targetChangeId, data.payload.mode);
                     await vscode.commands.executeCommand('jj-view.refresh');
                     break;
                 case 'upload':
-                    await vscode.commands.executeCommand('jj-view.upload', data.payload.commitId);
+                    await vscode.commands.executeCommand('jj-view.upload', data.payload);
                     break;
                 case 'selectionChange':
                     if (data.payload.commitIds.length === 0 && this._activeDetailsPanel) {
@@ -177,7 +177,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 const logStart = performance.now();
                 commits = await this._jj.getLog({ omitChanges: true });
                 const logDuration = performance.now() - logStart;
-                this.outputChannel?.appendLine(`[JjLogWebviewProvider] jj log took ${logDuration.toFixed(0)}ms`);
+                this.outputChannel?.appendLine(`[JjLogWebviewProvider] jj log took ${logDuration.toFixed(0)}ms, found ${commits.length} commits`);
 
                 this._cachedCommits = commits;
                 this._renderCommits(commits);
@@ -242,9 +242,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
     private _activeDetailsPanel?: vscode.WebviewPanel;
 
-    public async createCommitDetailsPanel(commitId: string) {
+    public async createCommitDetailsPanel(changeId: string) {
         // Fetch full log entry - this includes description, changes (file list), and immutability status
-        const logs = await this._jj.getLog({ revision: commitId });
+        const logs = await this._jj.getLog({ revision: changeId });
         if (logs.length === 0) {
             return;
         }
@@ -253,7 +253,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const initialData = {
             view: 'details',
             payload: {
-                commitId,
+                changeId,
                 description: log.description,
                 files: log.changes || [],
                 isImmutable: log.is_immutable,
@@ -261,7 +261,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         };
 
         if (this._activeDetailsPanel) {
-            this._activeDetailsPanel.title = `Commit: ${commitId.substring(0, 8)}`;
+            this._activeDetailsPanel.title = `Commit: ${changeId.substring(0, 8)}`;
             this._activeDetailsPanel.webview.html = this._getHtmlForWebview(
                 this._activeDetailsPanel.webview,
                 initialData,
@@ -272,7 +272,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
         const panel = vscode.window.createWebviewPanel(
             'jj-view.commitDetails',
-            `Commit: ${commitId.substring(0, 8)}`,
+            `Commit: ${changeId.substring(0, 8)}`,
             vscode.ViewColumn.Active,
             {
                 enableScripts: true,
@@ -302,27 +302,27 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     await vscode.commands.executeCommand(
                         'jj-view.setDescription',
                         message.payload.description,
-                        message.payload.commitId,
+                        message.payload.changeId,
                     );
                     vscode.window.showInformationMessage('Description updated');
                     break;
                 case 'openDiff': {
                     const file = message.payload.file;
-                    const commitId = message.payload.commitId;
+                    const changeId = message.payload.changeId;
                     const isImmutable = message.payload.isImmutable;
                     
-                    const { leftUri, rightUri } = createDiffUris(file, commitId, this._jj.workspaceRoot, { editable: !isImmutable });
+                    const { leftUri, rightUri } = createDiffUris(file, changeId, this._jj.workspaceRoot, { editable: !isImmutable });
 
                     await vscode.commands.executeCommand(
                         'vscode.diff',
                         leftUri,
                         rightUri,
-                        `${path.basename(file.path)} (${commitId.substring(0, 8)})${!isImmutable ? ' (Editable)' : ''}`,
+                        `${path.basename(file.path)} (${changeId.substring(0, 8)})${!isImmutable ? ' (Editable)' : ''}`,
                     );
                     break;
                 }
                 case 'openMultiDiff':
-                    await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.commitId);
+                    await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.changeId);
                     break;
             }
         });
@@ -343,7 +343,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             <head>
                 <meta charset="UTF-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}' ${webview.cspSource};">
                 <link href="${styleUri}" rel="stylesheet">
                 <link href="${codiconsUri}" rel="stylesheet">
                 <title>JJ Log</title>

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -152,7 +152,9 @@ export class JjScmProvider implements vscode.Disposable {
             }
             const { forceSnapshot, reason } = options;
             const reasonStr = reason ? ` (reason: ${reason})` : '';
-            this.outputChannel.appendLine(`Refreshing JJ SCM (snapshot: ${!!forceSnapshot})${reasonStr}...`);
+            const msg = `Refreshing JJ Scm (snapshot: ${!!forceSnapshot})${reasonStr}...`;
+            this.outputChannel.appendLine(msg);
+            console.log(`[Extension Host] ${msg}`);
             const start = performance.now();
             try {
                 // Clear any cached data that might be stale after external changes
@@ -348,7 +350,7 @@ export class JjScmProvider implements vscode.Disposable {
                     } else {
                         const groupId = `ancestor-${i}`;
                         group = this._sourceControl.createResourceGroup(groupId, label);
-                        group.hideWhenEmpty = true;
+                        group.hideWhenEmpty = false;
                         group.contextValue = contextValue;
                         this._parentGroups.push(group);
                     }

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -214,6 +214,8 @@ describe('ChangeDetectionManager', () => {
     
             // Wait for watchers to start
             await waitForLog('Working Copy Watcher] Started');
+            // Give it a bit more time to settle
+            await new Promise(resolve => setTimeout(resolve, 800));
     
             // Create a file to trigger the watcher
             const testFile = path.join(repo.path, 'test_watch.txt');

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -9,6 +9,7 @@ import { abandonCommand } from '../../commands/abandon';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
 import { JjScmProvider } from '../../jj-scm-provider';
+import { ScmContextValue } from '../../jj-context-keys';
 import * as vscode from 'vscode';
 
 vi.mock('vscode', async () => {
@@ -40,12 +41,12 @@ describe('abandonCommand', () => {
 
     // Helper to verify a change is truly abandoned (not just that @ moved)
     const expectChangeAbandoned = (changeId: string) => {
-        const visibleIds = repo.getLogOutput('change_id');
+        const visibleIds = repo.getLog('all()', 'change_id');
         expect(visibleIds).not.toContain(changeId);
     };
 
     const expectChangeVisible = (changeId: string) => {
-        const visibleIds = repo.getLogOutput('change_id');
+        const visibleIds = repo.getLog('all()', 'change_id');
         expect(visibleIds).toContain(changeId);
     };
 
@@ -65,7 +66,7 @@ describe('abandonCommand', () => {
         const changeId = repo.getChangeId('@');
 
         // Mock a SourceControlResourceGroup
-        const resourceGroup = { id: 'working-copy', label: 'Working Copy', resourceStates: [] };
+        const resourceGroup = { id: ScmContextValue.WorkingCopyGroup, label: 'Working Copy', resourceStates: [] };
 
         await abandonCommand(scmProvider, jj, [resourceGroup]);
 
@@ -93,7 +94,7 @@ describe('abandonCommand', () => {
         // Select C1 (Keep Me)
         (scmProvider.getSelectedCommitIds as unknown as { mockReturnValue: Function }).mockReturnValue([keepId]);
 
-        const resourceGroup = { id: 'working-copy', label: 'Working Copy', resourceStates: [] };
+        const resourceGroup = { id: ScmContextValue.WorkingCopyGroup, label: 'Working Copy', resourceStates: [] };
         await abandonCommand(scmProvider, jj, [resourceGroup]);
 
         // Verify C2 is gone

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ElectronApplication, type Frame } from 'playwright';
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import { TestRepo, buildGraph, type CommitId } from '../test-repo';
+import { launchVSCode, focusJJLog, getLogWebview } from './e2e-helpers';
+
+/**
+ * Finds the webview frame containing the Commit Details panel.
+ */
+async function getDetailsWebview(page: Page): Promise<Frame> {
+    const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
+        for (const f of frames) {
+            try {
+                // First check if the frame itself is valid and has a heading
+                // We don't want to use count() > 0 which can be slow; use visible check
+                const heading = f.locator('h2', { hasText: 'Commit Details' });
+                if (await heading.isVisible({ timeout: 500 })) {
+                    return f;
+                }
+                
+                const nested = await findFrame(f.childFrames());
+                if (nested) return nested;
+            } catch (e) {}
+        }
+        return undefined;
+    };
+
+    let guestFrame: Frame | undefined;
+    await expect.poll(async () => {
+        guestFrame = await findFrame(page.frames());
+        return guestFrame;
+    }, {
+        timeout: 30000,
+        message: 'Could not find Commit Details webview frame'
+    }).toBeDefined();
+
+    // Ensure the iframe is fully "ready" before returning
+    await expect(guestFrame!.locator('textarea')).toBeVisible({ timeout: 10000 });
+    return guestFrame!;
+}
+
+test.describe('Commit Details E2E', () => {
+    let repo: TestRepo;
+    let app: ElectronApplication;
+    let page: Page;
+    let userDataDir: string;
+    let nodes: Record<string, CommitId>;
+
+    test.beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'f.txt': 'base content', 'g.txt': 'other content' } },
+            { label: 'feature', parents: ['initial'], description: 'add feature', files: { 'f.txt': 'modified content' } },
+        ]);
+
+        const setup = await launchVSCode(repo);
+        app = setup.app;
+        page = setup.page;
+        userDataDir = setup.userDataDir;
+
+        await focusJJLog(page);
+    });
+
+    test.afterEach(async () => {
+        if (app) await app.close();
+        if (userDataDir) try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+        if (repo) repo.dispose();
+    });
+
+    test('Opens with correct ID, description, and file list', async () => {
+        const webview = await getLogWebview(page);
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+
+        // Click the commit to open details panel
+        await initialRow.click();
+
+        // Wait for the details panel tab to appear
+        const shortId = nodes['initial'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+
+        // Find the details webview
+        const details = await getDetailsWebview(page);
+
+        // Verify change ID is displayed
+        const idText = await details.locator('text=ID:').first().textContent();
+        expect(idText).toContain(nodes['initial'].changeId);
+
+        // Verify description is shown in the textarea (ignore trailing newlines)
+        const textarea = details.locator('textarea');
+        await expect(textarea).toHaveValue(/initial setup/);
+
+        // Verify file list shows the correct files
+        // 'initial' commit has f.txt (added) and g.txt (added)
+        await expect(details.locator('text=f.txt')).toBeVisible();
+        await expect(details.locator('text=g.txt')).toBeVisible();
+
+        // Verify the "Changed Files" count label
+        await expect(details.locator('text=Changed Files (2)')).toBeVisible();
+    });
+
+    test('Save description via button', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+
+        // Click to open details
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+
+        // Edit the description
+        const textarea = details.locator('textarea');
+        await textarea.fill('updated feature description');
+
+        // Click Save
+        const saveButton = details.locator('button', { hasText: 'Save Description' });
+        await saveButton.click();
+
+        // Verify the description was saved in the repo
+        await expect(async () => {
+            const desc = repo.getDescription(nodes['feature'].changeId);
+            expect(desc).toBe('updated feature description');
+        }).toPass({ timeout: 10000 });
+    });
+
+    test('Save description via Ctrl+S', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+
+        // Click to open details
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+
+        // Edit the description
+        const textarea = details.locator('textarea');
+        await textarea.fill('saved via keyboard');
+
+        // Focus the textarea and press Ctrl+S
+        await textarea.focus();
+        await page.keyboard.press('Control+s');
+
+        // Verify the description was saved in the repo
+        await expect(async () => {
+            const desc = repo.getDescription(nodes['feature'].changeId);
+            expect(desc).toBe('saved via keyboard');
+        }).toPass({ timeout: 10000 });
+    });
+
+    test('Open file diff from file list', async () => {
+        const webview = await getLogWebview(page);
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+
+        // Click to open details
+        await initialRow.click();
+
+        const shortId = nodes['initial'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+
+        // Click on a file in the list to open a diff
+        const fileRow = details.locator('text=f.txt').first();
+        await fileRow.click();
+
+        // A diff tab should open with the filename
+        await expect(page.getByRole('tab', { name: /f\.txt/ })).toBeVisible({ timeout: 10000 });
+    });
+
+    test('Open Multi-File Diff from button', async () => {
+        const webview = await getLogWebview(page);
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+
+        // Click to open details
+        await initialRow.click();
+
+        const shortId = nodes['initial'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+
+        // Click the Multi-file Diff button
+        const multiDiffButton = details.locator('button', { hasText: 'Multi-file Diff' });
+        await multiDiffButton.click();
+
+        // A multi-file diff tab should open with the change ID
+        await expect(page.getByRole('tab', { name: new RegExp(shortId) })).toBeVisible({ timeout: 10000 });
+    });
+
+    test('Panel updates when clicking different commit', async () => {
+        const webview = await getLogWebview(page);
+
+        // Open details for 'initial'
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+        await initialRow.click();
+
+        const shortId1 = nodes['initial'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId1}`) })).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+        await expect(details.locator('textarea')).toHaveValue(/initial setup/);
+
+        // Now click 'feature' — panel should update in-place (same webview, new content)
+        // Need to focus the JJ Log webview again first
+        await focusJJLog(page);
+        // Re-get the webview after focus since frames can be invalidated
+        const webview2 = await getLogWebview(page);
+        const featureRow = webview2.locator('.commit-row', { hasText: 'add feature' });
+        await featureRow.click();
+
+        const shortId2 = nodes['feature'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId2}`) })).toBeVisible({ timeout: 15000 });
+
+        // The panel is reused — wait for the textarea content to update within the SAME frame
+        await expect(async () => {
+            const detailsFrame = await getDetailsWebview(page);
+            await expect(detailsFrame.locator('textarea')).toHaveValue(/add feature/, { timeout: 2000 });
+        }).toPass({ timeout: 15000 });
+    });
+});

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -1,0 +1,306 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ElectronApplication } from 'playwright';
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import { TestRepo, buildGraph, type CommitId } from '../test-repo';
+import { launchVSCode, focusJJLog, getLogWebview, expectTree, entry, rightClickAndSelect, ROOT_ID, selectCommits, triggerRefresh } from './e2e-helpers';
+
+test.describe('JJ Log Context Menu E2E', () => {
+    let repo: TestRepo;
+    let app: ElectronApplication;
+    let page: Page;
+    let userDataDir: string;
+    let nodes: Record<string, CommitId>;
+    let dummyId: string;
+
+    test.beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+        repo.writeFile('dummy.txt', 'dummy content');
+        repo.describe('dummy');
+        dummyId = repo.getChangeId('@');
+        
+        // Setup a predictable graph
+        nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'f.txt': 'base' } },
+            { label: 'commit1', parents: ['initial'], description: 'commit1', files: { 'a.txt': 'a content' } },
+            { label: 'commit2', parents: ['initial'], description: 'commit2', files: { 'b.txt': 'b content' } }
+        ]);
+
+        const setup = await launchVSCode(repo);
+        app = setup.app;
+        page = setup.page;
+        userDataDir = setup.userDataDir;
+
+        await focusJJLog(page);
+    });
+
+    test.afterEach(async () => {
+        if (app) await app.close();
+        if (userDataDir) try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch {}
+        if (repo) repo.dispose();
+    });
+
+    test('Abandon and Undo', async () => {
+        const webview = await getLogWebview(page);
+        
+        await expect(webview.locator('.commit-row', { hasText: 'commit2' })).toBeVisible();
+        
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // Abandon commit 2
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        await rightClickAndSelect(page, commit2Row, 'Abandon');
+
+        await expectTree(repo, [
+            '@ ' + entry('*', '(empty)', initialId),
+            entry(commit1Id, 'commit1', initialId),
+            entry(initialId, 'initial', dummyId),
+            entry(dummyId, 'dummy', ROOT_ID),
+        ]);
+        // Undo — the button is a header action on the JJ Log pane
+        const undoBtn = page.getByRole('button', { name: 'Undo' }).first();
+        await expect(undoBtn).toBeVisible({ timeout: 5000 });
+        await undoBtn.click();
+        
+        // After undo, commit2 should be restored as the working copy
+        await expectTree(repo, [
+            '@ ' + entry(commit2Id, 'commit2', initialId),
+            entry(commit1Id, 'commit1', initialId),
+            entry(initialId, 'initial', dummyId),
+            entry(dummyId, 'dummy', ROOT_ID),
+        ]);
+    });
+
+    test('New Before (Single)', async () => {
+        const webview = await getLogWebview(page);
+        
+        await expect(webview.locator('.commit-row', { hasText: 'commit1' })).toBeVisible();
+        
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // New Before initial
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial' });
+        await rightClickAndSelect(page, initialRow, 'New Before');
+
+        // After "New Before" initial: 
+        // root -> dummyId -> middle (@) -> initial -> {commit1, commit2}
+        await expect(async () => {
+            await expectTree(repo, [
+                entry(commit2Id, 'commit2', initialId),
+                entry(commit1Id, 'commit1', initialId),
+                entry(initialId, 'initial', '*'),
+                '@ ' + entry('*', '(empty)', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
+    test('Multi-select Abandon', async () => {
+        const webview = await getLogWebview(page);
+        
+        await expect(webview.locator('.commit-row', { hasText: 'commit2' })).toBeVisible();
+
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const initialId = nodes['initial'].changeId;
+
+        // Select both
+        await selectCommits([commit2Row, commit1Row]);
+
+        // Right click commit 1 and abandon
+        await rightClickAndSelect(page, commit1Row, 'Abandon');
+
+        await expectTree(repo, [
+            '@ ' + entry('*', '(empty)', initialId),
+            entry(initialId, 'initial', dummyId),
+            entry(dummyId, 'dummy', ROOT_ID),
+        ]);
+    });
+
+    test('Multi-select New Before', async () => {
+        const webview = await getLogWebview(page);
+        
+        await expect(webview.locator('.commit-row', { hasText: 'commit2' })).toBeVisible();
+
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // Select both
+        await selectCommits([commit2Row, commit1Row]);
+
+        // Right click and New Before
+        await rightClickAndSelect(page, commit2Row, 'New Before');
+
+        // After "New Before" on multi-select [commit2, commit1]: a new empty commit
+        // is inserted before both (as their new parent), and @ moves there.
+        // Tree: root -> dummyId -> initial -> middle (@) -> {commit1, commit2}
+        await expect(async () => {
+            await expectTree(repo, [
+                entry(commit1Id, 'commit1', '*'),
+                entry(commit2Id, 'commit2', '*'),
+                '@ ' + entry('*', '(empty)', initialId),
+                entry(initialId, 'initial', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
+    test('Edit', async () => {
+        const webview = await getLogWebview(page);
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const commit1Id = nodes['commit1'].changeId;
+
+        // Edit commit 1
+        await rightClickAndSelect(page, commit1Row, 'Edit');
+
+        // Verification: @ should move to commit1
+        await expect(async () => {
+            const currentId = repo.getChangeId('@');
+            expect(currentId).toBe(commit1Id);
+        }).toPass();
+    });
+
+    test('Duplicate', async () => {
+        const webview = await getLogWebview(page);
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+
+        // Duplicate commit 1
+        await rightClickAndSelect(page, commit1Row, 'Duplicate');
+
+        // Verification: a new commit should be created with the same parent
+        // Note: jj duplicate does NOT move @.
+        // New duplicate (latest) -> commit2 (@) -> commit1 (original)
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        await expectTree(repo, [
+            expect.stringMatching(new RegExp(`^[a-z0-9]+ \\[${initialId}\\] commit1$`)),
+            '@ ' + entry(commit2Id, 'commit2', initialId),
+            entry(commit1Id, 'commit1', initialId),
+            entry(initialId, 'initial', dummyId),
+            entry(dummyId, 'dummy', ROOT_ID),
+        ]);
+    });
+
+    test('New Merge Change', async () => {
+        const webview = await getLogWebview(page);
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit1Id = nodes['commit1'].changeId;
+        const commit2Id = nodes['commit2'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // Select both
+        await selectCommits([commit1Row, commit2Row]);
+
+        // Merge selection
+        await rightClickAndSelect(page, commit1Row, 'New Merge Change');
+
+        // Verification: a new merge commit should be created
+        await expect(async () => {
+            await expectTree(repo, [
+                '@ ' + entry('*', '(empty)', [commit1Id, commit2Id]),
+                entry(commit2Id, 'commit2', initialId),
+                entry(commit1Id, 'commit1', initialId),
+                entry(initialId, 'initial', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
+    test('Rebase onto Selected', async () => {
+        const webview = await getLogWebview(page);
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit1Id = nodes['commit1'].changeId;
+        const commit2Id = nodes['commit2'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // Select commit2 as the destination, then right-click commit1 to rebase it
+        await selectCommits([commit2Row]);
+        await rightClickAndSelect(page, commit1Row, 'Rebase onto Selected');
+
+        // Verification: commit1 should now be a child of commit2
+        await expect(async () => {
+            await expectTree(repo, [
+                entry(commit1Id, 'commit1', commit2Id),
+                '@ ' + entry(commit2Id, 'commit2', initialId),
+                entry(initialId, 'initial', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
+    test('Set Bookmark', async () => {
+        const webview = await getLogWebview(page);
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+
+        // Set bookmark on commit 1
+        await rightClickAndSelect(page, commit1Row, 'Set Bookmark');
+        
+        // Wait for QuickPick/InputBox to appear
+        await expect(page.locator('.quick-input-widget')).toBeVisible({ timeout: 5000 });
+        await page.keyboard.type('my-bookmark', { delay: 50 });
+        await page.keyboard.press('Enter');
+
+        // Verification: bookmark pill should appear in the webview
+        await expect(commit1Row.locator('.bookmark-pill', { hasText: 'my-bookmark' })).toBeVisible({ timeout: 10000 });
+    });
+
+    test('Absorb', async () => {
+        const commit1Id = nodes['commit1'].changeId;
+        const webview = await getLogWebview(page);
+        // Move @ to commit1 and modify a file
+        repo.edit(commit1Id);
+        await triggerRefresh(page);
+        repo.writeFile('f.txt', 'modified in wc');
+        
+        await expect(async () => {
+            // Re-locate the row in each poll to handle refreshes/virtualization
+            const row = webview.locator('.commit-row', { hasText: 'commit1' });
+            // The working-copy class is the most reliable indicator
+            await expect(row).toHaveClass(/working-copy/, { timeout: 5000 });
+        }, "Absorb setup failed: commit1 did not become the working copy").toPass({ timeout: 30000 });
+        
+        // Re-locate one last time for the context menu action
+        const finalRow = webview.locator('.commit-row', { hasText: 'commit1' });
+        // Absorb into commit 1
+        console.log("DEBUG TEST: Attempting to right-click and Absorb on commit1");
+        await rightClickAndSelect(page, finalRow, 'Absorb');
+        console.log("DEBUG TEST: rightClickAndSelect completed without throwing");
+
+        // Verification: commit 1 should now have the change, and f.txt should no longer be modified in @
+        await expect(async () => {
+            const content = repo.getFileContent(commit1Id, 'f.txt');
+            expect(content).toBe('modified in wc');
+            const wcDiff = repo.getDiffSummary('@');
+            expect(wcDiff).not.toContain('f.txt');
+        }).toPass();
+    });
+
+    test('Show Multi-File Diff', async () => {
+        const webview = await getLogWebview(page);
+        // Target 'initial' which has actual file changes (f.txt added)
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial' });
+
+        // Show Multi-File Diff
+        await rightClickAndSelect(page, initialRow, 'Show Multi-File Diff');
+
+        // Verification: A diff editor should open.
+        const shortHash = nodes['initial'].changeId.substring(0, 8);
+        await expect(page.getByRole('tab', { name: new RegExp(shortHash) })).toBeVisible({ timeout: 10000 });
+    });
+});

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { _electron as electron, Page, type Frame, ElectronApplication } from 'playwright';
+import { expect, Locator } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { TestRepo } from '../test-repo';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+
+export const ROOT_ID = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+
+export interface VSCodeContext {
+    app: ElectronApplication;
+    page: Page;
+    userDataDir: string;
+}
+
+/**
+ * Standard setup for VS Code E2E tests.
+ * Initializes a user data directory with common settings and launches VS Code.
+ * Renamed to launchVSCode to avoid confusion with local setup functions in specs.
+ */
+export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-user-data-'));
+    const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-extensions-'));
+    const userSettingsDir = path.join(userDataDir, 'User');
+    fs.mkdirSync(userSettingsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(userSettingsDir, 'settings.json'), JSON.stringify({
+        "git.enabled": false,
+        "workbench.startupEditor": "none",
+        "workbench.sideBar.location": "left",
+        "scm.alwaysShowProviders": true,
+        "scm.alwaysShowActions": true,
+        "workbench.tips.enabled": false,
+        "window.titleBarStyle": "custom",
+        "security.workspace.trust.enabled": false,
+        "jj-view.fileWatcherMode": "watch",
+        "telemetry.telemetryLevel": "off",
+        "workbench.notification.displayMode": "hidden",
+        "notifications.showDoNotDisturb": true,
+        "update.mode": "none",
+        "extensions.autoCheckUpdates": false,
+        "extensions.autoUpdate": false
+    }, null, 2));
+
+    fs.writeFileSync(path.join(userSettingsDir, 'keybindings.json'), JSON.stringify([
+        {
+            "key": "ctrl+alt+l",
+            "command": "jj-view.logView.focus"
+        },
+        {
+            "key": "ctrl+alt+r",
+            "command": "jj-view.refresh"
+        }
+    ], null, 2));
+
+    const extensionPath = path.resolve(__dirname, '../../../../');
+    const vscodePath = await downloadAndUnzipVSCode();
+
+    const app = await electron.launch({
+        executablePath: vscodePath,
+        args: [
+            repo.path,
+            `--extensionDevelopmentPath=${extensionPath}`,
+            `--user-data-dir=${userDataDir}`,
+            `--extensions-dir=${extensionsDir}`,
+            '--disable-extensions', // Works alongside extensionDevelopmentPath in recent VS Code
+            '--disable-workspace-trust',
+            '--new-window',
+            '--skip-welcome',
+            '--skip-release-notes',
+            '--no-sandbox',
+            '--disable-gpu',
+            '--disable-dev-shm-usage',
+            '--disable-updates',
+        ],
+    });
+
+    const page = await app.firstWindow();
+    
+    // Capture page console logs for debugging
+    page.on('console', msg => {
+        if (process.env.DEBUG_E2E) {
+            console.log(`PAGE LOG: ${msg.text()}`);
+        }
+    });
+    page.on('pageerror', err => console.error(`PAGE ERROR: ${err.message}`));
+
+    // Wait for the workbench to be ready
+    await expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
+
+    // Hide notification toasts via CSS. Error-level toasts (e.g. "failed to load
+    // extension") bypass VS Code's Do Not Disturb / displayMode settings and can
+    // overlay buttons, causing click interception in tests.
+    await page.addStyleTag({ content: '.notifications-toasts { display: none !important; }' });
+
+    return { app, page, userDataDir };
+}
+
+/**
+ * Ensures the SCM view is open.
+ */
+export async function focusSCM(page: Page) {
+    await expect(async () => {
+        // Control+Shift+G is the standard VS Code shortcut to show/focus Source Control
+        await page.keyboard.press('Control+Shift+G');
+        
+        // Wait for either the input row or the side bar title to be visible
+        const scmTitle = page.locator('.pane-header', { hasText: 'Source Control' }).first();
+        const scmInput = page.getByRole('treeitem', { name: 'Source Control Input' });
+        
+        await expect(scmTitle.or(scmInput)).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+}
+
+/**
+ * Ensures the JJ Log pane is open and focused.
+ */
+export async function focusJJLog(page: Page) {
+    await expect(async () => {
+        await page.keyboard.press('Control+Alt+l');
+        // Check if the pane header appears
+        await expect(page.locator('.pane-header', { hasText: 'JJ Log' }).first()).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20000 });
+}
+
+/**
+ * Finds the webview frame containing the JJ Log commit rows.
+ */
+export async function getLogWebview(page: Page): Promise<Frame> {
+    // The panel header
+    await expect(page.locator('.pane-header', { hasText: 'JJ Log' })).toBeVisible({ timeout: 20000 });
+
+    async function findFrameWithSelector(frames: ReadonlyArray<Frame>, selector: string): Promise<Frame | undefined> {
+        for (const f of frames) {
+            try {
+                if (await f.locator(selector).count() > 0) return f;
+                const nested = await findFrameWithSelector(f.childFrames(), selector);
+                if (nested) return nested;
+            } catch (e) {}
+        }
+        return undefined;
+    }
+
+    let guestFrame: Frame | undefined;
+    await expect.poll(async () => {
+        guestFrame = await findFrameWithSelector(page.frames(), '.commit-row');
+        return guestFrame;
+    }, {
+        timeout: 30000,
+        message: 'Could not find JJ Log webview frame'
+    }).toBeDefined();
+
+    return guestFrame!;
+}
+
+/**
+ * Asserts that the repo log matches the expected structure.
+ */
+export async function expectTree(repo: TestRepo, expected: unknown[]) {
+    await expect.poll(async () => {
+        // Output format: [@] change_id [parent1,parent2] description
+        const log = repo.getLog('all()', 'if(current_working_copy, "@ ", "") ++ change_id ++ " [" ++ parents.map(|p| p.change_id()).join(",") ++ "] " ++ if(description, description.first_line(), "(empty)") ++ "\\n"');
+        const actual = log.split('\n').filter(l => l.trim()).filter(line => !line.startsWith('zzzzzzzz'));
+        return actual;
+    }, {
+        timeout: 10000,
+        message: 'Tree mismatch'
+    }).toEqual(expected.map(e => {
+        if (typeof e === 'string' && e.includes('*')) {
+            // Escape regex characters except for our * wildcard
+            const escaped = e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[a-z0-9]+');
+            return expect.stringMatching(new RegExp(`^${escaped}$`));
+        }
+        return e;
+    }));
+}
+
+/** Helper to format an entry for expectTree */
+export function entry(changeId: string, description: string, parents?: string | string[]): string {
+    const p = Array.isArray(parents) ? parents.join(',') : (parents || '');
+    return `${changeId} [${p}] ${description}`;
+}
+
+/**
+ * Robustly selects one or more commit rows in the webview and verifies the selection took effect.
+ * Uses aria-selected to verify the React state updated.
+ */
+export async function selectCommits(rows: Locator[]) {
+    for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        await row.click({
+            modifiers: i > 0 ? ['Meta'] : undefined,
+            force: true // Bypasses potential hover overlay issues
+        });
+        await expect(row).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+    }
+}
+
+/**
+ * Right-clicks a target element and clicks a context menu item by label.
+ *
+ * VS Code keeps a single `.monaco-menu-container` in the DOM at all times and
+ * toggles its `aria-hidden` attribute.  When the menu is **hidden** the element
+ * has `aria-hidden="true"`; when open the attribute is **removed** entirely.
+ * Playwright's `.isVisible()` treats `aria-hidden="true"` as hidden, which
+ * caused false-negatives with the bare `.monaco-menu-container` selector.
+ *
+ * We use `:not([aria-hidden="true"])` so the locator only matches an open menu.
+ */
+export async function rightClickAndSelect(page: Page, target: Locator, label: string) {
+    await expect(async () => {
+        // 1. Trigger the context menu natively
+        await target.click({ button: 'right' });
+        
+        // Give the menu a moment to open before we look for it
+        await page.waitForTimeout(300);
+
+        // 2. Wait for THE item to appear in an open menu.
+        // We use a short timeout here to fail FAST and retry the right-click if the menu didn't open.
+        const menuContainer = page.locator('.monaco-menu-container:not([aria-hidden="true"])');
+        const item = menuContainer.locator('.action-item', { hasText: label }).first();
+        
+        await expect(item).toBeVisible({ timeout: 100 });
+
+        const rect = await item.boundingBox();
+        if (!rect || rect.height === 0 || rect.width === 0) {
+            throw new Error(`Ghost menu detected for ${label}`);
+        }
+
+        // 3. Click it directly
+        await item.click();
+    }, `Failed to execute "${label}" via context menu`).toPass({ timeout: 30000 });
+}
+
+/**
+ * Triggers a manual refresh of the JJ Log view by clicking the refresh button in the view title.
+ */
+export async function triggerRefresh(page: Page) {
+    // Use the custom keybinding registered in launchVSCode
+    await page.keyboard.press('Control+Alt+R');
+    
+    // Give it a tiny moment to start the refresh process
+    await page.waitForTimeout(100);
+}
+

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import { TestRepo, buildGraph } from '../test-repo';
+import { launchVSCode, focusJJLog, getLogWebview, expectTree, entry, ROOT_ID } from './e2e-helpers';
+
+test.describe('JJ Log Pane E2E', () => {
+
+    test('Webview Initialization & Rendering', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            { label: 'side_branch', parents: ['initial'], description: 'side branch commit', files: { 'file2.txt': 'base2' } },
+            { label: 'wc', parents: ['initial'], description: 'working tree', files: { 'file.txt': 'mod' }, isWorkingCopy: true, bookmarks: ['main'] }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            const webview = await getLogWebview(page);
+            
+            // Assert all commit descriptions are present
+            await expect(webview.locator('.commit-desc', { hasText: 'initial setup' })).toBeVisible();
+            await expect(webview.locator('.commit-desc', { hasText: 'side branch commit' })).toBeVisible();
+            await expect(webview.locator('.commit-desc', { hasText: 'working tree' })).toBeVisible();
+
+            // Assert Working Copy row is styled bold
+            const wcDesc = webview.locator('.working-copy .commit-desc');
+            await expect(wcDesc).toHaveCSS('font-weight', '700' /* bold */);
+
+            // Assert Bookmark pill is present inside the working copy row
+            const bookmarkPill = webview.locator('.working-copy .bookmark-pill', { hasText: 'main' });
+            await expect(bookmarkPill).toBeVisible();
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Pane Header Actions: Undo and New Merge Change', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const dummyId = repo.getChangeId('@');
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            { label: 'side_branch', parents: ['initial'], description: 'side branch', files: { 'file2.txt': 'base2' } },
+            { label: 'wc', parents: ['initial'], description: 'working tree', files: { 'file.txt': 'mod' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            const webview = await getLogWebview(page);
+            // 1. New Merge Change (Requires Multi-select)
+            const sideBranchRow = webview.locator(`[data-change-id="${nodes['side_branch'].changeId}"]`);
+            const wcRow = webview.locator(`[data-change-id="${nodes['wc'].changeId}"]`);
+
+            // Click the first one normally, the second with Control
+            await sideBranchRow.click();
+            await expect(sideBranchRow).toHaveAttribute('data-selected', 'true');
+            
+            await wcRow.click({ modifiers: ['Control'] });
+            await expect(wcRow).toHaveAttribute('data-selected', 'true');
+
+            // Click the native 'New Merge Change' header action
+            // name-based locator is more robust for VS Code header actions
+            const mergeAction = page.getByRole('button', { name: 'New Merge Change' }).first();
+            await expect(mergeAction).toBeEnabled();
+            await mergeAction.click();
+
+            // Assert via repo that a new merge commit was created with correct parents
+            await expect(async () => {
+                const parents = repo.getParents('@');
+                expect(parents).toContain(nodes['side_branch'].changeId);
+                expect(parents).toContain(nodes['wc'].changeId);
+            }).toPass({ timeout: 5000 });
+
+            // Verify full tree: [merge, wc, side_branch, initial, dummy]
+            await expect(async () => {
+                const mergeChangeId = repo.getChangeId('@');
+                await expectTree(repo, [
+                    '@ ' + entry(mergeChangeId, '(empty)', [nodes['side_branch'].changeId, nodes['wc'].changeId]),
+                    entry(nodes['wc'].changeId, 'working tree', nodes['initial'].changeId),
+                    entry(nodes['side_branch'].changeId, 'side branch', nodes['initial'].changeId),
+                    entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                    entry(dummyId, '(empty)', ROOT_ID)
+                ]);
+            }).toPass();
+
+            // 2. Undo
+            const undoAction = page.getByRole('button', { name: 'Undo' }).first();
+            await undoAction.click();
+
+            // Assert the merge change was undone accurately
+            await expectTree(repo, [
+                '@ ' + entry(nodes['wc'].changeId, 'working tree', nodes['initial'].changeId),
+                entry(nodes['side_branch'].changeId, 'side branch', nodes['initial'].changeId),
+                entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                entry(dummyId, '(empty)', ROOT_ID)
+            ]);
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Hover Actions: New Child, Squash, Abandon', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const dummyId = repo.getChangeId('@');
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            { label: 'branch', parents: ['initial'], description: 'branch commit', files: { 'file2.txt': 'base2' } },
+            { label: 'wc', parents: ['branch'], description: 'working tree', files: { 'file.txt': 'mod' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            const webview = await getLogWebview(page);
+
+            // 1. New Child
+            const branchId = nodes['branch'].changeId;
+            const branchRow = webview.locator(`[data-change-id="${branchId}"]`);
+            await branchRow.hover();
+            await expect(branchRow).toHaveAttribute('data-hovered', 'true');
+            
+            const newChildBtn = branchRow.locator('[title="New Child"]');
+            await newChildBtn.click();
+
+            let childId = '';
+            await expect(async () => {
+                const currentId = repo.getChangeId('@');
+                // Ensure @ has actually moved away from wc
+                expect(currentId).not.toBe(nodes['wc'].changeId);
+                childId = currentId;
+            }).toPass({ timeout: 10000 });
+
+            // Make a file change in the child so it's not abandoned by 'jj edit'
+            // but keep description empty so 'jj squash' stays silent
+            repo.writeFile('child.txt', 'child content');
+
+            // Tree: [new_child(@), wc, branch, initial, dummy]
+            // Order: child is newest head, wc is other head.
+            await expect(async () => {
+                const childId = repo.getChangeId('@');
+                await expectTree(repo, [
+                    '@ ' + entry(childId, '(empty)', nodes['branch'].changeId),
+                    entry(nodes['wc'].changeId, 'working tree', nodes['branch'].changeId),
+                    entry(nodes['branch'].changeId, 'branch commit', nodes['initial'].changeId),
+                    entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                    entry(dummyId, '(empty)', ROOT_ID)
+                ]);
+            }).toPass();
+
+            // 2. Prepare for squash: move working copy away from the new child
+            const initialId = nodes['initial'].changeId;
+            const initialRow = webview.locator(`[data-change-id="${initialId}"]`);
+            await initialRow.hover();
+            
+            const editBtn = initialRow.locator('[title="Edit Commit"]');
+            await editBtn.click();
+
+            // Tree is the same commits, just @ moved. Order: [child, wc, branch, initial, dummy]
+            await expectTree(repo, [
+                entry(childId, '(empty)', nodes['branch'].changeId),
+                entry(nodes['wc'].changeId, 'working tree', nodes['branch'].changeId),
+                entry(nodes['branch'].changeId, 'branch commit', nodes['initial'].changeId),
+                '@ ' + entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                entry(dummyId, '(empty)', ROOT_ID)
+            ]);
+
+            // 3. Squash the child into branch
+            const childRow = webview.locator(`[data-change-id="${childId}"]`);
+            await expect(childRow).toBeVisible({ timeout: 10000 });
+            await childRow.hover();
+            await expect(childRow).toHaveAttribute('data-hovered', 'true');
+            const squashBtn = childRow.locator('[title="Squash into Parent"]');
+            await squashBtn.click();
+
+            // After squash: child is gone. branch has its changes.
+            await expectTree(repo, [
+                entry(nodes['wc'].changeId, 'working tree', nodes['branch'].changeId),
+                entry(nodes['branch'].changeId, 'branch commit', nodes['initial'].changeId),
+                '@ ' + entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                entry(dummyId, '(empty)', ROOT_ID)
+            ]);
+
+            // 4. Abandon the branch commit
+            const branchRowAfter = webview.locator(`[data-change-id="${branchId}"]`);
+            await branchRowAfter.hover();
+            const abandonBtn = branchRowAfter.locator('[title="Abandon Commit"]');
+            await abandonBtn.click();
+
+            // After abandon branch: branch is gone. wc (child of branch) becomes child of initial.
+            // Tree: [wc, initial(@)]
+            await expectTree(repo, [
+                entry(nodes['wc'].changeId, 'working tree', nodes['initial'].changeId),
+                '@ ' + entry(nodes['initial'].changeId, 'initial setup', dummyId),
+                entry(dummyId, '(empty)', ROOT_ID)
+            ]);
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Multi-select and Drag & Drop (Rebase)', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            { label: 'target', parents: ['initial'], description: 'target branch', files: { 'file_target.txt': 'target' } },
+            { label: 'source', parents: ['initial'], description: 'source branch', files: { 'file_source.txt': 'source' } }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            const webview = await getLogWebview(page);
+
+            const sourceRow = webview.locator(`[data-change-id="${nodes['source'].changeId}"]`);
+            const targetRow = webview.locator(`[data-change-id="${nodes['target'].changeId}"]`);
+
+            const sourceBox = await sourceRow.boundingBox();
+            const targetBox = await targetRow.boundingBox();
+
+            // Drag source onto target to rebase
+            if (sourceBox && targetBox) {
+                // Move to source
+                await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+                await page.mouse.down();
+                // Move to target
+                await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 10 });
+                await page.mouse.up();
+            }
+
+            // Verify rebase via repo
+            await expect(async () => {
+                // Check 'source' parent is now 'target' 
+                const parents = repo.getParents(nodes['source'].changeId);
+                expect(parents).toContain(nodes['target'].changeId);
+            }).toPass({ timeout: 10000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+});

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -1,0 +1,386 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import { TestRepo, buildGraph } from '../test-repo';
+import { launchVSCode, focusSCM } from './e2e-helpers';
+
+test.describe('SCM Pane E2E', () => {
+    test('Displays correct groups and populates SCM input', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'file.txt': 'base' } },
+            { label: 'conflict-side-1', parents: ['initial'], description: 'side 1', files: { 'file.txt': 'a' } },
+            { label: 'conflict-side-2', parents: ['initial'], description: 'side 2', files: { 'file.txt': 'b' } },
+            { label: 'merge', parents: ['conflict-side-1', 'conflict-side-2'], description: 'merge', isWorkingCopy: false },
+            { label: 'wc', parents: ['merge'], description: 'my working copy', files: { 'new-file.ts': 'console.log("hello");\n' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            // Verify groups
+            const mergeConflictsHeader = page.getByRole('treeitem', { name: 'Merge Conflicts' });
+            const workingCopyHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+
+            await expect(mergeConflictsHeader).toBeVisible();
+            await expect(workingCopyHeader).toBeVisible();
+
+            // Verify ancestor groups (merge commit is empty, so we see its parents @-2^1 and @-2^2)
+            await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({ timeout: 5000 });
+            await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible();
+
+            // Verify SCM input is populated with working copy description
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await expect(scmInputRow).toContainText('my working copy');
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Top-Level Commands: Commit and New Change', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'file.txt': 'base' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click(); // Focus the editor
+            
+            // Set Description and Commit
+            await page.keyboard.press('Control+A');
+            await page.keyboard.insertText('Updated description explicitly');
+            
+            // Commit using button inside the Source Control view title bar
+            const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
+            await commitButton.click();
+            
+            // Wait for description to clear out (indicating commit success)
+            await expect(async () => {
+                expect(repo.log()).toContain('Updated description explicitly');
+            }).toPass({ timeout: 5000 });
+
+            // Ensure wait for SCM refresh before next action
+            await expect(scmInputRow).not.toContainText('Updated description explicitly', { timeout: 10000 });
+
+            // Click New Change (+)
+            const newButton = page.getByRole('button', { name: 'New Change' }).first();
+            await newButton.click();
+            
+            // Wait for UI to reflect empty input box or wait for a specific commit in repo
+            await expect(async () => {
+                const wcDescription = repo.getDescription('@').trim();
+                expect(wcDescription).toBe('');
+            }).toPass({ timeout: 5000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Keyboard Shortcuts: Ctrl+S and Ctrl+Enter', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'file.txt': 'base' } },
+            { label: 'wc', parents: ['initial'], isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+            
+            // Set Description with Ctrl+S
+            await page.keyboard.press('Control+A');
+            await page.keyboard.insertText('Using keyboard shortcuts');
+            await page.keyboard.press('Control+S');
+            
+            // Wait for input to be stable (doesn't change back to what it was)
+            await expect(async () => {
+                expect(repo.getDescription('@').trim()).toBe('Using keyboard shortcuts');
+            }).toPass({ timeout: 5000 });
+
+            // Set Description to trigger commit
+            await page.keyboard.press('Control+A');
+            await page.keyboard.insertText('Commit via keyboard');
+            await page.keyboard.press('Control+S');
+            
+            await expect(async () => {
+                expect(repo.getDescription('@').trim()).toBe('Commit via keyboard');
+            }).toPass({ timeout: 5000 });
+
+            // Commit with Ctrl+Enter
+            await scmInputRow.click();
+            await page.keyboard.press('Control+Enter');
+            
+            // Wait for commit to appear in log
+            await expect(async () => {
+                const log = repo.log();
+                expect(log).toContain('Commit via keyboard');
+            }).toPass({ timeout: 5000 });
+
+            // Wait for input to clear in UI
+            await expect(scmInputRow).not.toContainText('Commit via keyboard', { timeout: 10000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Group-Level Actions: Abandon Working Copy and Squash Ancestor', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const commits = await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'base.txt': '1' } },
+            { label: 'ancestor', parents: ['initial'], description: 'ancestor change', files: { 'a.txt': '1' } },
+            { label: 'wc', parents: ['ancestor'], description: 'wc change', files: { 'w.txt': '1' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            // Wait for groups to settle
+            const wcGroupHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+            
+            // Hover over Working copy group to show abandon icon
+            await wcGroupHeader.hover();
+            const abandonIcon = wcGroupHeader.locator('.action-item', { has: page.locator('.codicon-trash') }).first();
+            await abandonIcon.click();
+            
+            // Assert via repo that wc change is abandoned. Poll until true.
+            await expect(async () => {
+                const isWcChangeStillPresent = repo.log().includes(commits['wc'].changeId);
+                expect(isWcChangeStillPresent).toBe(false);
+            }).toPass({ timeout: 5000 });
+
+            // Wait for SCM view to refresh before next action
+            await expect(wcGroupHeader).toBeVisible();
+
+            // Now test Squash Ancestor...
+            const ancestorRow = page.getByRole('treeitem', { name: /ancestor change/ });
+            await ancestorRow.hover();
+            // The row itself holds the action items for the group resource if hovered
+            const squashIcon = ancestorRow.locator('.action-item', { has: page.locator('.codicon-arrow-down') }).first();
+            await squashIcon.click();
+            
+            // Assert via repo that the ancestor was squashed into its parent (initial). Poll until true.
+            await expect(async () => {
+                const logAfterSquash = repo.log();
+                expect(logAfterSquash).not.toContain('ancestor change');
+            }).toPass({ timeout: 5000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('File-Level Actions: Discard Changes and Diff Editing (Right Side)', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'file.txt': 'base', 'file2.txt': 'base2', 'file3.txt': 'base3' } },
+            { label: 'wc', parents: ['initial'], description: 'wc change', files: { 'file.txt': 'mod', 'file2.txt': 'mod2', 'file3.txt': 'mod3' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            // Discard Changes (file3.txt)
+            const wcFile3Row = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
+            await wcFile3Row.hover();
+            
+            const discardIcon = wcFile3Row.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
+            await discardIcon.click();
+            
+            // Assert the file was restored by polling
+            await expect(async () => {
+                expect(repo.getFileContent('@', 'file3.txt').trim()).toBe('base3');
+            }).toPass({ timeout: 5000 });
+
+            // File-Level Squash (file.txt)
+            // Hover over file.txt in Working Copy and click Squash into Parent
+            // It shares the same codicon-arrow-down icon as the group squash action
+            const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
+            await wcFileRow.hover();
+            const squashFileIcon = wcFileRow.locator('.action-item', { has: page.locator('.codicon-arrow-down') }).first();
+            await squashFileIcon.click();
+
+            // Assert via repo that file.txt changes were squashed into the parent commit
+            await expect(async () => {
+                const parentChanges = repo.getDiffSummary('@-');
+                expect(parentChanges).toContain('A file.txt');
+                const wcChanges = repo.getDiffSummary('@');
+                expect(wcChanges).not.toContain('A file.txt');
+            }).toPass({ timeout: 5000 });
+
+            // Open Single File Diff (file2.txt)
+            const diffFileRow = page.getByRole('treeitem', { name: /file2\.txt, modified/ });
+            await diffFileRow.click();
+            
+            // Wait for Diff Editor
+            await page.waitForSelector('.monaco-diff-editor');
+
+            // In VS Code, diff editors have left and right. 
+            // We want to edit the right side (working copy).
+            const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+            await rightEditor.click();
+            await page.keyboard.press('Control+A');
+            await page.keyboard.insertText('edited from diff');
+            await page.keyboard.press('Control+S'); // Save
+            
+            // Wait for save indicator or poll the file content
+            await expect(async () => {
+                expect(repo.getFileContent('@', 'file2.txt').trim()).toBe('edited from diff');
+            }).toPass({ timeout: 5000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Additional Actions: Absorb, Edit, Show Details, Move to Child', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const commits = await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'base.txt': '1' } },
+            { label: 'ancestor', parents: ['initial'], description: 'ancestor change', files: { 'f1.txt': '1', 'f2.txt': '1' } },
+            // Working copy edit of the same file f1.txt (to test absorb) and a new one
+            { label: 'wc', parents: ['ancestor'], description: 'wc change', files: { 'f1.txt': '2', 'f3.txt': '1' }, isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            const wcGroupHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+
+            // 1. Absorb
+            await wcGroupHeader.hover();
+            const absorbIcon = wcGroupHeader.locator('.action-item', { has: page.locator('.codicon-magnet') }).first();
+            await absorbIcon.click();
+            
+            // Wait for SCM refresh to confirm absorb (the wc change for f1.txt is consumed into ancestor)
+            await expect(async () => {
+                expect(repo.getFileContent(commits['ancestor'].changeId, 'f1.txt').trim()).toBe('2');
+            }).toPass({ timeout: 5000 });
+
+            // 2. Show Details
+            // Use ancestorRow for group-level actions like Details
+            const ancestorRow = page.getByRole('treeitem', { name: /ancestor change/ }).first();
+            await ancestorRow.hover();
+            const detailsIcon = ancestorRow.locator('.action-item', { has: page.locator('.codicon-list-selection') }).first();
+            await detailsIcon.click();
+            
+            // Assert that the Commit Details panel opened (it opens as an editor tab)
+            await expect(page.getByRole('tab', { name: /^Commit: / })).toBeVisible({ timeout: 5000 });
+
+            // Ensure we switch focus back to SCM View if needed, though sidebar might still be visible
+            await focusSCM(page);
+
+            // 3. Move to Child (Pull from Ancestor)
+            // Groups are expanded by default, so f2.txt is already visible.
+            const ancestorFile = page.getByRole('treeitem', { name: /f2\.txt/ });
+            await ancestorFile.hover();
+            const moveToChildIcon = ancestorFile.locator('.action-item', { has: page.locator('.codicon-arrow-up') }).first();
+            await moveToChildIcon.click();
+
+            // Assert via repo that f2.txt from ancestor was moved to working copy
+            await expect(async () => {
+                const wcChanges = repo.getDiffSummary('@');
+                expect(wcChanges).toContain('A f2.txt');
+            }).toPass({ timeout: 5000 });
+
+            // 4. Edit (Make ancestor the working copy)
+            await ancestorRow.hover();
+            const editIcon = ancestorRow.locator('.action-item', { has: page.locator('.codicon-edit') }).first();
+            await editIcon.click();
+
+            // Assert via repo that the working copy is now the ancestor
+            await expect(async () => {
+                const changeId = repo.getWorkingCopyId();
+                expect(changeId).toBe(commits['ancestor'].changeId);
+            }).toPass({ timeout: 5000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+
+    test('Multi-File Diff and Diff Editing', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const commits = await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'f1.txt': '1', 'f2.txt': '1' } },
+            { label: 'ancestor', parents: ['initial'], description: 'ancestor change', files: { 'f1.txt': '2', 'f2.txt': '2' } },
+            { label: 'wc', parents: ['ancestor'], isWorkingCopy: true }
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+            // Hover over Ancestor group
+            const ancestorRow = page.getByRole('treeitem', { name: /ancestor change/ });
+            await ancestorRow.hover();
+            
+            // Use Multi-File Diff icon (diff-multiple)
+            const multiDiffIcon = ancestorRow.locator('.action-item', { has: page.locator('.codicon-diff-multiple') }).first();
+            await multiDiffIcon.click();
+
+            // Wait for Multi-File Diff View to appear
+            const tabList = page.locator('.tabs-and-actions-container');
+            await expect(tabList).toContainText('ancestor change');
+
+            // Wait for the diff editor inside the view
+            await page.waitForSelector('.monaco-diff-editor');
+            
+            // Find the editor for f1.txt's right side
+            const firstRightEditor = page.locator('.monaco-diff-editor .editor.modified').first();
+            await firstRightEditor.click();
+            
+            // Navigate out of readonly and type new text
+            await page.keyboard.press('Control+A');
+            await page.keyboard.insertText('edited from multi-diff');
+            await page.keyboard.press('Control+S');
+
+            // Ensure the ancestor commit was mutated with the diff edits
+            await expect(async () => {
+                const f1Content = repo.getFileContent(commits['ancestor'].changeId, 'f1.txt');
+                expect(f1Content.trim()).toBe('edited from multi-diff');
+            }).toPass({ timeout: 5000 });
+
+        } finally {
+            await app.close();
+            try { fs.rmSync(userDataDir, { recursive: true, force: true }); } catch { }
+            repo.dispose();
+        }
+    });
+});

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -696,7 +696,7 @@ suite('JJ SCM Provider Integration Test', function () {
                 type: 'moveBookmark',
                 payload: {
                     bookmark: 'integrated-bookmark',
-                    targetCommitId: childId,
+                    targetChangeId: childId,
                 },
             });
 

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -116,21 +116,21 @@ describe('JjService Unit Tests', () => {
                 },
             ]);
             // Insert 'Middle' before 'Child'
-            // Expected: Parent -> Middle -> Child
-            await jjService.new({ message: 'Middle', insertBefore: [ids['Child'].changeId] });
+            // Expected DAG: Parent -> Middle -> Child
+            // Also, 'jj new --before' should move @ to the new commit.
+            const middleId = await jjService.new({ message: 'Middle', insertBefore: [ids['Child'].changeId] });
 
-            // Child(@) should now have Middle as parent
-            const childParents = repo.getParents(ids['Child'].changeId);
-            // We need to find the ID of the newly created Middle commit.
-            // Since we inserted it, it should be the parent of Child.
-            // And Middle's parent should be Parent.
-
-            const middleId = childParents[0];
-            const middleDescription = repo.getDescription(middleId);
+            // 1. Verify Middle's parent is Parent
             const middleParents = repo.getParents(middleId);
+            expect(middleParents).toContain(ids['Parent'].changeId);
 
-            expect(middleDescription).toContain('Middle');
-            expect(middleParents[0]).toBe(ids['Parent'].changeId);
+            // 2. Verify Child's parent is now Middle
+            const childParents = repo.getParents(ids['Child'].changeId);
+            expect(childParents).toContain(middleId);
+
+            // 3. Verify @ is at Middle
+            const workingCopyId = repo.getWorkingCopyId();
+            expect(workingCopyId).toBe(middleId);
         });
 
         test('creates a new change with multiple parents (merge)', async () => {
@@ -169,22 +169,27 @@ describe('JjService Unit Tests', () => {
             ]);
             
             // Insert 'Middle' before Child1 and Child2
-            // Expected: Parent -> Middle -> Child1
+            // Expected DAG: Parent -> Middle -> Child1
             //                            -> Child2
-            await jjService.new({ 
+            const middleId = await jjService.new({ 
                 message: 'Middle', 
                 insertBefore: [ids['child1'].changeId, ids['child2'].changeId] 
             });
 
-            const userLog = await jjService.getLog();
-            const middle = userLog.find(l => l.description.includes('Middle'));
-            expect(middle).toBeDefined();
+            // 1. Verify Middle's parent is Parent
+            const middleParents = repo.getParents(middleId);
+            expect(middleParents).toContain(ids['parent'].changeId);
 
+            // 2. Verify Child1 and Child2 both have Middle as parent
             const c1Parents = repo.getParents(ids['child1'].changeId);
             const c2Parents = repo.getParents(ids['child2'].changeId);
 
-            expect(c1Parents[0]).toBe(middle!.change_id);
-            expect(c2Parents[0]).toBe(middle!.change_id);
+            expect(c1Parents).toContain(middleId);
+            expect(c2Parents).toContain(middleId);
+
+            // 3. Verify @ is at Middle
+            const workingCopyId = repo.getWorkingCopyId();
+            expect(workingCopyId).toBe(middleId);
         });
 
         test('creates change with parents AND insertBefore', async () => {
@@ -594,7 +599,7 @@ describe('JjService Unit Tests', () => {
 
         await jjService.duplicate(originalChangeId);
 
-        const logs = repo.getLogOutput('change_id ++ " " ++ description').split('\n');
+        const logs = repo.getLog('all()', 'change_id ++ " " ++ description').split('\n');
         const duplicates = logs.filter((l) => l.includes('original'));
         expect(duplicates.length).toBeGreaterThanOrEqual(2);
     });
@@ -609,7 +614,7 @@ describe('JjService Unit Tests', () => {
 
         const newChangeId = repo.getChangeId('@');
         expect(newChangeId).not.toBe(changeId);
-        const log = repo.getLogOutput('change_id');
+        const log = repo.getLog('all()', 'change_id');
         expect(log).not.toContain(changeId);
     });
 
@@ -637,10 +642,11 @@ describe('JjService Unit Tests', () => {
         expect(content).toBe('grandchild content');
 
         await jjService.duplicate('@');
-
-        const log = repo.getLogOutput('change_id');
-        const lines = log.trim().split('\n');
-        expect(lines.length).toBeGreaterThanOrEqual(2);
+        
+        // Use all() and increase timeout wait if needed, though run() handles sync
+        const logAfter = repo.getLog('all()', 'change_id');
+        const linesAfter = logAfter.trim().split('\n');
+        expect(linesAfter.length).toBeGreaterThanOrEqual(1); // At least child'
 
         await jjService.abandon('@');
     }, 30000);

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -111,6 +111,14 @@ export class TestRepo {
         this.exec(['edit', revision]);
     }
 
+    getWorkingCopyId(): string {
+        return this.exec(['log', '--ignore-working-copy', '-r', '@', '-T', 'change_id', '--no-graph']);
+    }
+
+    getDiffSummary(revision: string = '@'): string {
+        return this.exec(['diff', '-r', revision, '--summary']);
+    }
+
     bookmark(name: string, revision: string) {
         this.exec(['bookmark', 'create', name, '-r', revision]);
     }
@@ -147,11 +155,11 @@ export class TestRepo {
     }
 
     getChangeId(revision: string): string {
-        return this.exec(['log', '-r', revision, '-T', 'change_id', '--no-graph']);
+        return this.exec(['log', '--ignore-working-copy', '-r', revision, '-T', 'change_id', '--no-graph']);
     }
 
     getCommitId(revision: string): string {
-        return this.exec(['log', '-r', revision, '-T', 'commit_id', '--no-graph']);
+        return this.exec(['log', '--ignore-working-copy', '-r', revision, '-T', 'commit_id', '--no-graph']);
     }
 
     diff(relativePath: string, revision?: string): string {
@@ -196,15 +204,19 @@ export class TestRepo {
     }
 
     log(): string {
-        return this.exec(['log']);
+        return this.exec(['log', '--ignore-working-copy']);
     }
 
-    getLogOutput(template: string, revision: string = '::'): string {
-        return this.exec(['log', '-r', revision, '-T', template, '--color', 'never']);
+    getLogOutput(template: string): string {
+        return this.exec(['log', '--ignore-working-copy', '-T', template, '--color', 'never']);
+    }
+
+    getLog(revision: string, template: string): string {
+        return this.exec(['log', '--ignore-working-copy', '-r', revision, '-T', template, '--no-graph', '--color', 'never']);
     }
 
     isImmutable(revision: string): boolean {
-        const output = this.exec(['log', '-r', revision, '-T', 'immutable', '--no-graph', '--color', 'never']);
+        const output = this.exec(['log', '--ignore-working-copy', '-r', revision, '-T', 'immutable', '--no-graph', '--color', 'never']);
         return output.trim() === 'true';
     }
 }

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -138,7 +138,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
         await messageHandler({
             type: 'abandon',
             payload: {
-                commitId: commitToAbandonId,
+                changeId: commitToAbandonId,
             },
         });
 
@@ -176,7 +176,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
 
         await messageHandler({
             type: 'newChild',
-            payload: { commitId: parentId },
+            payload: { changeId: parentId },
         });
 
         const childId = repo.getChangeId('@');
@@ -203,7 +203,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
         // Send Edit
         await messageHandler({
             type: 'edit',
-            payload: { commitId: targetId },
+            payload: { changeId: targetId },
         });
 
         // Verify working copy is now targetId
@@ -247,7 +247,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
 
         await messageHandler({
             type: 'squash',
-            payload: { commitId: childId },
+            payload: { changeId: childId },
         });
 
         const parentContent = repo.getFileContent('@-', 'file.txt');
@@ -272,7 +272,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
             type: 'moveBookmark',
             payload: {
                 bookmark: 'my-bookmark',
-                targetCommitId: commitB,
+                targetChangeId: commitB,
             },
         });
 
@@ -299,8 +299,8 @@ suite('Webview Commands End-to-End Integration Test', function () {
         await messageHandler({
             type: 'rebaseCommit',
             payload: {
-                sourceCommitId: idB,
-                targetCommitId: idA,
+                sourceChangeId: idB,
+                targetChangeId: idA,
                 mode: 'source',
             },
         });

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -150,7 +150,7 @@ suite('Webview Selection Integration Test', function () {
     });
 
     test('Abandon command from webview triggers extension command', async () => {
-        const payload = { commitId: 'commit-to-abandon' };
+        const payload = { changeId: 'commit-to-abandon' };
         await messageHandler({
             type: 'abandon',
             payload,

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -131,10 +131,10 @@ const App: React.FC = () => {
 
     const handleGraphAction = (action: string, payload: any) => {
         if (action === 'select') {
-            const { commitId, multiSelect } = payload;
+            const { changeId, multiSelect } = payload;
 
             // 1. Calculate new selection state
-            const nextSelectedIds = calculateNextSelection(selectedCommitIds, commitId, multiSelect);
+            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, multiSelect);
 
             // 2. Update visual selection state
             setSelectedCommitIds(nextSelectedIds);
@@ -152,7 +152,7 @@ const App: React.FC = () => {
 
             // 4. Request Details ONLY if the item ends up selected
             // (If we toggled it off, we shouldn't open details)
-            if (nextSelectedIds.has(commitId)) {
+            if (nextSelectedIds.has(changeId)) {
                 vscode.postMessage({ type: 'getDetails', payload });
             }
             return;
@@ -177,7 +177,7 @@ const App: React.FC = () => {
         if (view === 'details' && detailsCommit) {
             vscode.postMessage({
                 type: 'saveDescription',
-                payload: { commitId: detailsCommit.commitId, description },
+                payload: { changeId: detailsCommit.changeId, description },
             });
         }
     };
@@ -186,7 +186,7 @@ const App: React.FC = () => {
         if (view === 'details' && detailsCommit) {
             vscode.postMessage({
                 type: 'openDiff',
-                payload: { commitId: detailsCommit.commitId, file, isImmutable },
+                payload: { changeId: detailsCommit.changeId, file, isImmutable },
             });
         }
     };
@@ -195,7 +195,7 @@ const App: React.FC = () => {
         if (view === 'details' && detailsCommit) {
             vscode.postMessage({
                 type: 'openMultiDiff',
-                payload: { commitId: detailsCommit.commitId },
+                payload: { changeId: detailsCommit.changeId },
             });
         }
     };
@@ -219,7 +219,7 @@ const App: React.FC = () => {
             const bookmarkName = active.data.current.name;
             const bookmarkRemote = active.data.current.remote;
             // commit-ID -> ID
-            const targetCommitId = over.data.current.commitId;
+            const targetChangeId = over.data.current.changeId;
 
             // Optimistic Update
             setCommits((prevCommits) => {
@@ -228,7 +228,7 @@ const App: React.FC = () => {
                     c.bookmarks?.some((b: any) => b.name === bookmarkName && b.remote === bookmarkRemote),
                 );
 
-                if (!sourceCommit || sourceCommit.change_id === targetCommitId) {
+                if (!sourceCommit || sourceCommit.change_id === targetChangeId) {
                     return prevCommits;
                 }
 
@@ -243,7 +243,7 @@ const App: React.FC = () => {
                     }
 
                     // Add to target
-                    if (commit.change_id === targetCommitId) {
+                    if (commit.change_id === targetChangeId) {
                         newBookmarks = [...newBookmarks, { name: bookmarkName, remote: bookmarkRemote }];
                     }
 
@@ -259,11 +259,11 @@ const App: React.FC = () => {
             // Send to extension
             vscode.postMessage({
                 type: 'moveBookmark',
-                payload: { bookmark: bookmarkName, targetCommitId },
+                payload: { bookmark: bookmarkName, targetChangeId },
             });
         } else if (activeType === 'commit') {
-            const sourceCommitId = active.data.current.commitId;
-            const targetCommitId = over.data.current.commitId;
+            const sourceChangeId = active.data.current.changeId;
+            const targetChangeId = over.data.current.changeId;
 
             // Detect modifier keys from the activator event or our state
             // Prefer tracking state for consistency with UI
@@ -271,7 +271,7 @@ const App: React.FC = () => {
 
             vscode.postMessage({
                 type: 'rebaseCommit',
-                payload: { sourceCommitId, targetCommitId, mode },
+                payload: { sourceChangeId, targetChangeId, mode },
             });
         }
     };
@@ -280,7 +280,7 @@ const App: React.FC = () => {
     if (view === 'details' && detailsCommit) {
         return (
             <CommitDetails
-                commitId={detailsCommit.commitId}
+                changeId={detailsCommit.changeId}
                 description={detailsCommit.description}
                 files={detailsCommit.files}
                 isImmutable={detailsCommit.isImmutable}

--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -7,8 +7,9 @@ import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { JjBookmark } from '../../jj-types';
 
-export const BasePill: React.FC<{ children: React.ReactNode; style?: React.CSSProperties }> = ({ children, style }) => (
+export const BasePill: React.FC<{ children: React.ReactNode; style?: React.CSSProperties; className?: string }> = ({ children, style, className }) => (
     <span
+        className={`bookmark-pill ${className || ''}`}
         style={{
             marginRight: '6px',
             borderRadius: '10px',

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { JjStatusEntry } from '../../jj-types';
 
 interface CommitDetailsProps {
-    commitId: string;
+    changeId: string;
     description: string;
     files: Array<{
         path: string;
@@ -22,7 +22,7 @@ interface CommitDetailsProps {
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
-    commitId,
+    changeId,
     description,
     files,
     isImmutable,
@@ -64,7 +64,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                 <div
                     style={{ fontSize: '12px', color: 'var(--vscode-descriptionForeground)', fontFamily: 'monospace' }}
                 >
-                    ID: {commitId}
+                    ID: {changeId}
                 </div>
             </div>
 

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -55,6 +55,14 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
     // Determine the max shortest ID length to display
     const maxShortestIdLength = React.useMemo(() => computeMaxShortestIdLength(commits), [commits]);
 
+    const hasImmutableSelection = React.useMemo(() => {
+        if (!selectedCommitIds || selectedCommitIds.size === 0) {
+            return false;
+        }
+        // Check ALL commits, not just displayRows, to ensure correctness even if some are off-screen
+        return commits.some((c) => selectedCommitIds.has(c.change_id) && c.is_immutable);
+    }, [commits, selectedCommitIds]);
+
     // Padding-left for the text area
     const graphAreaWidth = computeGraphAreaWidth(layout.width, LANE_WIDTH, LEFT_MARGIN, GAP);
 
@@ -74,11 +82,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
             <div style={{ position: 'relative', zIndex: 1 }}>
                 {displayRows.map((commit) => {
                     const isSelected = selectedCommitIds?.has(commit.change_id);
-                    const hasImmutableSelection =
-                        selectedCommitIds && selectedCommitIds.size > 0
-                            ? displayRows.some((c) => selectedCommitIds.has(c.change_id) && c.is_immutable)
-                            : false;
-
                     const height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
 
                     return (
@@ -96,7 +99,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
                             <CommitNode
                                 commit={commit}
                                 onClick={(modifiers) =>
-                                    onAction('select', { commitId: commit.change_id, ...modifiers })
+                                    onAction('select', { changeId: commit.change_id, ...modifiers })
                                 }
                                 onAction={onAction}
                                 isSelected={isSelected}

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -15,9 +15,11 @@ export { BookmarkPill } from './Bookmark';
 
 // Shared payload for all actions
 export interface ActionPayload {
-    commitId: string;
+    changeId: string;
     isImmutable?: boolean;
     url?: string;
+    multiSelect?: boolean;
+    [key: string]: unknown;
 }
 
 interface CommitNodeProps {
@@ -49,7 +51,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
         id: `commit-${commit.change_id}`,
         data: {
             type: 'commit',
-            commitId: commit.change_id,
+            changeId: commit.change_id,
             description: commit.description, // Pass description for preview
             change_id_shortest: commit.change_id_shortest, // Pass short ID for preview styles
         },
@@ -57,7 +59,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
 
     const { setNodeRef: setDroppableRef, isOver } = useDroppable({
         id: `commit-${commit.change_id}`,
-        data: { type: 'commit', commitId: commit.change_id },
+        data: { type: 'commit', changeId: commit.change_id },
     });
     const { active } = useDndContext();
     const [isHovered, setIsHovered] = React.useState(false);
@@ -122,20 +124,22 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
             {...listeners}
             {...attributes}
             className={`commit-row ${isWorkingCopy ? 'working-copy' : ''}`}
+            aria-selected={isSelected}
+            data-change-id={commit.change_id}
+            data-selected={isSelected}
+            data-hovered={isHovered}
             data-vscode-context={JSON.stringify({
                 webviewSection: 'commit',
                 viewItem: isSelected ? 'jj-commit-selected' : 'jj-commit',
-                commitId: commit.change_id,
+                commitId: commit.commit_id,
+                changeId: commit.change_id,
 
-                // Detailed Capabilities for Context Menu "when" clauses
-                // Only show Abandon in context menu for multi-selection (use hover button for single)
-                canAbandon: isSelected && selectionCount > 1 && !hasImmutableSelection,
+                // Abandon and New Before supported on multi-selection, but also on unselected items
+                canAbandon: !isImmutable && (!isSelected || !hasImmutableSelection),
+                canNewBefore: !isImmutable && (!isSelected || !hasImmutableSelection),
 
-                // Edit/NewBefore require mutable commits and currently single-item context
+                // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
                 canEdit: !isImmutable && (!isSelected || selectionCount <= 1),
-                canNewBefore: !isImmutable && (!isSelected || selectionCount <= 1),
-
-                // Duplicate works on any commit, but restricted to single-item context for now
                 canDuplicate: !isSelected || selectionCount <= 1,
 
                 // Rebase source must be mutable, and we rebase ONTO the current selection
@@ -241,30 +245,42 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                             icon="codicon-plus"
                             onClick={(e) => {
                                 e.stopPropagation();
-                                onAction('newChild', { commitId: commit.change_id });
+                                onAction('newChild', { changeId: commit.change_id });
                             }}
                         />
+
+                        {!isImmutable && (
+                            <IconButton
+                                title="Edit Commit"
+                                icon="codicon-edit"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAction('edit', { changeId: commit.change_id });
+                                }}
+                            />
+                        )}
 
                         {commit.parents_immutable &&
                             commit.parents_immutable.length === 1 &&
                             !commit.parents_immutable[0] && (
                                 <IconButton
-                                    title="Move to Parent (Squash)"
+                                    title="Squash into Parent"
                                     icon="codicon-arrow-down"
                                     onClick={(e) => {
+                                        console.log('[Webview] Squash clicked for:', commit.change_id);
                                         e.stopPropagation();
-                                        onAction('squash', { commitId: commit.change_id });
+                                        onAction('squash', { changeId: commit.change_id });
                                     }}
                                 />
                             )}
 
                         {!isImmutable && (
                             <IconButton
-                                title="Abandon"
+                                title="Abandon Commit"
                                 icon="codicon-trash"
                                 onClick={(e) => {
                                     e.stopPropagation();
-                                    onAction('abandon', { commitId: commit.change_id });
+                                    onAction('abandon', { changeId: commit.change_id });
                                 }}
                             />
                         )}
@@ -394,7 +410,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                 e.preventDefault();
                                 e.stopPropagation();
                                 onAction('openGerrit', {
-                                    commitId: commit.change_id,
+                                    changeId: commit.change_id,
                                     url: gerritCl.url,
                                 });
                             }}
@@ -437,7 +453,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                     role="button"
                                     onClick={(e) => {
                                         e.stopPropagation();
-                                        onAction('upload', { commitId: commit.change_id });
+                                        onAction('upload', { changeId: commit.change_id });
                                     }}
                                     title="Local changes need upload (Click to push)"
                                     style={{

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -121,10 +121,10 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
             />
         );
 
+        let content;
         if (node.isWorkingCopy) {
-            return (
-                <g key={node.commitId}>
-                    {isSelected && <Halo />}
+            content = (
+                <>
                     <circle cx={cx} cy={cy} r="8" fill="var(--vscode-sideBar-background)" />
                     <text
                         x={cx}
@@ -142,14 +142,11 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
                     >
                         @
                     </text>
-                </g>
+                </>
             );
-        }
-
-        if (node.conflict) {
-            return (
-                <g key={node.commitId}>
-                    {isSelected && <Halo />}
+        } else if (node.conflict) {
+            content = (
+                <>
                     <circle cx={cx} cy={cy} r="6" fill="var(--vscode-sideBar-background)" />
                     <line
                         x1={cx - 3}
@@ -169,14 +166,11 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
                         strokeWidth="2"
                         strokeLinecap="round"
                     />
-                </g>
+                </>
             );
-        }
-
-        if (node.isEmpty) {
-            return (
+        } else if (node.isEmpty) {
+            content = (
                 <circle
-                    key={node.commitId}
                     cx={cx}
                     cy={cy}
                     r="5"
@@ -186,19 +180,17 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
                     style={{ opacity: 0.8 }}
                 />
             );
-        }
-
-        if (isSelected) {
-            return (
-                <g key={node.commitId}>
-                    <Halo />
-                    <circle cx={cx} cy={cy} r="5" fill={node.color} stroke={node.color} strokeWidth="2" />
-                </g>
+        } else {
+            content = (
+                <circle cx={cx} cy={cy} r="5" fill={node.color} stroke={node.color} strokeWidth="2" />
             );
         }
 
         return (
-            <circle key={node.commitId} cx={cx} cy={cy} r="5" fill={node.color} stroke={node.color} strokeWidth="2" />
+            <g key={node.commitId}>
+                {isSelected && <Halo />}
+                {content}
+            </g>
         );
     };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
         "noUnusedParameters": true /* Report errors on unused parameters. */,
         "noUnusedLocals": true
     },
-    "exclude": ["vitest.config.ts", "playwright.config.ts", "node_modules", ".agents"]
+    "exclude": ["vitest.config.ts", "playwright.config.ts", "playwright.e2e.config.ts", "node_modules", ".agents"]
 }


### PR DESCRIPTION
- Added Playwright-based E2E testing infrastructure for Linux and macOS.
- Implemented initial E2E tests for Commit Details and Log Context Menus.
- Refactored command utilities to support multi-selection extraction.
- Migrated commands (abandon, absorb, bookmark, etc.) and webview providers  to use change IDs instead of commit IDs for better stability.
- Improved SCM view by ensuring ancestor groups remain visible when empty.
- Optimized window focus handling in ChangeDetectionManager to prevent E2E loops.