### PR TITLE
Refine gitignore pattern parsing for file watcher

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -208,7 +208,19 @@ export class ChangeDetectionManager implements vscode.Disposable {
             const data = await fs.readFile(gitIgnorePath, 'utf8');
             return data.split('\n')
                 .map(line => line.trim())
-                .filter(line => line.length > 0 && !line.startsWith('#') && !line.startsWith('!'));
+                .filter(line => line.length > 0 && !line.startsWith('#') && !line.startsWith('!'))
+                .map(line => {
+                    // Strip leading/trailing slashes and wildcards to pass as literals.
+                    // PARCEL-WATCHER BEHAVIOR:
+                    // 1. Literal paths (e.g. 'out') prune all descendants recursively.
+                    // 2. Glob patterns (e.g. 'out*') do NOT prune descendants recursively.
+                    // 
+                    // By stripping wildcards we ensure directory contents are ignored, which is the common case
+                    // for gitignore patterns like /out/. The caveat is that we lose true wildcard matching 
+                    // (e.g. /out*/ will only match a directory named exactly 'out').
+                    return line.replace(/^[\/*?]+|[\/*?]+$/g, '');
+                })
+                .filter(pattern => pattern.length > 0);
         } catch {
             return [];
         }

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -282,5 +282,43 @@ describe('ChangeDetectionManager', () => {
                  expect(found, 'Expected file watcher event for visible.txt').toBe(true);
              }, { timeout: 10000, interval: 100 });
          });
+
+        it('ignores directories matching literal patterns like /out/', async () => {
+            // Setup config to return 'watch'
+            mockGetConfiguration.mockReturnValue({
+                get: (key: string, defaultValue: unknown) => {
+                    if (key === 'fileWatcherMode') return 'watch';
+                    return defaultValue;
+                }
+            });
+
+            repo.writeFile('.gitignore', '/out*/');
+            
+            const ignoredDir = path.join(repo.path, 'out');
+            await fs.mkdir(ignoredDir, { recursive: true });
+
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy);
+
+            // Wait for watcher to start and settle
+            await waitForLog('Working Copy Watcher] Started');
+            await new Promise(resolve => setTimeout(resolve, 500));
+            triggerRefreshSpy.mockClear();
+
+            // 1. Write to the ignored directory — should NOT trigger
+            await fs.writeFile(path.join(ignoredDir, 'build.log'), 'building...');
+
+            // Wait to confirm no event fires for ignored file
+            await new Promise(resolve => setTimeout(resolve, 800));
+            const ignoredCalls = triggerRefreshSpy.mock.calls.filter(call => call[0].reason === 'file watcher event');
+            expect(ignoredCalls, 'File in /out/ directory should not have triggered a refresh').toHaveLength(0);
+
+            // 2. Write to a non-ignored path — SHOULD trigger
+            repo.writeFile('readme.md', 'hello');
+
+            await vi.waitFor(() => {
+                const found = triggerRefreshSpy.mock.calls.some(call => call[0].reason === 'file watcher event');
+                expect(found, 'Expected file watcher event for readme.md').toBe(true);
+            }, { timeout: 10000, interval: 100 });
+        });
     });
 });


### PR DESCRIPTION
- Strip leading/trailing slashes and wildcards from .gitignore patterns.
- This allows @parcel/watcher to treat them as literal paths, enabling recursive pruning of ignored directories (e.g., /out/).
- Add unit test to verify directory ignoring with refined patterns.