### PR TITLE
Implement jj-view.minChangeIdLength setting

### DIFF
--- a/.fantasticonrc.js
+++ b/.fantasticonrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-    inputDir: './media/custom-icons-src',
-    outputDir: './media/custom-icons',
-    fontTypes: ['woff'],
-    assetTypes: ['css', 'json'],
-    name: 'jj-view-icons',
-    prefix: 'jj-icon',
-    normalize: true
-};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 22
+                  cache: 'npm'
+
+            - name: Install Go
+              uses: actions/setup-go@v5
+              with:
+                  go-version: '1.21'
 
             - name: Install jj (Jujutsu)
               uses: taiki-e/install-action@v2
@@ -44,6 +50,9 @@ jobs:
             - name: Check Types
               if: runner.os == 'Linux'
               run: npm run check-types
+
+            - name: Build Extension (Verification)
+              run: npm run build
 
             - name: Run Unit Tests
               run: npm run test:unit

--- a/.svgtofontrc.js
+++ b/.svgtofontrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  src: 'media/custom-icons-src',
+  dist: 'media/custom-icons',
+  fontName: 'jj-view-icons',
+  css: true,
+  startUnicode: 0xf101,
+  svgicons2svgfont: {
+    fontHeight: 1000,
+    normalize: true
+  },
+  classNamePrefix: 'jj-icon',
+  website: null
+};

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.gerrit.host` | `null` | Gerrit host URL (e.g., https://experiment-review.googlesource.com). If not set, extension attempts to detect it from .gitreview or git remotes. |
 | `jj-view.gerrit.project` | `null` | Gerrit project name. If not set, extension attempts to detect it from git remotes. |
 | `jj-view.uploadCommand` | `null` | Custom command to run for upload. Example: 'git push'. The command will be prefixed with 'jj' and suffixed with '-r <revision>'. |
+| `jj-view.minChangeIdLength` | `1` | Minimum number of characters to display for change IDs. This affects the unique prefix calculation and UI truncation. |
 | `jj-view.maxMutableAncestors` | `10` | Maximum number of mutable ancestors to display in the SCM view. |
 
 ## File Watcher Mode

--- a/esbuild.js
+++ b/esbuild.js
@@ -5,6 +5,9 @@
 
 const esbuild = require('esbuild');
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');
@@ -81,9 +84,6 @@ async function main() {
 }
 
 async function copyAssets() {
-    const fs = require('fs');
-    const path = require('path');
-
     console.log('[build] Copying assets...');
 
     const assets = [
@@ -122,9 +122,6 @@ async function copyAssets() {
  * `npm pack` to download tarballs for missing platforms and extract them.
  */
 async function installNativeDeps() {
-    const fs = require('fs');
-    const path = require('path');
-
     const watcherPkg = require('@parcel/watcher/package.json');
     const optionalDeps = watcherPkg.optionalDependencies || {};
 
@@ -137,10 +134,11 @@ async function installNativeDeps() {
         const spec = `${name}@${version}`;
         console.log(`[build] Installing ${spec}...`);
         try {
-            const tarball = execSync(`npm pack ${spec} --pack-destination /tmp`, {
+            const tmpDir = os.tmpdir();
+            const tarball = execSync(`npm pack ${spec} --pack-destination "${tmpDir}"`, {
                 encoding: 'utf-8',
             }).trim();
-            const tarballPath = path.join('/tmp', tarball);
+            const tarballPath = path.join(tmpDir, tarball);
             fs.mkdirSync(destDir, { recursive: true });
             execSync(`tar xzf "${tarballPath}" --strip-components=1 -C "${destDir}"`, {
                 stdio: 'inherit',
@@ -153,8 +151,27 @@ async function installNativeDeps() {
     }
 }
 
-// Run copyAssets and installNativeDeps before main build
-Promise.all([copyAssets(), installNativeDeps()])
+async function buildIcons() {
+    console.log('[build] Building icons...');
+    const inputDir = path.join(__dirname, 'media/custom-icons-src');
+    console.log(`[build] Icon input dir: ${inputDir}`);
+
+    if (fs.existsSync(inputDir)) {
+        const files = fs.readdirSync(inputDir);
+        console.log(`[build] Contents of input dir: ${files.join(', ')}`);
+    } else {
+        console.error(`[build] Icon input dir does not exist: ${inputDir}`);
+    }
+
+    const iconDir = path.join(__dirname, 'media/custom-icons');
+    if (!fs.existsSync(iconDir)) {
+        fs.mkdirSync(iconDir, { recursive: true });
+    }
+    execSync('npm run build:icons', { stdio: 'inherit' });
+}
+
+// Run prerequisite tasks before main build
+Promise.all([buildIcons(), copyAssets(), installNativeDeps()])
     .then(main)
     .catch((e) => {
         console.error(e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,13 +33,13 @@
                 "esbuild": "^0.27.1",
                 "eslint": "^9.39.1",
                 "eslint-config-prettier": "^10.1.8",
-                "fantasticon": "^4.1.0",
                 "npm-run-all": "^4.1.5",
                 "ovsx": "^0.10.8",
                 "playwright": "^1.58.0",
                 "prettier": "^3.7.4",
                 "rimraf": "^6.1.2",
                 "sinon": "^21.0.1",
+                "svgtofont": "^6.5.1",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.48.1",
@@ -1119,6 +1119,28 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -3470,6 +3492,13 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/a-sync-waterfall": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+            "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/abbrev": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -3589,6 +3618,13 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3656,6 +3692,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3692,6 +3735,38 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/auto-config-loader": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/auto-config-loader/-/auto-config-loader-2.0.2.tgz",
+            "integrity": "sha512-0V8gZAGGqiFDP15d6d4/Emi6Gpozbr1S9lSfxJ+lNV8nF+7grhcgbHIgn3O/DQKybS+cDqVMC3rxH8k+o0ISpA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^5.0.0",
+                "jiti": "^2.4.1",
+                "jsonc-eslint-parser": "^2.3.0",
+                "lodash.merge": "^4.6.2",
+                "sucrase": "^3.35.0",
+                "toml-eslint-parser": "^0.10.0",
+                "yaml-eslint-parser": "^1.2.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            }
+        },
+        "node_modules/auto-config-loader/node_modules/ini": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+            "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
@@ -4080,16 +4155,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/case": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/case/-/case-1.6.3.tgz",
-            "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==",
-            "dev": true,
-            "license": "(MIT OR GPL-3.0-or-later)",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/chai": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4213,23 +4278,6 @@
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cli-color": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
-            "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.1",
-                "es5-ext": "^0.10.64",
-                "es6-iterator": "^2.0.3",
-                "memoizee": "^0.4.15",
-                "timers-ext": "^0.1.7"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
@@ -4368,6 +4416,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/colors-cli": {
+            "version": "1.0.33",
+            "resolved": "https://registry.npmjs.org/colors-cli/-/colors-cli-1.0.33.tgz",
+            "integrity": "sha512-PWGsmoJFdOB0t+BeHgmtuoRZUQucOLl5ii81NBzOOGVxlgE04muFNHlR5j8i8MKbOPELBl3243AI6lGBTj5ICQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "colors": "bin/colors"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            }
+        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4451,6 +4512,20 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -4463,6 +4538,42 @@
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
             }
+        },
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "~2.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/csstype": {
             "version": "3.2.3",
@@ -4478,18 +4589,14 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/d": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-            "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "es5-ext": "^0.10.64",
-                "type": "^2.7.2"
-            },
+            "license": "MIT",
             "engines": {
-                "node": ">=0.12"
+                "node": ">= 12"
             }
         },
         "node_modules/data-view-buffer": {
@@ -5081,62 +5188,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/es5-ext": {
-            "version": "0.10.64",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "ISC",
-            "dependencies": {
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.3",
-                "esniff": "^2.0.1",
-                "next-tick": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "node_modules/es6-symbol": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-            "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.2",
-                "ext": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
-        },
-        "node_modules/es6-weak-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "^0.10.46",
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.1"
-            }
-        },
         "node_modules/esbuild": {
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -5346,22 +5397,6 @@
                 "node": "*"
             }
         },
-        "node_modules/esniff": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.1",
-                "es5-ext": "^0.10.62",
-                "event-emitter": "^0.3.5",
-                "type": "^2.7.2"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/espree": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -5436,17 +5471,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
-        },
         "node_modules/expand-template": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -5474,136 +5498,6 @@
             "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
             "dev": true,
             "license": "Apache-2.0"
-        },
-        "node_modules/ext": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-            "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "type": "^2.7.2"
-            }
-        },
-        "node_modules/fantasticon": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-4.1.0.tgz",
-            "integrity": "sha512-Clnp+ic3eH33fEKfJOf7eDOUAjv/+cD7lqPQVMwDk+5jYVzNoBrQi1JVSSsSL+j1+S04bQDHH35RkpnsvBQILA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "case": "^1.6.3",
-                "cli-color": "^2.0.4",
-                "commander": "^14.0.2",
-                "glob": "^13.0.0",
-                "handlebars": "^4.7.8",
-                "slugify": "^1.6.6",
-                "svg2ttf": "^6.0.3",
-                "svgicons2svgfont": "^15.0.1",
-                "ttf2eot": "^3.1.0",
-                "ttf2woff": "^3.0.0",
-                "ttf2woff2": "^8.0.0"
-            },
-            "bin": {
-                "fantasticon": "bin/fantasticon"
-            },
-            "engines": {
-                "node": ">= 22.0"
-            }
-        },
-        "node_modules/fantasticon/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/fantasticon/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/fantasticon/node_modules/commander": {
-            "version": "14.0.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/fantasticon/node_modules/glob": {
-            "version": "13.0.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "minimatch": "^10.2.2",
-                "minipass": "^7.1.3",
-                "path-scurry": "^2.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/fantasticon/node_modules/lru-cache": {
-            "version": "11.2.6",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-            "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": "20 || >=22"
-            }
-        },
-        "node_modules/fantasticon/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/fantasticon/node_modules/path-scurry": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^11.0.0",
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -5678,6 +5572,30 @@
             "license": "MIT",
             "dependencies": {
                 "pend": "~1.2.0"
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/file-entry-cache": {
@@ -5830,6 +5748,19 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fs-constants": {
@@ -6150,28 +6081,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.5",
-                "neo-async": "^2.6.2",
-                "source-map": "^0.6.1",
-                "wordwrap": "^1.0.0"
-            },
-            "bin": {
-                "handlebars": "bin/handlebars"
-            },
-            "engines": {
-                "node": ">=0.4.7"
-            },
-            "optionalDependencies": {
-                "uglify-js": "^3.1.4"
-            }
-        },
         "node_modules/has-bigints": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -6401,6 +6310,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/image2uri": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/image2uri/-/image2uri-2.1.2.tgz",
+            "integrity": "sha512-3b2zRma8I3zulb4OCkZruRw1VsnysT9phBzOJj+x3lPkwybJtNa5Sz6Dw8jSQI6OL7Ns4H5h8Y26EJbwq4GhQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-fetch": "^3.3.1"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
             }
         },
         "node_modules/immediate": {
@@ -6859,13 +6781,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/is-regex": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7140,6 +7055,17 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
+        "node_modules/jiti": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+            "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7199,6 +7125,56 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/jsonc-eslint-parser": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+            "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.5.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/jsonc-eslint-parser/node_modules/espree": {
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.9.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/jsonc-parser": {
@@ -7336,6 +7312,13 @@
             "dependencies": {
                 "immediate": "~3.0.5"
             }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/linkify-it": {
             "version": "5.0.0",
@@ -7504,16 +7487,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/lru-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-            "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es5-ext": "~0.10.2"
-            }
-        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7598,32 +7571,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
         "node_modules/mdurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/memoizee": {
-            "version": "0.4.17",
-            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
-            "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "d": "^1.0.2",
-                "es5-ext": "^0.10.64",
-                "es6-weak-map": "^2.0.3",
-                "event-emitter": "^0.3.5",
-                "is-promise": "^2.2.2",
-                "lru-queue": "^0.1.0",
-                "next-tick": "^1.1.0",
-                "timers-ext": "^0.1.7"
-            },
-            "engines": {
-                "node": ">=0.12"
-            }
         },
         "node_modules/memorystream": {
             "version": "0.3.1",
@@ -7750,6 +7710,7 @@
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7991,6 +7952,18 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
+        },
         "node_modules/nan": {
             "version": "2.25.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
@@ -8042,20 +8015,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/neo-async": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/next-tick": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-            "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8084,6 +8043,46 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
         },
         "node_modules/node-gyp": {
             "version": "11.5.0",
@@ -8411,6 +8410,52 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
+        "node_modules/nunjucks": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+            "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "a-sync-waterfall": "^1.0.0",
+                "asap": "^2.0.3",
+                "commander": "^5.1.0"
+            },
+            "bin": {
+                "nunjucks-precompile": "bin/precompile"
+            },
+            "engines": {
+                "node": ">= 6.9.0"
+            },
+            "peerDependencies": {
+                "chokidar": "^3.3.0"
+            },
+            "peerDependenciesMeta": {
+                "chokidar": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/nunjucks/node_modules/commander": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/object-inspect": {
@@ -8965,6 +9010,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/pirates": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/playwright": {
@@ -9725,11 +9780,14 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-            "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
+            "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
             "dev": true,
-            "license": "BlueOak-1.0.0"
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/scheduler": {
             "version": "0.27.0",
@@ -10180,16 +10238,6 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
-        "node_modules/slugify": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-            "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -10229,16 +10277,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-js": {
@@ -10566,6 +10604,39 @@
                 "boundary": "^2.0.0"
             }
         },
+        "node_modules/sucrase": {
+            "version": "3.35.1",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.2",
+                "commander": "^4.0.0",
+                "lines-and-columns": "^1.1.6",
+                "mz": "^2.7.0",
+                "pirates": "^4.0.1",
+                "tinyglobby": "^0.2.11",
+                "ts-interface-checker": "^0.1.9"
+            },
+            "bin": {
+                "sucrase": "bin/sucrase",
+                "sucrase-node": "bin/sucrase-node"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/sucrase/node_modules/commander": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+            "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/supports-color": {
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -10790,6 +10861,42 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/svgo": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
+            "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^7.2.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^2.3.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.0.0",
+                "sax": "^1.5.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
+            }
+        },
+        "node_modules/svgo/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/svgpath": {
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
@@ -10798,6 +10905,116 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/fontello/svg2ttf?sponsor=1"
+            }
+        },
+        "node_modules/svgtofont": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/svgtofont/-/svgtofont-6.5.1.tgz",
+            "integrity": "sha512-qhKdsOBV83o3elEQP//lnEqyhyVfwvnspIqtnPSSxJAHK1Ze8/ELo13Ax28rJiN+2NkikVQEYePsM7ECYHJXBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "auto-config-loader": "^2.0.0",
+                "cheerio": "~1.0.0",
+                "colors-cli": "~1.0.28",
+                "fs-extra": "~11.2.0",
+                "image2uri": "^2.1.2",
+                "nunjucks": "^3.2.4",
+                "svg2ttf": "~6.0.3",
+                "svgicons2svgfont": "~15.0.0",
+                "svgo": "~3.3.0",
+                "ttf2eot": "~3.1.0",
+                "ttf2woff": "~3.0.0",
+                "ttf2woff2": "~8.0.0",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "svgtofont": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            },
+            "peerDependencies": {
+                "@types/svg2ttf": "~5.0.1"
+            },
+            "peerDependenciesMeta": {
+                "@types/svg2ttf": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/svgtofont/node_modules/cheerio": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+            "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "encoding-sniffer": "^0.2.0",
+                "htmlparser2": "^9.1.0",
+                "parse5": "^7.1.2",
+                "parse5-htmlparser2-tree-adapter": "^7.0.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^6.19.5",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18.17"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
+        "node_modules/svgtofont/node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/svgtofont/node_modules/htmlparser2": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+            "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.1.0",
+                "entities": "^4.5.0"
+            }
+        },
+        "node_modules/svgtofont/node_modules/undici": {
+            "version": "6.24.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+            "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
             }
         },
         "node_modules/table": {
@@ -11040,18 +11257,27 @@
                 "url": "https://bevry.me/fund"
             }
         },
-        "node_modules/timers-ext": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
-            "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+        "node_modules/thenify": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
-            "license": "ISC",
+            "license": "MIT",
             "dependencies": {
-                "es5-ext": "^0.10.64",
-                "next-tick": "^1.1.0"
+                "any-promise": "^1.0.0"
+            }
+        },
+        "node_modules/thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "thenify": ">= 3.1.0 < 4"
             },
             "engines": {
-                "node": ">=0.12"
+                "node": ">=0.8"
             }
         },
         "node_modules/tinybench": {
@@ -11153,6 +11379,35 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/toml-eslint-parser": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.10.1.tgz",
+            "integrity": "sha512-9mjy3frhioGIVGcwamlVlUyJ9x+WHw/TXiz9R4YOlmsIuBN43r9Dp8HZ35SF9EKjHrn3BUZj04CF+YqZ2oJ+7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/toml-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/transformation-matrix": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-3.1.0.tgz",
@@ -11175,6 +11430,13 @@
             "peerDependencies": {
                 "typescript": ">=4.8.4"
             }
+        },
+        "node_modules/ts-interface-checker": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+            "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/ts-node": {
             "version": "10.9.2",
@@ -11308,13 +11570,6 @@
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/type": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-            "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -11487,20 +11742,6 @@
             "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/uglify-js": {
-            "version": "3.19.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "bin": {
-                "uglifyjs": "bin/uglifyjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
         },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
@@ -11884,6 +12125,16 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -12046,13 +12297,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/wordwrap": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/workerpool": {
             "version": "9.3.4",
@@ -12220,6 +12464,53 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/yaml": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/yaml-eslint-parser": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+            "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-visitor-keys": "^3.0.0",
+                "yaml": "^2.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
+        "node_modules/yaml-eslint-parser/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/yargs": {
             "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,12 @@
                     "type": "string",
                     "description": "Custom command to run for upload. Example: 'git push'. The command will be prefixed with 'jj' and suffixed with '-r <revision>'."
                 },
+                "jj-view.minChangeIdLength": {
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 1,
+                    "description": "Minimum number of characters to display for change IDs. This affects the unique prefix calculation and UI truncation."
+                },
                 "jj-view.maxMutableAncestors": {
                     "type": "number",
                     "default": 10,
@@ -455,8 +461,8 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run check-types && npm run lint && node esbuild.js --production",
-        "build": "npm run build:icons && npm run check-types && npm run lint && node esbuild.js",
-        "build:icons": "mkdir -p ./media/custom-icons && fantasticon",
+        "build": "npm run check-types && npm run lint && node esbuild.js",
+        "build:icons": "svgtofont -s media/custom-icons-src -o media/custom-icons",
         "watch": "npm-run-all -p watch:*",
         "watch:esbuild": "node esbuild.js --watch",
         "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
@@ -496,13 +502,13 @@
         "esbuild": "^0.27.1",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
-        "fantasticon": "^4.1.0",
         "npm-run-all": "^4.1.5",
         "ovsx": "^0.10.8",
         "playwright": "^1.58.0",
         "prettier": "^3.7.4",
         "rimraf": "^6.1.2",
         "sinon": "^21.0.1",
+        "svgtofont": "^6.5.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.1",

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -9,6 +9,7 @@ import { JjService } from './jj-service';
 import { JjContextKey } from './jj-context-keys';
 import { JjLogEntry } from './jj-types';
 import { createDiffUris } from './uri-utils';
+import { formatDisplayChangeId, shortenChangeId } from './utils/jj-utils';
 
 import { GerritService } from './gerrit-service';
 
@@ -173,6 +174,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             
             try {
                 this.outputChannel?.appendLine(`[JjLogWebviewProvider] Refreshing...`);
+
                 // Default jj log (usually local heads/roots)
                 const logStart = performance.now();
                 commits = await this._jj.getLog({ omitChanges: true });
@@ -213,7 +215,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             this.outputChannel?.appendLine(`[JjLogWebviewProvider] Gerrit fetch took ${gerritDuration.toFixed(0)}ms`);
 
             if (hasChanges) {
-            this.outputChannel?.appendLine('[JjLogWebviewProvider] Gerrit data changed, re-rendering');
+                this.outputChannel?.appendLine('[JjLogWebviewProvider] Gerrit data changed, re-rendering');
                 this._renderCommits(this._cachedCommits);
             }
         } catch (e) {
@@ -222,6 +224,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     }
 
     private _renderCommits(commits: JjLogEntry[]) {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+
         if (this._gerrit.isEnabled) {
             for (const commit of commits) {
                 if (commit.commit_id) {
@@ -236,13 +241,16 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         }
         
         this._view?.webview.postMessage({
-            type: 'update', commits
+            type: 'update', commits, minChangeIdLength
         });
     }
 
     private _activeDetailsPanel?: vscode.WebviewPanel;
 
     public async createCommitDetailsPanel(changeId: string) {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+
         // Fetch full log entry - this includes description, changes (file list), and immutability status
         const logs = await this._jj.getLog({ revision: changeId });
         if (logs.length === 0) {
@@ -250,6 +258,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         }
         
         const log = logs[0];
+        const displayId = formatDisplayChangeId(changeId, log.change_id_shortest, minChangeIdLength);
         const initialData = {
             view: 'details',
             payload: {
@@ -257,11 +266,12 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 description: log.description,
                 files: log.changes || [],
                 isImmutable: log.is_immutable,
+                minChangeIdLength,
             },
         };
 
         if (this._activeDetailsPanel) {
-            this._activeDetailsPanel.title = `Commit: ${changeId.substring(0, 8)}`;
+            this._activeDetailsPanel.title = `Commit: ${displayId}`;
             this._activeDetailsPanel.webview.html = this._getHtmlForWebview(
                 this._activeDetailsPanel.webview,
                 initialData,
@@ -272,7 +282,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
         const panel = vscode.window.createWebviewPanel(
             'jj-view.commitDetails',
-            `Commit: ${changeId.substring(0, 8)}`,
+            `Commit: ${displayId}`,
             vscode.ViewColumn.Active,
             {
                 enableScripts: true,
@@ -317,7 +327,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                         'vscode.diff',
                         leftUri,
                         rightUri,
-                        `${path.basename(file.path)} (${changeId.substring(0, 8)})${!isImmutable ? ' (Editable)' : ''}`,
+                        `${path.basename(file.path)} (${shortenChangeId(changeId, minChangeIdLength)})${!isImmutable ? ' (Editable)' : ''}`,
                     );
                     break;
                 }

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -20,6 +20,7 @@ import { completeSquashCommand } from './commands/squash';
 import { getErrorMessage } from './commands/command-utils';
 import { RefreshScheduler } from './refresh-scheduler';
 import { createDiffUris } from './uri-utils';
+import { formatDisplayChangeId } from './utils/jj-utils';
 
 export interface JjResourceState extends vscode.SourceControlResourceState {
     revision: string;
@@ -171,7 +172,8 @@ export class JjScmProvider implements vscode.Disposable {
                 this.editProvider?.invalidateCache();
 
                 // 1. Fetch data in parallel for performance
-                const maxMutableAncestors = vscode.workspace.getConfiguration('jj-view').get<number>('maxMutableAncestors', 10);
+                const config = vscode.workspace.getConfiguration('jj-view');
+                const maxMutableAncestors = config.get<number>('maxMutableAncestors', 10);
                 const limit = maxMutableAncestors + 1;
 
                 // Chain getLog directly off getLogIds so it runs concurrently with getChildren and getConflictedFiles
@@ -304,9 +306,18 @@ export class JjScmProvider implements vscode.Disposable {
 
                 // Working Copy Changes
                 const changes = currentEntry?.changes || [];
+                if (currentEntry) {
+                    const config = vscode.workspace.getConfiguration('jj-view');
+                    const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+                    const shortId = formatDisplayChangeId(currentEntry.change_id, currentEntry.change_id_shortest, minChangeIdLength);
+                    this._workingCopyGroup.label = `Working Copy - ${shortId}`;
+                } else {
+                    this._workingCopyGroup.label = 'Working Copy';
+                }
+
                 // Working copy items are squashable if the parent is mutable
                 this._workingCopyGroup.resourceStates = changes.map((c) => {
-                    const state = this.toResourceState(c, currentEntry.change_id, {
+                    const state = this.toResourceState(c, currentEntry?.change_id || '@', {
                         squashable: parentMutable,
                         multipleAncestors: ancestorsToDisplay.length > 1,
                     });
@@ -317,7 +328,7 @@ export class JjScmProvider implements vscode.Disposable {
                 // 4. Update Conflict Group (conflictedPaths fetched above)
                 this._conflictGroup.resourceStates = conflictedPaths.map((path) => {
                     const entry: JjStatusEntry = { path, status: 'modified', conflicted: true };
-                    const state = this.toResourceState(entry, currentEntry.change_id);
+                    const state = this.toResourceState(entry, currentEntry?.change_id || '@');
                     decorationMap.set(state.resourceUri.toString(), entry);
                     return state;
                 });
@@ -334,7 +345,9 @@ export class JjScmProvider implements vscode.Disposable {
                 for (let i = 0; i < ancestorsToDisplay.length; i++) {
                     const { entry: ancestorEntry, prefix, isMutable, canSquash } = ancestorsToDisplay[i];
 
-                    const shortId = ancestorEntry.change_id_shortest || ancestorEntry.change_id.substring(0, 8);
+                    const config = vscode.workspace.getConfiguration('jj-view');
+                    const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+                    const shortId = formatDisplayChangeId(ancestorEntry.change_id, ancestorEntry.change_id_shortest, minChangeIdLength);
                     const desc = ancestorEntry.description?.trim() || '(no description)';
                     const label = `${prefix}: ${shortId} - ${desc}`;
 

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -82,15 +82,16 @@ test.describe('Commit Details E2E', () => {
         await initialRow.click();
 
         // Wait for the details panel tab to appear
-        const shortId = nodes['initial'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+        const shortId = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
 
         // Find the details webview
         const details = await getDetailsWebview(page);
 
-        // Verify change ID is displayed
-        const idText = await details.locator('text=ID:').first().textContent();
+        // Verify change ID is displayed in full (32 chars)
+        const idText = await details.locator('div[title]').first().textContent();
         expect(idText).toContain(nodes['initial'].changeId);
+        expect(nodes['initial'].changeId.length).toBe(32);
 
         // Verify description is shown in the textarea (ignore trailing newlines)
         const textarea = details.locator('textarea');
@@ -112,8 +113,8 @@ test.describe('Commit Details E2E', () => {
         // Click to open details
         await featureRow.click();
 
-        const shortId = nodes['feature'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
 
         const details = await getDetailsWebview(page);
 
@@ -139,8 +140,8 @@ test.describe('Commit Details E2E', () => {
         // Click to open details
         await featureRow.click();
 
-        const shortId = nodes['feature'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
 
         const details = await getDetailsWebview(page);
 
@@ -166,8 +167,8 @@ test.describe('Commit Details E2E', () => {
         // Click to open details
         await initialRow.click();
 
-        const shortId = nodes['initial'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+        const shortId = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
 
         const details = await getDetailsWebview(page);
 
@@ -186,8 +187,8 @@ test.describe('Commit Details E2E', () => {
         // Click to open details
         await initialRow.click();
 
-        const shortId = nodes['initial'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
+        const shortId = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({ timeout: 15000 });
 
         const details = await getDetailsWebview(page);
 
@@ -195,8 +196,8 @@ test.describe('Commit Details E2E', () => {
         const multiDiffButton = details.locator('button', { hasText: 'Multi-file Diff' });
         await multiDiffButton.click();
 
-        // A multi-file diff tab should open with the change ID
-        await expect(page.getByRole('tab', { name: new RegExp(shortId) })).toBeVisible({ timeout: 10000 });
+        // A multi-file diff tab should open with the change ID prefix
+        await expect(page.getByRole('tab', { name: new RegExp(`^${shortId}`) })).toBeVisible({ timeout: 10000 });
     });
 
     test('Panel updates when clicking different commit', async () => {
@@ -205,9 +206,8 @@ test.describe('Commit Details E2E', () => {
         // Open details for 'initial'
         const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
         await initialRow.click();
-
-        const shortId1 = nodes['initial'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId1}`) })).toBeVisible({ timeout: 15000 });
+        const shortId1 = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId1}`) })).toBeVisible({ timeout: 15000 });
 
         const details = await getDetailsWebview(page);
         await expect(details.locator('textarea')).toHaveValue(/initial setup/);
@@ -219,9 +219,8 @@ test.describe('Commit Details E2E', () => {
         const webview2 = await getLogWebview(page);
         const featureRow = webview2.locator('.commit-row', { hasText: 'add feature' });
         await featureRow.click();
-
-        const shortId2 = nodes['feature'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(`Commit: ${shortId2}`) })).toBeVisible({ timeout: 15000 });
+        const shortId2 = nodes['feature'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId2}`) })).toBeVisible({ timeout: 15000 });
 
         // The panel is reused — wait for the textarea content to update within the SAME frame
         await expect(async () => {

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -300,7 +300,7 @@ test.describe('JJ Log Context Menu E2E', () => {
         await rightClickAndSelect(page, initialRow, 'Show Multi-File Diff');
 
         // Verification: A diff editor should open.
-        const shortHash = nodes['initial'].changeId.substring(0, 8);
-        await expect(page.getByRole('tab', { name: new RegExp(shortHash) })).toBeVisible({ timeout: 10000 });
+        const shortId = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^${shortId}`) })).toBeVisible({ timeout: 10000 });
     });
 });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -40,6 +40,7 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
         "window.titleBarStyle": "custom",
         "security.workspace.trust.enabled": false,
         "jj-view.fileWatcherMode": "watch",
+        "jj-view.minChangeIdLength": 3,
         "telemetry.telemetryLevel": "off",
         "workbench.notification.displayMode": "hidden",
         "notifications.showDoNotDisturb": true,

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -27,7 +27,7 @@ test.describe('SCM Pane E2E', () => {
 
             // Verify groups
             const mergeConflictsHeader = page.getByRole('treeitem', { name: 'Merge Conflicts' });
-            const workingCopyHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+            const workingCopyHeader = page.getByRole('treeitem', { name: /Working Copy/ });
 
             await expect(mergeConflictsHeader).toBeVisible();
             await expect(workingCopyHeader).toBeVisible();
@@ -161,7 +161,7 @@ test.describe('SCM Pane E2E', () => {
         try {
             await focusSCM(page);
             // Wait for groups to settle
-            const wcGroupHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+            const wcGroupHeader = page.getByRole('treeitem', { name: /Working Copy/ });
             
             // Hover over Working copy group to show abandon icon
             await wcGroupHeader.hover();
@@ -250,10 +250,12 @@ test.describe('SCM Pane E2E', () => {
             const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
             await rightEditor.click();
             await page.keyboard.press('Control+A');
-            await page.keyboard.insertText('edited from diff');
-            await page.keyboard.press('Control+S'); // Save
+            await page.keyboard.press('Backspace');
+            await page.keyboard.type('edited from diff', { delay: 10 });
             
-            // Wait for save indicator or poll the file content
+            await page.keyboard.press('Control+s');
+            
+            // Assert the file content
             await expect(async () => {
                 expect(repo.getFileContent('@', 'file2.txt').trim()).toBe('edited from diff');
             }).toPass({ timeout: 5000 });
@@ -281,32 +283,33 @@ test.describe('SCM Pane E2E', () => {
             await refreshButton.click();
 
             // Wait for file2.txt to appear in SCM Working Copy
-            const newWcFileRow = page.getByRole('treeitem', { name: /file2\.txt, modified/ });
+            const newWcFileRow = page.getByRole('treeitem', { name: /file2\.txt, modified/ }).first();
             await expect(newWcFileRow).toBeVisible({ timeout: 5000 });
             
             // Hover over file2.txt to show the inline actions
             await newWcFileRow.hover();
+            
             // The squashInto action should be visible because we have two mutable ancestors (the previous wc commit, and initial).
-            // Use role and first() for robustness
             const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash into Ancestor/ }).first();
             await squashIntoIcon.click({ force: true });
 
             // SCM QuickPick should appear for Ancestor selection
-            // We should select "Ancestor 2:" which is `initial`.
             const quickPickInput = page.getByRole('listbox');
-            // We should select the `initial` commit.
+            await expect(quickPickInput).toBeVisible({ timeout: 5000 });
+            
             const ancestor2Option = page.getByRole('option', { name: /initial/i });
             await ancestor2Option.click();
             await expect(quickPickInput).not.toBeVisible({ timeout: 5000 });
 
-            // Verify the squash happened
+            // Verify the squash happened by waiting for there to be only ONE file2.txt row (the ancestor one)
+            await expect(page.getByRole('treeitem', { name: /file2\.txt, modified/ })).toHaveCount(1, { timeout: 10000 });
+            
             await expect(async () => {
                 const wcChanges = repo.getDiffSummary('@');
                 expect(wcChanges).not.toContain('file2.txt');
                 
-                // The ancestor should now have the change. Since we squashed it into "Ancestor 2:"
-                // (which is 'initial'), we check its content.
-                expect(repo.getFileContent('@~2', 'file2.txt').trim()).toBe('new mod2');
+                // The ancestor should now have the change.
+                expect(repo.getFileContent('@--', 'file2.txt').trim()).toBe('new mod2');
             }).toPass({ timeout: 5000 });
 
         } finally {
@@ -330,7 +333,7 @@ test.describe('SCM Pane E2E', () => {
 
         try {
             await focusSCM(page);
-            const wcGroupHeader = page.getByRole('treeitem', { name: 'Working Copy' });
+            const wcGroupHeader = page.getByRole('treeitem', { name: /Working Copy/ });
 
             // 1. Absorb
             await wcGroupHeader.hover();

--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { convertJjChangeIdToHex, shortenChangeId, getChangeIdDisplayLength, formatDisplayChangeId } from '../utils/jj-utils';
+
+describe('JJ Utils', () => {
+    describe('convertJjChangeIdToHex', () => {
+        it('should convert jj change ids to hex', () => {
+            expect(convertJjChangeIdToHex('zzzz')).toBe('0000');
+            expect(convertJjChangeIdToHex('yyyy')).toBe('1111');
+            expect(convertJjChangeIdToHex('kkkk')).toBe('ffff');
+            expect(convertJjChangeIdToHex('zyxw')).toBe('0123');
+        });
+
+        it('should throw on invalid characters', () => {
+            expect(() => convertJjChangeIdToHex('abc')).toThrow();
+        });
+    });
+
+    describe('shortenChangeId', () => {
+        it('should return empty string for empty input', () => {
+            expect(shortenChangeId('', 8)).toBe('');
+        });
+
+        it('should shorten longer IDs', () => {
+            expect(shortenChangeId('abcdefghij', 4)).toBe('abcd');
+            expect(shortenChangeId('abcdefghij', 8)).toBe('abcdefgh');
+        });
+
+        it('should return full ID if it is shorter than minLen', () => {
+            expect(shortenChangeId('abc', 8)).toBe('abc');
+        });
+
+        it('should handle minLen 0', () => {
+            expect(shortenChangeId('abc', 0)).toBe('');
+        });
+    });
+
+    describe('getChangeIdDisplayLength', () => {
+        it('should return minLen if shortestId is missing', () => {
+            expect(getChangeIdDisplayLength(undefined, 8)).toBe(8);
+            expect(getChangeIdDisplayLength(undefined, 1)).toBe(1);
+        });
+
+        it('should return minLen if shortestId is shorter than minLen', () => {
+            expect(getChangeIdDisplayLength('abc', 8)).toBe(8);
+        });
+
+        it('should return shortestId length if it is longer than minLen', () => {
+            expect(getChangeIdDisplayLength('abcdefghij', 4)).toBe(10);
+        });
+    });
+
+    describe('formatDisplayChangeId', () => {
+        const fullId = 'abcdefghijklmnopqrstuvwxyz';
+
+        it('should use minLen if shortestId is missing', () => {
+            expect(formatDisplayChangeId(fullId, undefined, 8)).toBe('abcdefgh');
+        });
+
+        it('should use minLen if shortestId is shorter than minLen', () => {
+            expect(formatDisplayChangeId(fullId, 'abc', 8)).toBe('abcdefgh');
+        });
+
+        it('should use shortestId length if it is longer than minLen', () => {
+            expect(formatDisplayChangeId(fullId, 'abcdefghij', 4)).toBe('abcdefghij');
+        });
+
+        it('should handle short full ID', () => {
+            expect(formatDisplayChangeId('abc', 'abc', 8)).toBe('abc');
+        });
+    });
+});

--- a/src/test/layout-utils.test.ts
+++ b/src/test/layout-utils.test.ts
@@ -16,22 +16,25 @@ describe('Layout Utils', () => {
     });
 
     describe('computeMaxShortestIdLength', () => {
-        it('should return 8 for empty commit list', () => {
-            expect(computeMaxShortestIdLength([])).toBe(8);
+        it('should return minLen for empty commit list', () => {
+            expect(computeMaxShortestIdLength([], 8)).toBe(8);
+            expect(computeMaxShortestIdLength([], 1)).toBe(1);
         });
 
-        it('should return 8 if no shortest IDs are present', () => {
+        it('should return minLen if no shortest IDs are present', () => {
             const commits = [{ change_id_shortest: undefined }, {}];
-            expect(computeMaxShortestIdLength(commits)).toBe(8);
+            expect(computeMaxShortestIdLength(commits, 8)).toBe(8);
+            expect(computeMaxShortestIdLength(commits, 12)).toBe(12);
         });
 
-        it('should return the maximum length of shortest IDs', () => {
+        it('should return the maximum length of shortest IDs if greater than minLen', () => {
             const commits = [
                 { change_id_shortest: 'abc' },
                 { change_id_shortest: 'abcde' },
                 { change_id_shortest: 'ab' },
             ];
-            expect(computeMaxShortestIdLength(commits)).toBe(5);
+            expect(computeMaxShortestIdLength(commits, 1)).toBe(5);
+            expect(computeMaxShortestIdLength(commits, 8)).toBe(8);
         });
 
         it('should ignore undefined shortest IDs', () => {
@@ -39,7 +42,7 @@ describe('Layout Utils', () => {
                 { change_id_shortest: 'abc' },
                 { change_id_shortest: undefined },
             ];
-            expect(computeMaxShortestIdLength(commits)).toBe(3);
+            expect(computeMaxShortestIdLength(commits, 1)).toBe(3);
         });
     });
 

--- a/src/utils/jj-utils.ts
+++ b/src/utils/jj-utils.ts
@@ -21,3 +21,34 @@ export function convertJjChangeIdToHex(jjChangeId: string): string {
     }
     return result;
 }
+
+/**
+ * Shortens a change ID to at least minLen characters.
+ * If changeId is shorter than minLen, it returns the full ID.
+ */
+export function shortenChangeId(changeId: string, minLen: number): string {
+    if (!changeId) {
+        return '';
+    }
+    return changeId.substring(0, Math.max(minLen, 0));
+}
+
+/**
+ * Calculates the total length of the change ID to display,
+ * respecting the unique prefix and the configured minimum length.
+ */
+export function getChangeIdDisplayLength(shortestId: string | undefined, minLen: number): number {
+    return Math.max(minLen, shortestId?.length || 0);
+}
+
+/**
+ * Formats a change ID for display using the unique prefix if available and the configured minimum length.
+ */
+export function formatDisplayChangeId(
+    changeId: string,
+    shortestId: string | undefined,
+    minLen: number,
+): string {
+    const displayLen = getChangeIdDisplayLength(shortestId, minLen);
+    return shortenChangeId(changeId, displayLen);
+}

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -24,6 +24,7 @@ const App: React.FC = () => {
 
     const [view] = React.useState<'graph' | 'details'>(initialView);
     const [commits, setCommits] = React.useState<any[]>((initialData?.payload as any)?.commits || []);
+    const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>((initialData?.payload as any)?.minChangeIdLength || 1);
     // Use ref to access latest commits in event listeners without triggering re-effects
     const commitsRef = React.useRef(commits);
     React.useEffect(() => {
@@ -92,6 +93,9 @@ const App: React.FC = () => {
                 case 'update':
                     if (view === 'graph') {
                         setCommits(message.commits);
+                        if (message.minChangeIdLength !== undefined) {
+                            setMinChangeIdLength(message.minChangeIdLength);
+                        }
                         setLoading(false);
                     }
                     break;
@@ -319,7 +323,12 @@ const App: React.FC = () => {
                         }
                     }}
                 >
-                    <CommitGraph commits={commits} onAction={handleGraphAction} selectedCommitIds={selectedCommitIds} />
+                    <CommitGraph 
+                        commits={commits} 
+                        onAction={handleGraphAction} 
+                        selectedCommitIds={selectedCommitIds} 
+                        minChangeIdLength={minChangeIdLength}
+                    />
                 </div>
                 {/* 
                   snapCenterToCursor ensures the preview is always centered on the mouse, 
@@ -340,7 +349,11 @@ const App: React.FC = () => {
                                 }}
                             />
                         ) : activeDragItem.type === 'commit' ? (
-                            <CommitDragPreview commit={activeDragItem} isCtrlPressed={isCtrlPressed} />
+                            <CommitDragPreview 
+                                commit={activeDragItem} 
+                                isCtrlPressed={isCtrlPressed} 
+                                minChangeIdLength={minChangeIdLength}
+                            />
                         ) : null
                     ) : null}
                 </DragOverlay>

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -63,6 +63,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                 <h2 style={{ margin: '0 0 10px 0' }}>Commit Details</h2>
                 <div
                     style={{ fontSize: '12px', color: 'var(--vscode-descriptionForeground)', fontFamily: 'monospace' }}
+                    title={changeId}
                 >
                     ID: {changeId}
                 </div>

--- a/src/webview/components/CommitDragPreview.tsx
+++ b/src/webview/components/CommitDragPreview.tsx
@@ -4,11 +4,13 @@
  */
 
 import * as React from 'react';
+import { getChangeIdDisplayLength, shortenChangeId } from '../../utils/jj-utils';
 
 export const CommitDragPreview: React.FC<{
     commit: any; // Simplified commit object or drag data
     isCtrlPressed: boolean;
-}> = ({ commit, isCtrlPressed }) => {
+    minChangeIdLength: number;
+}> = ({ commit, isCtrlPressed, minChangeIdLength }) => {
     // Mode Logic
     const mode = isCtrlPressed ? 'revision' : 'source';
     const isRevisionMode = mode === 'revision';
@@ -20,8 +22,9 @@ export const CommitDragPreview: React.FC<{
 
     // ID Formatting
     const fullId = commit.commitId || '';
-    const shortId = commit.change_id_shortest || fullId.substring(0, 8);
-    const remainderId = fullId.substring(shortId.length, 8);
+    const idDisplayLength = getChangeIdDisplayLength(commit.change_id_shortest, minChangeIdLength);
+    const shortId = commit.change_id_shortest || shortenChangeId(fullId, idDisplayLength);
+    const remainderId = fullId.substring(shortId.length, idDisplayLength);
 
     return (
         <div

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -13,9 +13,10 @@ interface CommitGraphProps {
     commits: any[];
     onAction: (action: string, payload: ActionPayload) => void;
     selectedCommitIds?: Set<string>;
+    minChangeIdLength: number;
 }
 
-export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, selectedCommitIds }) => {
+export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, selectedCommitIds, minChangeIdLength }) => {
     const layout = React.useMemo(() => computeGraphLayout(commits), [commits]);
     const displayRows = layout.rows || commits;
 
@@ -53,7 +54,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({ commits, onAction, sel
     const GAP = computeGap(fontSize);
     
     // Determine the max shortest ID length to display
-    const maxShortestIdLength = React.useMemo(() => computeMaxShortestIdLength(commits), [commits]);
+    const maxShortestIdLength = React.useMemo(() => computeMaxShortestIdLength(commits, minChangeIdLength), [commits, minChangeIdLength]);
 
     const hasImmutableSelection = React.useMemo(() => {
         if (!selectedCommitIds || selectedCommitIds.size === 0) {

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -208,9 +208,11 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                     {commit.change_id_shortest ? (
                         <>
                             <span style={{ fontWeight: 'bold' }}>{commit.change_id_shortest}</span>
-                            <span style={{ opacity: 0.5 }}>
-                                {commit.change_id.substring(commit.change_id_shortest.length, idDisplayLength)}
-                            </span>
+                            {commit.change_id.length > commit.change_id_shortest.length && (
+                                <span style={{ opacity: 0.6 }}>
+                                    {commit.change_id.substring(commit.change_id_shortest.length, idDisplayLength)}
+                                </span>
+                            )}
                         </>
                     ) : (
                         commit.change_id.substring(0, idDisplayLength)

--- a/src/webview/layout-utils.ts
+++ b/src/webview/layout-utils.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getChangeIdDisplayLength } from '../utils/jj-utils';
+
 /**
  * Calculates the gap between the commit graph and the text content based on font size.
  * Currently set to 0.5 * fontSize.
@@ -19,17 +21,11 @@ export interface ShortestIdCommit {
 }
 
 /**
- * Determines the maximum length of the shortest unique change ID prefix in the given list of commits.
- * Returns 8 as a fallback if no shortest IDs are available.
+ * Determines the maximum length of the shortest unique change ID prefix in the given list of commits,
+ * but at least minLen.
  */
-export function computeMaxShortestIdLength(commits: ShortestIdCommit[]): number {
-    let max = 0;
-    for (const commit of commits) {
-        if (commit.change_id_shortest) {
-            max = Math.max(max, commit.change_id_shortest.length);
-        }
-    }
-    return max > 0 ? max : 8;
+export function computeMaxShortestIdLength(commits: ShortestIdCommit[], minLen: number): number {
+    return commits.reduce((max, commit) => Math.max(max, getChangeIdDisplayLength(commit.change_id_shortest, minLen)), minLen);
 }
 
 /**


### PR DESCRIPTION
- Implement jj-view.minChangeIdLength setting to control the minimum length of change IDs displayed in the UI.
- Centralize change ID formatting logic in jj-utils.ts.
- Update SCM provider, log webview, and React components to respect the new setting.
- Refine SCM resource group labels: "Working Copy - <change_id>" and "Merge Conflicts".
- Add unit tests for the new utility functions.
- Update README.md with the new setting documentation.

This addresses the request for a min change id length setting in #70 