### PR TITLE
Fix Gerrit upload error: "r.substring is not a function"

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -7,14 +7,15 @@ import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
 
 import { GerritService } from '../gerrit-service';
-import { showJjError, withDelayedProgress } from './command-utils';
+import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function uploadCommand(
     jj: JjService,
     gerrit: GerritService,
-    revision: string,
+    args: unknown[],
     outputChannel: vscode.OutputChannel
 ): Promise<void> {
+    const revision = extractRevision(args) || '@';
     const config = vscode.workspace.getConfiguration('jj-view');
     const customCommand = config.get<string>('uploadCommand');
     const hasCustomCommand = !!(customCommand && customCommand.trim().length > 0);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,8 +188,8 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('jj-view.upload', async (revision: string) => {
-            await uploadCommand(jj, gerritService, revision, outputChannel);
+        vscode.commands.registerCommand('jj-view.upload', async (...args: unknown[]) => {
+            await uploadCommand(jj, gerritService, args, outputChannel);
         }),
     );
 

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -44,13 +44,12 @@ describe('uploadCommand', () => {
 
     test('uses custom upload command when configured (correctly)', async () => {
         // Setup config to return 'git push --force' ONLY when queried for 'uploadCommand'
-        // The current bug queries 'jj-view.uploadCommand', which should return undefined here
         mockConfig.get.mockImplementation((key: string) => {
             if (key === 'uploadCommand') return 'git push --force';
             return undefined;
         });
 
-        await uploadCommand(jjService, gerritService, 'rev-123', mockOutputChannel);
+        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         // Should use the custom command
         expect(jjService.upload).toHaveBeenCalledWith(['git', 'push', '--force'], 'rev-123');
@@ -60,11 +59,20 @@ describe('uploadCommand', () => {
     test('falls back to default when custom command is empty', async () => {
         mockConfig.get.mockReturnValue(undefined);
         
-        await uploadCommand(jjService, gerritService, 'rev-123', mockOutputChannel);
+        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
         
         // Default for non-Gerrit is git push
         expect(jjService.upload).toHaveBeenCalledWith(['git', 'push'], 'rev-123');
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
+    });
+
+    test('extracts revision from object payload (repro for r.substring error)', async () => {
+        mockConfig.get.mockReturnValue(undefined);
+        
+        // This simulates the webview payload: { changeId: 'rev-object' }
+        await uploadCommand(jjService, gerritService, [{ changeId: 'rev-object' }], mockOutputChannel);
+        
+        expect(jjService.upload).toHaveBeenCalledWith(['git', 'push'], 'rev-object');
     });
 
     test('suggests configuration when upload fails and no custom command set', async () => {
@@ -79,7 +87,7 @@ describe('uploadCommand', () => {
         ) => Thenable<string | undefined>;
         vi.mocked(showErrorMessage).mockResolvedValue('Configure Upload...');
 
-        await uploadCommand(jjService, gerritService, 'rev-123', mockOutputChannel);
+        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('Upload failed: upload failed'),
@@ -106,7 +114,7 @@ describe('uploadCommand', () => {
         ) => Thenable<string | undefined>;
         vi.mocked(showErrorMessage).mockResolvedValue('Show Log');
 
-        await uploadCommand(jjService, gerritService, 'rev-123', mockOutputChannel);
+        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('Upload failed: upload failed'),


### PR DESCRIPTION
The `uploadCommand` was expecting a revision string but receiving an object payload from the webview. This refactors the command to use `extractRevision` which handles both formats robustly.

- Refactor `uploadCommand` to accept generic `args: unknown[]`.
- Update `jj-view.upload` registration in `extension.ts`.
- Update unit tests and add reproduction case for object payload.