### PR TITLE
Fix visibility of "Squash" inline actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,25 +400,25 @@
                     "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/"
                 },
                 {
-                    "command": "jj-view.squash",
-                    "group": "inline@3",
-                    "when": "scmResourceState == 'jj.resource.workingCopy:squashable' || scmResourceState == 'jj.resource.ancestor:squashable'"
-                },
-                {
                     "command": "jj-view.squashInto",
                     "group": "inline@3",
-                    "when": "scmResourceState == 'jj.resource.workingCopy:squashable:multi' || scmResourceState == 'jj.resource.ancestor:squashable:multi'"
+                    "when": "scmResourceState =~ /jj\\.resource.*:squashable:multi/"
                 },
                 {
-                    "command": "jj-view.moveToChild",
-                    "icon": "$(git-merge)",
+                    "command": "jj-view.squash",
                     "group": "inline@4",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.ancestor/"
+                    "when": "scmResourceState =~ /jj\\.resource.*:squashable/"
                 },
                 {
                     "command": "jj-view.moveToChild",
                     "icon": "$(git-merge)",
                     "group": "inline@5",
+                    "when": "scmResourceState =~ /^jj\\.resource\\.ancestor/"
+                },
+                {
+                    "command": "jj-view.moveToChild",
+                    "icon": "$(git-merge)",
+                    "group": "inline@6",
                     "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/ && jj.hasChild"
                 }
             ],

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -299,6 +299,11 @@ test.describe('SCM Pane E2E', () => {
             const newWcFileRow = page.getByRole('treeitem', { name: /file3\.txt, modified/ }).first();
             await expect(newWcFileRow).toBeVisible({ timeout: 5000 });
             
+            // Hover to reveal inline actions
+            await newWcFileRow.hover();
+            const squashIcon = newWcFileRow.getByRole('button', { name: 'Squash into Parent', exact: true }).first();
+            await expect(squashIcon).toBeVisible();
+
             // The squashInto action should be visible because we have two mutable ancestors (the previous wc commit, and initial).
             const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash into Ancestor/ }).first();
             await hoverAndClick(newWcFileRow, squashIntoIcon);


### PR DESCRIPTION
The `when` clauses for the "Squash into Parent" and "Squash into Ancestor" inline actions previously only checked for exact matches. This meant the buttons were hidden when multiple ancestors were present (which adds the  `:multi` suffix). This changes the `when` clauses to use a unified regex  that matches the `:multi` suffix as well.

It also updates the E2E tests to hover over the file row before verifying inline action visibility, as these are only rendered on hover in VS Code.