### PR TITLE
fix(gerrit): ensure children inherit needsUpload status from parents

### DIFF
--- a/src/gerrit-service.ts
+++ b/src/gerrit-service.ts
@@ -514,4 +514,61 @@ export class GerritService implements vscode.Disposable {
             this.outputChannel?.appendLine(`[GerritService] Sync verification failed for ${commitId}: ${e}`);
         }
     }
+
+    /**
+     * Hydrates a list of commits with Gerrit information, including inherited
+     * 'needsUpload' statuses based on the commit graph.
+     */
+    public populateGerritInfo(commits: import('./jj-types').JjLogEntry[]): void {
+        if (!this.isEnabled) {
+            return;
+        }
+
+        const commitMap = new Map<string, import('./jj-types').JjLogEntry>();
+        for (const commit of commits) {
+            if (commit.commit_id) {
+                commitMap.set(commit.commit_id, commit);
+                commit.gerritCl = this.getCachedClStatus(
+                    commit.change_id,
+                    commit.description
+                );
+            }
+        }
+
+        const needsUploadCache = new Map<string, boolean>();
+        const computeNeedsUpload = (commitId: string): boolean => {
+            if (needsUploadCache.has(commitId)) {
+                return needsUploadCache.get(commitId)!;
+            }
+            
+            const commit = commitMap.get(commitId);
+            if (!commit) {
+                return false;
+            }
+            
+            let needsUpload = false;
+            const gerritCl = commit.gerritCl;
+            if (gerritCl && gerritCl.status === 'NEW' && !(gerritCl.currentRevision === commit.commit_id || gerritCl.synced)) {
+                needsUpload = true;
+            }
+            
+            if (!needsUpload && commit.parents) {
+                for (const parentId of commit.parents) {
+                    if (computeNeedsUpload(parentId)) {
+                        needsUpload = true;
+                        break;
+                    }
+                }
+            }
+            
+            needsUploadCache.set(commitId, needsUpload);
+            return needsUpload;
+        };
+
+        for (const commit of commits) {
+            if (commit.commit_id && commit.gerritCl && commit.gerritCl.status === 'NEW') {
+                commit.gerritNeedsUpload = computeNeedsUpload(commit.commit_id);
+            }
+        }
+    }
 }

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -228,14 +228,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
 
         if (this._gerrit.isEnabled) {
-            for (const commit of commits) {
-                if (commit.commit_id) {
-                    commit.gerritCl = this._gerrit.getCachedClStatus(
-                        commit.change_id,
-                        commit.description
-                    );
-                }
-            }
+            this._gerrit.populateGerritInfo(commits);
         } else {
             this.outputChannel?.appendLine('[JjLogWebviewProvider] Gerrit service is disabled.');
         }

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -45,6 +45,7 @@ export interface JjLogEntry {
     conflict?: boolean;
     changes?: JjStatusEntry[];
     gerritCl?: GerritClInfo;
+    gerritNeedsUpload?: boolean;
 }
 
 export interface JjStatusEntry {

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -7,6 +7,8 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GerritService } from '../gerrit-service';
 import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
+import { JjLogEntry } from '../jj-types';
+import { createMock } from './test-utils';
 
 vi.mock('vscode', () => ({
     workspace: {
@@ -174,5 +176,126 @@ describe('Gerrit Sync Verification', () => {
 
         // When revisions match, synced should not be set (it's already up to date — no need)
         expect(result?.synced).toBeUndefined();
+    });
+
+    describe('populateGerritInfo', () => {
+        beforeEach(async () => {
+             service = new GerritService(repo.path, jjService);
+             await service.awaitReady();
+        });
+
+        test('computes gerritNeedsUpload for a single out-of-sync commit', () => {
+            const commit = createMock<JjLogEntry>({
+                commit_id: 'c1',
+                change_id: 'I1',
+                description: 'desc',
+                author: { name: 'A', email: 'a@e.com', timestamp: '' },
+                committer: { name: 'A', email: 'a@e.com', timestamp: '' },
+                parents: [],
+            });
+
+            // Mock cache
+            vi.spyOn(service, 'getCachedClStatus').mockReturnValue({
+                changeId: 'I1',
+                changeNumber: 1,
+                status: 'NEW',
+                submittable: false,
+                url: '',
+                unresolvedComments: 0,
+                currentRevision: 'old-sha', // Out of sync
+                synced: false
+            });
+
+            service.populateGerritInfo([commit]);
+
+            expect(commit.gerritNeedsUpload).toBe(true);
+        });
+
+        test('computes gerritNeedsUpload recursively for descendants of out-of-sync commits', () => {
+            const c1 = createMock<JjLogEntry>({
+                commit_id: 'c1',
+                change_id: 'I1',
+                description: 'desc1',
+                author: { name: 'A', email: 'a@e.com', timestamp: '' },
+                committer: { name: 'A', email: 'a@e.com', timestamp: '' },
+                parents: [],
+            });
+            const c2 = createMock<JjLogEntry>({
+                commit_id: 'c2',
+                change_id: 'I2',
+                description: 'desc2',
+                author: { name: 'A', email: 'a@e.com', timestamp: '' },
+                committer: { name: 'A', email: 'a@e.com', timestamp: '' },
+                parents: ['c1'], // Child of c1
+            });
+            const c3 = createMock<JjLogEntry>({
+                commit_id: 'c3',
+                change_id: 'I3',
+                description: 'desc3',
+                author: { name: 'A', email: 'a@e.com', timestamp: '' },
+                committer: { name: 'A', email: 'a@e.com', timestamp: '' },
+                parents: ['c2'], // Child of c2
+            });
+
+            vi.spyOn(service, 'getCachedClStatus').mockImplementation((changeId) => {
+                if (changeId === 'I1') {
+                    return {
+                        changeId: 'I1',
+                        changeNumber: 1,
+                        status: 'NEW',
+                        submittable: false,
+                        url: '',
+                        unresolvedComments: 0,
+                        currentRevision: 'old-sha', // Out of sync
+                        synced: false
+                    };
+                }
+                if (changeId === 'I2' || changeId === 'I3') {
+                    return {
+                        changeId,
+                        changeNumber: 2,
+                        status: 'NEW',
+                        submittable: false,
+                        url: '',
+                        unresolvedComments: 0,
+                        currentRevision: changeId === 'I2' ? 'c2' : 'c3', // In sync directly
+                        synced: true
+                    };
+                }
+                return undefined;
+            });
+
+            service.populateGerritInfo([c1, c2, c3]);
+
+            expect(c1.gerritNeedsUpload).toBe(true); // Direct
+            expect(c2.gerritNeedsUpload).toBe(true); // Inherited from c1
+            expect(c3.gerritNeedsUpload).toBe(true); // Inherited transitively from c1
+        });
+
+        test('does not set gerritNeedsUpload if all are in sync', () => {
+            const commit = createMock<JjLogEntry>({
+                commit_id: 'c1',
+                change_id: 'I1',
+                description: 'desc',
+                author: { name: 'A', email: 'a@e.com', timestamp: '' },
+                committer: { name: 'A', email: 'a@e.com', timestamp: '' },
+                parents: [],
+            });
+
+            vi.spyOn(service, 'getCachedClStatus').mockReturnValue({
+                changeId: 'I1',
+                changeNumber: 1,
+                status: 'NEW',
+                submittable: false,
+                url: '',
+                unresolvedComments: 0,
+                currentRevision: 'c1', // In sync
+                synced: true
+            });
+
+            service.populateGerritInfo([commit]);
+
+            expect(commit.gerritNeedsUpload).toBe(false);
+        });
     });
 });

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -432,7 +432,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
 
                         {/* Sync Status Button or Icon */}
                         {gerritCl.status === 'NEW' &&
-                            (gerritCl.currentRevision === commit.commit_id || gerritCl.synced ? (
+                            (!commit.gerritNeedsUpload ? (
                                 // Synced - Non-interactive Icon
                                 <div
                                     title={gerritCl.synced ? "Synced (content matches Gerrit)" : "Up to date with Gerrit"}


### PR DESCRIPTION
If any commits in a chain require an upload, all of its descendants must also be uploaded to keep the remote branch structure intact. Previously this status did not correctly cascade to children in the UI.

This fix delegates the dependency graph calculation to a new centralized `GerritService.populateGerritInfo` method which populates a single `gerritNeedsUpload` UI flag.