### PR TITLE
fix: curve graph edges earlier to avoid intersecting nodes

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -69,12 +69,14 @@ export class JjService {
         let repoReal = repoRoot;
         let workspaceReal = this.workspaceRoot;
 
-        try { repoReal = await fs.realpath(repoRoot); } catch {}
-        try { workspaceReal = await fs.realpath(this.workspaceRoot); } catch {}
+        try {
+            repoReal = await fs.realpath(repoRoot);
+        } catch {}
+        try {
+            workspaceReal = await fs.realpath(this.workspaceRoot);
+        } catch {}
 
-        const relativeToWorkspace = path.isAbsolute(filePath)
-            ? path.relative(this.workspaceRoot, filePath)
-            : filePath;
+        const relativeToWorkspace = path.isAbsolute(filePath) ? path.relative(this.workspaceRoot, filePath) : filePath;
 
         const repoToWorkspace = path.relative(repoReal, workspaceReal);
         return path.normalize(path.join(repoToWorkspace, relativeToWorkspace));

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -20,7 +20,7 @@ function renderToAscii(
             change_id: string;
             description: string;
         }[];
-        edges: { x1: number; y1: number; x2: number; y2: number }[];
+        edges: { x1: number; y1: number; x2: number; y2: number; curveY?: number; isJoining?: boolean }[];
     },
     headId: string,
 ): string {
@@ -46,13 +46,9 @@ function renderToAscii(
         const edgeRoutes = layout.edges.map((e) => {
             if (e.x1 === e.x2) return { ...e, yBend: e.y1 }; // Straight
 
-            let lastY = e.y1;
-            for (const n of layout.nodes) {
-                if (n.x === e.x2 && n.y > e.y1 && n.y < e.y2) {
-                    lastY = Math.max(lastY, n.y);
-                }
-            }
-            return { ...e, yBend: lastY + 0.5 };
+            // jj log curves around row offsets. It typically curves just before the target
+            // row `curveY`, so visual yBend is exactly midway above curveY
+            return { ...e, yBend: (e.curveY ?? e.y2) - 0.5 };
         });
 
         // 1. Commit Row
@@ -76,7 +72,7 @@ function renderToAscii(
                         return e.x1 === x && Math.min(e.y1, e.y2) < node.y && Math.max(e.y1, e.y2) > node.y;
                     } else {
                         if (x === e.x1 && node.y < e.yBend && node.y > e.y1) return true;
-                        if (x === e.x2 && node.y > e.yBend && node.y < e.y2) return true;
+                        if (x === e.x2 && node.y > e.yBend && node.y < e.y2 && !e.isJoining) return true;
                         return false;
                     }
                 });
@@ -87,10 +83,28 @@ function renderToAscii(
                 lineStr += ' ';
             }
         }
-        while (lineStr.length < width * 2 - 1) {
-            lineStr += ' ';
-        }
-        rows.push(`${lineStr.trimEnd()}  ${log.change_id.substring(0, 8)} ${log.description.split('\n')[0]}`.trimEnd());
+        // Find furthest active lane for this row to determine padding width
+        let maxActiveLane = node.x;
+        edgeRoutes.forEach((e) => {
+            if (e.y2 >= layout.rows.length - 1) return; // Skip edges to root marker
+            if (e.y1 === node.y) {
+                // If an edge originates from this node (a fork), the target lane is active
+                maxActiveLane = Math.max(maxActiveLane, e.x2);
+            }
+            if (e.x1 === e.x2) {
+                if (Math.min(e.y1, e.y2) < node.y && Math.max(e.y1, e.y2) > node.y)
+                    maxActiveLane = Math.max(maxActiveLane, e.x1);
+            } else {
+                if (node.y < e.yBend && node.y > e.y1) maxActiveLane = Math.max(maxActiveLane, e.x1);
+                if (node.y > e.yBend && node.y < e.y2) maxActiveLane = Math.max(maxActiveLane, e.x2);
+            }
+        });
+
+        const paddedStr = lineStr.trimEnd();
+        const requiredLength = maxActiveLane * 2 + 1;
+        const finalStr = paddedStr.padEnd(requiredLength, ' ');
+
+        rows.push(`${finalStr}  ${log.change_id.substring(0, 8)} ${log.description.split('\n')[0]}`.trimEnd());
 
         if (log.parents.length === 0) {
             continue; // No spacer rows needed after a root commit.
@@ -216,7 +230,7 @@ function renderToAscii(
                             } else {
                                 // Diagonal edge: occupies x1 before yBend, and x2 after yBend
                                 if (x === e.x1 && yMid < e.yBend && yMid > e.y1) return true;
-                                if (x === e.x2 && yMid > e.yBend && yMid < e.y2) return true;
+                                if (x === e.x2 && yMid >= e.yBend && yMid < e.y2 && !e.isJoining) return true;
                                 return false;
                             }
                         });
@@ -538,6 +552,66 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
 
         const headLog = logs.find((l) => l.is_working_copy);
         const headId = headLog ? headLog.change_id : '';
+
+        const userTemplate = 'change_id.shortest(8) ++ " " ++ description ++ "\\n\\n"';
+        const expectedOutput = repo.getLogOutput(userTemplate).trim();
+        const generatedOutput = renderToAscii(layout, headId).trim();
+
+        expect(generatedOutput).toBe(expectedOutput);
+    });
+
+    test('Multiple Children Curve Routing (Stack Layout Fix)', async () => {
+        // Setup:
+        // Root -> P
+        // P -> A
+        // P -> B
+        // P -> C
+        await buildGraph(repo, [
+            { label: 'root', description: 'Root' },
+            { label: 'p', description: 'P', parents: ['root'] },
+            { label: 'a', description: 'A', parents: ['p'] },
+            { label: 'b', description: 'B', parents: ['p'] },
+            { label: 'c', description: 'C', parents: ['p'], isWorkingCopy: true },
+        ]);
+
+        const logs = await jjService.getLog();
+        const layout = computeGraphLayout(logs);
+
+        const headLog = logs.find((l) => l.is_working_copy);
+        const headId = headLog ? headLog.change_id : '';
+
+        const userTemplate = 'change_id.shortest(8) ++ " " ++ description ++ "\\n\\n"';
+        const expectedOutput = repo.getLogOutput(userTemplate).trim();
+        const generatedOutput = renderToAscii(layout, headId).trim();
+
+        expect(generatedOutput).toBe(expectedOutput);
+    });
+
+    test('Complex Overlapping Multi-Child Layout (Issue with lanes assigned incorrectly)', async () => {
+        await buildGraph(repo, [
+            { label: 'lv', description: 'lv' },
+            { label: 'vq', description: 'vq', parents: ['lv'] },
+            { label: 'mp', description: 'mp', parents: ['vq'] },
+            { label: 'xn', description: 'xn', parents: ['lv'] },
+            { label: 'yz', description: 'yz', parents: ['lv'] },
+            { label: 'on', description: 'on', parents: ['lv'] },
+            { label: 'zo', description: 'zo', parents: ['lv'] },
+            { label: 'kp', description: 'kp', parents: ['vq', 'zo'] },
+            { label: 'lr', description: 'lr', parents: ['kp'] },
+            { label: 'pl', description: 'pl', parents: ['lr'] },
+            { label: 'mn', description: 'mn', parents: ['pl'] },
+            { label: 'tx', description: 'tx', parents: ['pl'] },
+            { label: 'rt', description: 'rt', parents: ['kp'] },
+            { label: 'po', description: 'po', parents: ['rt'] },
+            { label: 'sm', description: 'sm', parents: ['po'] },
+            { label: 'yu', description: 'yu', parents: ['sm'] },
+            { label: 'vx', description: 'vx', parents: ['yu'] },
+            { label: 'ux', description: 'ux', parents: ['vx'] },
+            { label: 'wr', description: 'wr', parents: ['ux'], isWorkingCopy: true },
+        ]);
+
+        const layout = computeGraphLayout(await jjService.getLog());
+        const headId = layout.nodes[0].changeId;
 
         const userTemplate = 'change_id.shortest(8) ++ " " ++ description ++ "\\n\\n"';
         const expectedOutput = repo.getLogOutput(userTemplate).trim();

--- a/src/test/subdirectory-mapping.test.ts
+++ b/src/test/subdirectory-mapping.test.ts
@@ -28,13 +28,13 @@ describe('JjService Subdirectory Mapping', () => {
         const subService = new JjService(workspacePath);
         const discoveredRoot = await subService.getRepoRoot();
 
-        // Ask jj to evaluate the repository root from the top-level repo path 
-        // to get the exact canonicalized string format that Rust generates 
-        // for this system. This avoids Node.js string-matching quirks with 
+        // Ask jj to evaluate the repository root from the top-level repo path
+        // to get the exact canonicalized string format that Rust generates
+        // for this system. This avoids Node.js string-matching quirks with
         // Windows 8.3 short paths or macOS symlinks altogether!
         const rootService = new JjService(repo.path);
         const expectedRoot = await rootService.getRepoRoot();
-        
+
         expect(discoveredRoot).toBe(expectedRoot);
     });
 

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -53,10 +53,17 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
             // Straight Vertical
             d = `M ${sx} ${sy} L ${ex} ${ey}`;
         } else {
-            // Rail Routing: Bend at the row boundary just above the parent to keep the structure clean.
-            // We use the top of the parent's row as the midpoint for the S-curve.
-            const prevRowY = rowOffsets[y2] ? rowOffsets[y2] - ROW_HEADER_HEIGHT : ey - ROW_HEADER_HEIGHT;
-            const midY = prevRowY + ROW_HEADER_HEIGHT;
+            // Rail Routing
+            const cY = edge.curveY ?? y2;
+            let midY: number;
+
+            if (rowOffsets[cY] !== undefined) {
+                // S-curve crosses boundary right above the curve row
+                midY = rowOffsets[cY];
+            } else {
+                // If it curves offscreen, use ey but subtract the offset to get the row boundary
+                midY = ey - CY_OFFSET;
+            }
 
             // Direction for horizontal
             const dirX = x2 > x1 ? 1 : -1;
@@ -86,8 +93,10 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
             // End: (ex, midY + R)
             d += ` Q ${ex} ${midY} ${ex} ${midY + R}`;
 
-            // Vertical to End
-            d += ` L ${ex} ${ey}`;
+            if (!edge.isJoining) {
+                // Vertical to End
+                d += ` L ${ex} ${ey}`;
+            }
         }
 
         return (

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -134,27 +134,62 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
     // 5. Resolve Edges
     pendingEdges.forEach((pe) => {
         const target = nodeMap.get(pe.targetCommitId);
+        let targetX: number;
+        let targetY: number;
+
+        let isJoining = false;
         if (target) {
-            edges.push({
-                x1: pe.x1,
-                y1: pe.y1,
-                x2: target.x,
-                y2: target.y,
-                color: pe.color,
-                type: 'parent',
-            });
+            targetY = target.y;
+            // Cross-lane edges (pe.x1 !== pe.targetLane) are "joining" an existing
+            // vertical line in pe.targetLane. They should merge into that lane, not
+            // chase the target if it later moved to a different lane.
+            // Same-lane edges (pe.x1 === pe.targetLane) "own" the lane and follow
+            // the target to its final position (e.g. when a later sibling rebalances
+            // the parent leftward).
+            targetX = pe.x1 !== pe.targetLane ? pe.targetLane : target.x;
+
+            // For joining edges where the target moved lanes (targetX !== target.x),
+            // cap y2 at the curveY of the "owning" edge — the edge that travels
+            // vertically through pe.targetLane and then curves to target.x.
+            // This prevents the joining edge from drawing a vertical line past
+            // where the lane actually curves away.
+            if (targetX !== target.x) {
+                const ownerEdge = edges.find((e) => e.x1 === pe.targetLane && e.x2 === target.x && e.y2 === target.y);
+
+                if (ownerEdge) {
+                    targetY = ownerEdge.curveY ?? ownerEdge.y2;
+                    isJoining = true;
+                }
+            }
         } else {
-            // Parent is off-screen.
-            // Draw to the bottom of the graph at the assigned lane.
-            edges.push({
-                x1: pe.x1,
-                y1: pe.y1,
-                x2: pe.targetLane,
-                y2: sortedRows.length,
-                color: pe.color,
-                type: 'parent',
-            });
+            targetX = pe.targetLane;
+            targetY = sortedRows.length;
         }
+
+        let curveY = targetY;
+        if (pe.x1 !== targetX) {
+            // For joining edges, also check the target lane for blocking nodes.
+            // Owning edges only check their source lane — they travel vertically
+            // through the source lane and curve at the end.
+            const checkTargetLane = pe.x1 !== pe.targetLane;
+            for (let y = pe.y1 + 1; y < targetY; y++) {
+                if (nodes[y] && (nodes[y].x === pe.x1 || (checkTargetLane && nodes[y].x === targetX))) {
+                    curveY = y;
+                    break;
+                }
+            }
+        }
+
+        edges.push({
+            x1: pe.x1,
+            y1: pe.y1,
+            x2: targetX,
+            y2: targetY,
+            curveY,
+            color: pe.color,
+            type: 'parent',
+            isJoining,
+        });
     });
 
     const width = Math.max(

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -22,8 +22,10 @@ export interface GraphEdge {
     y1: number;
     x2: number;
     y2: number;
+    curveY?: number; // Row index where the line bends horizontally
     color: string;
     type: 'parent' | 'merge'; // 'parent' usually means from Child -> Parent (Vertical/Fork). 'merge' means incoming?
+    isJoining?: boolean; // True if this edge seamlessly merges into another edge's trunk
 }
 
 export interface GraphLayout {


### PR DESCRIPTION
Updates the graph routing logic to route edges cleanly around nodes in the same lane.
- Computes `curveY` and `isJoining` properties during graph layout to identify where edges should bend to avoid collisions.
- Refines `GraphRail` S-curve rendering to bend at `curveY` rather than just above the parent.
- Fixes visual overlap bugs where edges incorrectly drew straight through unrelated nodes.
- Adds routing tests in `graph-curve-y.test.ts` and updates existing expected layout outputs.

This should fix #92 as well as a number of other graph rendering bugs