### PR TITLE
fix: auto-update commit details panel

### DIFF
--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -209,6 +209,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
             // Background fetch Gerrit status for commits
             await this.refreshGerrit();
+
+            // Also refresh details panel if open
+            await this.refreshDetailsPanel();
         }
     }
 
@@ -261,6 +264,56 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     }
 
     private _activeDetailsPanel?: vscode.WebviewPanel;
+    private _currentDetailsChangeId?: string;
+
+    public async refreshDetailsPanel() {
+        if (!this._activeDetailsPanel || !this._currentDetailsChangeId) {
+            return;
+        }
+
+        const changeId = this._currentDetailsChangeId;
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+        const logTheme = config.get<string>('logTheme', 'default');
+        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
+        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
+
+        // Fetch full log entry - this includes description, changes (file list), and immutability status
+        let logs: JjLogEntry[];
+        try {
+            logs = await this._jj.getLog({ revision: changeId });
+        } catch (e) {
+            // Commit no longer exists (e.g. was abandoned)
+            this._activeDetailsPanel.dispose();
+            return;
+        }
+
+        if (logs.length === 0) {
+            this._activeDetailsPanel.dispose();
+            return;
+        }
+
+        const log = logs[0];
+        const filesWithStats = await this._jj.getChanges(changeId).catch(() => log.changes || []);
+
+        this._activeDetailsPanel.webview.postMessage({
+            type: 'updateDetails',
+            payload: {
+                changeId,
+                description: log.description,
+                files: filesWithStats,
+                isImmutable: log.is_immutable,
+                author: log.author,
+                bookmarks: log.bookmarks || [],
+                isEmpty: log.is_empty,
+                isConflict: log.conflict,
+                minChangeIdLength,
+                theme: logTheme,
+                titleWidthRuler,
+                bodyWidthRuler,
+            },
+        });
+    }
 
     public async createCommitDetailsPanel(changeId: string) {
         const config = vscode.workspace.getConfiguration('jj-view');
@@ -299,6 +352,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             },
         };
 
+        this._currentDetailsChangeId = changeId;
+
         if (this._activeDetailsPanel) {
             this._activeDetailsPanel.title = `Commit: ${displayId}`;
             this._activeDetailsPanel.webview.html = this._getHtmlForWebview(
@@ -326,6 +381,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         panel.onDidDispose(() => {
             if (this._activeDetailsPanel === panel) {
                 this._activeDetailsPanel = undefined;
+                this._currentDetailsChangeId = undefined;
                 // Notify graph view to clear selection
                 if (this._view) {
                     this._view.webview.postMessage({ type: 'setSelection', ids: [] });

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -260,6 +260,53 @@ test.describe('Commit Details E2E', () => {
         }).toPass({ timeout: 15000 });
     });
 
+    test('Panel auto-updates when commit description is changed externally', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+
+        // Click to open details
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({
+            timeout: 15000,
+        });
+
+        const details = await getDetailsWebview(page);
+
+        // Verify description is shown in the textarea
+        const textarea = details.locator('textarea');
+        await expect(textarea).toHaveValue(/add feature/);
+
+        // Change the description externally using jj CLI
+        repo.describe('externally updated description', nodes['feature'].changeId);
+
+        // Verify the details panel updates automatically (eventually, as file watcher triggers refresh)
+        // Wait up to 15s since file-watchers and graph rebuilds can take a moment
+        await expect(textarea).toHaveValue(/externally updated description/, { timeout: 15000 });
+    });
+
+    test('Panel auto-closes when commit is abandoned', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+
+        // Click to open details
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        const tabLocator = page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) });
+
+        await expect(tabLocator).toBeVisible({
+            timeout: 15000,
+        });
+
+        // Abandon the commit externally
+        repo.abandon(nodes['feature'].changeId);
+
+        // Verify the details panel closes automatically
+        await expect(tabLocator).toBeHidden({ timeout: 15000 });
+    });
+
     test('Format Body button rewraps text while preserving title separation', async () => {
         const webview = await getLogWebview(page);
         const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -98,8 +98,12 @@ export class TestRepo {
         this.exec(['status']);
     }
 
-    describe(message: string) {
-        this.exec(['describe', '-m', message]);
+    describe(message: string, revision?: string) {
+        const args = ['describe', '-m', message];
+        if (revision) {
+            args.push('-r', revision);
+        }
+        this.exec(args);
     }
 
     getDescription(revision: string): string {

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -40,7 +40,7 @@ const App: React.FC = () => {
     const [selectedCommitIds, setSelectedCommitIds] = React.useState<Set<string>>(new Set());
 
     // Details State
-    const [detailsCommit] = React.useState<any>(initialData?.payload || null);
+    const [detailsCommit, setDetailsCommit] = React.useState<any>(initialData?.payload || null);
 
     // Drag State
     const [activeDragItem, setActiveDragItem] = React.useState<any | null>(null);
@@ -110,7 +110,7 @@ const App: React.FC = () => {
                 case 'updateDetails':
                     // If we get an update while in details view (e.g. after save)
                     if (view === 'details') {
-                        // Optional: update local state if needed via message
+                        setDetailsCommit(message.payload);
                     }
                     break;
                 case 'setSelection':


### PR DESCRIPTION
The commit details panel now automatically updates when the underlying commit's description or files change. It relies on the file watcher to detect changes and push a refresh to the webview.

Additionally, if the commit is abandoned or otherwise disappears from the log output, the details panel will automatically close.

Includes an e2e test verifying the external description update and the auto-close behavior.

Fixes #98 