### PR TITLE
style: improve styling and alignment of status pills in commit details

### DIFF
--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -7,12 +7,14 @@ import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { JjBookmark } from '../../jj-types';
 
-export const BasePill: React.FC<{ children: React.ReactNode; style?: React.CSSProperties; className?: string }> = ({
-    children,
-    style,
-    className,
-}) => (
+export const BasePill: React.FC<{
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+    className?: string;
+    title?: string;
+}> = ({ children, style, className, title }) => (
     <span
+        title={title}
         className={`bookmark-pill ${className || ''}`}
         style={{
             marginRight: '6px',
@@ -25,6 +27,7 @@ export const BasePill: React.FC<{ children: React.ReactNode; style?: React.CSSPr
             justifyContent: 'center',
             flexShrink: 0,
             verticalAlign: 'middle',
+            boxSizing: 'border-box',
             border: '1px solid transparent',
             ...style,
         }}

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import wordWrap from 'word-wrap';
 import { JjStatusEntry } from '../../jj-types';
-import { BookmarkPill } from './Bookmark';
+import { BookmarkPill, BasePill } from './Bookmark';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
 
 interface CommitDetailsProps {
@@ -170,30 +170,38 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
             <div style={{ marginBottom: '12px' }}>
                 <h2 style={{ margin: '0 0 10px 0', display: 'flex', alignItems: 'center', gap: '10px' }}>
                     Commit Details
-                    <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                    <div
+                        style={{
+                            display: 'flex',
+                            gap: '6px',
+                            flexWrap: 'wrap',
+                            fontSize: '11px',
+                            fontWeight: 'normal',
+                        }}
+                    >
                         {isImmutable && (
-                            <span
+                            <BasePill
                                 style={badgeStyle('var(--vscode-gitDecoration-untrackedResourceForeground)')}
                                 title="This commit cannot be modified"
                             >
                                 Immutable
-                            </span>
+                            </BasePill>
                         )}
                         {isEmpty && (
-                            <span
+                            <BasePill
                                 style={badgeStyle('var(--vscode-gitDecoration-ignoredResourceForeground)')}
                                 title="This commit has no file changes"
                             >
                                 Empty
-                            </span>
+                            </BasePill>
                         )}
                         {isConflict && (
-                            <span
+                            <BasePill
                                 style={badgeStyle('var(--vscode-gitDecoration-conflictingResourceForeground)')}
                                 title="This commit has unresolved conflicts"
                             >
-                                Conflict
-                            </span>
+                                Conflicted
+                            </BasePill>
                         )}
                         {bookmarks?.map((b) => (
                             <BookmarkPill key={`${b.name}-${b.remote}`} bookmark={b} />
@@ -548,10 +556,8 @@ function getFileColor(status: string): string {
 
 function badgeStyle(color: string): React.CSSProperties {
     return {
-        fontSize: '10px',
-        padding: '2px 6px',
-        borderRadius: '10px',
-        border: `1px solid ${color}`,
+        border: `1px solid color-mix(in srgb, ${color}, transparent 50%)`,
+        backgroundColor: `color-mix(in srgb, ${color}, transparent 90%)`,
         color: color,
         textTransform: 'uppercase',
         fontWeight: 'bold',


### PR DESCRIPTION
- Change "Conflict" text to "Conflicted" for grammatical consistency with other adjectives
- Refactor the Immutable, Empty, and Conflicted status badges to use the shared `BasePill` component to standardize padding, alignment, and height with bookmark pills
- Use `color-mix` to give the status pills a subtle tinted background and border that matches the bookmark pill aesthetics

Fixes #97 