### PR TITLE
Add more time units to `getRelativeTimeString`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,12 @@
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+
+    "[typescript]": {
+        "editor.rulers": [120]
+    },
+    "[typescriptreact]": {
+        "editor.rulers": [120]
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add more time units to the relative time string (up to years) for
+  author/committer timestamps.
+
 ## 1.20.0
 
 ### Features

--- a/src/test/person-info.test.ts
+++ b/src/test/person-info.test.ts
@@ -47,12 +47,60 @@ describe('PersonInfo Logic', () => {
 
     describe('getRelativeTimeString', () => {
         it('calculates relative time correctly', () => {
-            const now = Date.now();
-            const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString();
-            expect(getRelativeTimeString(oneHourAgo)).toContain('1 hour ago');
+            // Set "now" to be February 10 at 12:34:56 so that we have some wiggle room for testing values in the past.
+            const now = new Date('2026-02-10T12:34:56.000Z').getTime();
 
-            const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
-            expect(getRelativeTimeString(twoDaysAgo)).toContain('2 days ago');
+            // Timestamp in the future.
+            expect(getRelativeTimeString('2026-03-01', now)).toEqual('2026-03-01');
+
+            // Same timestamp.
+            expect(getRelativeTimeString(new Date(now).toISOString(), now)).toEqual('just now');
+            // Difference is less than 1 second.
+            expect(getRelativeTimeString('2026-02-10T12:34:55.001Z', now)).toEqual('just now');
+
+            // Difference is less than 1 minute.
+            expect(getRelativeTimeString('2026-02-10T12:34:55.000Z', now)).toEqual('1 second ago');
+            expect(getRelativeTimeString('2026-02-10T12:34:30.000Z', now)).toEqual('26 seconds ago');
+            expect(getRelativeTimeString('2026-02-10T12:34:00.000Z', now)).toEqual('56 seconds ago');
+            expect(getRelativeTimeString('2026-02-10T12:33:56.001Z', now)).toEqual('59 seconds ago');
+
+            // Difference is less than 1 hour.
+            expect(getRelativeTimeString('2026-02-10T12:33:56.000Z', now)).toEqual('1 minute ago');
+            expect(getRelativeTimeString('2026-02-10T12:30:00.000Z', now)).toEqual('4 minutes ago');
+            expect(getRelativeTimeString('2026-02-10T12:00:00.000Z', now)).toEqual('34 minutes ago');
+            expect(getRelativeTimeString('2026-02-10T11:34:56.001Z', now)).toEqual('59 minutes ago');
+
+            // Difference is less than 1 day.
+            expect(getRelativeTimeString('2026-02-10T11:34:56.000Z', now)).toEqual('1 hour ago');
+            expect(getRelativeTimeString('2026-02-10T10:34:56.001Z', now)).toEqual('1 hour ago');
+            expect(getRelativeTimeString('2026-02-10T10:34:56.000Z', now)).toEqual('2 hours ago');
+            expect(getRelativeTimeString('2026-02-10T00:00:00.000Z', now)).toEqual('12 hours ago');
+            expect(getRelativeTimeString('2026-02-09T12:34:56.001Z', now)).toEqual('23 hours ago');
+
+            // Difference is less than 1 week.
+            expect(getRelativeTimeString('2026-02-09T12:34:56.000Z', now)).toEqual('1 day ago');
+            expect(getRelativeTimeString('2026-02-09T00:00:00.000Z', now)).toEqual('1 day ago');
+            expect(getRelativeTimeString('2026-02-05T00:00:00.000Z', now)).toEqual('5 days ago');
+            expect(getRelativeTimeString('2026-02-03T12:34:56.001Z', now)).toEqual('6 days ago');
+
+            // Difference is less than 1 month, which is 30.4375 days.
+            expect(getRelativeTimeString('2026-02-03T12:34:56.000Z', now)).toEqual('1 week ago');
+            expect(getRelativeTimeString('2026-01-28T00:00:00.000Z', now)).toEqual('1 week ago');
+            expect(getRelativeTimeString('2026-01-21T00:00:00.000Z', now)).toEqual('2 weeks ago');
+            expect(getRelativeTimeString('2026-01-14T00:00:00.000Z', now)).toEqual('3 weeks ago');
+            expect(getRelativeTimeString('2026-01-11T02:04:56.001Z', now)).toEqual('4 weeks ago');
+
+            // Difference is less than 1 year, which is 365.25 days.
+            expect(getRelativeTimeString('2026-01-11T02:04:56.000Z', now)).toEqual('1 month ago');
+            expect(getRelativeTimeString('2026-01-11T00:00:00.000Z', now)).toEqual('1 month ago');
+            expect(getRelativeTimeString('2025-12-01T00:00:00.000Z', now)).toEqual('2 months ago');
+            expect(getRelativeTimeString('2025-07-01T00:00:00.000Z', now)).toEqual('7 months ago');
+            expect(getRelativeTimeString('2025-02-10T13:00:00.000Z', now)).toEqual('11 months ago');
+            expect(getRelativeTimeString('2025-02-10T06:34:56.001Z', now)).toEqual('11 months ago');
+
+            // Difference is at least 1 year.
+            expect(getRelativeTimeString('2025-02-10T06:34:56.000Z', now)).toEqual('1 year ago');
+            expect(getRelativeTimeString('2020-01-01T00:00:00.000Z', now)).toEqual('6 years ago');
         });
     });
 });

--- a/src/webview/components/PersonInfo.tsx
+++ b/src/webview/components/PersonInfo.tsx
@@ -10,21 +10,40 @@ export interface PersonInfoProps {
     label: string;
 }
 
-export function getRelativeTimeString(timestamp: string): string {
+export function getRelativeTimeString(timestamp: string, now: number | null = null): string {
     const time = new Date(timestamp).getTime();
     if (isNaN(time)) return timestamp;
 
-    const now = Date.now();
-    const diff = now - time;
+    // If we assume a year is 365.25 days:
+    const SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60;
+    const SECONDS_PER_MONTH = SECONDS_PER_YEAR / 12;
 
-    const seconds = Math.floor(diff / 1000);
+    const diffMs = (now ?? Date.now()) - time;
+    // This function only works for timestamps in the past.
+    // (We could make it work for timestamps in the future, but that isn't a valid input for now.)
+    if (diffMs < 0) return timestamp;
+
+    // Display a single unit of time from seconds to years.
+    const seconds = Math.floor(diffMs / 1000);
     const minutes = Math.floor(seconds / 60);
     const hours = Math.floor(minutes / 60);
     const days = Math.floor(hours / 24);
-
-    if (days > 0) return `${days} day${days > 1 ? 's' : ''} ago`;
-    if (hours > 0) return `${hours} hour${hours > 1 ? 's' : ''} ago`;
-    if (minutes > 0) return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+    const weeks = Math.floor(days / 7);
+    const months = Math.floor(seconds / SECONDS_PER_MONTH);
+    const years = Math.floor(seconds / SECONDS_PER_YEAR);
+    for (const [x, unit] of [
+        [years, 'year'],
+        [months, 'month'],
+        [weeks, 'week'],
+        [days, 'day'],
+        [hours, 'hour'],
+        [minutes, 'minute'],
+        [seconds, 'second'],
+    ] satisfies Array<[number, string]>) {
+        if (x > 0) {
+            return `${x} ${unit}${x > 1 ? 's' : ''} ago`;
+        }
+    }
     return 'just now';
 }
 


### PR DESCRIPTION
Now supports up to years for relative timestamps in the `PersonInfo` view. `jj` uses https://docs.rs/timeago/latest/timeago/, which estimates 1 month to be 2,628,003 seconds, but we'll just calculate based on "1 year = 365.25 days".

Also added VS Code editor rulers to match the line limit in TypeScript and React files.