### PR TITLE
Add action to delete stale .git/index.lock on error

### DIFF
--- a/src/commands/abandon.ts
+++ b/src/commands/abandon.ts
@@ -54,6 +54,6 @@ export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, 
         await scmProvider.refresh();
         vscode.window.showInformationMessage(`Abandoned ${revisions.length} change(s).`);
     } catch (e: unknown) {
-        showJjError(e, 'Error abandoning commit', scmProvider.outputChannel);
+        await showJjError(e, 'Failed to abandon', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/absorb.ts
+++ b/src/commands/absorb.ts
@@ -19,6 +19,6 @@ export async function absorbCommand(scmProvider: JjScmProvider, jj: JjService, a
         await scmProvider.refresh({ reason: 'after absorb' });
         vscode.window.setStatusBarMessage('Absorb completed.', 3000);
     } catch (e: unknown) {
-        showJjError(e, 'Absorb failed', scmProvider.outputChannel);
+        await showJjError(e, 'Absorb failed', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/bookmark.ts
+++ b/src/commands/bookmark.ts
@@ -37,13 +37,13 @@ export async function setBookmarkCommand(
                     await withDelayedProgress(`Setting bookmark ${name}...`, jj.moveBookmark(name, revision));
                     await scmProvider.refresh({ reason: 'after bookmark set' });
                 } catch (e: unknown) {
-                    showJjError(e, 'Error setting bookmark', scmProvider.outputChannel);
+                    await showJjError(e, 'Error setting bookmark', jj, scmProvider.outputChannel);
                 }
             }
         });
 
         quickPick.show();
     } catch (e: unknown) {
-        showJjError(e, 'Error checking bookmarks', scmProvider.outputChannel);
+        await showJjError(e, 'Error checking bookmarks', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -6,6 +6,9 @@
 import { JjResourceState } from '../jj-scm-provider';
 import { ScmContextValue } from '../jj-context-keys';
 import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { JjService } from '../jj-service';
 
 // Internal type guards to keep the messy VS Code argument matching encapsulated
 
@@ -211,11 +214,29 @@ export async function withDelayedProgress<T>(title: string, promise: Promise<T>)
 export async function showJjError(
     error: unknown,
     prefix: string,
+    jj: JjService,
     outputChannel?: vscode.OutputChannel,
     extraActions: string[] = [],
 ): Promise<string | undefined> {
     const message = getErrorMessage(error);
-    const fullMessage = `${prefix}: ${message}`;
+    let fullMessage = `${prefix}: ${message}`;
+
+    const isLockError = JjService.isIndexLockError(error);
+    const DELETE_LOCK = 'Delete Lock File';
+    let lockPath: string | undefined;
+
+    if (isLockError) {
+        try {
+            const repoRoot = await jj.getRepoRoot();
+            lockPath = path.join(repoRoot, '.git', 'index.lock');
+            fullMessage = `${prefix}: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.`;
+            if (!extraActions.includes(DELETE_LOCK)) {
+                extraActions = [DELETE_LOCK, ...extraActions];
+            }
+        } catch (e) {
+            // Ignore if we can't figure out the repo root
+        }
+    }
 
     if (!process.env.VITEST) {
         console.error(fullMessage, error);
@@ -227,6 +248,14 @@ export async function showJjError(
 
     if (selection === SHOW_LOG) {
         outputChannel?.show();
+    } else if (selection === DELETE_LOCK && lockPath) {
+        try {
+            await fs.unlink(lockPath);
+            outputChannel?.appendLine(`[Info] Deleted lock file at ${lockPath}`);
+        } catch (e) {
+            outputChannel?.appendLine(`[Error] Failed to delete lock file: ${getErrorMessage(e)}`);
+            vscode.window.showErrorMessage(`Failed to delete lock file: ${getErrorMessage(e)}`);
+        }
     }
     return selection;
 }

--- a/src/commands/commit-prompt.ts
+++ b/src/commands/commit-prompt.ts
@@ -31,6 +31,6 @@ export async function commitPromptCommand(scmProvider: JjScmProvider, jj: JjServ
         await withDelayedProgress('Committing...', jj.commit(message));
         await scmProvider.refresh({ reason: 'after commit' });
     } catch (err: unknown) {
-        showJjError(err, 'Error committing change', scmProvider.outputChannel);
+        await showJjError(err, 'Error committing change', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -19,6 +19,6 @@ export async function commitCommand(scmProvider: JjScmProvider, jj: JjService) {
         await withDelayedProgress('Committing...', jj.commit(message));
         await scmProvider.refresh({ reason: 'after commit' });
     } catch (err: unknown) {
-        showJjError(err, 'Error committing change', scmProvider.outputChannel);
+        await showJjError(err, 'Error committing change', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/describe-prompt.ts
+++ b/src/commands/describe-prompt.ts
@@ -31,6 +31,6 @@ export async function describePromptCommand(scmProvider: JjScmProvider, jj: JjSe
         await withDelayedProgress('Setting description...', jj.describe(description));
         await scmProvider.refresh({ reason: 'after describe' });
     } catch (err: unknown) {
-        showJjError(err, 'Error setting description', scmProvider.outputChannel);
+        await showJjError(err, 'Error setting description', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -23,6 +23,6 @@ export async function setDescriptionCommand(scmProvider: JjScmProvider, jj: JjSe
         await withDelayedProgress('Setting description...', jj.describe(description, revision));
         await scmProvider.refresh({ reason: 'after describe' });
     } catch (e: unknown) {
-        showJjError(e, 'Error setting description', scmProvider.outputChannel);
+        await showJjError(e, 'Error setting description', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/details.ts
+++ b/src/commands/details.ts
@@ -15,6 +15,6 @@ export async function showDetailsCommand(logWebviewProvider: JjLogWebviewProvide
     try {
         await logWebviewProvider.createCommitDetailsPanel(revision);
     } catch (e: unknown) {
-        showJjError(e, 'Error showing details', logWebviewProvider.outputChannel);
+        await showJjError(e, 'Error showing details', logWebviewProvider.jj, logWebviewProvider.outputChannel);
     }
 }

--- a/src/commands/discard-change.ts
+++ b/src/commands/discard-change.ts
@@ -90,7 +90,7 @@ export async function discardChangeCommand(
         workspaceEdit.replace(uri, modifiedRange, originalTextStr);
         await vscode.workspace.applyEdit(workspaceEdit);
         await modifiedDoc.save();
-    } catch (e) {
-        showJjError(e, 'Failed to discard change', scmProvider.outputChannel);
+    } catch (e: unknown) {
+        await showJjError(e, 'Failed to discard change', scmProvider.jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/duplicate.ts
+++ b/src/commands/duplicate.ts
@@ -17,6 +17,6 @@ export async function duplicateCommand(scmProvider: JjScmProvider, jj: JjService
         await withDelayedProgress('Duplicating...', jj.duplicate(revision));
         await scmProvider.refresh({ reason: 'after duplicate' });
     } catch (e: unknown) {
-        showJjError(e, 'Error duplicating commit', scmProvider.outputChannel);
+        await showJjError(e, 'Error duplicating commit', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -17,6 +17,6 @@ export async function editCommand(scmProvider: JjScmProvider, jj: JjService, arg
         await withDelayedProgress('Editing...', jj.edit(revision));
         await scmProvider.refresh({ reason: 'after edit' });
     } catch (e: unknown) {
-        showJjError(e, 'Error editing commit', scmProvider.outputChannel);
+        await showJjError(e, 'Error editing commit', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/merge-editor.ts
+++ b/src/commands/merge-editor.ts
@@ -18,6 +18,6 @@ export async function openMergeEditorCommand(scmProvider: JjScmProvider, arg: un
     try {
         await scmProvider.openMergeEditor(resourceStates);
     } catch (e: unknown) {
-        showJjError(e, 'Error opening merge editor', scmProvider.outputChannel);
+        await showJjError(e, 'Error opening merge editor', scmProvider.jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -51,6 +51,6 @@ export async function newMergeChangeCommand(
         await jj.new({ parents: revisions });
         await scmProvider.refresh();
     } catch (e: unknown) {
-        showJjError(e, 'Failed to create merge', scmProvider.outputChannel);
+        await showJjError(e, 'Failed to create merge', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -73,7 +73,7 @@ export async function moveToParentInDiffCommand(scmProvider: JjScmProvider, jj: 
         await jj.movePartialToParent(relPath, ranges, revision);
         vscode.window.showInformationMessage(`Moved changes from ${revision} to parent.`);
     } catch (e: unknown) {
-        showJjError(e, 'Failed to move changes', scmProvider.outputChannel);
+        await showJjError(e, 'Failed to move changes', jj, scmProvider.outputChannel);
     } finally {
         await scmProvider.refresh();
     }

--- a/src/commands/multi-diff.ts
+++ b/src/commands/multi-diff.ts
@@ -55,7 +55,7 @@ export async function showMultiFileDiffCommand(
                 await vscode.commands.executeCommand('vscode.changes', title, resourceTuples);
             })(),
         );
-    } catch (err) {
-        showJjError(err, 'Failed to open multi-file diff', outputChannel);
+    } catch (err: unknown) {
+        await showJjError(err, 'Failed to open multi-file diff', jj, outputChannel);
     }
 }

--- a/src/commands/new-before.ts
+++ b/src/commands/new-before.ts
@@ -42,6 +42,6 @@ export async function newBeforeCommand(scmProvider: JjScmProvider, jj: JjService
         await withDelayedProgress('Creating new change...', jj.new({ insertBefore: revisions }));
         scmProvider.refresh();
     } catch (e: unknown) {
-        showJjError(e, `Error creating new commit before ${revisions.join(', ')}`, scmProvider.outputChannel);
+        await showJjError(e, `Error creating new commit before ${revisions.join(', ')}`, jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,6 +30,6 @@ export async function newCommand(scmProvider: JjScmProvider, jj: JjService, args
         await withDelayedProgress('Creating new change...', jj.new({ parents }));
         await scmProvider.refresh({ reason: 'after new' });
     } catch (e: unknown) {
-        showJjError(e, 'Error creating new commit', scmProvider.outputChannel);
+        await showJjError(e, 'Error creating new commit', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/rebase.ts
+++ b/src/commands/rebase.ts
@@ -31,6 +31,6 @@ export async function rebaseOntoSelectedCommand(scmProvider: JjScmProvider, jj: 
         );
         await vscode.commands.executeCommand('jj-view.refresh');
     } catch (err: unknown) {
-        showJjError(err, 'Error rebasing', scmProvider.outputChannel);
+        await showJjError(err, 'Error rebasing', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -10,6 +10,6 @@ export async function refreshCommand(scmProvider: JjScmProvider) {
     try {
         await scmProvider.refresh({ reason: 'manual refresh command', forceSnapshot: true });
     } catch (err: unknown) {
-        showJjError(err, 'Error refreshing', scmProvider.outputChannel);
+        await showJjError(err, 'Error refreshing', scmProvider.jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -19,6 +19,6 @@ export async function restoreCommand(scmProvider: JjScmProvider, jj: JjService, 
         await withDelayedProgress('Restoring files...', jj.restore(paths));
         await scmProvider.refresh({ reason: 'after restore' });
     } catch (e: unknown) {
-        showJjError(e, 'Error restoring files', scmProvider.outputChannel);
+        await showJjError(e, 'Error restoring files', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -16,6 +16,6 @@ export async function showCurrentChangeCommand(jj: JjService, outputChannel: vsc
             vscode.window.showErrorMessage('No log entry found for current revision.');
         }
     } catch (err: unknown) {
-        showJjError(err, 'Error getting jj log', outputChannel);
+        await showJjError(err, 'Error getting jj log', jj, outputChannel);
     }
 }

--- a/src/commands/squash-change.ts
+++ b/src/commands/squash-change.ts
@@ -146,7 +146,7 @@ export async function squashChangeCommand(
             await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
             await vscode.window.showTextDocument(uri, { viewColumn, preview: false });
         }
-    } catch (e) {
-        showJjError(e, 'Failed to squash change', scmProvider.outputChannel);
+    } catch (e: unknown) {
+        await showJjError(e, 'Failed to squash change', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/squash-into.ts
+++ b/src/commands/squash-into.ts
@@ -67,6 +67,6 @@ export async function squashIntoCommand(scmProvider: JjScmProvider, jj: JjServic
 
         await scmProvider.refresh({ reason: 'after squash into ancestor' });
     } catch (e: unknown) {
-        showJjError(e, 'Error squashing into ancestor', scmProvider.outputChannel);
+        await showJjError(e, 'Error squashing into ancestor', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/squash.ts
+++ b/src/commands/squash.ts
@@ -99,7 +99,7 @@ export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, a
 
         await scmProvider.refresh({ reason: 'after squash' });
     } catch (e: unknown) {
-        showJjError(e, 'Error squashing', scmProvider.outputChannel);
+        await showJjError(e, 'Error squashing', jj, scmProvider.outputChannel);
     }
 }
 
@@ -193,7 +193,7 @@ export async function completeSquashCommand(scmProvider: JjScmProvider, jj: JjSe
         if (err.code === 'ENOENT') {
             vscode.window.showErrorMessage('No pending squash operation found.');
         } else {
-            showJjError(e, 'Failed to complete squash', scmProvider.outputChannel);
+            await showJjError(e, 'Failed to complete squash', jj, scmProvider.outputChannel);
         }
     }
 }

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -13,6 +13,6 @@ export async function undoCommand(scmProvider: JjScmProvider, jj: JjService) {
         await withDelayedProgress('Undoing...', jj.undo());
         await scmProvider.refresh();
     } catch (e: unknown) {
-        showJjError(e, 'Error undoing', scmProvider.outputChannel);
+        await showJjError(e, 'Error undoing', jj, scmProvider.outputChannel);
     }
 }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -44,7 +44,7 @@ export async function uploadCommand(
     } catch (e: unknown) {
         const CONFIGURE = 'Configure Upload...';
         const extraActions = hasCustomCommand ? [] : [CONFIGURE];
-        const selection = await showJjError(e, 'Upload failed', outputChannel, extraActions);
+        const selection = await showJjError(e, 'Upload failed', jj, outputChannel, extraActions);
 
         if (selection === CONFIGURE) {
             vscode.commands.executeCommand('workbench.action.openSettings', 'jj-view.uploadCommand');

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -35,6 +35,10 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         });
     }
 
+    public get jj(): JjService {
+        return this._jj;
+    }
+
     public resolveWebviewView(
         webviewView: vscode.WebviewView,
         _context: vscode.WebviewViewResolveContext,

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -50,7 +50,7 @@ export class JjScmProvider implements vscode.Disposable {
 
     constructor(
         _context: vscode.ExtensionContext,
-        private jj: JjService,
+        public readonly jj: JjService,
         workspaceRoot: string,
         public readonly outputChannel: vscode.OutputChannel,
         public readonly contentProvider?: JjDocumentContentProvider,
@@ -406,7 +406,35 @@ export class JjScmProvider implements vscode.Disposable {
                 this._sourceControl.count = this._workingCopyGroup.resourceStates.length;
             } catch (e: unknown) {
                 const err = e as { message?: string };
-                if (
+                if (JjService.isIndexLockError(e)) {
+                    const repoRoot = await this.jj.getRepoRoot();
+                    const lockPath = path.join(repoRoot, '.git', 'index.lock');
+                    const DELETE_LOCK = 'Delete Lock File';
+                    vscode.window
+                        .showErrorMessage(
+                            `jj failed: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.`,
+                            DELETE_LOCK,
+                            'Show Log',
+                        )
+                        .then(async (selection) => {
+                            if (selection === DELETE_LOCK) {
+                                try {
+                                    await fs.unlink(lockPath);
+                                    this.outputChannel.appendLine(`[Info] Deleted lock file at ${lockPath}`);
+                                    await this.refresh({ forceSnapshot: true, reason: 'lock file deleted' });
+                                } catch (unlinkErr) {
+                                    this.outputChannel.appendLine(
+                                        `[Error] Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
+                                    );
+                                    vscode.window.showErrorMessage(
+                                        `Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
+                                    );
+                                }
+                            } else if (selection === 'Show Log') {
+                                this.outputChannel.show();
+                            }
+                        });
+                } else if (
                     err.message &&
                     ((err.message.includes('Object') && err.message.includes('not found')) ||
                         err.message.includes('No such file or directory'))

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -57,6 +57,11 @@ export class JjService {
         return this._lastWriteTime;
     }
 
+    static isIndexLockError(error: unknown): boolean {
+        const message = error instanceof Error ? error.message : String(error);
+        return message.includes('index.lock') || message.includes('Could not acquire lock');
+    }
+
     private toRelative(filePath: string): string {
         if (path.isAbsolute(filePath)) {
             return path.relative(this.workspaceRoot, filePath);

--- a/src/test/commands/index-lock-error.test.ts
+++ b/src/test/commands/index-lock-error.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, test, expect, afterEach, vi, Mock } from 'vitest';
+import { JjService } from '../../jj-service';
+import { showJjError } from '../../commands/command-utils';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { TestRepo } from '../test-repo';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock({
+        // Overrides
+        window: { showErrorMessage: vi.fn() },
+    });
+});
+
+describe('Index Lock Error Handling', () => {
+    let repo: TestRepo;
+    let jjService: JjService;
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        if (repo) {
+            repo.dispose();
+        }
+    });
+
+    describe('JjService with real lock file', () => {
+        test('commit command triggers lock error and showJjError can delete it', async () => {
+            repo = new TestRepo();
+            repo.init();
+
+            const mockLogger = vi.fn();
+            jjService = new JjService(repo.path, mockLogger);
+
+            // Create a fake lock file
+            const lockPath = path.join(repo.path, '.git', 'index.lock');
+            fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+            fs.writeFileSync(lockPath, '');
+
+            // Re-mock to return 'Delete Lock File' action
+            const showErrorMessage = vscode.window.showErrorMessage as Mock;
+            showErrorMessage.mockResolvedValueOnce('Delete Lock File');
+
+            try {
+                // This should throw an error because the index is locked during git export
+                await jjService.commit('test commit');
+                expect.unreachable('Expected commit to throw an error due to index.lock');
+            } catch (e: unknown) {
+                // Verify the error is recognized
+                expect(JjService.isIndexLockError(e)).toBe(true);
+
+                const mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+                const result = await showJjError(e, 'Prefix', jjService, mockOutputChannel, []);
+
+                // Verify recovery
+                expect(result).toBe('Delete Lock File');
+                expect(fs.existsSync(lockPath)).toBe(false);
+                expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('Deleted lock file'));
+
+                // Verify that another commit will now succeed
+                await expect(jjService.commit('test commit 2')).resolves.not.toThrow();
+            }
+        });
+    });
+
+    describe('JjService.isIndexLockError patterns', () => {
+        test('returns true for known lock error patterns', () => {
+            const error1 = new Error('Could not acquire lock for index file');
+            const error2 = new Error('Error: .git/index.lock already exists');
+            const error3 = 'Some string error with index.lock in it';
+
+            expect(JjService.isIndexLockError(error1)).toBe(true);
+            expect(JjService.isIndexLockError(error2)).toBe(true);
+            expect(JjService.isIndexLockError(error3)).toBe(true);
+        });
+
+        test('returns false for unrelated errors', () => {
+            const error1 = new Error('Permission denied');
+            const error2 = new Error('No such file or directory');
+            const error3 = 'Not a jj repository';
+
+            expect(JjService.isIndexLockError(error1)).toBe(false);
+            expect(JjService.isIndexLockError(error2)).toBe(false);
+            expect(JjService.isIndexLockError(error3)).toBe(false);
+        });
+    });
+
+    describe('showJjError with mock errors', () => {
+        let testRepo: TestRepo;
+        let jjService: JjService;
+
+        beforeEach(() => {
+            testRepo = new TestRepo();
+            testRepo.init();
+
+            const mockLogger = vi.fn();
+            jjService = new JjService(testRepo.path, mockLogger);
+        });
+
+        afterEach(() => {
+            if (testRepo) {
+                testRepo.dispose();
+            }
+        });
+
+        test('adds Delete Lock File action for lock errors with repository root', async () => {
+            const error = new Error('Could not acquire lock for index file');
+            const mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+
+            // Re-mock to return standard selection
+            const showErrorMessage = vscode.window.showErrorMessage as Mock;
+            showErrorMessage.mockResolvedValueOnce(undefined);
+
+            await showJjError(error, 'Prefix', jjService, mockOutputChannel, []);
+
+            expect(showErrorMessage).toHaveBeenCalledWith(
+                'Prefix: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.',
+                'Show Log',
+                'Delete Lock File',
+            );
+        });
+
+        test('deletes lock file when action is selected', async () => {
+            const error = new Error('Could not acquire lock for index file');
+            const mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+
+            const lockPath = path.join(testRepo.path, '.git', 'index.lock');
+            fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+            fs.writeFileSync(lockPath, '');
+
+            // Re-mock to return 'Delete Lock File' action
+            const showErrorMessage = vscode.window.showErrorMessage as Mock;
+            showErrorMessage.mockResolvedValueOnce('Delete Lock File');
+
+            const result = await showJjError(error, 'Prefix', jjService, mockOutputChannel, []);
+
+            expect(result).toBe('Delete Lock File');
+            expect(fs.existsSync(lockPath)).toBe(false);
+            expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(expect.stringContaining('Deleted lock file'));
+        });
+
+        test('does not add action if repo root is missing', async () => {
+            const error = new Error('Could not acquire lock for index file');
+            const mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+
+            // Create a separate service pointing to an empty non-jj directory
+            const emptyDirRepo = new TestRepo(); // not calling init()
+            const emptyJjService = new JjService(emptyDirRepo.path, vi.fn());
+
+            const showErrorMessage = vscode.window.showErrorMessage as Mock;
+            showErrorMessage.mockResolvedValueOnce(undefined);
+
+            try {
+                await showJjError(error, 'Prefix', emptyJjService, mockOutputChannel, []);
+            } finally {
+                emptyDirRepo.dispose();
+            }
+
+            expect(showErrorMessage).toHaveBeenCalledWith(
+                'Prefix: Could not acquire lock for index file', // Original simple message
+                'Show Log',
+                // No Delete Lock File
+            );
+        });
+
+        test('does not duplicate Delete Lock File action if already present', async () => {
+            const error = new Error('Could not acquire lock for index file');
+            const mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+
+            const showErrorMessage = vscode.window.showErrorMessage as Mock;
+            showErrorMessage.mockResolvedValueOnce(undefined);
+
+            await showJjError(error, 'Prefix', jjService, mockOutputChannel, ['Delete Lock File']);
+
+            expect(showErrorMessage).toHaveBeenCalledWith(
+                'Prefix: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.',
+                'Show Log',
+                'Delete Lock File',
+            );
+        });
+    });
+});


### PR DESCRIPTION
Detects `index.lock` errors during Jujutsu commands and offers a quick action to delete the stale lock file.

To support this globally, `showJjError` now accepts a `JjService` instance so it can automatically fetch the repository root. All command callsites  and associated tests were updated to adopt the new error handler signature.

Fixes #111 