### PR TITLE
Exclude immutable commits from the SCM pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "jj-view",
-    "version": "1.19.0",
+    "version": "1.20.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "jj-view",
-            "version": "1.19.0",
+            "version": "1.20.0",
             "dependencies": {
                 "@dnd-kit/core": "^6.3.1",
                 "@dnd-kit/modifiers": "^9.0.0",
@@ -302,6 +302,7 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -2649,6 +2650,7 @@
             "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2676,6 +2678,7 @@
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2789,6 +2792,7 @@
             "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.50.1",
                 "@typescript-eslint/types": "8.50.1",
@@ -3117,7 +3121,8 @@
             "version": "0.0.44",
             "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.44.tgz",
             "integrity": "sha512-F7qPRumUK3EHjNdopfICLGRf3iNPoZQt+McTHAn4AlOWPB3W2kL4H0S7uqEqbyZ6rCxaeDjpAn3MCUnwTu/VJQ==",
-            "license": "CC-BY-4.0"
+            "license": "CC-BY-4.0",
+            "peer": true
         },
         "node_modules/@vscode/test-cli": {
             "version": "0.0.12",
@@ -3519,6 +3524,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5262,6 +5268,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -9329,6 +9336,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9338,6 +9346,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -11337,6 +11346,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11701,6 +11711,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11929,6 +11940,7 @@
             "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -12022,6 +12034,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/src/jj-context-keys.ts
+++ b/src/jj-context-keys.ts
@@ -35,7 +35,6 @@ export enum ScmContextValue {
     // Group States
     WorkingCopyGroup = 'jj.group.workingCopy',
     ConflictGroup = 'jj.group.conflict',
-    AncestorGroup = 'jj.group.ancestor',
     AncestorGroupMutable = 'jj.group.ancestor:mutable',
     AncestorGroupSquashable = 'jj.group.ancestor:squashable',
 
@@ -44,7 +43,7 @@ export enum ScmContextValue {
     WorkingCopySquashable = 'jj.resource.workingCopy:squashable',
     WorkingCopySquashableMulti = 'jj.resource.workingCopy:squashable:multi',
     Conflict = 'jj.resource.conflict',
-    Ancestor = 'jj.resource.ancestor',
+    AncestorMutable = 'jj.resource.ancestor:mutable',
     AncestorSquashable = 'jj.resource.ancestor:squashable',
     AncestorSquashableMulti = 'jj.resource.ancestor:squashable:multi',
 }

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -272,7 +272,7 @@ export class JjScmProvider implements vscode.Disposable {
 
                         for (let i = 0; i < parentEntries.length; i++) {
                             const parentEntry = parentEntries[i];
-                            if (!parentEntry) continue;
+                            if (!parentEntry || parentEntry.is_immutable) continue;
 
                             const prefix = isMerge ? `@-${ancestorDepth}^${i + 1}` : `@-${ancestorDepth}`;
 
@@ -366,11 +366,9 @@ export class JjScmProvider implements vscode.Disposable {
 
                     // Reuse existing group or create new one
                     let group: vscode.SourceControlResourceGroup;
-                    const contextValue = ancestorEntry.is_immutable
-                        ? ScmContextValue.AncestorGroup
-                        : canSquash
-                          ? ScmContextValue.AncestorGroupSquashable
-                          : ScmContextValue.AncestorGroupMutable;
+                    const contextValue = canSquash
+                        ? ScmContextValue.AncestorGroupSquashable
+                        : ScmContextValue.AncestorGroupMutable;
 
                     if (i < this._parentGroups.length) {
                         group = this._parentGroups[i];
@@ -583,7 +581,7 @@ export class JjScmProvider implements vscode.Disposable {
                     ? options.multipleAncestors
                         ? ScmContextValue.AncestorSquashableMulti
                         : ScmContextValue.AncestorSquashable
-                    : ScmContextValue.Ancestor,
+                    : ScmContextValue.AncestorMutable,
             revision: revision,
         };
     }

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -148,7 +148,7 @@ suite('JJ SCM Provider Integration Test', function () {
         );
         assert.ok(resourceState, 'Parent resource should be visible');
         const expectedContext = [
-            ScmContextValue.Ancestor,
+            ScmContextValue.AncestorMutable,
             ScmContextValue.AncestorSquashable,
             ScmContextValue.AncestorSquashableMulti,
         ];
@@ -177,7 +177,7 @@ suite('JJ SCM Provider Integration Test', function () {
         }
 
         const expectedContext2 = [
-            ScmContextValue.Ancestor,
+            ScmContextValue.AncestorMutable,
             ScmContextValue.AncestorSquashable,
             ScmContextValue.AncestorSquashableMulti,
         ];
@@ -793,12 +793,8 @@ suite('JJ SCM Provider Integration Test', function () {
 
             await scmProvider.refresh();
             let parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
-            // Root is immutable, so parent group should be immutable
-            assert.strictEqual(
-                parentGroups[0].contextValue,
-                ScmContextValue.AncestorGroup,
-                'Parent (Root) should be immutable',
-            );
+            // Root is immutable, so no parent group should be created
+            assert.strictEqual(parentGroups.length, 0, 'Should have 0 parent groups when parent is immutable');
 
             // 2. Create C2 on top of C1
             repo.new([], 'C2');
@@ -807,9 +803,9 @@ suite('JJ SCM Provider Integration Test', function () {
 
             await scmProvider.refresh();
             parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
-            assert.strictEqual(parentGroups.length, 1, 'Should only show 1 ancestor group (direct parent)');
+            assert.strictEqual(parentGroups.length, 1, 'Should show 1 ancestor group (direct parent)');
 
-            // This is the key assertion: Did the reused group update its context value?
+            // This is the key assertion: Did the group get the correct context value?
             assert.strictEqual(
                 parentGroups[0].contextValue,
                 ScmContextValue.AncestorGroupMutable,
@@ -889,7 +885,6 @@ suite('JJ SCM Provider Integration Test', function () {
         // Since @ is a merge, its parents are 'left commit' and 'right commit'.
         assert.ok(
             [
-                ScmContextValue.AncestorGroup,
                 ScmContextValue.AncestorGroupMutable,
                 ScmContextValue.AncestorGroupSquashable,
             ].includes(parentGroups[0].contextValue as ScmContextValue),


### PR DESCRIPTION
Immutable commits are not very useful in the source control view and can be viewed in the graph instead. This updates `JjScmProvider` to completely omit immutable commits when generating ancestor groups for the SCM pane, and updates integration tests to expect no parent groups when the parent commit is immutable.

Fixes #109 . I decided to just remove them, because it isn't possible to default to collapsed.