### PR TITLE
Add JJ_VIEW_EXTENSION environment variable for conditional config

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.maxMutableAncestors`          | `10`        | Maximum number of mutable ancestors to display in the SCM view.                                                                                                                                                                                                                                      |
 | `jj-view.logTheme`                     | `"default"` | Color theme for the graph lanes in the JJ Log view. Available options: `default`, `oceanic`, `sunset`, `neon`, `pastel`, `monochrome`.                                                                                                                                                               |
 
+## Advanced Configuration
+
+### Conditional `jj` configuration
+
+When `jj-view` executes `jj` commands, it sets the `JJ_VIEW_EXTENSION=1` environment variable. This allows you to configure conditional logic in your `.jjconfig.toml` file to apply specific settings only when interacting with the repository via the VS Code extension.
+
+For example, you can configure a different default log revset for the extension:
+
+```toml
+[[--scope]]
+--when.environments = ["JJ_VIEW_EXTENSION=1"]
+[--scope.revsets]
+log = "trunk().." # Or any other revset you prefer for the graph view
+```
+
 ## File Watcher Mode
 
 The `"watch"` mode uses [parcel-watcher](https://github.com/parcel-bundler/watcher) for native, event-driven file change detection instead of periodic polling. This is more efficient for large repos, but may require additional setup depending on your platform.

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -180,7 +180,14 @@ export class JjService {
 
                 const finalOptions = {
                     cwd: this.workspaceRoot,
-                    env: { ...process.env, PAGER: 'cat', JJ_NO_PAGER: '1', JJ_EDITOR: 'cat', EDITOR: 'cat' },
+                    env: {
+                        ...process.env,
+                        PAGER: 'cat',
+                        JJ_NO_PAGER: '1',
+                        JJ_EDITOR: 'cat',
+                        EDITOR: 'cat',
+                        JJ_VIEW_EXTENSION: '1',
+                    },
                     maxBuffer: 100 * 1024 * 1024,
                     ...options,
                 };

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -884,10 +884,9 @@ suite('JJ SCM Provider Integration Test', function () {
         // The first parent group is the merge commit itself (for some reason, oh wait! The parents are the parents of @!)
         // Since @ is a merge, its parents are 'left commit' and 'right commit'.
         assert.ok(
-            [
-                ScmContextValue.AncestorGroupMutable,
-                ScmContextValue.AncestorGroupSquashable,
-            ].includes(parentGroups[0].contextValue as ScmContextValue),
+            [ScmContextValue.AncestorGroupMutable, ScmContextValue.AncestorGroupSquashable].includes(
+                parentGroups[0].contextValue as ScmContextValue,
+            ),
             `Unexpected parent context value: ${parentGroups[0].contextValue}`,
         );
     });

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -58,6 +58,36 @@ describe('JjService Unit Tests', () => {
         expect(changes.length).toBe(0);
     });
 
+    test('supplies JJ_VIEW_EXTENSION environment variable', async () => {
+        // Write a conditional config that changes the default log revset
+        // only when JJ_VIEW_EXTENSION=1 is present in the environment.
+        // Modern jj stores repo configs outside the repo for security,
+        // so we must query the path dynamically.
+        const configPath = cp
+            .execFileSync('jj', ['config', 'path', '--repo'], { cwd: repo.path, encoding: 'utf-8' })
+            .trim();
+        const configContent = `
+[[--scope]]
+--when.environments = ["JJ_VIEW_EXTENSION=1"]
+[--scope.revsets]
+log = "none()"
+`;
+        // Append to existing config
+        fs.appendFileSync(configPath, configContent, 'utf-8');
+
+        // Verify that JjService picks up the environment variable by
+        // checking the output of getLog without a revision (which uses revsets.log)
+        repo.new(['@'], 'child');
+
+        // JjService execution should use JJ_VIEW_EXTENSION=1, making revsets.log = "none()"
+        const logs = await jjService.getLog();
+        expect(logs.length).toBe(0);
+
+        // TestRepo execution should NOT use JJ_VIEW_EXTENSION=1, making revsets.log = "@"
+        const repoLogDesc = repo.getDescription('@');
+        expect(repoLogDesc).toContain('child');
+    });
+
     describe('new command', () => {
         test('creates a new change', async () => {
             const oldChangeId = repo.getChangeId('@');


### PR DESCRIPTION
Sets the `JJ_VIEW_EXTENSION=1` environment variable when the extension executes `jj` commands via `JjService`. This allows users to write conditional TOML blocks in their `.jjconfig.toml` that only apply when interacting with the repository through the VS Code extension.

For example, users can now configure a different default log revset:
```toml
[[--scope]]
--when.environments = ["JJ_VIEW_EXTENSION=1"]
[--scope.revsets]
log = "trunk().."
```

Also added a unit test to verify that the conditional config works correctly by appending a test condition to the temporary repo's config file via `jj config path --repo`. Documented the new variable in README.md.

Fixes #108 