### PR TITLE
Show ignored file decorations in the Explorer pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 codicons/
 test-results/
 media/custom-icons/
+playwright-report/

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -5,33 +5,58 @@
 
 import * as vscode from 'vscode';
 import { JjStatusEntry } from './jj-types';
+import { JjService } from './jj-service';
 
 export class JjDecorationProvider implements vscode.FileDecorationProvider {
-    private _onDidChangeFileDecorations = new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
-    readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
+    private readonly _onDidChangeFileDecorations: vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined> =
+        new vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined>();
+    readonly onDidChangeFileDecorations: vscode.Event<vscode.Uri | vscode.Uri[] | undefined> =
+        this._onDidChangeFileDecorations.event;
 
-    private decorations = new Map<string, JjStatusEntry>();
+    // Parsed from `jj status` (e.g., Modified, Added, Conflict)
+    private scmStatusDecorations = new Map<string, JjStatusEntry>();
 
-    constructor() {}
+    private pendingChecks = new Map<string, vscode.Uri>();
+    private checkTimeout?: NodeJS.Timeout;
 
-    provideFileDecoration(
-        uri: vscode.Uri,
-        _token: vscode.CancellationToken,
-    ): vscode.ProviderResult<vscode.FileDecoration> {
-        const entry = this.decorations.get(uri.toString());
-        if (!entry) {
+    // Cache to prevent re-evaluating the same file status repeatedly
+    private trackedStatusCache = new Map<string, boolean>();
+    private resolveCallbacks = new Map<string, (decoration: vscode.FileDecoration | undefined) => void>();
+
+    constructor(
+        private jjService: JjService,
+        private workspaceRoot: string,
+    ) {}
+
+    private _clearIgnoredFileDecorationsCache(): boolean {
+        if (this.trackedStatusCache.size > 0 || this.pendingChecks.size > 0) {
+            this.trackedStatusCache.clear();
+            this.pendingChecks.clear();
+            for (const callback of this.resolveCallbacks.values()) {
+                callback(undefined);
+            }
+            this.resolveCallbacks.clear();
+            return true;
+        }
+        return false;
+    }
+
+    clearIgnoredFileDecorationsCache() {
+        this._clearIgnoredFileDecorationsCache();
+        this._onDidChangeFileDecorations.fire(undefined);
+    }
+
+    private getScmStatusDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
+        const uriString = uri.toString();
+        const scmStatus = this.scmStatusDecorations.get(uriString);
+        if (!scmStatus) {
             return undefined;
         }
 
-        const status = entry.status;
-        const conflicted = entry.conflicted;
+        const { status, conflicted } = scmStatus;
 
         if (conflicted) {
-            return new vscode.FileDecoration(
-                '!',
-                'Conflicted',
-                new vscode.ThemeColor('jj.conflicted'), // Or gitDecoration.conflictingResourceForeground
-            );
+            return new vscode.FileDecoration('!', 'Conflicted', new vscode.ThemeColor('jj.conflicted'));
         }
 
         switch (status) {
@@ -71,12 +96,180 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         }
     }
 
-    setDecorations(decorations: Map<string, JjStatusEntry>) {
-        if (this.areDecorationsEqual(this.decorations, decorations)) {
+    private getWorkspaceRelativePath(uri: vscode.Uri): string | undefined {
+        if (!this.workspaceRoot) {
+            return undefined;
+        }
+
+        const normalizedFsPath = uri.fsPath.replace(/\\/g, '/');
+        const normalizedRoot = this.workspaceRoot.replace(/\\/g, '/');
+
+        const isWin = process.platform === 'win32';
+        let fsPathMatch = normalizedFsPath;
+        let rootMatch = normalizedRoot;
+
+        if (isWin) {
+            fsPathMatch = fsPathMatch.toLowerCase();
+            rootMatch = rootMatch.toLowerCase();
+        }
+
+        if (!fsPathMatch.startsWith(rootMatch)) {
+            return undefined;
+        }
+
+        let relativePath = normalizedFsPath.substring(normalizedRoot.length);
+        if (relativePath.startsWith('/')) {
+            relativePath = relativePath.substring(1);
+        }
+        return relativePath;
+    }
+
+    provideFileDecoration(
+        uri: vscode.Uri,
+        _token: vscode.CancellationToken,
+    ): vscode.ProviderResult<vscode.FileDecoration> {
+        // 1. Check if we have an SCM status decoration from jj status
+        const scmStatusDecoration = this.getScmStatusDecoration(uri);
+        if (scmStatusDecoration) {
+            return scmStatusDecoration;
+        }
+
+        // 2. Ignore non-file systems or if context not set
+        if (uri.scheme !== 'file' || !this.jjService) {
+            return undefined;
+        }
+
+        // 3. Ignore paths outside our workspace entirely
+        const relativePath = this.getWorkspaceRelativePath(uri);
+        if (relativePath === undefined) {
+            return undefined;
+        }
+
+        return this.getTrackedStatusDecoration(uri, relativePath);
+    }
+
+    private getTrackedStatusDecoration(
+        uri: vscode.Uri,
+        relativePath: string,
+    ): vscode.ProviderResult<vscode.FileDecoration> {
+        // jj intuitively ignores the .jj directory
+        if (relativePath === '.jj' || relativePath.startsWith('.jj/') || relativePath.startsWith('.jj\\')) {
+            return new vscode.FileDecoration(
+                undefined,
+                'Ignored',
+                new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
+            );
+        }
+
+        // 4. Check cache for tracked status
+        const cachedTrackingStatus = this.trackedStatusCache.get(relativePath);
+        if (cachedTrackingStatus === true) {
+            return undefined; // Tracked, no gray decoration needed
+        } else if (cachedTrackingStatus === false) {
+            return new vscode.FileDecoration(
+                undefined,
+                'Ignored',
+                new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
+            );
+        }
+
+        // 5. Not in cache, schedule a batched check
+        return new Promise<vscode.FileDecoration | undefined>((resolve) => {
+            this.resolveCallbacks.set(relativePath, resolve);
+            this.pendingChecks.set(relativePath, uri);
+
+            if (this.checkTimeout) {
+                clearTimeout(this.checkTimeout);
+            }
+
+            this.checkTimeout = setTimeout(() => {
+                this.flushPendingChecks();
+            }, 50);
+        });
+    }
+
+    private async flushPendingChecks() {
+        if (!this.jjService || this.pendingChecks.size === 0) {
             return;
         }
-        this.decorations = decorations;
-        this._onDidChangeFileDecorations.fire(undefined); // Refresh all
+
+        const pathsToCheck = Array.from(this.pendingChecks.keys());
+        const callbacksStr = pathsToCheck.map((p) => ({
+            path: p,
+            uri: this.pendingChecks.get(p)!,
+            resolve: this.resolveCallbacks.get(p)!,
+        }));
+
+        this.pendingChecks.clear();
+        this.resolveCallbacks.clear();
+
+        try {
+            // Ask JJ which of these paths are tracked
+            // We use chunking in case the list of visible files is excessively large (unlikely, but safe)
+            const chunkSize = 100;
+            const trackedSet = new Set<string>();
+
+            for (let i = 0; i < pathsToCheck.length; i += chunkSize) {
+                const chunk = pathsToCheck.slice(i, i + chunkSize);
+                const trackedArray = await this.jjService.checkTrackedPaths(chunk);
+                for (const trackedPath of trackedArray) {
+                    // jj output comes with forward slashes usually
+                    trackedSet.add(trackedPath.replace(/\\/g, '/'));
+                }
+            }
+
+            for (const item of callbacksStr) {
+                const normalizedItemPath = item.path.replace(/\\/g, '/');
+
+                // Fast exact match (if it's a file)
+                let isTracked = trackedSet.has(normalizedItemPath);
+
+                // If not exact match, check prefix (if it's a directory)
+                // jj file list <dir> outputs the tracked files inside the directory,
+                // e.g., 'dir/file1.txt', 'dir/file2.txt'
+                if (!isTracked) {
+                    const prefix = normalizedItemPath + '/';
+                    for (const trackedFile of trackedSet) {
+                        if (trackedFile.startsWith(prefix)) {
+                            isTracked = true;
+                            break;
+                        }
+                    }
+                }
+
+                this.trackedStatusCache.set(item.path, isTracked);
+
+                if (isTracked) {
+                    item.resolve(undefined);
+                } else {
+                    item.resolve(
+                        new vscode.FileDecoration(
+                            undefined,
+                            'Ignored',
+                            new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
+                        ),
+                    );
+                }
+            }
+        } catch (e) {
+            console.error('Failed to check tracked paths', e);
+            for (const item of callbacksStr) {
+                item.resolve(undefined);
+            }
+        }
+    }
+
+    updateScmStatusAndClearIgnoredCache(scmStatusDecorations: Map<string, JjStatusEntry>) {
+        const scmChanged = !this.areDecorationsEqual(this.scmStatusDecorations, scmStatusDecorations);
+        if (scmChanged) {
+            this.scmStatusDecorations = scmStatusDecorations;
+        }
+        
+        const cacheCleared = this._clearIgnoredFileDecorationsCache();
+
+        if (scmChanged || cacheCleared) {
+            this._onDidChangeFileDecorations.fire(undefined); // Refresh all
+        }
     }
 
     private areDecorationsEqual(map1: Map<string, JjStatusEntry>, map2: Map<string, JjStatusEntry>): boolean {
@@ -95,7 +288,11 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         }
         return true;
     }
+
     dispose() {
+        if (this.checkTimeout) {
+            clearTimeout(this.checkTimeout);
+        }
         this._onDidChangeFileDecorations.dispose();
     }
 }

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -57,7 +57,7 @@ export class JjScmProvider implements vscode.Disposable {
         public readonly editProvider?: JjEditFileSystemProvider,
     ) {
         this._sourceControl = vscode.scm.createSourceControl('jj', 'Jujutsu', vscode.Uri.file(workspaceRoot));
-        this.decorationProvider = new JjDecorationProvider();
+        this.decorationProvider = new JjDecorationProvider(this.jj, workspaceRoot);
         this._refreshScheduler = new RefreshScheduler((options) => this.refresh(options));
 
         // Create groups in order of display
@@ -396,8 +396,8 @@ export class JjScmProvider implements vscode.Disposable {
                     });
                 }
 
-                // Update Decoration Provider
-                this.decorationProvider.setDecorations(decorationMap);
+                // Update Decoration
+                this.decorationProvider.updateScmStatusAndClearIgnoredCache(decorationMap);
 
                 // Update SCM Count - Only count Working Copy changes
                 // VS Code sums all groups by default if count is not set, so we must set it explicitly.

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -646,6 +646,33 @@ export class JjService {
             .filter((line) => line.length > 0);
     }
 
+    /**
+     * Checks which of the provided paths are tracked by jj.
+     * @param paths An array of workspace-relative paths to check.
+     * @returns A subset of the input `paths` that are tracked. Note that for
+     * directories, it returns the tracked files contained within them.
+     */
+    async checkTrackedPaths(paths: string[]): Promise<string[]> {
+        if (paths.length === 0) {
+            return [];
+        }
+
+        // Use a template to ensure clean, machine-readable output.
+        // Paths are passed as positional arguments (filesets).
+        // Since paths is just an array of workspace-relative strings, they act as implicit fileset matches.
+        // E.g., jj file list path/to/a path/to/b
+        const args = ['list', '-T', 'path.display() ++ "\\n"', ...paths];
+        try {
+            const output = await this.run('file', args, { useCachedSnapshot: true, label: 'checkTrackedPaths' });
+            return output
+                .split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0);
+        } catch {
+            return [];
+        }
+    }
+
     async moveChanges(paths: string[], fromRevision: string, toRevision: string): Promise<void> {
         const relativePaths = paths.map((p) => this.toRelative(p));
         await this.run('squash', ['--from', fromRevision, '--into', toRevision, ...relativePaths], {

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -510,4 +510,53 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('File Watcher automatically updates SCM decorations', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'tracked.txt': 'base', 'unmodified.txt': 'base' } },
+            { label: 'wc', parents: ['initial'], isWorkingCopy: true },
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            // Wait for initial load
+            const initialWcGroup = page.getByRole('treeitem', { name: /Working Copy/ });
+            await expect(initialWcGroup).toBeVisible();
+
+            // Wait a bit for file watcher to initialize
+            await page.waitForTimeout(2000);
+
+            // 1. Modify tracked.txt via filesystem (File Watcher picks it up)
+            repo.writeFile('tracked.txt', 'modified');
+
+            // 2. Wait for it to appear with "Modified" decoration
+            const trackedRow = page.getByRole('treeitem', { name: /tracked\.txt.*modified/i });
+            await expect(trackedRow).toBeVisible({ timeout: 15000 });
+
+            // 3. Create a completely untracked file and add it to .gitignore
+            repo.writeFile('.gitignore', 'totally-untracked.txt\n');
+            repo.writeFile('totally-untracked.txt', 'ignored content');
+
+            // 4. Focus the File Explorer pane to see the ignored decoration
+            await page.keyboard.press('Control+Shift+E');
+
+            // 5. Wait for the File Explorer to show the ignored file decoration
+            // VS Code appends " • Ignored" to an inner element's aria-label
+            const ignoredRow = page.getByRole('treeitem', { name: /totally-untracked\.txt/i });
+            const ignoredLabel = ignoredRow.locator('[aria-label*="Ignored"]');
+            await expect(ignoredLabel).toBeVisible({ timeout: 15000 });
+
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/jj-decoration-provider.test.ts
+++ b/src/test/jj-decoration-provider.test.ts
@@ -4,8 +4,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { accessPrivate } from './test-utils';
-import { JjStatusEntry } from '../jj-types';
+import * as vscode from 'vscode';
+import { accessPrivate, createMock } from './test-utils';
+import { JjStatusEntry } from '../jj-types'; // Retained as it's used
+import { JjService } from '../jj-service';
 
 // Mock vscode
 vi.mock('vscode', () => {
@@ -15,11 +17,24 @@ vi.mock('vscode', () => {
             fire = () => {};
             dispose = () => {};
         },
-        ThemeColor: class {},
-        FileDecoration: class {},
+        ThemeColor: class {
+            constructor(public id: string) {}
+        },
+        FileDecoration: class {
+            constructor(
+                public badge?: string,
+                public tooltip?: string,
+                public color?: vscode.ThemeColor,
+            ) {}
+        },
+        workspace: {
+            asRelativePath: (uri: vscode.Uri, _includeWorkspaceFolder: boolean) => {
+                return uri.fsPath.replace('/ws/', '');
+            },
+        },
         Uri: {
             parse: (s: string) => ({ toString: () => s }),
-            file: (s: string) => ({ toString: () => `file://${s}` }),
+            file: (s: string) => ({ toString: () => `file://${s}`, fsPath: s, scheme: 'file' }),
         },
     };
 });
@@ -34,36 +49,171 @@ describe('JjDecorationProvider', () => {
     beforeEach(() => {
         // Reset mocks
         vi.clearAllMocks();
-        provider = new JjDecorationProvider();
-
-        // Access the private property
-        const emitter = accessPrivate(provider, '_onDidChangeFileDecorations');
-        fireSpy = vi.spyOn(emitter, 'fire');
+        // provider and fireSpy are now instantiated in each test to pass specific mocks
     });
 
     it('should fire event when decorations change', () => {
-        const decorations = new Map<string, JjStatusEntry>();
-        decorations.set('file:///a', { path: 'a', status: 'modified' });
+        provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
+        fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
 
-        provider.setDecorations(decorations);
+        const scmStatusDecorations = new Map<string, JjStatusEntry>();
+        scmStatusDecorations.set('file:///a', { path: 'a', status: 'modified' });
+
+        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations);
 
         expect(fireSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should NOT fire event when decorations are identical', () => {
-        const decorations1 = new Map<string, JjStatusEntry>();
-        decorations1.set('file:///a', { path: 'a', status: 'modified' });
+    it('should return SCM status decorations if present', async () => {
+        provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
+        const uri1 = (await import('vscode')).Uri.file('/ws/file1.txt');
 
-        provider.setDecorations(decorations1);
+        const scmStatusDecorations = new Map<string, JjStatusEntry>();
+        scmStatusDecorations.set(uri1.toString(), { path: '/ws/file1.txt', status: 'modified' });
+
+        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations);
+        
+        const token = createMock<vscode.CancellationToken>();
+        const result = await provider.provideFileDecoration(uri1, token);
+        expect(result).toBeDefined();
+        expect(result?.tooltip).toBe('Modified');
+    });
+
+    it('should NOT fire event when decorations are identical', () => {
+        provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
+        fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
+
+        const scmStatusDecorations1 = new Map<string, JjStatusEntry>();
+        scmStatusDecorations1.set('file:///a', { path: 'a', status: 'modified' });
+
+        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations1);
+
         expect(fireSpy).toHaveBeenCalledTimes(1);
 
         // precise clone
         const decorations2 = new Map<string, JjStatusEntry>();
         decorations2.set('file:///a', { path: 'a', status: 'modified' });
 
-        provider.setDecorations(decorations2);
+        provider.updateScmStatusAndClearIgnoredCache(decorations2);
 
         // This confirms the fix
         expect(fireSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return ignored decoration for untracked files', async () => {
+        const mockJjService = createMock<JjService>({
+            checkTrackedPaths: vi.fn().mockResolvedValue(['tracked.txt']),
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+
+        const uriTracked = (await import('vscode')).Uri.file('/ws/tracked.txt');
+        const uriIgnored = (await import('vscode')).Uri.file('/ws/ignored.txt');
+        const uriOutside = (await import('vscode')).Uri.file('/outside/file.txt');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        // Outside workspace should return immediately undefined
+        expect(provider.provideFileDecoration(uriOutside, mockToken)).toBeUndefined();
+
+        // Schedule checks
+        const pTracked = provider.provideFileDecoration(uriTracked, mockToken);
+        const pIgnored = provider.provideFileDecoration(uriIgnored, mockToken);
+
+        // Wait for flush timeout
+        await new Promise((r) => setTimeout(r, 60));
+
+        const resTracked = await pTracked;
+        const resIgnored = await pIgnored;
+
+        expect(resTracked).toBeUndefined();
+        expect((resIgnored as vscode.FileDecoration).color).toBeDefined();
+
+        // Assert jjService was called with both relative paths
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalledWith(['tracked.txt', 'ignored.txt']);
+    });
+
+    it('should immediately return ignored decoration for .jj folder and its contents', async () => {
+        const mockJjService = createMock<JjService>({});
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+        const jjFolder = (await import('vscode')).Uri.file('/ws/.jj');
+        const jjContent = (await import('vscode')).Uri.file('/ws/.jj/config.toml');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        const decFolder = provider.provideFileDecoration(jjFolder, mockToken) as vscode.FileDecoration;
+        const decContent = provider.provideFileDecoration(jjContent, mockToken) as vscode.FileDecoration;
+
+        expect(decFolder?.color).toBeDefined();
+        expect(decContent?.color).toBeDefined();
+    });
+
+    it('should return undefined for non-file schemes or outside workspace', async () => {
+        const mockJjService = createMock<JjService>({});
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+        const gitUri = createMock<vscode.Uri>({ scheme: 'git', fsPath: '/ws/file', toString: () => '' });
+        const outsideUri = createMock<vscode.Uri>({ scheme: 'file', fsPath: '/outside/file', toString: () => '' });
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        expect(provider.provideFileDecoration(gitUri, mockToken)).toBeUndefined();
+        expect(provider.provideFileDecoration(outsideUri, mockToken)).toBeUndefined();
+    });
+
+    it('should return cached status synchronously without queuing', async () => {
+        const mockJjService = createMock<JjService>({
+            checkTrackedPaths: vi.fn(),
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+
+        // Exploit accessPrivate to inject cache
+        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<string, boolean>;
+        cache.set('cached_tracked.txt', true);
+        cache.set('cached_ignored.txt', false);
+
+        const uriTracked = (await import('vscode')).Uri.file('/ws/cached_tracked.txt');
+        const uriIgnored = (await import('vscode')).Uri.file('/ws/cached_ignored.txt');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        const decTracked = provider.provideFileDecoration(uriTracked, mockToken);
+        const decIgnored = provider.provideFileDecoration(uriIgnored, mockToken) as vscode.FileDecoration;
+
+        expect(decTracked).toBeUndefined();
+        expect(decIgnored?.color).toBeDefined();
+
+        // Promise should not have been created, meaning No jj checking
+        expect(mockJjService.checkTrackedPaths).not.toHaveBeenCalled();
+    });
+
+    it('should chunk requests if there are more than 100 pending checks', async () => {
+        const mockJjService = createMock<JjService>({
+            checkTrackedPaths: vi.fn().mockResolvedValue([]),
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        // Request 150 items
+        for (let i = 0; i < 150; i++) {
+            const uri = (await import('vscode')).Uri.file(`/ws/file${i}.txt`);
+            provider.provideFileDecoration(uri, mockToken);
+        }
+
+        await new Promise((r) => setTimeout(r, 60));
+
+        // checkTrackedPaths should be called twice (chunk size 100 and then 50)
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(mockJjService.checkTrackedPaths).mock.calls[0][0].length).toBe(100);
+        expect(vi.mocked(mockJjService.checkTrackedPaths).mock.calls[1][0].length).toBe(50);
+    });
+
+    it('should fire onDidChangeFileDecorations when clearIgnoredFileDecorationsCache is called', () => {
+        provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
+        const fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
+        
+        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<string, boolean>;
+        cache.set('dummy', true);
+
+        expect(cache.size).toBe(1);
+
+        provider.clearIgnoredFileDecorationsCache();
+
+        expect(cache.size).toBe(0);
+        expect(fireSpy).toHaveBeenCalledWith(undefined);
     });
 });

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -117,4 +117,131 @@ suite('JJ Decoration Integration Test', function () {
         assert.ok(decoration, 'Decoration should be defined for parent file');
         assert.strictEqual(decoration?.badge, 'M', 'Badge should be M for modified file in parent');
     });
+
+    test('Decorations show Correct Status for Ignored Files', async () => {
+        // Create an ignored file by adding a .gitignore and a file matching it
+        repo.writeFile('.gitignore', 'ignored_file.txt\nignored_dir/\n');
+        repo.writeFile('ignored_file.txt', 'this is ignored');
+        repo.writeFile('ignored_dir/test.txt', 'also ignored');
+        repo.writeFile('tracked_file.txt', 'this is tracked');
+
+        // Wait for jj to pick up the ignore rules
+        await scmProvider.refresh();
+
+        // Check decoration for tracked file
+        const trackedUri = vscode.Uri.file(path.join(repo.path, 'tracked_file.txt'));
+        const pTracked = scmProvider.decorationProvider.provideFileDecoration(
+            trackedUri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        // Check decoration for ignored file
+        const ignoredUri = vscode.Uri.file(path.join(repo.path, 'ignored_file.txt'));
+        const pIgnored = scmProvider.decorationProvider.provideFileDecoration(
+            ignoredUri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        // Check decoration for ignored directory
+        const ignoredDirUri = vscode.Uri.file(path.join(repo.path, 'ignored_dir/test.txt'));
+        const pIgnoredDir = scmProvider.decorationProvider.provideFileDecoration(
+            ignoredDirUri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        const [decTracked, decIgnored, decIgnoredDir] = await Promise.all([pTracked, pIgnored, pIgnoredDir]);
+
+        assert.ok(decTracked !== undefined, 'Tracked file should have a decoration (Added)');
+        assert.strictEqual(decTracked?.badge, 'A', 'Tracked file should be Marked as Added by status');
+        assert.strictEqual(decTracked?.tooltip, 'Added', 'Tracked file should NOT be Ignored');
+
+        assert.ok(decIgnored, 'Ignored file should have a decoration');
+        assert.strictEqual(decIgnored?.tooltip, 'Ignored', 'Should have Ignored tooltip');
+
+        assert.ok(decIgnoredDir, 'Ignored directory contents should have a decoration');
+        assert.strictEqual(decIgnoredDir?.tooltip, 'Ignored', 'Should have Ignored tooltip');
+    });
+
+    test('Decorations show Correct Status for .jj directory bypass', async () => {
+        const jjFolder = vscode.Uri.file(path.join(repo.path, '.jj'));
+        const jjContent = vscode.Uri.file(path.join(repo.path, '.jj/config.toml'));
+
+        // Provide decorations
+        const decFolder = scmProvider.decorationProvider.provideFileDecoration(
+            jjFolder,
+            new vscode.CancellationTokenSource().token,
+        ) as vscode.FileDecoration;
+        const decContent = scmProvider.decorationProvider.provideFileDecoration(
+            jjContent,
+            new vscode.CancellationTokenSource().token,
+        ) as vscode.FileDecoration;
+
+        assert.ok(decFolder, '.jj folder should have a decoration');
+        assert.strictEqual(decFolder.tooltip, 'Ignored', 'Should have Ignored tooltip');
+        assert.ok(decContent, '.jj folder contents should have a decoration');
+        assert.strictEqual(decContent.tooltip, 'Ignored', 'Should have Ignored tooltip');
+    });
+
+    test('Decorations handle Force-Tracked Ignored Files', async () => {
+        // Create a file that is tracked FIRST
+        repo.writeFile('force_tracked.txt', 'tracked content');
+        await scmProvider.refresh(); // Snapshots and tracks it
+
+        // Now add it to .gitignore
+        repo.writeFile('.gitignore', 'force_tracked.txt\n');
+        await scmProvider.refresh(); // Snapshots .gitignore, but force_tracked.txt is ALREADY tracked
+
+        const uri = vscode.Uri.file(path.join(repo.path, 'force_tracked.txt'));
+        const trackedDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
+            uri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        await trackedDecorationPromise;
+        // Because it was modified in the Working Copy (or Added), it should show up explicitly, BUT let's commit it so it has NO explicit status.
+        repo.describe('commit force tracked');
+        repo.new();
+        await scmProvider.refresh();
+
+        const committedDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
+            uri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        const committedDecoration = await committedDecorationPromise;
+
+        // Because it is tracked (despite .gitignore), it should NOT be ignored.
+        // It should be undefined because it has no explicit changes in the new empty working copy.
+        assert.ok(committedDecoration === undefined, 'Force-tracked ignored file should NOT be marked as ignored');
+    });
+
+    test('Decorations clear cache and update on .gitignore change', async () => {
+        const fileName = 'dynamic_ignore.txt';
+        const uri = vscode.Uri.file(path.join(repo.path, fileName));
+
+        // 1. File exists and is tracked in the working copy
+        repo.writeFile(fileName, 'content');
+        await scmProvider.refresh(); // Automatically tracked as 'A'
+
+        const initialTrackedDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
+            uri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+        await initialTrackedDecorationPromise;
+        // Here, it would actually be marked as 'A' (Added), but essentially not ignored
+
+        // 2. Ignore it first, then untrack it (jj file untrack requires the file to be ignored)
+        repo.writeFile('.gitignore', fileName + '\n');
+        repo.untrack(fileName);
+        await scmProvider.refresh(); // This clears the decoration cache!
+
+        const finalIgnoredDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
+            uri,
+            new vscode.CancellationTokenSource().token,
+        ) as Promise<vscode.FileDecoration | undefined>;
+
+        const finalIgnoredDecoration = await finalIgnoredDecorationPromise;
+        assert.ok(finalIgnoredDecoration !== undefined, 'Should now be ignored');
+        assert.strictEqual(finalIgnoredDecoration?.tooltip, 'Ignored', 'Should have Ignored tooltip');
+    });
 });

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -125,6 +125,11 @@ export class TestRepo {
         return this.exec(['diff', '-r', revision, '--summary']);
     }
 
+    untrack(path: string | string[]): void {
+        const paths = Array.isArray(path) ? path : [path];
+        this.exec(['file', 'untrack', ...paths]);
+    }
+
     bookmark(name: string, revision: string) {
         this.exec(['bookmark', 'create', name, '-r', revision]);
     }


### PR DESCRIPTION
Previously, the VS Code File Explorer didn't reflect the ignored status of files governed by `.gitignore` in a jujutsu repository. The extension only provided decorations for tracked features like `Modified` or `Added` files inside the Source Control (SCM) pane.

To improve the visibility of repository boundaries, `JjDecorationProvider` has been expanded to parse and natively decorate untracked or ignored files in the File Explorer. When the extension encounters files outside of the `.jj` tracking sphere, it dynamically schedules a batched query against `jj file list` to capture the current tracking status without choking the host's event loop during large workspace traversals.

This process includes a debounced, chunk-based tracking cache that intelligently limits redundant executions. Whenever native SCM changes are triggered—or when `.gitignore` itself is modified—the tracking cache is automatically flushed, forcing the UI to visually refresh the ignored decorations seamlessly.

Fixes #115 