### PR TITLE
Add dirty state indicators to Commit Details view

### DIFF
--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -15,14 +15,16 @@ export async function setDescriptionCommand(scmProvider: JjScmProvider, jj: JjSe
 
     const description = message ?? scmProvider.sourceControl.inputBox.value;
 
-    if (!description) {
-        return;
+    if (message === undefined && !scmProvider.sourceControl.inputBox.value) {
+        return false;
     }
 
     try {
         await withDelayedProgress('Setting description...', jj.describe(description, revision));
         await scmProvider.refresh({ reason: 'after describe' });
+        return true;
     } catch (e: unknown) {
         await showJjError(e, 'Error setting description', jj, scmProvider.outputChannel);
+        return false;
     }
 }

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -404,13 +404,24 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 case 'webviewLoaded':
                     // Panel handles its own state via initialData
                     break;
-                case 'saveDescription':
-                    await vscode.commands.executeCommand(
+                case 'saveDescription': {
+                    const success = await vscode.commands.executeCommand<boolean>(
                         'jj-view.setDescription',
                         message.payload.description,
                         message.payload.changeId,
                     );
+                    if (this._activeDetailsPanel) {
+                        if (success) {
+                            this._activeDetailsPanel.webview.postMessage({
+                                type: 'saveComplete',
+                                payload: { description: message.payload.description }
+                            });
+                        } else {
+                            this._activeDetailsPanel.webview.postMessage({ type: 'saveFailed' });
+                        }
+                    }
                     break;
+                }
                 case 'openDiff': {
                     const file = message.payload.file;
                     const changeId = message.payload.changeId;
@@ -431,6 +442,12 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 case 'openMultiDiff':
                     await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.changeId);
                     break;
+                case 'dirtyStateChange':
+                    if (this._activeDetailsPanel) {
+                        const baseTitle = `Commit: ${displayId}`;
+                        this._activeDetailsPanel.title = message.payload.isDirty ? `${baseTitle}*` : baseTitle;
+                    }
+                    break;
             }
         });
     }
@@ -450,7 +467,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             <head>
                 <meta charset="UTF-8">
                 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}' ${webview.cspSource};">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; font-src ${webview.cspSource}; script-src 'nonce-${nonce}' ${webview.cspSource};">
                 <link href="${styleUri}" rel="stylesheet">
                 <link href="${codiconsUri}" rel="stylesheet">
                 <title>JJ Log</title>

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -40,22 +40,36 @@ describe('setDescriptionCommand', () => {
     });
 
     test('updates description from string argument', async () => {
-        await setDescriptionCommand(scmProvider, jj, ['new description']);
+        const result = await setDescriptionCommand(scmProvider, jj, ['new description']);
+        expect(result).toBe(true);
         const description = repo.getDescription('@');
         expect(description.trim()).toBe('new description');
     });
 
     test('updates description from input box when message is omitted', async () => {
         scmProvider.sourceControl.inputBox.value = 'from input box';
-        await setDescriptionCommand(scmProvider, jj, []);
+        const result = await setDescriptionCommand(scmProvider, jj, []);
+        expect(result).toBe(true);
         const description = repo.getDescription('@');
         expect(description.trim()).toBe('from input box');
     });
 
+    test('returns false if description is empty or omitted', async () => {
+        // input box is empty, and args is empty
+        const result = await setDescriptionCommand(scmProvider, jj, []);
+        expect(result).toBe(false);
+    });
+
     test('updates description for specific revision', async () => {
         repo.new([], 'child');
-        await setDescriptionCommand(scmProvider, jj, ['updated parent', '@-']);
+        const result = await setDescriptionCommand(scmProvider, jj, ['updated parent', '@-']);
+        expect(result).toBe(true);
         const description = repo.getDescription('@-');
         expect(description.trim()).toBe('updated parent');
+    });
+
+    test('returns false on jj describe failure', async () => {
+        const result = await setDescriptionCommand(scmProvider, jj, ['description', 'invalid_rev']);
+        expect(result).toBe(false);
     });
 });

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -165,13 +165,24 @@ test.describe('Commit Details E2E', () => {
 
         const details = await getDetailsWebview(page);
 
+        // the button initially says "Saved" and is disabled
+        const saveButton = details.locator('button', { hasText: /^Saved/ });
+        await expect(saveButton).toBeDisabled();
+
         // Edit the description
         const textarea = details.locator('textarea');
         await textarea.fill('updated feature description');
 
+        // Verify dirty indicator logic
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes \((⌘|Ctrl\+)S\)/ });
+        await expect(saveChangesButton).toBeEnabled();
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+
         // Click Save
-        const saveButton = details.locator('button', { hasText: 'Save' });
-        await saveButton.click();
+        await saveChangesButton.click();
+
+        // Verify the tab title resets
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}$`) })).toBeVisible();
 
         // Verify the description was saved in the repo
         await expect(async () => {
@@ -198,9 +209,15 @@ test.describe('Commit Details E2E', () => {
         const textarea = details.locator('textarea');
         await textarea.fill('saved via keyboard');
 
+        // Verify dirty state
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+
         // Focus the textarea and press Ctrl+S
         await textarea.focus();
         await page.keyboard.press('Control+s');
+
+        // Verify the tab title resets
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}$`) })).toBeVisible();
 
         // Verify the description was saved in the repo
         await expect(async () => {

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -113,6 +113,11 @@ const App: React.FC = () => {
                         setDetailsCommit(message.payload);
                     }
                     break;
+                case 'saveComplete':
+                    if (view === 'details') {
+                        setDetailsCommit((prev: any) => prev ? { ...prev, description: message.payload.description } : prev);
+                    }
+                    break;
                 case 'setSelection':
                     // External request to set selection (e.g. from closing details tab)
                     const newIds = new Set<string>(message.ids || []);
@@ -309,6 +314,9 @@ const App: React.FC = () => {
                 onSave={handleSaveDescription}
                 onOpenDiff={handleOpenDiff}
                 onOpenMultiDiff={handleOpenMultiDiff}
+                onDirtyStateChange={(isDirty) => {
+                    vscode.postMessage({ type: 'dirtyStateChange', payload: { isDirty } });
+                }}
             />
         );
     }

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -33,6 +33,7 @@ interface CommitDetailsProps {
     onSave: (description: string) => void;
     onOpenDiff: (file: JjStatusEntry, isImmutable: boolean) => void;
     onOpenMultiDiff: () => void;
+    onDirtyStateChange?: (isDirty: boolean) => void;
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
@@ -53,23 +54,47 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
     onSave,
     onOpenDiff,
     onOpenMultiDiff,
+    onDirtyStateChange,
 }) => {
     const [draftDescription, setDraftDescription] = React.useState(description);
     const [isSaving, setIsSaving] = React.useState(false);
 
+    const isDirty = draftDescription !== description;
+
+    const saveTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
     const backdropRef = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
         setDraftDescription(description);
+        setIsSaving(false);
+        if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     }, [description]);
+
+    React.useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            if (event.data.type === 'saveFailed') {
+                setIsSaving(false);
+                if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+            }
+        };
+        window.addEventListener('message', handleMessage);
+        return () => window.removeEventListener('message', handleMessage);
+    }, []);
+
+    React.useEffect(() => {
+        if (onDirtyStateChange) {
+            onDirtyStateChange(isDirty);
+        }
+    }, [isDirty, onDirtyStateChange]);
 
     const handleSave = () => {
         setIsSaving(true);
         onSave(draftDescription);
-        // We expect the backend to maybe close this panel or provide feedback
-        // For now, simple loading state
-        setTimeout(() => setIsSaving(false), 1000);
+        
+        // Fallback to clear the saving state after 15s in case of silent failure
+        if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = setTimeout(() => setIsSaving(false), 15000);
     };
 
     const handleFormat = () => {
@@ -314,24 +339,27 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                             Format Body
                         </button>
                         <button
+                            title={`Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`}
                             onClick={handleSave}
-                            disabled={isSaving}
+                            disabled={isSaving || !isDirty}
+                            className={isDirty && !isSaving ? 'btn-dirty' : ''}
                             style={{
                                 padding: '2px 8px',
                                 color: 'var(--vscode-button-foreground)',
-                                backgroundColor: 'var(--vscode-button-background)',
-                                border: 'none',
-                                cursor: 'pointer',
-                                opacity: isSaving ? 0.7 : 1,
+                                backgroundColor: isDirty ? 'var(--vscode-button-background)' : 'var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background))',
+                                border: '1px solid transparent',
+                                cursor: isSaving || !isDirty ? 'default' : 'pointer',
+                                opacity: isSaving ? 0.7 : (!isDirty ? 0.6 : 1),
                                 display: 'flex',
                                 alignItems: 'center',
                                 fontSize: '12px',
                                 gap: '4px',
                                 borderRadius: '2px',
+                                transition: 'background-color 0.2s, color 0.2s',
                             }}
                         >
-                            <span className="codicon codicon-save"></span>
-                            {isSaving ? 'Saving...' : 'Save'}
+                            <span className={`codicon ${isDirty ? 'codicon-save' : 'codicon-check'}`}></span>
+                            {isSaving ? 'Saving...' : (isDirty ? `Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})` : 'Saved')}
                         </button>
                     </div>
                 </div>
@@ -424,6 +452,19 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                         .commit-textarea::selection {
                             color: transparent !important;
                             background-color: var(--vscode-editor-selectionBackground) !important;
+                        }
+                        .btn-dirty .codicon-save {
+                            animation: jiggle-icon 2s infinite ease-in-out;
+                            display: inline-block;
+                            transform-origin: center;
+                        }
+                        @keyframes jiggle-icon {
+                            0%, 65%, 100% { transform: rotate(0deg); }
+                            70% { transform: rotate(12deg); }
+                            77% { transform: rotate(-8deg); }
+                            84% { transform: rotate(4deg); }
+                            91% { transform: rotate(-2deg); }
+                            98% { transform: rotate(0deg); }
                         }
                     `}</style>
                 </div>


### PR DESCRIPTION
This implements visual feedback when the commit description is modified but unsaved. The webview tab title now appends an asterisk, and the save button updates to show a jiggle animation alongside a label indicating keyboard shortcuts. The backend is also updated to track and respond to these dirty state changes and save events.

This addresses most of #113 . I still need to look into what caused the re-render.