### PR TITLE
Prompt to save unsaved description on commit details close

### DIFF
--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -269,6 +269,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
     private _activeDetailsPanel?: vscode.WebviewPanel;
     private _currentDetailsChangeId?: string;
+    private _currentDetailsIsDirty = false;
+    private _currentDetailsDraftDescription?: string;
 
     public async refreshDetailsPanel() {
         if (!this._activeDetailsPanel || !this._currentDetailsChangeId) {
@@ -382,16 +384,36 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 enableScripts: true,
                 localResourceRoots: [this._extensionUri],
                 enableCommandUris: true,
+                retainContextWhenHidden: true,
             },
         );
         this._activeDetailsPanel = panel;
 
         panel.webview.html = this._getHtmlForWebview(panel.webview, initialData);
 
-        panel.onDidDispose(() => {
+        panel.onDidDispose(async () => {
             if (this._activeDetailsPanel === panel) {
+                const wasDirty = this._currentDetailsIsDirty;
+                const draft = this._currentDetailsDraftDescription;
+                const changeId = this._currentDetailsChangeId;
+
                 this._activeDetailsPanel = undefined;
                 this._currentDetailsChangeId = undefined;
+                this._currentDetailsIsDirty = false;
+                this._currentDetailsDraftDescription = undefined;
+
+                if (wasDirty && draft !== undefined && changeId) {
+                    const choice = await vscode.window.showWarningMessage(
+                        `Do you want to save the changes to the commit description?`,
+                        { modal: true },
+                        'Save',
+                        "Don't Save"
+                    );
+                    if (choice === 'Save') {
+                        await vscode.commands.executeCommand('jj-view.setDescription', draft, changeId);
+                    }
+                }
+
                 // Notify graph view to clear selection
                 if (this._view) {
                     this._view.webview.postMessage({ type: 'setSelection', ids: [] });
@@ -446,6 +468,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     if (this._activeDetailsPanel) {
                         const baseTitle = `Commit: ${displayId}`;
                         this._activeDetailsPanel.title = message.payload.isDirty ? `${baseTitle}*` : baseTitle;
+                        this._currentDetailsIsDirty = message.payload.isDirty;
+                        this._currentDetailsDraftDescription = message.payload.draftDescription;
                     }
                     break;
             }

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -449,4 +449,43 @@ test.describe('Commit Details E2E', () => {
             await expect(frame.getByTitle('This commit cannot be modified')).toBeVisible({ timeout: 1000 });
         }).toPass({ timeout: 20000 });
     });
+
+    test('Prompts to save when closing a dirty details panel', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+
+        // Click to open details
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        const tabLocator = page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) });
+        await expect(tabLocator).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+        const textarea = details.locator('textarea');
+        await textarea.fill('updated via test before close');
+
+        // Verify dirty indicator logic to make sure the state is registered
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes \((⌘|Ctrl\+)S\)/ });
+        await expect(saveChangesButton).toBeEnabled();
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+
+        // Close the tab using the tab close button
+        const tabCloseButton = tabLocator.getByRole('button', { name: 'Close' });
+        await tabCloseButton.click();
+
+        // Wait for the native VS Code dialog (which is now rendered as custom HTML by our settings)
+        const dialog = page.locator('.monaco-dialog-box');
+        await expect(dialog).toBeVisible({ timeout: 5000 });
+        
+        // Click "Save"
+        const saveDialogButton = dialog.getByRole('button', { name: 'Save', exact: true });
+        await saveDialogButton.click();
+
+        // Verify the description was saved in the repo
+        await expect(async () => {
+            const desc = repo.getDescription(nodes['feature'].changeId);
+            expect(desc).toBe('updated via test before close');
+        }).toPass({ timeout: 10000 });
+    });
 });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -41,6 +41,7 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
                 'scm.alwaysShowActions': true,
                 'workbench.tips.enabled': false,
                 'window.titleBarStyle': 'custom',
+                'window.dialogStyle': 'custom',
                 'security.workspace.trust.enabled': false,
                 'jj-view.fileWatcherMode': 'watch',
                 'jj-view.minChangeIdLength': 3,

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -314,8 +314,8 @@ const App: React.FC = () => {
                 onSave={handleSaveDescription}
                 onOpenDiff={handleOpenDiff}
                 onOpenMultiDiff={handleOpenMultiDiff}
-                onDirtyStateChange={(isDirty) => {
-                    vscode.postMessage({ type: 'dirtyStateChange', payload: { isDirty } });
+                onDirtyStateChange={(isDirty, draftDescription) => {
+                    vscode.postMessage({ type: 'dirtyStateChange', payload: { isDirty, draftDescription } });
                 }}
             />
         );

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -33,7 +33,7 @@ interface CommitDetailsProps {
     onSave: (description: string) => void;
     onOpenDiff: (file: JjStatusEntry, isImmutable: boolean) => void;
     onOpenMultiDiff: () => void;
-    onDirtyStateChange?: (isDirty: boolean) => void;
+    onDirtyStateChange?: (isDirty: boolean, draftDescription: string) => void;
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
@@ -84,9 +84,9 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
 
     React.useEffect(() => {
         if (onDirtyStateChange) {
-            onDirtyStateChange(isDirty);
+            onDirtyStateChange(isDirty, draftDescription);
         }
-    }, [isDirty, onDirtyStateChange]);
+    }, [isDirty, draftDescription, onDirtyStateChange]);
 
     const handleSave = () => {
         setIsSaving(true);


### PR DESCRIPTION
Closing a commit details panel with unsaved changes previously discarded the draft description silently. This adds a safety net by tracking the draft state across every keystroke in the webview and showing a VS Code warning dialogue when the panel is disposed.

The commit details webview is also now configured to retain its DOM context when hidden. This ensures that simply switching to a different tab and back no longer causes the panel to re-render and lose its unsaved draft state.

Additionally, end-to-end tests now configure VS Code to use DOM-rendered modals to verify the dirty close behavior automatically.

Fixes #113 