### PR TITLE
Add compact graph label alignment config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,19 @@
                     ],
                     "description": "Color theme for the graph lanes in the JJ Log view."
                 },
+                "jj-view.graphLabelAlignment": {
+                    "type": "string",
+                    "default": "aligned",
+                    "enum": [
+                        "aligned",
+                        "compact"
+                    ],
+                    "enumDescriptions": [
+                        "Keep commit messages aligned in a single column.",
+                        "Place commit messages immediately to the right of their node."
+                    ],
+                    "description": "Controls the horizontal alignment of commit messages in the log view."
+                },
                 "jj-view.commit.titleWidthRuler": {
                     "type": "number",
                     "default": 50,

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -29,7 +29,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         this._gerrit.onDidUpdate(() => this.refreshGerrit());
 
         vscode.workspace.onDidChangeConfiguration((e) => {
-            if (e.affectsConfiguration('jj-view.logTheme')) {
+            if (e.affectsConfiguration('jj-view.logTheme') || e.affectsConfiguration('jj-view.graphLabelAlignment')) {
                 this._renderCommits(this._cachedCommits);
             }
         });
@@ -51,23 +51,29 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         // it uses the latest cached data instead of the initial stale data.
         webviewView.onDidChangeVisibility(() => {
             if (!webviewView.visible) {
-                const currentTheme = vscode.workspace.getConfiguration('jj-view').get<string>('logTheme', 'default');
+                const config = vscode.workspace.getConfiguration('jj-view');
+                const currentTheme = config.get<string>('logTheme', 'default');
+                const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
                 webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
                     view: 'graph',
                     payload: {
                         commits: this._cachedCommits,
                         theme: currentTheme,
+                        graphLabelAlignment,
                     },
                 });
             }
         });
 
-        const initialTheme = vscode.workspace.getConfiguration('jj-view').get<string>('logTheme', 'default');
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const initialTheme = config.get<string>('logTheme', 'default');
+        const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
         webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
             view: 'graph',
             payload: {
                 commits: this._cachedCommits,
                 theme: initialTheme,
+                graphLabelAlignment,
             },
         });
 
@@ -248,6 +254,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const config = vscode.workspace.getConfiguration('jj-view');
         const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
         const logTheme = config.get<string>('logTheme', 'default');
+        const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
 
         if (this._gerrit.isEnabled) {
             this._gerrit.populateGerritInfo(commits);
@@ -260,6 +267,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             commits,
             minChangeIdLength,
             theme: logTheme,
+            graphLabelAlignment,
         });
     }
 

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -28,6 +28,9 @@ const App: React.FC = () => {
         (initialData?.payload as any)?.minChangeIdLength || 1,
     );
     const [theme, setTheme] = React.useState<string>(initialData?.payload?.theme || 'default');
+    const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>(
+        (initialData?.payload as any)?.graphLabelAlignment || 'aligned',
+    );
     // Use ref to access latest commits in event listeners without triggering re-effects
     const commitsRef = React.useRef(commits);
     React.useEffect(() => {
@@ -103,6 +106,9 @@ const App: React.FC = () => {
                         }
                         if (message.theme !== undefined) {
                             setTheme(message.theme);
+                        }
+                        if (message.graphLabelAlignment !== undefined) {
+                            setGraphLabelAlignment(message.graphLabelAlignment);
                         }
                         setLoading(false);
                     }
@@ -346,6 +352,7 @@ const App: React.FC = () => {
                         onAction={handleGraphAction}
                         selectedCommitIds={selectedCommitIds}
                         minChangeIdLength={minChangeIdLength}
+                        graphLabelAlignment={graphLabelAlignment}
                     />
                 </div>
                 {/* 

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -14,6 +14,7 @@ interface CommitGraphProps {
     onAction: (action: string, payload: ActionPayload) => void;
     selectedCommitIds?: Set<string>;
     minChangeIdLength: number;
+    graphLabelAlignment?: string;
 }
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
@@ -21,14 +22,34 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     onAction,
     selectedCommitIds,
     minChangeIdLength,
+    graphLabelAlignment = 'aligned',
 }) => {
-    const layout = React.useMemo(() => computeGraphLayout(commits), [commits]);
-    const displayRows = layout.rows || commits;
-
     // Width of a lane in pixels
     const LANE_WIDTH = 16;
     const ROW_HEIGHT_NORMAL = 28;
     const ROW_HEIGHT_EXPANDED = 44; // Reduced to 44px (28 top - 6 overlap + 22 bottom)
+
+    // Total graph width calculation
+    const LEFT_MARGIN = 12; // Match GraphRail
+    // Dynamic sizing based on font
+    // Fallback to 13px if not available
+    const fontSize = typeof document !== 'undefined' ? parseInt(getComputedStyle(document.body).fontSize) || 13 : 13;
+    const GAP = computeGap(fontSize);
+
+    const layout = React.useMemo(() => computeGraphLayout(commits), [commits]);
+    const displayRows = layout.rows || commits;
+
+    const compactPaddingMap = React.useMemo(() => {
+        if (graphLabelAlignment !== 'compact') {
+            return undefined;
+        }
+        const map = new Map<string, number>();
+        layout.nodes.forEach((n) => {
+            const padding = computeGraphAreaWidth(n.x + 1, LANE_WIDTH, LEFT_MARGIN, GAP);
+            map.set(n.commitId, padding);
+        });
+        return map;
+    }, [layout.nodes, graphLabelAlignment]);
 
     // Calculate Row Offsets
     // This allows us to have variable height rows while keeping the graph aligned.
@@ -48,14 +69,6 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
 
         return { rowOffsets: offsets, totalHeight: currentOffset };
     }, [displayRows]);
-
-    // Total graph width calculation
-    const LEFT_MARGIN = 12; // Match GraphRail
-
-    // Dynamic sizing based on font
-    // Fallback to 13px if not available
-    const fontSize = typeof document !== 'undefined' ? parseInt(getComputedStyle(document.body).fontSize) || 13 : 13;
-    const GAP = computeGap(fontSize);
 
     // Determine the max shortest ID length to display
     const maxShortestIdLength = React.useMemo(
@@ -91,13 +104,13 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 {displayRows.map((commit) => {
                     const isSelected = selectedCommitIds?.has(commit.change_id);
                     const height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
-
+                    const paddingLeft = compactPaddingMap?.get(commit.commit_id) ?? graphAreaWidth;
                     return (
                         <div
                             key={commit.commit_id}
                             style={{
                                 height: height,
-                                paddingLeft: graphAreaWidth,
+                                paddingLeft: paddingLeft,
                                 display: 'flex',
                                 whiteSpace: 'nowrap',
                                 overflow: 'hidden',


### PR DESCRIPTION
Add a config option called graphLabelAlignment to control how the commit labels are aligned in the JJ Log view graph. The current behavior of aligning the labels to the right of the entire graph is called 'aligned' and is the default. The new behavior of aligning the labels immediately to the right of their commit graph nodes is called 'compact'.

Default ('aligned'):
<img width="528" height="395" alt="Screenshot 2026-03-20 at 10 33 17 AM" src="https://github.com/user-attachments/assets/b271b577-3624-4375-99a8-0d3a87669748" />

New ('compact'):
<img width="533" height="397" alt="Screenshot 2026-03-20 at 10 33 51 AM" src="https://github.com/user-attachments/assets/0a1a8fd1-867d-4d88-8829-920576df7017" />

Config option:
<img width="718" height="155" alt="Screenshot 2026-03-20 at 10 34 18 AM" src="https://github.com/user-attachments/assets/4b98822c-d1c8-4f9f-9b81-ea2a877abbb0" />
<img width="737" height="149" alt="Screenshot 2026-03-20 at 10 34 07 AM" src="https://github.com/user-attachments/assets/305884b2-6aac-44f8-bce2-1e2b3e65b60c" />
