### PR TITLE
Migrate Commit Details to Custom Editor API

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
     ],
     "main": "./dist/extension.js",
     "contributes": {
+        "customEditors": [
+            {
+                "viewType": "jj-view.commitDetailsEditor",
+                "displayName": "Commit Details",
+                "selector": [
+                    {
+                        "filenamePattern": "*.jj-commit"
+                    }
+                ],
+                "priority": "default"
+            }
+        ],
         "icons": {
             "jj-icon-squash-into": {
                 "description": "Squash into Ancestor icon",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { JjScmProvider } from './jj-scm-provider';
 import { JjDocumentContentProvider } from './jj-content-provider';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjLogWebviewProvider } from './jj-log-webview-provider';
+import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 import { GerritService } from './gerrit-service';
 import { abandonCommand } from './commands/abandon';
 import { newMergeChangeCommand, MergeCommandArg } from './commands/merge';
@@ -215,11 +216,21 @@ export function activate(context: vscode.ExtensionContext) {
         }),
     );
 
+    const commitDetailsProvider = new JjCommitDetailsEditorProvider(context.extensionUri, jj);
+    context.subscriptions.push(
+        vscode.window.registerCustomEditorProvider(JjCommitDetailsEditorProvider.viewType, commitDetailsProvider, {
+            webviewOptions: {
+                retainContextWhenHidden: true,
+            },
+        }),
+    );
+
     // Register view provider
     const logWebviewProvider = new JjLogWebviewProvider(
         context.extensionUri,
         jj,
         gerritService,
+        commitDetailsProvider,
         (ids) => {
             scmProvider.handleSelectionChange(ids);
         },

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { JjService } from './jj-service';
+import { createDiffUris } from './uri-utils';
+import { shortenChangeId } from './utils/jj-utils';
+
+export class JjCommitDocument implements vscode.CustomDocument {
+    public readonly uri: vscode.Uri;
+    public readonly changeId: string;
+    public draftDescription?: string;
+
+    constructor(uri: vscode.Uri, changeId: string) {
+        this.uri = uri;
+        this.changeId = changeId;
+    }
+
+    dispose(): void {}
+}
+
+export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvider<JjCommitDocument> {
+    public static readonly viewType = 'jj-view.commitDetailsEditor';
+
+    private readonly _onDidChangeCustomDocument = new vscode.EventEmitter<
+        vscode.CustomDocumentEditEvent<JjCommitDocument>
+    >();
+    public readonly onDidChangeCustomDocument = this._onDidChangeCustomDocument.event;
+
+    // Track all open panels for refreshing
+    private readonly _panels = new Map<string, Set<vscode.WebviewPanel>>();
+
+    constructor(
+        private readonly _extensionUri: vscode.Uri,
+        private readonly _jj: JjService,
+    ) {}
+
+    public async refresh(): Promise<void> {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+        const logTheme = config.get<string>('logTheme', 'default');
+        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
+        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
+
+        for (const [changeId, panels] of this._panels.entries()) {
+            if (panels.size === 0) continue;
+
+            try {
+                const logs = await this._jj.getLog({ revision: changeId });
+                if (logs.length === 0) {
+                    panels.forEach((p) => p.dispose());
+                    continue;
+                }
+
+                const log = logs[0];
+                const filesWithStats = await this._jj.getChanges(changeId).catch(() => log.changes || []);
+
+                for (const panel of panels) {
+                    panel.webview.postMessage({
+                        type: 'updateDetails',
+                        payload: {
+                            changeId,
+                            commitId: log.commit_id,
+                            description: log.description,
+                            files: filesWithStats,
+                            isImmutable: log.is_immutable,
+                            author: log.author,
+                            committer: log.committer,
+                            bookmarks: log.bookmarks || [],
+                            tags: log.tags || [],
+                            isEmpty: log.is_empty,
+                            isConflict: log.conflict,
+                            minChangeIdLength,
+                            theme: logTheme,
+                            titleWidthRuler,
+                            bodyWidthRuler,
+                        },
+                    });
+                }
+            } catch (e) {
+                // Ignore errors for individual refreshes
+            }
+        }
+    }
+
+    public async saveCustomDocument(
+        document: JjCommitDocument,
+        _cancellation: vscode.CancellationToken,
+    ): Promise<void> {
+        if (document.draftDescription !== undefined) {
+            await vscode.commands.executeCommand(
+                'jj-view.setDescription',
+                document.draftDescription,
+                document.changeId,
+            );
+        }
+    }
+
+    public async saveCustomDocumentAs(
+        _document: JjCommitDocument,
+        _destination: vscode.Uri,
+        _cancellation: vscode.CancellationToken,
+    ): Promise<void> {
+        // Not applicable for this editor
+        await this.saveCustomDocument(_document, _cancellation);
+    }
+
+    public async revertCustomDocument(
+        _document: JjCommitDocument,
+        _cancellation: vscode.CancellationToken,
+    ): Promise<void> {
+        // We handle reversion by telling the webview to reload the data.
+        // It's easiest to just leave it as is or trigger a refresh command.
+    }
+
+    public backupCustomDocument(
+        document: JjCommitDocument,
+        _context: vscode.CustomDocumentBackupContext,
+        _cancellation: vscode.CancellationToken,
+    ): Promise<vscode.CustomDocumentBackup> {
+        // CustomEditor requires a backup implementation to truly support hot-exit, but we can provide a dummy for now.
+        return Promise.resolve({
+            id: document.uri.toString(),
+            delete: () => {},
+        });
+    }
+
+    public async openCustomDocument(
+        uri: vscode.Uri,
+        _openContext: vscode.CustomDocumentOpenContext,
+        _token: vscode.CancellationToken,
+    ): Promise<JjCommitDocument> {
+        // URI format: jj-commit://commit/Commit:%20<shortId>?changeId=<changeId>
+        const query = new URLSearchParams(uri.query);
+        const changeId = query.get('changeId') || uri.path.split('/').pop() || uri.path;
+        return new JjCommitDocument(uri, changeId);
+    }
+
+    public async resolveCustomEditor(
+        document: JjCommitDocument,
+        panel: vscode.WebviewPanel,
+        _token: vscode.CancellationToken,
+    ): Promise<void> {
+        // Track the panel
+        if (!this._panels.has(document.changeId)) {
+            this._panels.set(document.changeId, new Set());
+        }
+        this._panels.get(document.changeId)!.add(panel);
+
+        panel.onDidDispose(() => {
+            this._panels.get(document.changeId)?.delete(panel);
+            if (this._panels.get(document.changeId)?.size === 0) {
+                this._panels.delete(document.changeId);
+            }
+        });
+
+        panel.webview.options = {
+            enableScripts: true,
+            localResourceRoots: [this._extensionUri],
+            enableCommandUris: true,
+        };
+
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+        const logTheme = config.get<string>('logTheme', 'default');
+        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
+        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
+
+        try {
+            const logs = await this._jj.getLog({ revision: document.changeId });
+            if (logs.length === 0) {
+                panel.dispose();
+                return;
+            }
+
+            const log = logs[0];
+            const filesWithStats = await this._jj.getChanges(document.changeId).catch(() => log.changes || []);
+
+            const initialData = {
+                view: 'details',
+                payload: {
+                    changeId: document.changeId,
+                    commitId: log.commit_id,
+                    description: log.description,
+                    files: filesWithStats,
+                    isImmutable: log.is_immutable,
+                    author: log.author,
+                    committer: log.committer,
+                    bookmarks: log.bookmarks || [],
+                    tags: log.tags || [],
+                    isEmpty: log.is_empty,
+                    isConflict: log.conflict,
+                    minChangeIdLength,
+                    theme: logTheme,
+                    titleWidthRuler,
+                    bodyWidthRuler,
+                },
+            };
+
+            panel.webview.html = this._getHtmlForWebview(panel.webview, initialData);
+
+            panel.webview.onDidReceiveMessage(async (message) => {
+                switch (message.type) {
+                    case 'webviewLoaded':
+                        break;
+                    case 'dirtyStateChange': {
+                        const isDirty = message.payload.isDirty;
+                        if (isDirty) {
+                            document.draftDescription = message.payload.draftDescription;
+                            // Notify VS Code that the document is dirty
+                            this._onDidChangeCustomDocument.fire({
+                                document,
+                                undo: () => {},
+                                redo: () => {},
+                                label: 'Edit Description',
+                            });
+                        }
+                        break;
+                    }
+                    case 'saveDescription': {
+                        // Natively trigger save which will call our saveCustomDocument
+                        await vscode.commands.executeCommand('workbench.action.files.save');
+                        panel.webview.postMessage({
+                            type: 'saveComplete',
+                            payload: { description: message.payload.description },
+                        });
+                        break;
+                    }
+                    case 'openDiff': {
+                        const file = message.payload.file;
+                        const changeId = message.payload.changeId;
+                        const isImmutable = message.payload.isImmutable;
+
+                        const { leftUri, rightUri } = createDiffUris(file, changeId, this._jj.workspaceRoot, {
+                            editable: !isImmutable,
+                        });
+
+                        await vscode.commands.executeCommand(
+                            'vscode.diff',
+                            leftUri,
+                            rightUri,
+                            `${path.basename(file.path)} (${shortenChangeId(changeId, minChangeIdLength)})${!isImmutable ? ' (Editable)' : ''}`,
+                        );
+                        break;
+                    }
+                    case 'openMultiDiff':
+                        await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.changeId);
+                        break;
+                }
+            });
+        } catch (e) {
+            panel.dispose();
+        }
+    }
+
+    private _getHtmlForWebview(webview: vscode.Webview, initialData?: unknown) {
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'dist', 'webview', 'index.js'));
+        const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.css'));
+        const codiconsUri = webview.asWebviewUri(
+            vscode.Uri.joinPath(this._extensionUri, 'media', 'codicons', 'codicon.css'),
+        );
+
+        let nonceText = '';
+        const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        for (let i = 0; i < 32; i++) {
+            nonceText += possible.charAt(Math.floor(Math.random() * possible.length));
+        }
+
+        const initialDataScript = initialData ? `window.vscodeInitialData = ${JSON.stringify(initialData)};` : '';
+
+        return `<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; font-src ${webview.cspSource}; script-src 'nonce-${nonceText}' ${webview.cspSource};">
+                <link href="${styleUri}" rel="stylesheet">
+                <link href="${codiconsUri}" rel="stylesheet">
+                <title>JJ Log</title>
+            </head>
+            <body>
+                <div id="root"></div>
+                <script nonce="${nonceText}">
+                    ${initialDataScript}
+                </script>
+                <script nonce="${nonceText}" src="${scriptUri}"></script>
+            </body>
+            </html>`;
+    }
+}

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -264,7 +264,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         if (scmChanged) {
             this.scmStatusDecorations = scmStatusDecorations;
         }
-        
+
         const cacheCleared = this._clearIgnoredFileDecorationsCache();
 
         if (scmChanged || cacheCleared) {

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -4,12 +4,11 @@
  */
 
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { JjService } from './jj-service';
 import { JjContextKey } from './jj-context-keys';
 import { JjLogEntry } from './jj-types';
-import { createDiffUris } from './uri-utils';
-import { formatDisplayChangeId, shortenChangeId } from './utils/jj-utils';
+import { shortenChangeId } from './utils/jj-utils';
+import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 
 import { GerritService } from './gerrit-service';
 
@@ -22,6 +21,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         private readonly _extensionUri: vscode.Uri,
         private readonly _jj: JjService,
         private readonly _gerrit: GerritService,
+        private readonly _commitDetailsProvider: JjCommitDetailsEditorProvider,
         private readonly _onSelectionChange: (commits: string[]) => void,
         public readonly outputChannel?: vscode.OutputChannel, // Optional
     ) {
@@ -144,17 +144,26 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 case 'upload':
                     await vscode.commands.executeCommand('jj-view.upload', data.payload);
                     break;
-                case 'selectionChange':
-                    if (data.payload.commitIds.length === 0 && this._activeDetailsPanel) {
-                        // Close details panel if selection is cleared
-                        // Must clear reference first to avoid loop with onDidDispose
-                        const panel = this._activeDetailsPanel;
-                        this._activeDetailsPanel = undefined;
-                        panel.dispose();
-                    }
-
+                case 'selectionChange': {
                     const count = data.payload.commitIds.length;
                     const hasImmutable = !!data.payload.hasImmutableSelection;
+
+                    if (count !== 1) {
+                        const tabsToClose: vscode.Tab[] = [];
+                        for (const tabGroup of vscode.window.tabGroups.all) {
+                            for (const tab of tabGroup.tabs) {
+                                if (
+                                    tab.input instanceof vscode.TabInputCustom &&
+                                    tab.input.viewType === JjCommitDetailsEditorProvider.viewType
+                                ) {
+                                    tabsToClose.push(tab);
+                                }
+                            }
+                        }
+                        if (tabsToClose.length > 0) {
+                            await vscode.window.tabGroups.close(tabsToClose);
+                        }
+                    }
 
                     // Compute Capabilities
                     const allowAbandon = count > 0 && !hasImmutable;
@@ -185,6 +194,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                         this._onSelectionChange(data.payload.commitIds);
                     }
                     break;
+                }
             }
         });
     }
@@ -221,7 +231,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             await this.refreshGerrit();
 
             // Also refresh details panel if open
-            await this.refreshDetailsPanel();
+            await this._commitDetailsProvider.refresh();
         }
     }
 
@@ -275,213 +285,35 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         });
     }
 
-    private _activeDetailsPanel?: vscode.WebviewPanel;
-    private _currentDetailsChangeId?: string;
-    private _currentDetailsIsDirty = false;
-    private _currentDetailsDraftDescription?: string;
-
-    public async refreshDetailsPanel() {
-        if (!this._activeDetailsPanel || !this._currentDetailsChangeId) {
-            return;
-        }
-
-        const changeId = this._currentDetailsChangeId;
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-        const logTheme = config.get<string>('logTheme', 'default');
-        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
-        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
-
-        // Fetch full log entry - this includes description, changes (file list), and immutability status
-        let logs: JjLogEntry[];
-        try {
-            logs = await this._jj.getLog({ revision: changeId });
-        } catch (e) {
-            // Commit no longer exists (e.g. was abandoned)
-            this._activeDetailsPanel.dispose();
-            return;
-        }
-
-        if (logs.length === 0) {
-            this._activeDetailsPanel.dispose();
-            return;
-        }
-
-        const log = logs[0];
-        const filesWithStats = await this._jj.getChanges(changeId).catch(() => log.changes || []);
-
-        this._activeDetailsPanel.webview.postMessage({
-            type: 'updateDetails',
-            payload: {
-                changeId,
-                commitId: log.commit_id,
-                description: log.description,
-                files: filesWithStats,
-                isImmutable: log.is_immutable,
-                author: log.author,
-                committer: log.committer,
-                bookmarks: log.bookmarks || [],
-                tags: log.tags || [],
-                isEmpty: log.is_empty,
-                isConflict: log.conflict,
-                minChangeIdLength,
-                theme: logTheme,
-                titleWidthRuler,
-                bodyWidthRuler,
-            },
-        });
-    }
-
     public async createCommitDetailsPanel(changeId: string) {
         const config = vscode.workspace.getConfiguration('jj-view');
         const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-        const logTheme = config.get<string>('logTheme', 'default');
-        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
-        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
-
-        // Fetch full log entry - this includes description, changes (file list), and immutability status
-        const logs = await this._jj.getLog({ revision: changeId });
-        if (logs.length === 0) {
-            return;
-        }
-
-        const log = logs[0];
-        const displayId = formatDisplayChangeId(changeId, log.change_id_shortest, minChangeIdLength);
-
-        // Fetch actual changes with additions/deletions stats
-        const filesWithStats = await this._jj.getChanges(changeId).catch(() => log.changes || []);
-
-        const initialData = {
-            view: 'details',
-            payload: {
-                changeId,
-                commitId: log.commit_id,
-                description: log.description,
-                files: filesWithStats,
-                isImmutable: log.is_immutable,
-                author: log.author,
-                committer: log.committer,
-                bookmarks: log.bookmarks || [],
-                tags: log.tags || [],
-                isEmpty: log.is_empty,
-                isConflict: log.conflict,
-                minChangeIdLength,
-                theme: logTheme,
-                titleWidthRuler,
-                bodyWidthRuler,
-            },
-        };
-
-        this._currentDetailsChangeId = changeId;
-
-        if (this._activeDetailsPanel) {
-            this._activeDetailsPanel.title = `Commit: ${displayId}`;
-            this._activeDetailsPanel.webview.html = this._getHtmlForWebview(
-                this._activeDetailsPanel.webview,
-                initialData,
-            );
-            this._activeDetailsPanel.reveal();
-            return;
-        }
-
-        const panel = vscode.window.createWebviewPanel(
-            'jj-view.commitDetails',
-            `Commit: ${displayId}`,
-            vscode.ViewColumn.Active,
-            {
-                enableScripts: true,
-                localResourceRoots: [this._extensionUri],
-                enableCommandUris: true,
-                retainContextWhenHidden: true,
-            },
-        );
-        this._activeDetailsPanel = panel;
-
-        panel.webview.html = this._getHtmlForWebview(panel.webview, initialData);
-
-        panel.onDidDispose(async () => {
-            if (this._activeDetailsPanel === panel) {
-                const wasDirty = this._currentDetailsIsDirty;
-                const draft = this._currentDetailsDraftDescription;
-                const changeId = this._currentDetailsChangeId;
-
-                this._activeDetailsPanel = undefined;
-                this._currentDetailsChangeId = undefined;
-                this._currentDetailsIsDirty = false;
-                this._currentDetailsDraftDescription = undefined;
-
-                if (wasDirty && draft !== undefined && changeId) {
-                    const choice = await vscode.window.showWarningMessage(
-                        `Do you want to save the changes to the commit description?`,
-                        { modal: true },
-                        'Save',
-                        "Don't Save"
-                    );
-                    if (choice === 'Save') {
-                        await vscode.commands.executeCommand('jj-view.setDescription', draft, changeId);
-                    }
-                }
-
-                // Notify graph view to clear selection
-                if (this._view) {
-                    this._view.webview.postMessage({ type: 'setSelection', ids: [] });
-                }
-            }
+        const shortId = shortenChangeId(changeId, minChangeIdLength);
+        const uri = vscode.Uri.from({
+            scheme: 'jj-commit',
+            authority: 'commit',
+            path: `/Commit: ${shortId}`,
+            query: `changeId=${changeId}`,
         });
 
-        panel.webview.onDidReceiveMessage(async (message) => {
-            switch (message.type) {
-                case 'webviewLoaded':
-                    // Panel handles its own state via initialData
-                    break;
-                case 'saveDescription': {
-                    const success = await vscode.commands.executeCommand<boolean>(
-                        'jj-view.setDescription',
-                        message.payload.description,
-                        message.payload.changeId,
-                    );
-                    if (this._activeDetailsPanel) {
-                        if (success) {
-                            this._activeDetailsPanel.webview.postMessage({
-                                type: 'saveComplete',
-                                payload: { description: message.payload.description }
-                            });
-                        } else {
-                            this._activeDetailsPanel.webview.postMessage({ type: 'saveFailed' });
-                        }
+        const tabsToClose: vscode.Tab[] = [];
+        for (const tabGroup of vscode.window.tabGroups.all) {
+            for (const tab of tabGroup.tabs) {
+                if (
+                    tab.input instanceof vscode.TabInputCustom &&
+                    tab.input.viewType === JjCommitDetailsEditorProvider.viewType
+                ) {
+                    if (tab.input.uri.toString() !== uri.toString()) {
+                        tabsToClose.push(tab);
                     }
-                    break;
                 }
-                case 'openDiff': {
-                    const file = message.payload.file;
-                    const changeId = message.payload.changeId;
-                    const isImmutable = message.payload.isImmutable;
-
-                    const { leftUri, rightUri } = createDiffUris(file, changeId, this._jj.workspaceRoot, {
-                        editable: !isImmutable,
-                    });
-
-                    await vscode.commands.executeCommand(
-                        'vscode.diff',
-                        leftUri,
-                        rightUri,
-                        `${path.basename(file.path)} (${shortenChangeId(changeId, minChangeIdLength)})${!isImmutable ? ' (Editable)' : ''}`,
-                    );
-                    break;
-                }
-                case 'openMultiDiff':
-                    await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.changeId);
-                    break;
-                case 'dirtyStateChange':
-                    if (this._activeDetailsPanel) {
-                        const baseTitle = `Commit: ${displayId}`;
-                        this._activeDetailsPanel.title = message.payload.isDirty ? `${baseTitle}*` : baseTitle;
-                        this._currentDetailsIsDirty = message.payload.isDirty;
-                        this._currentDetailsDraftDescription = message.payload.draftDescription;
-                    }
-                    break;
             }
-        });
+        }
+        if (tabsToClose.length > 0) {
+            await vscode.window.tabGroups.close(tabsToClose);
+        }
+
+        await vscode.commands.executeCommand('vscode.openWith', uri, JjCommitDetailsEditorProvider.viewType);
     }
 
     private _getHtmlForWebview(webview: vscode.Webview, initialData?: unknown) {

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -16,10 +16,9 @@ async function getDetailsWebview(page: Page): Promise<Frame> {
     const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
         for (const f of frames) {
             try {
-                // First check if the frame itself is valid and has a heading
-                // We don't want to use count() > 0 which can be slow; use visible check
-                const heading = f.locator('h2', { hasText: 'Commit Details' });
-                if (await heading.isVisible({ timeout: 500 })) {
+                // Return the first iframe that is actually visible (not hidden by VS Code's tab switching)
+                // We consider it the active webview if its textarea is visible, meaning it's the actively displayed tab
+                if (await f.locator('textarea').isVisible({ timeout: 50 })) {
                     return f;
                 }
 
@@ -174,15 +173,15 @@ test.describe('Commit Details E2E', () => {
         await textarea.fill('updated feature description');
 
         // Verify dirty indicator logic
-        const saveChangesButton = details.locator('button', { hasText: /Save Changes \((⌘|Ctrl\+)S\)/ });
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes|Saved/ });
         await expect(saveChangesButton).toBeEnabled();
-        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+        await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).toHaveClass(/dirty/);
 
         // Click Save
         await saveChangesButton.click();
 
-        // Verify the tab title resets
-        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}$`) })).toBeVisible();
+        // Verify the Save button is disabled (via our Webview state checking it's clean)
+        await expect(saveChangesButton).toBeDisabled({ timeout: 15000 });
 
         // Verify the description was saved in the repo
         await expect(async () => {
@@ -210,14 +209,15 @@ test.describe('Commit Details E2E', () => {
         await textarea.fill('saved via keyboard');
 
         // Verify dirty state
-        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+        await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).toHaveClass(/dirty/);
 
         // Focus the textarea and press Ctrl+S
         await textarea.focus();
         await page.keyboard.press('Control+s');
 
-        // Verify the tab title resets
-        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}$`) })).toBeVisible();
+        // Verify the Save button is disabled (via our Webview state checking it's clean)
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes|Saved/ });
+        await expect(saveChangesButton).toBeDisabled({ timeout: 15000 });
 
         // Verify the description was saved in the repo
         await expect(async () => {
@@ -468,7 +468,7 @@ test.describe('Commit Details E2E', () => {
         // Verify dirty indicator logic to make sure the state is registered
         const saveChangesButton = details.locator('button', { hasText: /Save Changes \((⌘|Ctrl\+)S\)/ });
         await expect(saveChangesButton).toBeEnabled();
-        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}\\*$`) })).toBeVisible();
+        await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).toHaveClass(/dirty/);
 
         // Close the tab using the tab close button
         const tabCloseButton = tabLocator.getByRole('button', { name: 'Close' });
@@ -477,7 +477,7 @@ test.describe('Commit Details E2E', () => {
         // Wait for the native VS Code dialog (which is now rendered as custom HTML by our settings)
         const dialog = page.locator('.monaco-dialog-box');
         await expect(dialog).toBeVisible({ timeout: 5000 });
-        
+
         // Click "Save"
         const saveDialogButton = dialog.getByRole('button', { name: 'Save', exact: true });
         await saveDialogButton.click();

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -550,7 +550,6 @@ test.describe('SCM Pane E2E', () => {
             const ignoredRow = page.getByRole('treeitem', { name: /totally-untracked\.txt/i });
             const ignoredLabel = ignoredRow.locator('[aria-label*="Ignored"]');
             await expect(ignoredLabel).toBeVisible({ timeout: 15000 });
-
         } finally {
             await app.close();
             try {

--- a/src/test/jj-decoration-provider.test.ts
+++ b/src/test/jj-decoration-provider.test.ts
@@ -72,7 +72,7 @@ describe('JjDecorationProvider', () => {
         scmStatusDecorations.set(uri1.toString(), { path: '/ws/file1.txt', status: 'modified' });
 
         provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations);
-        
+
         const token = createMock<vscode.CancellationToken>();
         const result = await provider.provideFileDecoration(uri1, token);
         expect(result).toBeDefined();
@@ -205,7 +205,7 @@ describe('JjDecorationProvider', () => {
     it('should fire onDidChangeFileDecorations when clearIgnoredFileDecorationsCache is called', () => {
         provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
         const fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
-        
+
         const cache = accessPrivate(provider, 'trackedStatusCache') as Map<string, boolean>;
         cache.set('dummy', true);
 

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -668,6 +668,7 @@ suite('JJ SCM Provider Integration Test', function () {
             // Use JjLogWebviewProvider
             const { JjLogWebviewProvider } = await import('../jj-log-webview-provider');
             const { GerritService } = await import('../gerrit-service');
+            const { JjCommitDetailsEditorProvider } = await import('../jj-commit-details-editor-provider');
             const extensionUri = vscode.Uri.file(__dirname); // Mock URI
             const gerritService = createMock<InstanceType<typeof GerritService>>({
                 onDidUpdate: () => {
@@ -677,10 +678,12 @@ suite('JJ SCM Provider Integration Test', function () {
                 startPolling: () => {},
                 dispose: () => {},
             });
+            const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, jj);
             const provider = new JjLogWebviewProvider(
                 extensionUri,
                 jj,
                 gerritService,
+                commitDetailsProvider,
                 () => {},
                 scmProvider.outputChannel,
             );

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -18,6 +18,7 @@ import { editCommand } from '../commands/edit';
 import { undoCommand } from '../commands/undo';
 import { TestRepo } from './test-repo';
 import { createMock, asSinonStub } from './test-utils';
+import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 
 suite('Webview Commands End-to-End Integration Test', function () {
     let jj: JjService;
@@ -88,7 +89,15 @@ suite('Webview Commands End-to-End Integration Test', function () {
             stopPolling: () => {},
             dispose: () => {},
         });
-        provider = new JjLogWebviewProvider(extensionUri, jj, gerritService, () => {}, scm.outputChannel);
+        const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, jj);
+        provider = new JjLogWebviewProvider(
+            extensionUri,
+            jj,
+            gerritService,
+            commitDetailsProvider,
+            () => {},
+            scm.outputChannel,
+        );
 
         // Mock 'vscode.commands.executeCommand'
         executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -11,6 +11,7 @@ import { JjLogWebviewProvider } from '../jj-log-webview-provider';
 import { GerritService } from '../gerrit-service';
 import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
+import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 
 function createMockWebviewView() {
     let visibilityListener: (e: void) => void | undefined;
@@ -65,7 +66,15 @@ suite('Webview Initialization Integration Test', function () {
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
         });
-        provider = new JjLogWebviewProvider(extensionUri, jj, gerritService, () => {}, outputChannel);
+        const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, jj);
+        provider = new JjLogWebviewProvider(
+            extensionUri,
+            jj,
+            gerritService,
+            commitDetailsProvider,
+            () => {},
+            outputChannel,
+        );
     });
 
     teardown(async () => {

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -11,6 +11,7 @@ import { JjLogWebviewProvider } from '../jj-log-webview-provider';
 import { GerritService } from '../gerrit-service';
 import { TestRepo } from './test-repo';
 import { createMock, asSinonStub } from './test-utils';
+import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 
 suite('Webview Selection Integration Test', function () {
     let jj: JjService;
@@ -64,7 +65,15 @@ suite('Webview Selection Integration Test', function () {
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
         });
-        provider = new JjLogWebviewProvider(extensionUri, jj, gerritService, () => {}, outputChannel);
+        const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, jj);
+        provider = new JjLogWebviewProvider(
+            extensionUri,
+            jj,
+            gerritService,
+            commitDetailsProvider,
+            () => {},
+            outputChannel,
+        );
 
         // Spy on vscode.commands.executeCommand; stub jj-view.* to avoid errors
         executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -111,6 +111,30 @@ const App: React.FC = () => {
                             setGraphLabelAlignment(message.graphLabelAlignment);
                         }
                         setLoading(false);
+
+                        // Validate current selection against new commits list
+                        setSelectedCommitIds((prevIds) => {
+                            if (prevIds.size === 0) return prevIds;
+
+                            const validIds = Array.from(prevIds).filter((id) =>
+                                message.commits.some((c: any) => c.change_id === id),
+                            );
+
+                            if (validIds.length !== prevIds.size) {
+                                const newIds = new Set(validIds);
+                                const hasImmutable = hasImmutableSelection(newIds, message.commits);
+
+                                vscode.postMessage({
+                                    type: 'selectionChange',
+                                    payload: {
+                                        commitIds: validIds,
+                                        hasImmutableSelection: hasImmutable,
+                                    },
+                                });
+                                return newIds;
+                            }
+                            return prevIds;
+                        });
                     }
                     break;
                 case 'updateDetails':
@@ -121,7 +145,9 @@ const App: React.FC = () => {
                     break;
                 case 'saveComplete':
                     if (view === 'details') {
-                        setDetailsCommit((prev: any) => prev ? { ...prev, description: message.payload.description } : prev);
+                        setDetailsCommit((prev: any) =>
+                            prev ? { ...prev, description: message.payload.description } : prev,
+                        );
                     }
                     break;
                 case 'setSelection':

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -57,17 +57,35 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
     onDirtyStateChange,
 }) => {
     const [draftDescription, setDraftDescription] = React.useState(description);
+    const draftDescriptionRef = React.useRef(draftDescription);
     const [isSaving, setIsSaving] = React.useState(false);
+
+    // Keep the ref strictly in sync with the state for use inside effects
+    // that shouldn't re-run on every keystroke.
+    React.useEffect(() => {
+        draftDescriptionRef.current = draftDescription;
+    }, [draftDescription]);
 
     const isDirty = draftDescription !== description;
 
     const saveTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
     const backdropRef = React.useRef<HTMLDivElement>(null);
+    const prevDescriptionRef = React.useRef(description);
 
     React.useEffect(() => {
-        setDraftDescription(description);
+        // Synchronize the draft description with the canonical description from the backend.
+        // We only overwrite the draft if the user hasn't made any unsaved edits (the draft
+        // matches the previous description), or if the only difference is trailing whitespace
+        // (to account for formatting adjustments applied by jj during save).
+        if (
+            draftDescriptionRef.current === prevDescriptionRef.current ||
+            draftDescriptionRef.current.trimEnd() === description.trimEnd()
+        ) {
+            setDraftDescription(description);
+        }
         setIsSaving(false);
+        prevDescriptionRef.current = description;
         if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
     }, [description]);
 
@@ -90,8 +108,16 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
 
     const handleSave = () => {
         setIsSaving(true);
-        onSave(draftDescription);
-        
+
+        // jj enforces a trailing newline. Ensure we have one so our state matches what jj will return
+        let finalDescription = draftDescription;
+        if (!finalDescription.endsWith('\n')) {
+            finalDescription += '\n';
+            setDraftDescription(finalDescription);
+        }
+
+        onSave(finalDescription);
+
         // Fallback to clear the saving state after 15s in case of silent failure
         if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
         saveTimeoutRef.current = setTimeout(() => setIsSaving(false), 15000);
@@ -346,10 +372,12 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                             style={{
                                 padding: '2px 8px',
                                 color: 'var(--vscode-button-foreground)',
-                                backgroundColor: isDirty ? 'var(--vscode-button-background)' : 'var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background))',
+                                backgroundColor: isDirty
+                                    ? 'var(--vscode-button-background)'
+                                    : 'var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background))',
                                 border: '1px solid transparent',
                                 cursor: isSaving || !isDirty ? 'default' : 'pointer',
-                                opacity: isSaving ? 0.7 : (!isDirty ? 0.6 : 1),
+                                opacity: isSaving ? 0.7 : !isDirty ? 0.6 : 1,
                                 display: 'flex',
                                 alignItems: 'center',
                                 fontSize: '12px',
@@ -359,7 +387,11 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                             }}
                         >
                             <span className={`codicon ${isDirty ? 'codicon-save' : 'codicon-check'}`}></span>
-                            {isSaving ? 'Saving...' : (isDirty ? `Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})` : 'Saved')}
+                            {isSaving
+                                ? 'Saving...'
+                                : isDirty
+                                  ? `Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`
+                                  : 'Saved'}
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
Refactors the Commit Details panel to leverage VS Code's native Custom Editor API (`vscode.CustomEditorProvider`) for improved tab management and dirty state integration.

Key changes:
- Introduces `JjCommitDetailsEditorProvider` to manage `.jj-commit` virtual documents.
- Updates `JjLogWebviewProvider` to programmatically enforce single-pane visibility by closing stale Custom Editor tabs upon commit deselection or switching.
- Resolves a phantom dirty state race condition in the React webview by synchronizing the draft description with `jj`'s appended trailing newlines on save.
- Refactors E2E tests (`commit-details.spec.ts`) to correctly handle Playwright iframe visibility checks against the new Custom Editor DOM structure.

This further improves on the solutions to #113 