### PR TITLE
Fix flaky file watcher e2e test by forcing explorer refresh

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -70,9 +70,10 @@ You MUST run individual test cases when writing a new test or debugging a broken
 **Filtering:**
 You MUST run individual test cases when writing a new test or debugging a broken test.
 
-- **Run a single test case (Recommended):** Use the `-g` flag for grep along with the filename.
+- **Run a single test case (Very Strongly Recommended):** Use the `-g` flag for grep along with the filename.
+    When debugging a flaky test, append `--repeat-each 5 --max-failures 1` to run it multiple times and fail fast.
     ```bash
-    npm run test:e2e -- <filename> -g "<test-name>"
+    npm run test:e2e -- <filename> -g "<test-name>" [--repeat-each 5 --max-failures 1]
     # Example: npm run test:e2e -- scm.spec.ts -g "squash button visibility"
     ```
 - **Run a specific test file:** Pass the filename.

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -51,6 +51,7 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
                 'update.mode': 'none',
                 'extensions.autoCheckUpdates': false,
                 'extensions.autoUpdate': false,
+                'explorer.excludeGitIgnore': false,
             },
             null,
             2,
@@ -68,6 +69,10 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
                 {
                     key: 'ctrl+alt+r',
                     command: 'jj-view.refresh',
+                },
+                {
+                    key: 'ctrl+alt+e',
+                    command: 'workbench.files.action.refreshFilesExplorer',
                 },
             ],
             null,

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -546,8 +546,13 @@ test.describe('SCM Pane E2E', () => {
             await page.keyboard.press('Control+Shift+E');
 
             // 5. Wait for the File Explorer to show the ignored file decoration
+            // Force a refresh first because VS Code file watchers can sometimes miss fast external writes in tests
+            await page.keyboard.press('Control+Alt+E');
+
             // VS Code appends " • Ignored" to an inner element's aria-label
             const ignoredRow = page.getByRole('treeitem', { name: /totally-untracked\.txt/i });
+            await expect(ignoredRow).toBeVisible({ timeout: 15000 });
+
             const ignoredLabel = ignoredRow.locator('[aria-label*="Ignored"]');
             await expect(ignoredLabel).toBeVisible({ timeout: 15000 });
         } finally {


### PR DESCRIPTION
Updates the E2E test helpers to bind `Ctrl+Alt+E` to `workbench.files.action.refreshFilesExplorer` and explicitly disable `explorer.excludeGitIgnore` settings bleed. The `scm.spec.ts` test now uses this keyboard shortcut to guarantee that files created externally via Node `fs` operations appear in the File Explorer before the decoration assertions run. Testing skill documentation was also updated with commands for debugging flakes.