### PR TITLE
Refactor commit description formatting to use Prettier

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -71,7 +71,7 @@ You MUST run individual test cases when writing a new test or debugging a broken
 You MUST run individual test cases when writing a new test or debugging a broken test.
 
 - **Run a single test case (Very Strongly Recommended):** Use the `-g` flag for grep along with the filename.
-    When debugging a flaky test, append `--repeat-each 5 --max-failures 1` to run it multiple times and fail fast.
+  When debugging a flaky test, append `--repeat-each 5 --max-failures 1` to run it multiple times and fail fast.
     ```bash
     npm run test:e2e -- <filename> -g "<test-name>" [--repeat-each 5 --max-failures 1]
     # Example: npm run test:e2e -- scm.spec.ts -g "squash button visibility"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
                 "@vscode-elements/elements": "^2.4.0",
                 "@vscode/codicons": "^0.0.44",
                 "parse-diff": "^0.11.1",
+                "prettier": "^3.8.1",
                 "react": "^19.2.3",
-                "react-dom": "^19.2.3",
-                "word-wrap": "^1.2.5"
+                "react-dom": "^19.2.3"
             },
             "devDependencies": {
                 "@playwright/test": "^1.58.0",
@@ -28,7 +28,6 @@
                 "@types/react-dom": "^19.2.3",
                 "@types/sinon": "^21.0.0",
                 "@types/vscode": "^1.104.0",
-                "@types/word-wrap": "^1.2.0",
                 "@vscode/test-cli": "^0.0.12",
                 "@vscode/test-electron": "^2.5.2",
                 "@vscode/vsce": "^3.7.1",
@@ -38,7 +37,6 @@
                 "npm-run-all": "^4.1.5",
                 "ovsx": "^0.10.8",
                 "playwright": "^1.58.0",
-                "prettier": "^3.7.4",
                 "rimraf": "^6.1.2",
                 "sinon": "^21.0.1",
                 "svgtofont": "^6.5.1",
@@ -2737,13 +2735,6 @@
             "version": "1.107.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.107.0.tgz",
             "integrity": "sha512-XS8YE1jlyTIowP64+HoN30OlC1H9xqSlq1eoLZUgFEC8oUTO6euYZxti1xRiLSfZocs4qytTzR6xCBYtioQTCg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/word-wrap": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/word-wrap/-/word-wrap-1.2.0.tgz",
-            "integrity": "sha512-qYH1V4lSe7A8Sr9a4Jsrk98BJJK6IL4/jUH2kTvwHIixOU2U3f5xwoiXcAQVXzXY7uuMsUGWxefswRJnEpK1bw==",
             "dev": true,
             "license": "MIT"
         },
@@ -9165,10 +9156,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.7.4",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
-            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-            "dev": true,
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -12300,6 +12290,7 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -545,7 +545,6 @@
         "@types/react-dom": "^19.2.3",
         "@types/sinon": "^21.0.0",
         "@types/vscode": "^1.104.0",
-        "@types/word-wrap": "^1.2.0",
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
@@ -555,7 +554,6 @@
         "npm-run-all": "^4.1.5",
         "ovsx": "^0.10.8",
         "playwright": "^1.58.0",
-        "prettier": "^3.7.4",
         "rimraf": "^6.1.2",
         "sinon": "^21.0.1",
         "svgtofont": "^6.5.1",
@@ -572,8 +570,8 @@
         "@vscode-elements/elements": "^2.4.0",
         "@vscode/codicons": "^0.0.44",
         "parse-diff": "^0.11.1",
+        "prettier": "^3.8.1",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3",
-        "word-wrap": "^1.2.5"
+        "react-dom": "^19.2.3"
     }
 }

--- a/src/test/format-utils.test.ts
+++ b/src/test/format-utils.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatCommitDescription } from '../utils/format-utils';
+
+function trimLiteral(str: string): string {
+    return str.replace(/^\n/, '').replace(/\n$/, '');
+}
+
+describe('formatCommitDescription', async () => {
+    it('does not format single-line descriptions', async () => {
+        expect(await formatCommitDescription('Single line title', 72)).toBe('Single line title');
+    });
+
+    it('wraps long body paragraphs while preserving the title and empty line spacing', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+This is a very long text that will definitely exceed the standard seventy-two character limit that is expected of most commit bodies.
+`);
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+This is a very long text that will definitely exceed the standard
+seventy-two character limit that is expected of most commit bodies.
+`),
+        );
+    });
+
+    it('does not wrap trailer blocks (e.g. Gerrit)', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+Some normal body that needs wrapping because it is very long and goes way past the seventy two character limit.
+
+Change-Id: I1234567890123456789012345678901234567890
+Signed-off-by: Some Really Long Name <some.really.long.email@example.com>
+`);
+        const formatted = await formatCommitDescription(description, 72);
+
+        // Body should be wrapped, but trailer remains untouched
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+Some normal body that needs wrapping because it is very long and goes
+way past the seventy two character limit.
+
+Change-Id: I1234567890123456789012345678901234567890
+Signed-off-by: Some Really Long Name <some.really.long.email@example.com>
+`),
+        );
+    });
+
+    it('preserves multiple paragraphs', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+Paragraph 1
+
+Paragraph 2 is very long and goes way past the seventy two character limit so it will be wrapped.
+`);
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+Paragraph 1
+
+Paragraph 2 is very long and goes way past the seventy two character
+limit so it will be wrapped.
+`),
+        );
+    });
+
+    it('redistributes newlines within a paragraph', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+This is a manually
+wrapped paragraph that
+should be re-distributed
+so that lines are filled up to
+the seventy-two character limit.
+`);
+
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+This is a manually wrapped paragraph that should be re-distributed so
+that lines are filled up to the seventy-two character limit.
+`),
+        );
+    });
+
+    it('preserves bulleted and numbered lists and indents their wrapped lines', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+Here are some points:
+* First bullet is very very long and goes way past the seventy two character limit so it needs to be wrapped.
+* Second bullet
+- Third bullet that is also way too long and needs to be wrapped properly at the limit.
+
+1. First numbered item
+2. Second numbered item that is extremely long and will surely exceed the seventy two character line limit.
+`);
+
+        const formatted = await formatCommitDescription(description, 72);
+
+        // Note: Prettier normalizes list markers (e.g. `-` becomes `*` or vice versa depending on config, default is `-` for first level).
+        // Let's rely on standard Prettier output.
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+Here are some points:
+
+- First bullet is very very long and goes way past the seventy two
+  character limit so it needs to be wrapped.
+- Second bullet
+
+* Third bullet that is also way too long and needs to be wrapped
+  properly at the limit.
+
+1. First numbered item
+2. Second numbered item that is extremely long and will surely exceed
+   the seventy two character line limit.
+`),
+        );
+    });
+
+    it('reflows tightly wrapped lines in multiple paragraphs and bulleted lists', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+First paragraph that
+was wrapped far too
+early and should be
+reflowed completely.
+
+Second paragraph that
+also suffers from
+premature wrapping.
+
+* A bullet point that
+was wrapped prematurely
+before reaching the
+width limit.
+* Another bullet
+wrapped too short.
+
+1. A numbered list item
+that was wrapped
+too tightly.
+2. Another numbered item.
+`);
+
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+First paragraph that was wrapped far too early and should be reflowed
+completely.
+
+Second paragraph that also suffers from premature wrapping.
+
+- A bullet point that was wrapped prematurely before reaching the width
+  limit.
+- Another bullet wrapped too short.
+
+1. A numbered list item that was wrapped too tightly.
+2. Another numbered item.
+`),
+        );
+    });
+
+    it('only exempts trailers if they are at the end of the commit message', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+Looks-Like-Trailer: This is a very long text that goes past seventy two characters and it should be formatted even though the line starts with a trailer-like syntax.
+This-Is-Also-Not-Trailer: Because it is not at the absolute end of the commit message!
+
+Actual-Trailer: With a very very very long message that would otherwise be wrapped, but it's immune
+
+
+`);
+
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+Looks-Like-Trailer: This is a very long text that goes past seventy two
+characters and it should be formatted even though the line starts with a
+trailer-like syntax. This-Is-Also-Not-Trailer: Because it is not at the
+absolute end of the commit message!
+
+Actual-Trailer: With a very very very long message that would otherwise be wrapped, but it's immune
+`),
+        );
+    });
+
+    it('exempts trailers using the equals sign instead of a colon', async () => {
+        const description = trimLiteral(`
+Feature Title
+
+This is a regular short body.
+
+TESTED= On a real physical device that has a very small screen and it works perfectly without any issues whatsoever
+SKIP_PRESUBMIT= Because I am absolutely certain that these changes are flawless and I do not have time to wait for the slow CI servers
+FUN_FACT= Did you know that the first computer bug was an actual real-life moth found inside a Harvard Mark II computer in 1947?
+`);
+
+        const formatted = await formatCommitDescription(description, 72);
+
+        expect(formatted).toBe(
+            trimLiteral(`
+Feature Title
+
+This is a regular short body.
+
+TESTED= On a real physical device that has a very small screen and it works perfectly without any issues whatsoever
+SKIP_PRESUBMIT= Because I am absolutely certain that these changes are flawless and I do not have time to wait for the slow CI servers
+FUN_FACT= Did you know that the first computer bug was an actual real-life moth found inside a Harvard Mark II computer in 1947?
+`),
+        );
+    });
+});

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1196,7 +1196,7 @@ log = "none()"
             // Setup: 1 tracked file, 1 untracked file
             repo.writeFile('tracked.txt', 'tracked content');
             repo.describe('commit tracked'); // Committing marks it as tracked
-            
+
             // In jj, files are auto-tracked unless ignored. So to have an untracked file, we ignore it.
             repo.writeFile('.gitignore', 'untracked.txt\n');
             repo.writeFile('untracked.txt', 'untracked content');
@@ -1209,7 +1209,7 @@ log = "none()"
             // Pass a path that causes jj file list to error (outside repo)
             const inputPaths = ['../outside.txt'];
             const paths = await jjService.checkTrackedPaths(inputPaths);
-            
+
             // Should return the exact input paths array
             expect(paths).toEqual(inputPaths);
         });

--- a/src/utils/format-utils.ts
+++ b/src/utils/format-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as prettier from 'prettier/standalone';
+import * as markdownPlugin from 'prettier/plugins/markdown';
+
+export async function formatCommitDescription(description: string, bodyWidthRuler: number): Promise<string> {
+    // Separate the title, any empty lines immediately following it, and the content body.
+    const titleMatch = description.match(/^([^\n]*)\n((?:[ \t]*\n)*)([\s\S]*)$/);
+    if (!titleMatch || !titleMatch[3].trim()) return description; // Nothing to format
+
+    const [, title, emptyPrefix, contentToFormat] = titleMatch;
+
+    // Isolate trailing trailer blocks using a regex.
+    // The trailer section must be the final paragraph of the message, composed
+    // entirely of lines formatted as "Token-Name: Value".
+    const trailerLine = '[\\w-]+[:=]\\s[^\\n]*';
+    const trailerBlock = `(?:${trailerLine}(?:\\n|$))+`;
+    const trailingTrailersRegex = new RegExp(`(?:^|\\n\\s*\\n)(${trailerBlock})\\s*$`);
+
+    const match = contentToFormat.match(trailingTrailersRegex);
+
+    let bodyText = contentToFormat;
+    let trailers = '';
+
+    if (match) {
+        const trailerBlock = match[1];
+        const trailerEndIndex = contentToFormat.lastIndexOf(trailerBlock);
+        bodyText = contentToFormat.substring(0, trailerEndIndex).trimEnd();
+        trailers = trailerBlock.trimEnd();
+    }
+
+    let formattedBody = bodyText;
+    if (bodyText !== '') {
+        formattedBody = await prettier.format(bodyText, {
+            parser: 'markdown',
+            plugins: [markdownPlugin],
+            printWidth: bodyWidthRuler,
+            proseWrap: 'always',
+        });
+
+        // Prettier adds a trailing newline, remove it to match existing behavior
+        formattedBody = formattedBody.trimEnd();
+    }
+
+    const separator = formattedBody && trailers ? '\n\n' : '';
+    return `${title}\n${emptyPrefix}${formattedBody}${separator}${trailers}`;
+}

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as React from 'react';
-import wordWrap from 'word-wrap';
+import { formatCommitDescription } from '../../utils/format-utils';
 import { JjStatusEntry } from '../../jj-types';
 import { BookmarkPill, BasePill, TagPill } from './Bookmark';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
@@ -123,32 +123,11 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         saveTimeoutRef.current = setTimeout(() => setIsSaving(false), 15000);
     };
 
-    const handleFormat = () => {
-        const lines = draftDescription.split('\n');
-        if (lines.length <= 1) return; // Nothing to format if it's just the title
-
-        const title = lines[0];
-        const bodyLines = lines.slice(1);
-
-        // Find the first non-empty line after the title to start formatting
-        let bodyStartIndex = 0;
-        while (bodyStartIndex < bodyLines.length && bodyLines[bodyStartIndex].trim() === '') {
-            bodyStartIndex++;
+    const handleFormat = async () => {
+        const newDescription = await formatCommitDescription(draftDescription, bodyWidthRuler);
+        if (newDescription !== draftDescription) {
+            setDraftDescription(newDescription);
         }
-
-        const emptyPrefix = '\n'.repeat(bodyStartIndex);
-        const contentToFormat = bodyLines.slice(bodyStartIndex).join('\n');
-
-        if (contentToFormat.trim() === '') return; // Nothing to format
-
-        // Preserve paragraph breaks (double newlines) by splitting, formatting, and rejoining
-        const paragraphs = contentToFormat.split(/\n\s*\n/);
-        const formattedParagraphs = paragraphs.map((p) =>
-            wordWrap(p, { width: bodyWidthRuler, trim: true, indent: '' }),
-        );
-
-        const newDescription = `${title}\n${emptyPrefix}${formattedParagraphs.join('\n\n')}`;
-        setDraftDescription(newDescription);
     };
 
     const renderRuler = (width: number, isTitle: boolean, color: string) => (


### PR DESCRIPTION
Replaces the manual `word-wrap` integration with Prettier's standalone Markdown formatter to provide robust and standard-compliant reflowing of commit descriptions. The parsing logic is updated to intelligently isolate trailing commit trailers (both `:` and `=` formats) so they bypass width restrictions, while multi-paragraph bodies and lists are properly reflowed. Comprehensive test coverage is added to ensure format stability across edge cases.

Fixes #131 