### PR TITLE
Fix CLI invocations by explicitly disabling UI formatting

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -159,6 +159,15 @@ export class JjService {
             finalArgs.push('--ignore-working-copy');
         }
 
+        finalArgs.unshift(
+            '--config',
+            'ui.log-word-wrap=false',
+            '--config',
+            'ui.color="never"',
+            '--config',
+            'ui.paginate="never"',
+        );
+
         const start = performance.now();
         const allArgs = [command, ...finalArgs];
         const displayArgs = allArgs.slice(0, 2);


### PR DESCRIPTION
Injects global configuration overrides into all `jj` command executions through `JjService` to prevent user config (like `ui.log-word-wrap=true`) from breaking the extension's parsing logic.

Fixes #106 