### PR TITLE
Hide editor actions for immutable commits

### DIFF
--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -488,4 +488,33 @@ test.describe('Commit Details E2E', () => {
             expect(desc).toBe('updated via test before close');
         }).toPass({ timeout: 10000 });
     });
+
+    test('Hides buttons and disables editor for immutable commits', async () => {
+        // Configure 'initial' to be immutable
+        repo.config('revset-aliases."immutable_heads()"', `commit_id("${nodes['initial'].commitId}")`);
+        await focusJJLog(page);
+
+        const webview = await getLogWebview(page);
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+
+        // Click to open details
+        await initialRow.click();
+        const shortId = nodes['initial'].changeId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({
+            timeout: 15000,
+        });
+
+        const details = await getDetailsWebview(page);
+
+        // Verify textarea is disabled
+        const textarea = details.locator('textarea');
+        await expect(textarea).toBeDisabled();
+
+        // Verify buttons are hidden
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes|Saved/ });
+        await expect(saveChangesButton).toBeHidden();
+
+        const formatButton = details.locator('button', { hasText: 'Format Body' });
+        await expect(formatButton).toBeHidden();
+    });
 });

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -325,53 +325,57 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                         </a>
                     </div>
                     <div style={{ display: 'flex', gap: '8px' }}>
-                        <button
-                            onClick={handleFormat}
-                            title={`Format body to ${bodyWidthRuler} characters`}
-                            style={{
-                                background: 'none',
-                                border: 'none',
-                                padding: '2px 4px',
-                                cursor: 'pointer',
-                                color: 'var(--vscode-textLink-foreground)',
-                                display: 'flex',
-                                alignItems: 'center',
-                                fontSize: '12px',
-                                gap: '4px',
-                            }}
-                        >
-                            <span className="codicon codicon-word-wrap"></span>
-                            Format Body
-                        </button>
-                        <button
-                            title={`Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`}
-                            onClick={handleSave}
-                            disabled={isSaving || !isDirty}
-                            className={isDirty && !isSaving ? 'btn-dirty' : ''}
-                            style={{
-                                padding: '2px 8px',
-                                color: 'var(--vscode-button-foreground)',
-                                backgroundColor: isDirty
-                                    ? 'var(--vscode-button-background)'
-                                    : 'var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background))',
-                                border: '1px solid transparent',
-                                cursor: isSaving || !isDirty ? 'default' : 'pointer',
-                                opacity: isSaving ? 0.7 : !isDirty ? 0.6 : 1,
-                                display: 'flex',
-                                alignItems: 'center',
-                                fontSize: '12px',
-                                gap: '4px',
-                                borderRadius: '2px',
-                                transition: 'background-color 0.2s, color 0.2s',
-                            }}
-                        >
-                            <span className={`codicon ${isDirty ? 'codicon-save' : 'codicon-check'}`}></span>
-                            {isSaving
-                                ? 'Saving...'
-                                : isDirty
-                                  ? `Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`
-                                  : 'Saved'}
-                        </button>
+                        {!isImmutable && (
+                            <>
+                                <button
+                                    onClick={handleFormat}
+                                    title={`Format body to ${bodyWidthRuler} characters`}
+                                    style={{
+                                        background: 'none',
+                                        border: 'none',
+                                        padding: '2px 4px',
+                                        cursor: 'pointer',
+                                        color: 'var(--vscode-textLink-foreground)',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        fontSize: '12px',
+                                        gap: '4px',
+                                    }}
+                                >
+                                    <span className="codicon codicon-word-wrap"></span>
+                                    Format Body
+                                </button>
+                                <button
+                                    title={`Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`}
+                                    onClick={handleSave}
+                                    disabled={isSaving || !isDirty}
+                                    className={isDirty && !isSaving ? 'btn-dirty' : ''}
+                                    style={{
+                                        padding: '2px 8px',
+                                        color: 'var(--vscode-button-foreground)',
+                                        backgroundColor: isDirty
+                                            ? 'var(--vscode-button-background)'
+                                            : 'var(--vscode-button-secondaryBackground, var(--vscode-editorWidget-background))',
+                                        border: '1px solid transparent',
+                                        cursor: isSaving || !isDirty ? 'default' : 'pointer',
+                                        opacity: isSaving ? 0.7 : !isDirty ? 0.6 : 1,
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        fontSize: '12px',
+                                        gap: '4px',
+                                        borderRadius: '2px',
+                                        transition: 'background-color 0.2s, color 0.2s',
+                                    }}
+                                >
+                                    <span className={`codicon ${isDirty ? 'codicon-save' : 'codicon-check'}`}></span>
+                                    {isSaving
+                                        ? 'Saving...'
+                                        : isDirty
+                                          ? `Save Changes (${navigator.platform.toUpperCase().indexOf('MAC') >= 0 ? '⌘S' : 'Ctrl+S'})`
+                                          : 'Saved'}
+                                </button>
+                            </>
+                        )}
                     </div>
                 </div>
                 <div
@@ -425,6 +429,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                         className="commit-textarea"
                         ref={textareaRef}
                         value={draftDescription}
+                        disabled={isImmutable}
                         onChange={(e) => setDraftDescription(e.target.value)}
                         onScroll={() => {
                             if (backdropRef.current && textareaRef.current) {


### PR DESCRIPTION
Conditionally renders the "Format Body" and "Save Changes" buttons so they are hidden when viewing an immutable commit. Also disables the commit message textarea to prevent editing. Adds dynamic E2E tests to verify the UI correctly reflects the immutable state.

Fixes #127 