### PR TITLE
allow explicitly empty commit descriptions

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -3,17 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export async function commitCommand(scmProvider: JjScmProvider, jj: JjService) {
-    const message = scmProvider.sourceControl.inputBox.value;
-    if (!message) {
-        vscode.window.showWarningMessage('Please provide a commit message');
-        return;
-    }
+    const message = scmProvider.sourceControl.inputBox.value.trim();
 
     try {
         await withDelayedProgress('Committing...', jj.commit(message));

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -13,11 +13,15 @@ export async function setDescriptionCommand(scmProvider: JjScmProvider, jj: JjSe
     const revision =
         (message && typeof args[1] === 'string' ? args[1] : undefined) ?? extractRevisions(revisionArgs)[0] ?? '@';
 
-    const description = message ?? scmProvider.sourceControl.inputBox.value;
-
-    if (message === undefined && !scmProvider.sourceControl.inputBox.value) {
-        return false;
+    let description = message;
+    if (description === undefined) {
+        if (revision === '@') {
+            description = scmProvider.sourceControl.inputBox.value;
+        } else {
+            return false;
+        }
     }
+    description = description.trim();
 
     try {
         await withDelayedProgress('Setting description...', jj.describe(description, revision));

--- a/src/test/commands/commit.test.ts
+++ b/src/test/commands/commit.test.ts
@@ -41,14 +41,22 @@ describe('commitCommand', () => {
         vi.clearAllMocks();
     });
 
-    test('shows warning if input box is empty', async () => {
+    test('commits change successfully with empty description', async () => {
+        repo.new(undefined, 'initial');
+        const initialId = repo.getChangeId('@');
+
         const inputBoxMock = scmProvider.sourceControl.inputBox;
-        inputBoxMock.value = '';
+        inputBoxMock.value = '   ';
         await commitCommand(scmProvider, jj);
 
-        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Please provide a commit message');
-        const desc = repo.getDescription('@');
-        expect(desc).toBe('');
+        const oldChangeDesc = repo.getDescription(initialId);
+        expect(oldChangeDesc.trim()).toBe('');
+
+        const currentDesc = repo.getDescription('@');
+        expect(currentDesc.trim()).toBe('');
+
+        expect(scmProvider.sourceControl.inputBox.value).toBe('   ');
+        expect(scmProvider.refresh).toHaveBeenCalled();
     });
 
     test('commits change successfully', async () => {

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -54,10 +54,13 @@ describe('setDescriptionCommand', () => {
         expect(description.trim()).toBe('from input box');
     });
 
-    test('returns false if description is empty or omitted', async () => {
+    test('allows empty descriptions when invoked from input box', async () => {
         // input box is empty, and args is empty
+        scmProvider.sourceControl.inputBox.value = '   ';
         const result = await setDescriptionCommand(scmProvider, jj, []);
-        expect(result).toBe(false);
+        expect(result).toBe(true);
+        const description = repo.getDescription('@');
+        expect(description.trim()).toBe('');
     });
 
     test('updates description for specific revision', async () => {
@@ -66,6 +69,22 @@ describe('setDescriptionCommand', () => {
         expect(result).toBe(true);
         const description = repo.getDescription('@-');
         expect(description.trim()).toBe('updated parent');
+    });
+
+    test('clears description for a non-working-copy commit when provided an empty message', async () => {
+        repo.new([], 'child');
+        jj.describe('parent description', '@-');
+        jj.describe('working copy description', '@');
+        scmProvider.sourceControl.inputBox.value = 'fallback description';
+        
+        // Explicitly clear the parent's description
+        const result = await setDescriptionCommand(scmProvider, jj, ['   ', '@-']);
+        expect(result).toBe(true);
+        const description = repo.getDescription('@-');
+        expect(description.trim()).toBe('');
+        
+        // Ensure working copy wasn't affected
+        expect(repo.getDescription('@').trim()).toBe('working copy description');
     });
 
     test('returns false on jj describe failure', async () => {

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -110,10 +110,9 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         setIsSaving(true);
 
         // jj enforces a trailing newline. Ensure we have one so our state matches what jj will return
-        let finalDescription = draftDescription;
-        if (!finalDescription.endsWith('\n')) {
+        let finalDescription = draftDescription.trim();
+        if (finalDescription !== '') {
             finalDescription += '\n';
-            setDraftDescription(finalDescription);
         }
 
         onSave(finalDescription);


### PR DESCRIPTION
The VS Code extension now gracefully supports setting entirely empty descriptions through both the SCM panel and Commit Details view, aligning with native jj capabilities. Unnecessary validations preventing empty commits were removed, string trimming was implemented across inputs, and safeguards were added to prevent accidental input box fallback when describing non-working-copy revisions.

Fixes #140 