### PR TITLE
Fix commit details dirty indicator for empty descriptions

### DIFF
--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -64,7 +64,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                         payload: {
                             changeId,
                             commitId: log.commit_id,
-                            description: log.description,
+                            description: (log.description || '').trim(),
                             files: filesWithStats,
                             isImmutable: log.is_immutable,
                             author: log.author,
@@ -184,7 +184,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                 payload: {
                     changeId: document.changeId,
                     commitId: log.commit_id,
-                    description: log.description,
+                    description: (log.description || '').trim(),
                     files: filesWithStats,
                     isImmutable: log.is_immutable,
                     author: log.author,

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -226,6 +226,58 @@ test.describe('Commit Details E2E', () => {
         }).toPass({ timeout: 10000 });
     });
 
+    test('Dirty indicator works when starting from an empty message', async () => {
+        // Create a new empty commit using the CLI directly
+        repo.new([nodes['initial'].changeId]);
+        const newCommitId = repo.getChangeId('@');
+        
+        // Wait for the file watcher to detect the change and refresh the graph.
+        await page.waitForTimeout(1000);
+
+        // Refresh the webview by focusing it to pick up graph updates
+        await focusJJLog(page);
+
+        const webview = await getLogWebview(page);
+        
+        // The new commit should be visible and have (no description)
+        const emptyRow = webview.locator('.commit-row', { hasText: '(no description)' }).first();
+
+        // Click to open details
+        await expect(emptyRow).toBeVisible({ timeout: 15000 });
+        await emptyRow.click();
+
+        const shortId = newCommitId.substring(0, 3);
+        await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({
+            timeout: 15000,
+        });
+
+        const details = await getDetailsWebview(page);
+
+        // Edit the description
+        const textarea = details.locator('textarea');
+        await expect(textarea).toHaveValue('');
+        
+        await textarea.fill('brand new message');
+
+        // Verify dirty state
+        await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).toHaveClass(/dirty/);
+        const saveChangesButton = details.locator('button', { hasText: /Save Changes/ });
+        await expect(saveChangesButton).toBeEnabled();
+
+        // Click Save
+        await saveChangesButton.click();
+
+        // Verify the Save button is disabled (via our Webview state checking it's clean)
+        await expect(details.locator('button', { hasText: 'Saved' })).toBeDisabled({ timeout: 15000 });
+        await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).not.toHaveClass(/dirty/);
+
+        // Verify the description was saved in the repo
+        await expect(async () => {
+            const desc = repo.getDescription(newCommitId);
+            expect(desc).toBe('brand new message');
+        }).toPass({ timeout: 10000 });
+    });
+
     test('Open file diff from file list', async () => {
         const webview = await getLogWebview(page);
         const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -109,11 +109,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
     const handleSave = () => {
         setIsSaving(true);
 
-        // jj enforces a trailing newline. Ensure we have one so our state matches what jj will return
-        let finalDescription = draftDescription.trim();
-        if (finalDescription !== '') {
-            finalDescription += '\n';
-        }
+        const finalDescription = draftDescription.trim();
 
         onSave(finalDescription);
 


### PR DESCRIPTION
Previously, opening a commit with an empty description and typing something would not clear the dirty indicator upon save. This was caused by trailing newlines being artificially added to the webview state and mismatched with JJ's trimmed logs. This change updates the frontend and backend to safely trim commit descriptions at the integration boundary, removing manual newline appendages in the webview. Tests were updated and a new E2E test was added to verify the dirty indicator transition from an empty message.