### PR TITLE
feat: add "New After" command and group context menu items

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
             },
             {
                 "command": "jj-view.new",
-                "title": "New Change",
+                "title": "New",
                 "category": "JJ View",
                 "icon": "$(plus)"
             },
@@ -241,6 +241,12 @@
             {
                 "command": "jj-view.newBefore",
                 "title": "New Before",
+                "category": "JJ View",
+                "icon": "$(source-control)"
+            },
+            {
+                "command": "jj-view.newAfter",
+                "title": "New After",
                 "category": "JJ View",
                 "icon": "$(source-control)"
             },
@@ -342,49 +348,59 @@
             ],
             "webview/context": [
                 {
-                    "command": "jj-view.edit",
-                    "when": "webviewSection == 'commit' && canEdit",
-                    "group": "navigation"
+                    "command": "jj-view.showMultiFileDiff",
+                    "when": "webviewSection == 'commit'",
+                    "group": "1_diff@1"
+                },
+                {
+                    "command": "jj-view.new",
+                    "when": "webviewSection == 'commit' && canNewChild",
+                    "group": "2_edit@1"
                 },
                 {
                     "command": "jj-view.newBefore",
                     "when": "webviewSection == 'commit' && canNewBefore",
-                    "group": "navigation"
+                    "group": "2_edit@2"
+                },
+                {
+                    "command": "jj-view.newAfter",
+                    "when": "webviewSection == 'commit' && canNewAfter",
+                    "group": "2_edit@3"
+                },
+                {
+                    "command": "jj-view.edit",
+                    "when": "webviewSection == 'commit' && canEdit",
+                    "group": "2_edit@4"
                 },
                 {
                     "command": "jj-view.duplicate",
                     "when": "webviewSection == 'commit' && canDuplicate",
-                    "group": "navigation"
-                },
-                {
-                    "command": "jj-view.newMergeChange",
-                    "when": "webviewSection == 'commit' && canMerge",
-                    "group": "navigation"
-                },
-                {
-                    "command": "jj-view.rebaseOntoSelected",
-                    "when": "webviewSection == 'commit' && canRebaseOnto",
-                    "group": "navigation"
+                    "group": "4_changes@1"
                 },
                 {
                     "command": "jj-view.abandon",
                     "when": "webviewSection == 'commit' && canAbandon",
-                    "group": "navigation"
-                },
-                {
-                    "command": "jj-view.setBookmark",
-                    "when": "webviewSection == 'commit'",
-                    "group": "navigation"
+                    "group": "4_changes@2"
                 },
                 {
                     "command": "jj-view.absorb",
                     "when": "webviewSection == 'commit' && canAbsorb",
-                    "group": "navigation"
+                    "group": "4_changes@3"
                 },
                 {
-                    "command": "jj-view.showMultiFileDiff",
+                    "command": "jj-view.rebaseOntoSelected",
+                    "when": "webviewSection == 'commit' && canRebaseOnto",
+                    "group": "5_rebase@1"
+                },
+                {
+                    "command": "jj-view.newMergeChange",
+                    "when": "webviewSection == 'commit' && canMerge",
+                    "group": "5_rebase@2"
+                },
+                {
+                    "command": "jj-view.setBookmark",
                     "when": "webviewSection == 'commit'",
-                    "group": "navigation"
+                    "group": "3_bookmark@1"
                 }
             ],
             "scm/title": [

--- a/src/commands/new-after.ts
+++ b/src/commands/new-after.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import { JjService } from '../jj-service';
+import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
+import { JjScmProvider } from '../jj-scm-provider';
+
+export async function newAfterCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    let revisions: string[] = [];
+
+    // 1. Revisions from arguments (context menu, etc)
+    const argRevisions = extractRevisions(args);
+
+    // 2. Selection from provider
+    const selectedIds = scmProvider.getSelectedCommitIds();
+
+    if (argRevisions.length > 0) {
+        // If the right-clicked commit is part of the selection, use the full selection.
+        // This allows "New After" to apply to multiple selected commits if you right-click one of them.
+        const target = argRevisions[0];
+        if (selectedIds.includes(target)) {
+            revisions = selectedIds;
+        } else {
+            revisions = argRevisions;
+        }
+    } else if (selectedIds.length > 0) {
+        revisions = selectedIds;
+    } else {
+        // Fallback: Default to working copy
+        revisions = ['@'];
+    }
+
+    if (revisions.length === 0) {
+        vscode.window.showErrorMessage('No commit selected to create a new change after.');
+        return;
+    }
+
+    try {
+        await withDelayedProgress('Creating new change...', jj.new({ insertAfter: revisions }));
+        scmProvider.refresh();
+    } catch (e: unknown) {
+        await showJjError(e, `Error creating new commit after ${revisions.join(', ')}`, jj, scmProvider.outputChannel);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { squashChangeCommand } from './commands/squash-change';
 import { setBookmarkCommand } from './commands/bookmark';
 import { absorbCommand } from './commands/absorb';
 import { newBeforeCommand } from './commands/new-before';
+import { newAfterCommand } from './commands/new-after';
 
 export interface Api {
     scmProvider: JjScmProvider;
@@ -183,6 +184,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.newBefore', async (...args: unknown[]) => {
             await newBeforeCommand(scmProvider, jj, args);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.newAfter', async (...args: unknown[]) => {
+            await newAfterCommand(scmProvider, jj, args);
         }),
     );
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -129,6 +129,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 case 'newBefore':
                     await vscode.commands.executeCommand('jj-view.newBefore', ...(data.payload.changeIds || []));
                     break;
+                case 'newAfter':
+                    await vscode.commands.executeCommand('jj-view.newAfter', ...(data.payload.changeIds || []));
+                    break;
                 case 'resolve':
                     await this._jj.resolve(data.payload);
                     await vscode.commands.executeCommand('jj-view.refresh');

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -689,8 +689,10 @@ export class JjService {
         });
     }
 
-    async new(options: { message?: string; parents?: string[]; insertBefore?: string[] } = {}): Promise<string> {
-        const { message, parents = [], insertBefore = [] } = options;
+    async new(
+        options: { message?: string; parents?: string[]; insertBefore?: string[]; insertAfter?: string[] } = {},
+    ): Promise<string> {
+        const { message, parents = [], insertBefore = [], insertAfter = [] } = options;
         const args: string[] = [];
         if (message) {
             args.push('-m', message);
@@ -698,16 +700,16 @@ export class JjService {
         for (const rev of insertBefore) {
             args.push('--insert-before', rev);
         }
-
-        if (insertBefore.length > 0) {
-            // When insertBefore is used, parents must be specified with --insert-after
-            for (const rev of parents) {
-                args.push('--insert-after', rev);
-            }
-        } else {
-            // Standard usage: parents are positional arguments
-            args.push(...parents);
+        for (const rev of insertAfter) {
+            args.push('--insert-after', rev);
         }
+
+        if ((insertBefore.length > 0 || insertAfter.length > 0) && parents.length > 0) {
+            throw new Error('Cannot specify parents along with insertBefore or insertAfter.');
+        }
+
+        // Standard usage: parents are positional arguments
+        args.push(...parents);
 
         await this.run('new', args, { isMutation: true, label: 'new' });
         const output = await this.run('log', ['-r', '@', '--no-graph', '-T', 'change_id'], {

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -76,13 +76,13 @@ describe('setDescriptionCommand', () => {
         jj.describe('parent description', '@-');
         jj.describe('working copy description', '@');
         scmProvider.sourceControl.inputBox.value = 'fallback description';
-        
+
         // Explicitly clear the parent's description
         const result = await setDescriptionCommand(scmProvider, jj, ['   ', '@-']);
         expect(result).toBe(true);
         const description = repo.getDescription('@-');
         expect(description.trim()).toBe('');
-        
+
         // Ensure working copy wasn't affected
         expect(repo.getDescription('@').trim()).toBe('working copy description');
     });

--- a/src/test/commands/new-after.test.ts
+++ b/src/test/commands/new-after.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { JjService } from '../../jj-service';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { newAfterCommand } from '../../commands/new-after';
+import { TestRepo, buildGraph } from '../test-repo';
+
+// Mock vscode
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock({
+        window: {
+            showErrorMessage: vi.fn(),
+            withProgress: vi.fn(async (_options, task) => await task(() => {})),
+        },
+    });
+});
+
+describe('newAfterCommand', () => {
+    let repo: TestRepo;
+    let jj: JjService;
+    let scmProvider: JjScmProvider;
+
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path);
+
+        // Mock SCM Provider
+        scmProvider = {
+            refresh: vi.fn().mockResolvedValue(undefined),
+            getSelectedCommitIds: vi.fn().mockReturnValue([]),
+        } as unknown as JjScmProvider;
+    });
+
+    afterEach(async () => {
+        repo.dispose();
+    });
+
+    it('should create a new commit after the selected commit (between commit and its children)', async () => {
+        // Setup repo: root -> A -> B
+        const ids = await buildGraph(repo, [
+            { label: 'A', description: 'A' },
+            { label: 'B', parents: ['A'], description: 'B', isWorkingCopy: true },
+        ]);
+        const revA = ids['A'].changeId;
+        const revB = ids['B'].changeId;
+
+        await newAfterCommand(scmProvider, jj, [revA]);
+
+        // Expected: root -> A -> New -> B
+        const parentsOfB = repo.getParents(revB)[0];
+
+        // B should be a child of New
+        // Verify chain: B -> New -> A
+        const revNew = parentsOfB;
+        expect(revNew).not.toBe(revA);
+
+        const parentsOfNew = repo.getParents(revNew)[0];
+        expect(parentsOfNew).toBe(revA);
+
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+
+    it('should create a new commit after a leaf commit', async () => {
+        // Setup repo: root -> A -> B
+        const ids = await buildGraph(repo, [
+            { label: 'A', description: 'A' },
+            { label: 'B', parents: ['A'], description: 'B', isWorkingCopy: true },
+        ]);
+        const revB = ids['B'].changeId;
+
+        await newAfterCommand(scmProvider, jj, [revB]);
+
+        // Expected: root -> A -> B -> New
+        // New should have B as its parent
+        const childrenOfB = repo.getChildren(revB);
+        expect(childrenOfB.length).toBe(1);
+
+        const revNew = childrenOfB[0];
+        const parentsOfNew = repo.getParents(revNew)[0];
+        expect(parentsOfNew).toBe(revB);
+
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+
+    it('should use selected commit if no argument provided', async () => {
+        // Setup repo: root -> A -> B
+        const ids = await buildGraph(repo, [
+            { label: 'A', description: 'A' },
+            { label: 'B', parents: ['A'], description: 'B', isWorkingCopy: true },
+        ]);
+        const revA = ids['A'].changeId;
+        const revB = ids['B'].changeId;
+
+        // Simulate selection of A
+        const getSelectedCommitIdsSpy = vi.spyOn(scmProvider, 'getSelectedCommitIds');
+        getSelectedCommitIdsSpy.mockReturnValue([revA]);
+
+        await newAfterCommand(scmProvider, jj, []);
+
+        // Expected: root -> A -> New -> B
+        const parentsOfB = repo.getParents(revB)[0];
+        expect(parentsOfB).not.toBe(revA);
+
+        const revNew = parentsOfB;
+        const parentsOfNew = repo.getParents(revNew)[0];
+        expect(parentsOfNew).toBe(revA);
+    });
+
+    it('should default to @ if no argument and no selection', async () => {
+        // Setup repo: root -> Parent -> A
+        const ids = await buildGraph(repo, [
+            { label: 'Parent', description: 'Parent' },
+            { label: 'A', parents: ['Parent'], description: 'A', isWorkingCopy: true },
+        ]);
+        const revA = ids['A'].changeId;
+
+        // Mock no selection
+        const getSelectedCommitIdsSpy = vi.spyOn(scmProvider, 'getSelectedCommitIds');
+        getSelectedCommitIdsSpy.mockReturnValue([]);
+
+        await newAfterCommand(scmProvider, jj, []);
+
+        // Expected: root -> Parent -> A -> New
+        const childrenOfA = repo.getChildren(revA);
+        expect(childrenOfA.length).toBe(1);
+
+        const revNew = childrenOfA[0];
+        const parentsOfNew = repo.getParents(revNew)[0];
+        expect(parentsOfNew).toBe(revA);
+    });
+
+    it('should support multiple selected commits (insert after multiple)', async () => {
+        // Setup repo: root -> A -> B -> C
+        //                     \-> X -> Y
+        const ids = await buildGraph(repo, [
+            { label: 'A', description: 'A' },
+            { label: 'B', parents: ['A'], description: 'B' },
+            { label: 'C', parents: ['B'], description: 'C' },
+            { label: 'X', parents: ['A'], description: 'X' },
+            { label: 'Y', parents: ['X'], description: 'Y' },
+        ]);
+        const revB = ids['B'].changeId;
+        const revX = ids['X'].changeId;
+
+        // Mock multiple selection
+        const getSelectedCommitIdsSpy = vi.spyOn(scmProvider, 'getSelectedCommitIds');
+        getSelectedCommitIdsSpy.mockReturnValue([revB, revX]);
+
+        await newAfterCommand(scmProvider, jj, []);
+
+        // Expected: root -> A -> B -> New -> C
+        //                     \-> X -/    \-> Y
+        // New commit has parents B and X.
+        // C and Y have parent New.
+
+        const childrenOfB = repo.getChildren(revB);
+        const childrenOfX = repo.getChildren(revX);
+
+        // B and X should have exactly 1 child, which is the New commit
+        expect(childrenOfB.length).toBe(1);
+        expect(childrenOfX.length).toBe(1);
+        expect(childrenOfB[0]).toBe(childrenOfX[0]);
+
+        const newCommitId = childrenOfB[0];
+
+        // C and Y should have the new commit as parent
+        const parentsOfC = repo.getParents(ids['C'].changeId);
+        const parentsOfY = repo.getParents(ids['Y'].changeId);
+        expect(parentsOfC[0]).toBe(newCommitId);
+        expect(parentsOfY[0]).toBe(newCommitId);
+
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+});

--- a/src/test/directory-watcher.test.ts
+++ b/src/test/directory-watcher.test.ts
@@ -26,7 +26,7 @@ vi.mock('@parcel/watcher', async (importOriginal) => {
     };
 });
 
-describe('DirectoryWatcher (real @parcel/watcher)', () => {
+describe('DirectoryWatcher (real @parcel/watcher)', { retry: os.platform() === 'win32' ? 3 : 0 }, () => {
     let tmpDir: string;
     let outputChannel: OutputChannel;
     let callback: Mock;

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -230,7 +230,7 @@ test.describe('Commit Details E2E', () => {
         // Create a new empty commit using the CLI directly
         repo.new([nodes['initial'].changeId]);
         const newCommitId = repo.getChangeId('@');
-        
+
         // Wait for the file watcher to detect the change and refresh the graph.
         await page.waitForTimeout(1000);
 
@@ -238,7 +238,7 @@ test.describe('Commit Details E2E', () => {
         await focusJJLog(page);
 
         const webview = await getLogWebview(page);
-        
+
         // The new commit should be visible and have (no description)
         const emptyRow = webview.locator('.commit-row', { hasText: '(no description)' }).first();
 
@@ -256,7 +256,7 @@ test.describe('Commit Details E2E', () => {
         // Edit the description
         const textarea = details.locator('textarea');
         await expect(textarea).toHaveValue('');
-        
+
         await textarea.fill('brand new message');
 
         // Verify dirty state

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -170,6 +170,78 @@ test.describe('JJ Log Context Menu E2E', () => {
         }).toPass();
     });
 
+    test('New After (Single)', async () => {
+        const webview = await getLogWebview(page);
+
+        await expect(webview.locator('.commit-row', { hasText: 'initial' })).toBeVisible();
+
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // New After initial
+        const initialRow = webview.locator('.commit-row', { hasText: 'initial' });
+        await rightClickAndSelect(page, initialRow, 'New After');
+
+        // After "New After" initial:
+        // root -> dummyId -> initial -> middle (@) -> {commit1, commit2}
+        await expect(async () => {
+            await expectTree(repo, [
+                entry(commit1Id, 'commit1', '*'),
+                entry(commit2Id, 'commit2', '*'),
+                '@ ' + entry('*', '(empty)', initialId),
+                entry(initialId, 'initial', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
+    test('Multi-select New After', async () => {
+        const webview = await getLogWebview(page);
+
+        const commit2Id = nodes['commit2'].changeId;
+        const commit1Id = nodes['commit1'].changeId;
+        const initialId = nodes['initial'].changeId;
+
+        // Create children so "insert after" has something to rebase
+        repo.new([commit1Id]);
+        repo.describe('child1');
+        const child1Id = repo.getChangeId('@');
+
+        repo.new([commit2Id]);
+        repo.describe('child2');
+        const child2Id = repo.getChangeId('@');
+
+        await triggerRefresh(page);
+
+        await expect(webview.locator('.commit-row', { hasText: 'child1' })).toBeVisible();
+
+        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+
+        // Select both
+        await selectCommits([commit2Row, commit1Row]);
+
+        // Right click and New After
+        await rightClickAndSelect(page, commit2Row, 'New After');
+
+        // After "New After" on multi-select [commit2, commit1]: a new empty commit
+        // is inserted after both (as their new child).
+        // Then child1 and child2 are rebased on top of the new commit.
+        // Tree: root -> dummyId -> initial -> {commit1, commit2} -> middle (@) -> {child1, child2}
+        await expect(async () => {
+            await expectTree(repo, [
+                entry(child1Id, 'child1', '*'),
+                entry(child2Id, 'child2', '*'),
+                expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[(${commit1Id},${commit2Id}|${commit2Id},${commit1Id})\\] \\(empty\\)$`)),
+                entry(commit2Id, 'commit2', initialId),
+                entry(commit1Id, 'commit1', initialId),
+                entry(initialId, 'initial', dummyId),
+                entry(dummyId, 'dummy', ROOT_ID),
+            ]);
+        }).toPass();
+    });
+
     test('Edit', async () => {
         const webview = await getLogWebview(page);
         const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -215,35 +215,45 @@ export async function getLogWebview(page: Page): Promise<Frame> {
  * Asserts that the repo log matches the expected structure.
  */
 export async function expectTree(repo: TestRepo, expected: unknown[]) {
-    await expect
-        .poll(
-            async () => {
-                // Output format: [@] change_id [parent1,parent2] description
-                const log = repo.getLog(
-                    'all()',
-                    'if(current_working_copy, "@ ", "") ++ change_id ++ " [" ++ parents.map(|p| p.change_id()).join(",") ++ "] " ++ if(description, description.first_line(), "(empty)") ++ "\\n"',
-                );
-                const actual = log
-                    .split('\n')
-                    .filter((l) => l.trim())
-                    .filter((line) => !line.startsWith('zzzzzzzz'));
-                return actual;
-            },
-            {
-                timeout: 10000,
-                message: 'Tree mismatch',
-            },
-        )
-        .toEqual(
-            expected.map((e) => {
-                if (typeof e === 'string' && e.includes('*')) {
-                    // Escape regex characters except for our * wildcard
-                    const escaped = e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[a-z0-9]+');
-                    return expect.stringMatching(new RegExp(`^${escaped}$`));
-                }
-                return e;
-            }),
-        );
+    let lastActual: string[] = [];
+    try {
+        await expect
+            .poll(
+                async () => {
+                    // Output format: [@] change_id [parent1,parent2] description
+                    const log = repo.getLog(
+                        'all()',
+                        'if(current_working_copy, "@ ", "") ++ change_id ++ " [" ++ parents.map(|p| p.change_id()).join(",") ++ "] " ++ if(description, description.first_line(), "(empty)") ++ "\\n"',
+                    );
+                    const actual = log
+                        .split('\n')
+                        .filter((l) => l.trim())
+                        .filter((line) => !line.startsWith('zzzzzzzz'));
+                    lastActual = actual;
+                    return actual;
+                },
+                {
+                    timeout: 10000,
+                    message: 'Tree mismatch',
+                },
+            )
+            .toEqual(
+                expected.map((e) => {
+                    if (typeof e === 'string' && e.includes('*')) {
+                        // Escape regex characters except for our * wildcard
+                        const escaped = e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[a-z0-9]+');
+                        return expect.stringMatching(new RegExp(`^${escaped}$`));
+                    }
+                    return e;
+                }),
+            );
+    } catch (e: unknown) {
+        const formatTree = (tree: unknown[]) => tree.map((line) => `  ${String(line)}`).join('\n');
+        if (e instanceof Error) {
+            e.message = `${e.message}\n\nExpected Tree:\n${formatTree(expected)}\n\nActual Tree:\n${formatTree(lastActual)}`;
+        }
+        throw e;
+    }
 }
 
 /** Helper to format an entry for expectTree */

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -7,7 +7,7 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { TestRepo, buildGraph } from '../test-repo';
-import { launchVSCode, focusSCM, hoverAndClick } from './e2e-helpers';
+import { launchVSCode, focusSCM, hoverAndClick, expectTree, entry, ROOT_ID } from './e2e-helpers';
 
 test.describe('SCM Pane E2E', () => {
     test('Displays correct groups and populates SCM input', async () => {
@@ -63,9 +63,11 @@ test.describe('SCM Pane E2E', () => {
     test('Top-Level Commands: Commit and New Change', async () => {
         const repo = new TestRepo();
         repo.init();
-        await buildGraph(repo, [
+        const commits = await buildGraph(repo, [
             { label: 'initial', description: 'initial', files: { 'file.txt': 'base' }, isWorkingCopy: true },
         ]);
+        const initialId = commits['initial'].changeId;
+        const workspaceRootId = repo.getParents(initialId)[0];
 
         const { app, page, userDataDir } = await launchVSCode(repo);
 
@@ -90,15 +92,20 @@ test.describe('SCM Pane E2E', () => {
             // Ensure wait for SCM refresh before next action
             await expect(scmInputRow).not.toContainText('Updated description explicitly', { timeout: 10000 });
 
+            const prevWcId = repo.getWorkingCopyId();
+
             // Click New Change (+)
-            const newButton = page.getByRole('button', { name: 'New Change' }).first();
+            const newButton = page.getByRole('button', { name: 'New', exact: true }).first();
+            await expect(newButton).toBeVisible();
             await newButton.click();
 
-            // Wait for UI to reflect empty input box or wait for a specific commit in repo
-            await expect(async () => {
-                const wcDescription = repo.getDescription('@').trim();
-                expect(wcDescription).toBe('');
-            }).toPass({ timeout: 5000 });
+            // Wait for UI to reflect empty input box and tree to update
+            await expectTree(repo, [
+                expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[${prevWcId}\\] \\(empty\\)$`)),
+                entry(prevWcId, '(empty)', initialId),
+                entry(initialId, 'Updated description explicitly', workspaceRootId),
+                entry(workspaceRootId, '(empty)', ROOT_ID),
+            ]);
         } finally {
             await app.close();
             try {

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -222,35 +222,64 @@ log = "none()"
             expect(workingCopyId).toBe(middleId);
         });
 
-        test('creates change with parents AND insertBefore', async () => {
-            // Setup: Root -> Parent -> Child
-            // We want to insert 'Middle' between Parent and Child, but also have 'Root' as a parent (merge)
-            // Expected: (Root, Parent) -> Middle -> Child
+        test('creates change inserted after', async () => {
+            // Setup: Parent -> Child
             const ids = await buildGraph(repo, [
-                { label: 'root', description: 'root' },
-                { label: 'parent', parents: ['root'], description: 'parent' },
-                { label: 'child', parents: ['parent'], description: 'child' },
+                { label: 'Parent', description: 'Parent' },
+                { label: 'Child', parents: ['Parent'], description: 'Child', isWorkingCopy: true },
             ]);
 
-            await jjService.new({
+            // Insert 'Middle' after 'Parent'
+            // Expected DAG: Parent -> Middle -> Child
+            const middleId = await jjService.new({ message: 'Middle', insertAfter: [ids['Parent'].changeId] });
+
+            // 1. Verify Middle's parent is Parent
+            const middleParents = repo.getParents(middleId);
+            expect(middleParents).toContain(ids['Parent'].changeId);
+
+            // 2. Verify Child's parent is now Middle
+            const childParents = repo.getParents(ids['Child'].changeId);
+            expect(childParents).toContain(middleId);
+            // Child no longer has Parent directly
+            expect(childParents).not.toContain(ids['Parent'].changeId);
+
+            // 3. Verify @ is at Middle
+            const workingCopyId = repo.getWorkingCopyId();
+            expect(workingCopyId).toBe(middleId);
+        });
+
+        test('creates change inserted after multiple revisions', async () => {
+            // Setup: P1 -> Child1
+            //        P2 -> Child2
+            const ids = await buildGraph(repo, [
+                { label: 'root', description: 'root' },
+                { label: 'P1', parents: ['root'], description: 'P1' },
+                { label: 'P2', parents: ['root'], description: 'P2' },
+                { label: 'Child1', parents: ['P1'], description: 'Child1' },
+                { label: 'Child2', parents: ['P2'], description: 'Child2', isWorkingCopy: true },
+            ]);
+
+            // Insert 'Middle' after P1 and P2
+            // Expected DAG: P1 -> Middle -> Child1
+            //               P2 -/        \-> Child2
+            const middleId = await jjService.new({
                 message: 'Middle',
-                parents: [ids['root'].changeId, ids['parent'].changeId],
-                insertBefore: [ids['child'].changeId],
+                insertAfter: [ids['P1'].changeId, ids['P2'].changeId],
             });
 
-            const userLog = await jjService.getLog();
-            const middle = userLog.find((l) => l.description.includes('Middle'));
-            expect(middle).toBeDefined();
+            // 1. Verify Middle's parents are P1 and P2
+            const middleParents = repo.getParents(middleId);
+            expect(middleParents).toContain(ids['P1'].changeId);
+            expect(middleParents).toContain(ids['P2'].changeId);
 
-            // Check parents of Middle
-            const middleParents = repo.getParents(middle!.change_id);
-            expect(middleParents).toHaveLength(2);
-            expect(middleParents).toContain(ids['root'].changeId);
-            expect(middleParents).toContain(ids['parent'].changeId);
+            // 2. Verify Child1 and Child2's parent is now Middle
+            const child1Parents = repo.getParents(ids['Child1'].changeId);
+            expect(child1Parents).toContain(middleId);
+            expect(child1Parents).not.toContain(ids['P1'].changeId);
 
-            // Check parent of Child (should be Middle)
-            const childParents = repo.getParents(ids['child'].changeId);
-            expect(childParents[0]).toBe(middle!.change_id);
+            const child2Parents = repo.getParents(ids['Child2'].changeId);
+            expect(child2Parents).toContain(middleId);
+            expect(child2Parents).not.toContain(ids['P2'].changeId);
         });
     });
 

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -198,6 +198,12 @@ export class TestRepo {
         return output.split(' ');
     }
 
+    getChildren(revision: string): string[] {
+        const output = this.exec(['log', '-r', `children(${revision})`, '-T', 'change_id ++ "\\n"', '--no-graph']);
+        if (!output) return [];
+        return output.trim().split('\n').filter(Boolean);
+    }
+
     track(relativePath: string) {
         this.exec(['file', 'track', relativePath]);
     }

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -134,13 +134,15 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 commitId: commit.commit_id,
                 changeId: commit.change_id,
 
-                // Abandon and New Before supported on multi-selection, but also on unselected items
+                // Abandon, New Before, and New After supported on multi-selection, but also on unselected items
                 canAbandon: !isImmutable && (!isSelected || !hasImmutableSelection),
                 canNewBefore: !isImmutable && (!isSelected || !hasImmutableSelection),
+                canNewAfter: !isSelected || !hasImmutableSelection,
 
                 // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
                 canEdit: !isImmutable && (!isSelected || selectionCount <= 1),
                 canDuplicate: !isSelected || selectionCount <= 1,
+                canNewChild: !isSelected || selectionCount <= 1,
 
                 // Rebase source must be mutable, and we rebase ONTO the current selection
                 canRebaseOnto: !isImmutable && !isSelected && selectionCount > 0,

--- a/src/webview/components/PersonInfo.tsx
+++ b/src/webview/components/PersonInfo.tsx
@@ -72,8 +72,12 @@ export const PersonInfo: React.FC<PersonInfoProps> = ({ person, label }) => {
 
     return (
         <div style={{ display: 'flex', alignItems: 'center', fontSize: '13px' }} className="person-info">
-            <span style={{ color: 'var(--vscode-descriptionForeground)', marginRight: '6px', flexShrink: 0 }}>{label}:</span>
-            <strong style={{ color: 'var(--vscode-foreground)', marginRight: '6px', flexShrink: 0 }}>{nameToDisplay}</strong>
+            <span style={{ color: 'var(--vscode-descriptionForeground)', marginRight: '6px', flexShrink: 0 }}>
+                {label}:
+            </span>
+            <strong style={{ color: 'var(--vscode-foreground)', marginRight: '6px', flexShrink: 0 }}>
+                {nameToDisplay}
+            </strong>
             <span
                 style={{
                     color: hasEmail ? 'var(--vscode-descriptionForeground)' : 'var(--vscode-errorForeground)',


### PR DESCRIPTION
Introduces the `jj-view.newAfter` command, allowing users to insert a new commit after selected revisions via the commit graph context menu.

- Routes `--insert-after` targets to the `jj` CLI while preventing positional argument overlaps that typically cause graph loops.
- Implements `newAfterCommand` to handle single and multi-select target correctly.
- Reorganizes the commit node context menu into logical groups (diff, edit, bookmark, changes, rebase) for better usability.
- Adds unit and E2E test coverage for the new action.

Fixes #151 