### PR TITLE
Fix empty diff view on Windows

### DIFF
--- a/src/jj-content-provider.ts
+++ b/src/jj-content-provider.ts
@@ -35,13 +35,12 @@ export class JjDocumentContentProvider implements vscode.TextDocumentContentProv
         const query = new URLSearchParams(uri.query);
         const base = query.get('base');
         const side = query.get('side');
-        const explicitPath = query.get('path');
 
         if (!base || !side) {
             return '';
         }
 
-        const filePath = explicitPath || uri.fsPath;
+        const filePath = uri.fsPath;
         const cacheKey = `${base}|${filePath}`;
 
         // Track this URI for future invalidation

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -26,7 +26,7 @@ export function createDiffUris(
     const leftUri = vscode.Uri.from({
         scheme: 'jj-view',
         path: leftPath,
-        query: `base=${revision}&side=left&path=${encodeURIComponent(leftPath)}`,
+        query: `base=${revision}&side=left`,
     });
 
     let rightUri: vscode.Uri;


### PR DESCRIPTION
Fix #147

Instead of reading the path from the query parameters, it reads it through the intended `.fsPath` accessor. I don't fully understand why the path was passed twice. 