### PR TITLE
fix: prepend global arguments before jj subcommands

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -154,25 +154,24 @@ export class JjService {
     ): Promise<string> {
         const opId = this._nextOpId++;
 
-        const finalArgs = [...args];
-        if (options.useCachedSnapshot) {
-            finalArgs.push('--ignore-working-copy');
-        }
-
-        finalArgs.unshift(
+        const globalArgs = [
             '--config',
             'ui.log-word-wrap=false',
             '--config',
             'ui.color="never"',
             '--config',
             'ui.paginate="never"',
-        );
+        ];
+
+        if (options.useCachedSnapshot) {
+            globalArgs.push('--ignore-working-copy');
+        }
 
         const start = performance.now();
-        const allArgs = [command, ...finalArgs];
-        const displayArgs = allArgs.slice(0, 2);
+        const allArgs = [...globalArgs, command, ...args];
+        const displayArgs = [command, ...args].slice(0, 2);
         const prefix = options.label ? `[${options.label}] ` : '';
-        const commandStr = `${prefix}jj ${displayArgs.join(' ')}${allArgs.length > 2 ? '...' : ''}`;
+        const commandStr = `${prefix}jj ${displayArgs.join(' ')}${[command, ...args].length > 2 ? '...' : ''}`;
 
         const isMutation = !!options.isMutation;
         let timeout: NodeJS.Timeout | undefined;
@@ -201,7 +200,7 @@ export class JjService {
                     ...options,
                 };
 
-                cp.execFile('jj', [command, ...finalArgs], finalOptions, (err, stdout, stderr) => {
+                cp.execFile('jj', allArgs, finalOptions, (err, stdout, stderr) => {
                     const duration = performance.now() - start;
                     const cachedInfo = options.useCachedSnapshot ? ' (cached)' : '';
                     this.logger(`[${duration.toFixed(0)}ms]${cachedInfo} ${commandStr}`);

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -233,7 +233,9 @@ test.describe('JJ Log Context Menu E2E', () => {
             await expectTree(repo, [
                 entry(child1Id, 'child1', '*'),
                 entry(child2Id, 'child2', '*'),
-                expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[(${commit1Id},${commit2Id}|${commit2Id},${commit1Id})\\] \\(empty\\)$`)),
+                expect.stringMatching(
+                    new RegExp(`^@ [a-z0-9]+ \\[(${commit1Id},${commit2Id}|${commit2Id},${commit1Id})\\] \\(empty\\)$`),
+                ),
                 entry(commit2Id, 'commit2', initialId),
                 entry(commit1Id, 'commit1', initialId),
                 entry(initialId, 'initial', dummyId),


### PR DESCRIPTION
Modifies `JjService` so that global `jj` arguments such as `--config` and `--ignore-working-copy` are placed before the subcommand in the execution arguments list, rather than after it. This fixes an issue where custom upload commands with extra config arguments were syntactically malformed and failed. Also formats a long RegExp assertion in the log context menu E2E test.

Fixes #157 