### PR TITLE
feat(colocation): Recommend disabling Git extension when colocated

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.graphLabelAlignment`          | `"aligned"` | Controls the horizontal alignment of commit messages in the log view. Available options: `aligned`, `compact`.                                                                                                                                                                                       |
 | `jj-view.commit.titleWidthRuler`       | `50`        | Width at which to display a ruler in the commit details description editor for the title line.                                                                                                                                                                                                       |
 | `jj-view.commit.bodyWidthRuler`        | `72`        | Width at which to display a ruler in the commit details description editor for the body.                                                                                                                                                                                                             |
+| `jj-view.suppressGitColocationWarning` | `false`     | Suppress the warning to disable the built-in Git extension in colocated repositories.                                                                                                                                                                                                                |
 
 ## Advanced Configuration
 

--- a/package.json
+++ b/package.json
@@ -127,6 +127,11 @@
                     "type": "number",
                     "default": 72,
                     "description": "Width at which to display a ruler in the commit details description editor for the body."
+                },
+                "jj-view.suppressGitColocationWarning": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Suppress the warning to disable the built-in Git extension in colocated repositories."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,8 @@
 
 import * as vscode from 'vscode';
 
+import { checkGitColocation } from './git-colocation';
+
 import { JjService } from './jj-service';
 import { JjScmProvider } from './jj-scm-provider';
 import { JjDocumentContentProvider } from './jj-content-provider';
@@ -314,6 +316,9 @@ export function activate(context: vscode.ExtensionContext) {
             await showMultiFileDiffCommand(jj, outputChannel, ...args);
         }),
     );
+
+    // Fire and forget: check if we should warn about git colocation
+    checkGitColocation(jj).catch((e) => outputChannel.appendLine(`[Extension] Colocation check failed: ${e}`));
 
     return {
         scmProvider,

--- a/src/git-colocation.ts
+++ b/src/git-colocation.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { JjService } from './jj-service';
+
+/** Checks if the repository is git-colocated and prompts the user to disable the Git extension if necessary. */
+export async function checkGitColocation(jj: JjService): Promise<void> {
+    const gitRoot = await jj.getGitRoot();
+    if (!gitRoot) {
+        return; // Not git-backed
+    }
+
+    const repoRoot = await jj.getRepoRoot();
+
+    // Normalize paths to compare. A colocated repo has its .git dir at the repo root.
+    const isColocated = path.normalize(gitRoot) === path.normalize(path.join(repoRoot, '.git'));
+    if (!isColocated) {
+        return;
+    }
+
+    const gitConfig = vscode.workspace.getConfiguration('git');
+    const isGitEnabled = gitConfig.get<boolean>('enabled') !== false;
+    const isGitExtensionPresent = !!vscode.extensions.getExtension('vscode.git');
+
+    if (!isGitEnabled || !isGitExtensionPresent) {
+        return;
+    }
+
+    const jjViewConfig = vscode.workspace.getConfiguration('jj-view');
+    const isSuppressed = jjViewConfig.get<boolean>('suppressGitColocationWarning') === true;
+
+    if (isSuppressed) {
+        return;
+    }
+
+    const disableAction = 'Disable Git Extension';
+    const ignoreAction = "Don't Show Again";
+    const result = await vscode.window.showInformationMessage(
+        'Colocated Jujutsu and Git repository detected. We recommend disabling the built-in Git extension to avoid conflicting source control views.',
+        disableAction,
+        ignoreAction,
+    );
+
+    if (result === disableAction) {
+        await vscode.commands.executeCommand('workbench.action.openSettings', 'git.enabled');
+    } else if (result === ignoreAction) {
+        await jjViewConfig.update('suppressGitColocationWarning', true, vscode.ConfigurationTarget.Global);
+    }
+}

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -45,6 +45,14 @@ export class JjService {
         return this._repoRoot;
     }
 
+    async getGitRoot(): Promise<string | null> {
+        try {
+            return await this.run('git', ['root'], { useCachedSnapshot: true, label: 'getGitRoot' });
+        } catch {
+            return null;
+        }
+    }
+
     get hasActiveWriteOps(): boolean {
         return this._writeOperationCount > 0;
     }

--- a/src/test/git-colocation.integration.test.ts
+++ b/src/test/git-colocation.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import * as cp from 'child_process';
+import { checkGitColocation } from '../git-colocation';
+import { TestRepo } from './test-repo';
+import { JjService } from '../jj-service';
+
+suite('Git Colocation Integration Test Suite', () => {
+    let repo: TestRepo;
+    let jjService: JjService;
+    let sandbox: sinon.SinonSandbox;
+
+    suiteSetup(() => {
+        repo = new TestRepo();
+        // Create a colocated repo
+        cp.execFileSync('jj', ['git', 'init', '--colocate'], { cwd: repo.path, encoding: 'utf-8' });
+        jjService = new JjService(repo.path);
+    });
+
+    suiteTeardown(() => {
+        repo.dispose();
+    });
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('should show warning for colocated repo', async () => {
+        // Mock vscode configuration to ensure git is enabled and warning is not suppressed
+        const getConfigurationStub = sandbox.stub(vscode.workspace, 'getConfiguration');
+        
+        getConfigurationStub.withArgs('git').returns({
+            get: (key: string) => key === 'enabled' ? true : undefined,
+            has: () => true,
+            inspect: () => undefined,
+            update: async () => {},
+        } as vscode.WorkspaceConfiguration);
+
+        getConfigurationStub.withArgs('jj-view').returns({
+            get: (key: string) => key === 'suppressGitColocationWarning' ? false : undefined,
+            has: () => true,
+            inspect: () => undefined,
+            update: async () => {},
+        } as vscode.WorkspaceConfiguration);
+
+        // Stub getExtension to pretend vscode.git is active (since test environment might disable it)
+        const getExtensionStub = sandbox.stub(vscode.extensions, 'getExtension');
+        getExtensionStub.withArgs('vscode.git').returns({ id: 'vscode.git' } as vscode.Extension<vscode.ExtensionContext>);
+
+        // Spy on showInformationMessage
+        const showInformationMessageSpy = sandbox.stub(vscode.window, 'showInformationMessage');
+        showInformationMessageSpy.resolves(undefined);
+
+        await checkGitColocation(jjService);
+
+        assert.ok(showInformationMessageSpy.calledOnce, 'Warning should be shown');
+        assert.ok(showInformationMessageSpy.firstCall.args[0].includes('Colocated Jujutsu and Git repository detected'), 'Warning message should be correct');
+    });
+
+    test('should not show warning if suppressed', async () => {
+        const getConfigurationStub = sandbox.stub(vscode.workspace, 'getConfiguration');
+        
+        getConfigurationStub.withArgs('git').returns({
+            get: (key: string) => key === 'enabled' ? true : undefined,
+            has: () => true,
+            inspect: () => undefined,
+            update: async () => {},
+        } as vscode.WorkspaceConfiguration);
+
+        getConfigurationStub.withArgs('jj-view').returns({
+            get: (key: string) => key === 'suppressGitColocationWarning' ? true : undefined,
+            has: () => true,
+            inspect: () => undefined,
+            update: async () => {},
+        } as vscode.WorkspaceConfiguration);
+
+        const getExtensionStub = sandbox.stub(vscode.extensions, 'getExtension');
+        getExtensionStub.withArgs('vscode.git').returns({ id: 'vscode.git' } as vscode.Extension<vscode.ExtensionContext>);
+
+        const showInformationMessageSpy = sandbox.stub(vscode.window, 'showInformationMessage');
+        showInformationMessageSpy.resolves(undefined);
+
+        await checkGitColocation(jjService);
+
+        assert.ok(showInformationMessageSpy.notCalled, 'Warning should not be shown when suppressed');
+    });
+});

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -58,6 +58,12 @@ describe('JjService Unit Tests', () => {
         expect(changes.length).toBe(0);
     });
 
+    test('getGitRoot returns valid path for git-backed repo', async () => {
+        const gitRoot = await jjService.getGitRoot();
+        expect(gitRoot).toBeTruthy();
+        expect(gitRoot).toContain('.git');
+    });
+
     test('supplies JJ_VIEW_EXTENSION environment variable', async () => {
         // Write a conditional config that changes the default log revset
         // only when JJ_VIEW_EXTENSION=1 is present in the environment.


### PR DESCRIPTION
Detects when the repository is git-colocated by checking `jj git root` against the repository root. If the VS Code `git` extension is active and enabled, it prompts the user to disable it to prevent conflicting source control views. Also adds a `jj-view.suppressGitColocationWarning` setting to ignore the warning.

Fixes #155