### PR TITLE
fix: eliminate file explorer decoration flicker during SCM refreshes

### DIFF
--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -20,7 +20,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
     private checkTimeout?: NodeJS.Timeout;
 
     // Cache to prevent re-evaluating the same file status repeatedly
-    private trackedStatusCache = new Map<string, boolean>();
+    private trackedStatusCache = new Map<string, { isTracked: boolean; uri: vscode.Uri }>();
     private resolveCallbacks = new Map<string, (decoration: vscode.FileDecoration | undefined) => void>();
 
     constructor(
@@ -28,21 +28,13 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         private workspaceRoot: string,
     ) {}
 
-    private _clearIgnoredFileDecorationsCache(): boolean {
-        if (this.trackedStatusCache.size > 0 || this.pendingChecks.size > 0) {
-            this.trackedStatusCache.clear();
-            this.pendingChecks.clear();
-            for (const callback of this.resolveCallbacks.values()) {
-                callback(undefined);
-            }
-            this.resolveCallbacks.clear();
-            return true;
-        }
-        return false;
-    }
-
     clearIgnoredFileDecorationsCache() {
-        this._clearIgnoredFileDecorationsCache();
+        this.trackedStatusCache.clear();
+        this.pendingChecks.clear();
+        for (const callback of this.resolveCallbacks.values()) {
+            callback(undefined);
+        }
+        this.resolveCallbacks.clear();
         this._onDidChangeFileDecorations.fire(undefined);
     }
 
@@ -162,30 +154,34 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         }
 
         // 4. Check cache for tracked status
-        const cachedTrackingStatus = this.trackedStatusCache.get(relativePath);
-        if (cachedTrackingStatus === true) {
-            return undefined; // Tracked, no gray decoration needed
-        } else if (cachedTrackingStatus === false) {
-            return new vscode.FileDecoration(
-                undefined,
-                'Ignored',
-                new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
-            );
+        const cacheEntry = this.trackedStatusCache.get(relativePath);
+        if (cacheEntry) {
+            return cacheEntry.isTracked
+                ? undefined
+                : new vscode.FileDecoration(
+                      undefined,
+                      'Ignored',
+                      new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
+                  );
         }
 
         // 5. Not in cache, schedule a batched check
         return new Promise<vscode.FileDecoration | undefined>((resolve) => {
             this.resolveCallbacks.set(relativePath, resolve);
-            this.pendingChecks.set(relativePath, uri);
-
-            if (this.checkTimeout) {
-                clearTimeout(this.checkTimeout);
-            }
-
-            this.checkTimeout = setTimeout(() => {
-                this.flushPendingChecks();
-            }, 50);
+            this.queueCheck(uri, relativePath);
         });
+    }
+
+    private queueCheck(uri: vscode.Uri, relativePath: string) {
+        this.pendingChecks.set(relativePath, uri);
+
+        if (this.checkTimeout) {
+            clearTimeout(this.checkTimeout);
+        }
+
+        this.checkTimeout = setTimeout(() => {
+            this.flushPendingChecks();
+        }, 50);
     }
 
     private async flushPendingChecks() {
@@ -197,7 +193,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         const callbacksStr = pathsToCheck.map((p) => ({
             path: p,
             uri: this.pendingChecks.get(p)!,
-            resolve: this.resolveCallbacks.get(p)!,
+            resolve: this.resolveCallbacks.get(p),
         }));
 
         this.pendingChecks.clear();
@@ -237,56 +233,112 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
                     }
                 }
 
-                this.trackedStatusCache.set(item.path, isTracked);
+                const oldStatus = this.trackedStatusCache.get(item.path)?.isTracked;
+                this.trackedStatusCache.set(item.path, { isTracked, uri: item.uri });
 
-                if (isTracked) {
-                    item.resolve(undefined);
-                } else {
-                    item.resolve(
-                        new vscode.FileDecoration(
-                            undefined,
-                            'Ignored',
-                            new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
-                        ),
-                    );
+                const resolve = item.resolve;
+                if (resolve) {
+                    if (isTracked) {
+                        resolve(undefined);
+                    } else {
+                        resolve(
+                            new vscode.FileDecoration(
+                                undefined,
+                                'Ignored',
+                                new vscode.ThemeColor('gitDecoration.ignoredResourceForeground'),
+                            ),
+                        );
+                    }
+                } else if (oldStatus !== undefined && oldStatus !== isTracked) {
+                    this._onDidChangeFileDecorations.fire(item.uri);
                 }
             }
         } catch (e) {
             console.error('Failed to check tracked paths', e);
             for (const item of callbacksStr) {
-                item.resolve(undefined);
+                if (item.resolve) {
+                    item.resolve(undefined);
+                }
             }
         }
     }
 
-    updateScmStatusAndClearIgnoredCache(scmStatusDecorations: Map<string, JjStatusEntry>) {
-        const scmChanged = !this.areDecorationsEqual(this.scmStatusDecorations, scmStatusDecorations);
-        if (scmChanged) {
-            this.scmStatusDecorations = scmStatusDecorations;
+    private async updateTrackedStatusDecorations() {
+        if (!this.jjService || this.trackedStatusCache.size === 0) {
+            return;
         }
 
-        const cacheCleared = this._clearIgnoredFileDecorationsCache();
+        const entries = Array.from(this.trackedStatusCache.entries());
+        const pathsToCheck = entries.map(([p]) => p);
 
-        if (scmChanged || cacheCleared) {
-            this._onDidChangeFileDecorations.fire(undefined); // Refresh all
+        try {
+            const chunkSize = 100;
+            const trackedSet = new Set<string>();
+
+            for (let i = 0; i < pathsToCheck.length; i += chunkSize) {
+                const chunk = pathsToCheck.slice(i, i + chunkSize);
+                const trackedArray = await this.jjService.checkTrackedPaths(chunk);
+                for (const trackedPath of trackedArray) {
+                    trackedSet.add(trackedPath.replace(/\\/g, '/'));
+                }
+            }
+
+            const changedUris: vscode.Uri[] = [];
+
+            for (const [itemPath, cacheEntry] of entries) {
+                const normalizedItemPath = itemPath.replace(/\\/g, '/');
+                let isTracked = trackedSet.has(normalizedItemPath);
+
+                if (!isTracked) {
+                    const prefix = normalizedItemPath + '/';
+                    for (const trackedFile of trackedSet) {
+                        if (trackedFile.startsWith(prefix)) {
+                            isTracked = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (cacheEntry.isTracked !== isTracked) {
+                    this.trackedStatusCache.set(itemPath, { isTracked, uri: cacheEntry.uri });
+                    changedUris.push(cacheEntry.uri);
+                }
+            }
+
+            if (changedUris.length > 0) {
+                this._onDidChangeFileDecorations.fire(changedUris);
+            }
+        } catch (e) {
+            console.error('Failed to revalidate tracked cache', e);
         }
     }
 
-    private areDecorationsEqual(map1: Map<string, JjStatusEntry>, map2: Map<string, JjStatusEntry>): boolean {
-        if (map1.size !== map2.size) {
-            return false;
+    private updateScmStatusDecorations(scmStatusDecorations: Map<string, JjStatusEntry>) {
+        const changedUris: vscode.Uri[] = [];
+
+        // Compare old and new SCM status
+        for (const [key, newEntry] of scmStatusDecorations.entries()) {
+            const oldEntry = this.scmStatusDecorations.get(key);
+            if (!oldEntry || oldEntry.status !== newEntry.status || oldEntry.conflicted !== newEntry.conflicted) {
+                changedUris.push(vscode.Uri.parse(key));
+            }
+        }
+        for (const key of this.scmStatusDecorations.keys()) {
+            if (!scmStatusDecorations.has(key)) {
+                changedUris.push(vscode.Uri.parse(key));
+            }
         }
 
-        for (const [key, val1] of map1) {
-            const val2 = map2.get(key);
-            if (!val2) {
-                return false;
-            }
-            if (val1.path !== val2.path || val1.status !== val2.status || val1.conflicted !== val2.conflicted) {
-                return false;
-            }
+        this.scmStatusDecorations = scmStatusDecorations;
+
+        if (changedUris.length > 0) {
+            this._onDidChangeFileDecorations.fire(changedUris);
         }
-        return true;
+    }
+
+    updateScmAndTrackedStatus(scmStatusDecorations: Map<string, JjStatusEntry>) {
+        this.updateScmStatusDecorations(scmStatusDecorations);
+        this.updateTrackedStatusDecorations();
     }
 
     dispose() {

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -397,7 +397,7 @@ export class JjScmProvider implements vscode.Disposable {
                 }
 
                 // Update Decoration
-                this.decorationProvider.updateScmStatusAndClearIgnoredCache(decorationMap);
+                this.decorationProvider.updateScmAndTrackedStatus(decorationMap);
 
                 // Update SCM Count - Only count Working Copy changes
                 // VS Code sums all groups by default if count is not set, so we must set it explicitly.

--- a/src/test/jj-decoration-provider.test.ts
+++ b/src/test/jj-decoration-provider.test.ts
@@ -59,7 +59,7 @@ describe('JjDecorationProvider', () => {
         const scmStatusDecorations = new Map<string, JjStatusEntry>();
         scmStatusDecorations.set('file:///a', { path: 'a', status: 'modified' });
 
-        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations);
+        provider.updateScmAndTrackedStatus(scmStatusDecorations);
 
         expect(fireSpy).toHaveBeenCalledTimes(1);
     });
@@ -71,7 +71,7 @@ describe('JjDecorationProvider', () => {
         const scmStatusDecorations = new Map<string, JjStatusEntry>();
         scmStatusDecorations.set(uri1.toString(), { path: '/ws/file1.txt', status: 'modified' });
 
-        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations);
+        provider.updateScmAndTrackedStatus(scmStatusDecorations);
 
         const token = createMock<vscode.CancellationToken>();
         const result = await provider.provideFileDecoration(uri1, token);
@@ -86,7 +86,7 @@ describe('JjDecorationProvider', () => {
         const scmStatusDecorations1 = new Map<string, JjStatusEntry>();
         scmStatusDecorations1.set('file:///a', { path: 'a', status: 'modified' });
 
-        provider.updateScmStatusAndClearIgnoredCache(scmStatusDecorations1);
+        provider.updateScmAndTrackedStatus(scmStatusDecorations1);
 
         expect(fireSpy).toHaveBeenCalledTimes(1);
 
@@ -94,7 +94,7 @@ describe('JjDecorationProvider', () => {
         const decorations2 = new Map<string, JjStatusEntry>();
         decorations2.set('file:///a', { path: 'a', status: 'modified' });
 
-        provider.updateScmStatusAndClearIgnoredCache(decorations2);
+        provider.updateScmAndTrackedStatus(decorations2);
 
         // This confirms the fix
         expect(fireSpy).toHaveBeenCalledTimes(1);
@@ -162,13 +162,17 @@ describe('JjDecorationProvider', () => {
         });
         provider = new JjDecorationProvider(mockJjService, '/ws');
 
-        // Exploit accessPrivate to inject cache
-        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<string, boolean>;
-        cache.set('cached_tracked.txt', true);
-        cache.set('cached_ignored.txt', false);
-
         const uriTracked = (await import('vscode')).Uri.file('/ws/cached_tracked.txt');
         const uriIgnored = (await import('vscode')).Uri.file('/ws/cached_ignored.txt');
+
+        // Exploit accessPrivate to inject cache
+        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<
+            string,
+            { isTracked: boolean; uri: vscode.Uri }
+        >;
+        cache.set('cached_tracked.txt', { isTracked: true, uri: uriTracked });
+        cache.set('cached_ignored.txt', { isTracked: false, uri: uriIgnored });
+
         const mockToken = createMock<vscode.CancellationToken>({});
 
         const decTracked = provider.provideFileDecoration(uriTracked, mockToken);
@@ -202,12 +206,16 @@ describe('JjDecorationProvider', () => {
         expect(vi.mocked(mockJjService.checkTrackedPaths).mock.calls[1][0].length).toBe(50);
     });
 
-    it('should fire onDidChangeFileDecorations when clearIgnoredFileDecorationsCache is called', () => {
+    it('should fire event when clearIgnoredFileDecorationsCache is called', async () => {
         provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
         const fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
 
-        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<string, boolean>;
-        cache.set('dummy', true);
+        const uri = (await import('vscode')).Uri.file('/ws/dummy');
+        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<
+            string,
+            { isTracked: boolean; uri: vscode.Uri }
+        >;
+        cache.set('dummy', { isTracked: true, uri });
 
         expect(cache.size).toBe(1);
 
@@ -215,5 +223,82 @@ describe('JjDecorationProvider', () => {
 
         expect(cache.size).toBe(0);
         expect(fireSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should fire event when SCM decorations are removed', () => {
+        provider = new JjDecorationProvider(createMock<JjService>({}), '/ws');
+        const fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
+
+        const scmStatusDecorations1 = new Map<string, JjStatusEntry>();
+        scmStatusDecorations1.set('file:///a', { path: 'a', status: 'modified' });
+
+        provider.updateScmAndTrackedStatus(scmStatusDecorations1);
+        expect(fireSpy).toHaveBeenCalledTimes(1);
+        vi.mocked(fireSpy).mockClear();
+
+        const decorations2 = new Map<string, JjStatusEntry>();
+        // file:///a is removed
+
+        provider.updateScmAndTrackedStatus(decorations2);
+
+        // Should fire because file:///a was removed
+        expect(fireSpy).toHaveBeenCalledTimes(1);
+        const firedUris = vi.mocked(fireSpy).mock.calls[0][0] as vscode.Uri[];
+        expect(firedUris[0].toString()).toBe('file:///a');
+    });
+
+    it('should fire event when tracked status changes during background cache update', async () => {
+        const mockJjService = createMock<JjService>({
+            checkTrackedPaths: vi.fn().mockResolvedValue(['tracked.txt']), // Only tracked.txt is tracked
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+        const fireSpy = vi.spyOn(accessPrivate(provider, '_onDidChangeFileDecorations'), 'fire');
+
+        const uri1 = (await import('vscode')).Uri.file('/ws/tracked.txt');
+        const uri2 = (await import('vscode')).Uri.file('/ws/ignored.txt');
+
+        // Inject initial cache state (opposite of reality)
+        const cache = accessPrivate(provider, 'trackedStatusCache') as Map<
+            string,
+            { isTracked: boolean; uri: vscode.Uri }
+        >;
+        cache.set('tracked.txt', { isTracked: false, uri: uri1 }); // Currently untracked, but jj answers tracked
+        cache.set('ignored.txt', { isTracked: true, uri: uri2 }); // Currently tracked, but jj answers ignored
+
+        // Private method invocation
+        const updateFn = accessPrivate(provider, 'updateTrackedStatusDecorations') as () => Promise<void>;
+        await updateFn.call(provider);
+
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalled();
+
+        // It should have fired with both URIs because both changed
+        expect(fireSpy).toHaveBeenCalledTimes(1);
+        const firedUris = vi.mocked(fireSpy).mock.calls[0][0] as vscode.Uri[];
+        expect(firedUris).toHaveLength(2);
+        expect(firedUris.some((u) => u.fsPath.endsWith('tracked.txt'))).toBe(true);
+        expect(firedUris.some((u) => u.fsPath.endsWith('ignored.txt'))).toBe(true);
+
+        // Cache should be updated
+        expect(cache.get('tracked.txt')?.isTracked).toBe(true);
+        expect(cache.get('ignored.txt')?.isTracked).toBe(false);
+    });
+
+    it('should consider a directory tracked if it contains tracked files', async () => {
+        const mockJjService = createMock<JjService>({
+            // checkTrackedPaths returns the files inside, not the dir itself
+            checkTrackedPaths: vi.fn().mockResolvedValue(['my-dir/file.txt']),
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+
+        const dirUri = (await import('vscode')).Uri.file('/ws/my-dir');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        const pDir = provider.provideFileDecoration(dirUri, mockToken);
+
+        await new Promise((r) => setTimeout(r, 60));
+        const resDir = await pDir;
+
+        // If it's considered tracked, it returns undefined instead of the 'Ignored' decoration
+        expect(resDir).toBeUndefined();
     });
 });


### PR DESCRIPTION
Refactors the decoration provider to compute targeted diff arrays instead of dropping the global decoration cache with undefined. Explicitly compares incoming and existing SCM status maps to isolate changed URIs, while background cache validation is now independently analyzed for precise tracking updates. Includes accurate renaming of SCM update functions and comprehensive unit tests verifying the targeted URI firing behavior for cache deletions, background validation, and directory prefix mapping.

This approach avoids flicker, but it is more risky than the old approach.
1) There isn't a mechanism for pruning the cache, so it will continue to grow as the user views files in the explorer
2) It's complicated, so there might be bugs

Fixes #166