### PR TITLE
fix: correctly resolve target child in Move to Child comman

### DIFF
--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -6,51 +6,44 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { JjService } from '../jj-service';
-import { JjScmProvider, JjResourceState } from '../jj-scm-provider';
-import { collectResourceStates, showJjError } from './command-utils';
+import { JjScmProvider } from '../jj-scm-provider';
+import { collectResourceStates, extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function moveToChildCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
+    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
 
-    if (resourceStates.length === 0) {
+    if (paths.length === 0) {
         return;
     }
 
-    const grouped = new Map<string, string[]>();
-    for (const r of resourceStates) {
-        const state = r as JjResourceState;
-        const rev = state.revision || '@';
-        if (!grouped.has(rev)) {
-            grouped.set(rev, []);
-        }
-        grouped.get(rev)!.push(r.resourceUri.fsPath);
-    }
+    const revision = extractRevision(args) || '@';
 
-    for (const [revision, paths] of grouped) {
-        if (revision === '@') {
-            const children = await jj.getChildren('@');
-            let targetChild: string | undefined;
+    try {
+        const children = await jj.getChildren(revision);
+        let targetChild: string | undefined;
 
-            if (children.length === 0) {
-                vscode.window.showErrorMessage('No child commits to move changes to.');
-                return;
-            } else if (children.length === 1) {
-                targetChild = children[0];
-            } else {
-                targetChild = await vscode.window.showQuickPick(children, { placeHolder: 'Select child commit' });
-            }
-
-            if (targetChild) {
-                await jj.moveChanges(paths, '@', targetChild);
-            }
-        } else if (revision === '@-') {
-            await jj.moveChanges(paths, '@-', '@');
+        if (children.length === 0) {
+            const revDisplay = revision === '@' ? 'the working copy' : revision;
+            vscode.window.showErrorMessage(`No child commits to move changes to for ${revDisplay}.`);
+            return;
+        } else if (children.length === 1) {
+            targetChild = children[0];
         } else {
-            // Assume generic revision is a parent or ancestor we want to pull changes from into @
-            await jj.moveChanges(paths, revision, '@');
+            targetChild = await vscode.window.showQuickPick(children, {
+                placeHolder: `Select child commit for ${revision}`,
+            });
         }
+
+        if (!targetChild) {
+            return;
+        }
+
+        await withDelayedProgress('Moving changes...', jj.moveChanges(paths, revision, targetChild));
+        await scmProvider.refresh();
+    } catch (e: unknown) {
+        await showJjError(e, 'Error moving changes to child', jj, scmProvider.outputChannel);
     }
-    await scmProvider.refresh();
 }
 
 export async function moveToParentInDiffCommand(scmProvider: JjScmProvider, jj: JjService, editor: vscode.TextEditor) {

--- a/src/test/commands/move.test.ts
+++ b/src/test/commands/move.test.ts
@@ -52,4 +52,44 @@ describe('moveToChildCommand', () => {
         const childContent = repo.getFileContent(ids['child'].changeId, fileName);
         expect(childContent).toBe('modified');
     }, 30000);
+
+    test('moves file changes to explicit child using revision', async () => {
+        const fileName = 'move2.txt';
+        // Ancestor (modified) -> Child -> WorkingCopy
+        const ids = await buildGraph(repo, [
+            { label: 'ancestor', description: 'ancestor', files: { [fileName]: 'modified' } },
+            { label: 'child', parents: ['ancestor'], description: 'child' },
+            { label: 'wc', parents: ['child'], description: 'wc', isWorkingCopy: true },
+        ]);
+
+        const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
+        const args = [{ resourceUri: fileUri, revision: ids['ancestor'].changeId }];
+
+        await moveToChildCommand(scmProvider, jj, args);
+
+        const childContent = repo.getFileContent(ids['child'].changeId, fileName);
+        expect(childContent).toBe('modified');
+    }, 30000);
+
+    test('prompts for child if multiple children exist', async () => {
+        const fileName = 'move3.txt';
+        // Ancestor (modified) -> Child1
+        //                     -> Child2
+        const ids = await buildGraph(repo, [
+            { label: 'ancestor', description: 'ancestor', files: { [fileName]: 'modified' } },
+            { label: 'child1', parents: ['ancestor'], description: 'child1' },
+            { label: 'child2', parents: ['ancestor'], description: 'child2' },
+        ]);
+
+        const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
+        const args = [{ resourceUri: fileUri, revision: ids['ancestor'].changeId }];
+
+        const mockShowQuickPick = vscode.window.showQuickPick as import('vitest').Mock;
+        mockShowQuickPick.mockResolvedValueOnce(ids['child2'].changeId);
+
+        await moveToChildCommand(scmProvider, jj, args);
+
+        const child2Content = repo.getFileContent(ids['child2'].changeId, fileName);
+        expect(child2Content).toBe('modified');
+    }, 30000);
 });

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -570,4 +570,61 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('Move to Child on Grandparent Commits', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'base.txt': '1' } },
+            {
+                label: 'grandparent',
+                parents: ['initial'],
+                description: 'grandparent change',
+                files: { 'gp.txt': '1' },
+            },
+            {
+                label: 'parent',
+                parents: ['grandparent'],
+                description: 'parent change',
+                files: { 'p.txt': '1' },
+            },
+            {
+                label: 'wc',
+                parents: ['parent'],
+                description: 'wc change',
+                files: { 'wc.txt': '1' },
+                isWorkingCopy: true,
+            },
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            // Groups are expanded by default, find the gp.txt file under the grandparent change
+            const gpFile = page.getByRole('treeitem', { name: /gp\.txt/ });
+
+            // Hover over gp.txt and click Move to Child (codicon-arrow-up)
+            const moveToChildIcon = gpFile.locator('.action-item', { has: page.locator('.codicon-arrow-up') }).first();
+            await hoverAndClick(gpFile, moveToChildIcon);
+
+            // Assert via repo that gp.txt from grandparent was moved to parent, NOT the working copy
+            await expect(async () => {
+                const parentChanges = repo.getDiffSummary('@-');
+                expect(parentChanges).toContain('A gp.txt');
+                expect(parentChanges).toContain('A p.txt');
+
+                const wcChanges = repo.getDiffSummary('@');
+                expect(wcChanges).not.toContain('A gp.txt');
+                expect(wcChanges).toContain('A wc.txt');
+            }).toPass({ timeout: 5000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });


### PR DESCRIPTION
Previously, moving changes from an ancestor commit would incorrectly fall back to pulling the files directly into the working copy. The command has been updated to dynamically fetch the actual children of the selected commit, prompting the user if multiple branches exist, ensuring changes are strictly moved to their immediate child. Includes a new E2E test to verify grandparent-to-parent moves.

Fixes #167