### PR TITLE
fix: deselect commit in graph when closing its details panel

### DIFF
--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -30,6 +30,9 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
     >();
     public readonly onDidChangeCustomDocument = this._onDidChangeCustomDocument.event;
 
+    private readonly _onDidClosePanel = new vscode.EventEmitter<string>();
+    public readonly onDidClosePanel = this._onDidClosePanel.event;
+
     // Track all open panels for refreshing
     private readonly _panels = new Map<string, Set<vscode.WebviewPanel>>();
 
@@ -154,6 +157,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             this._panels.get(document.changeId)?.delete(panel);
             if (this._panels.get(document.changeId)?.size === 0) {
                 this._panels.delete(document.changeId);
+                this._onDidClosePanel.fire(document.changeId);
             }
         });
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -33,6 +33,13 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 this._renderCommits(this._cachedCommits);
             }
         });
+
+        this._commitDetailsProvider.onDidClosePanel((changeId) => {
+            this._view?.webview.postMessage({
+                type: 'panelClosed',
+                payload: { changeId },
+            });
+        });
     }
 
     public get jj(): JjService {

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -539,6 +539,10 @@ test.describe('Commit Details E2E', () => {
             const desc = repo.getDescription(nodes['feature'].changeId);
             expect(desc).toBe('updated via test before close');
         }).toPass({ timeout: 10000 });
+
+        // Verify the node is no longer selected in the graph
+        const updatedFeatureRow = webview.locator('.commit-row', { hasText: 'updated via test before close' });
+        await expect(updatedFeatureRow).toHaveAttribute('aria-selected', 'false', { timeout: 10000 });
     });
 
     test('Hides buttons and disables editor for immutable commits', async () => {

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -165,6 +165,22 @@ const App: React.FC = () => {
                         },
                     });
                     break;
+                case 'panelClosed':
+                    setSelectedCommitIds((prevIds) => {
+                        if (prevIds.has(message.payload.changeId) && prevIds.size === 1) {
+                            const clearedIds = new Set<string>();
+                            vscode.postMessage({
+                                type: 'selectionChange',
+                                payload: {
+                                    commitIds: [],
+                                    hasImmutableSelection: false,
+                                },
+                            });
+                            return clearedIds;
+                        }
+                        return prevIds;
+                    });
+                    break;
             }
         };
 


### PR DESCRIPTION
When the user manually closes a commit details panel, the graph did not register the close event and left the commit node selected. This change introduces an `onDidClosePanel` event that signals the main webview to clear its selection state when the panel is disposed. Also includes an E2E test to verify this behavior.

Fixes #171 