### PR TITLE
feat: Implement visualization and support for divergent commits

### DIFF
--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 import { JjContextKey } from './jj-context-keys';
 import { JjLogEntry } from './jj-types';
-import { shortenChangeId } from './utils/jj-utils';
+import { formatCommitTitle } from './utils/jj-utils';
 import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 
 import { GerritService } from './gerrit-service';
@@ -128,7 +128,12 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     await vscode.commands.executeCommand('jj-view.abandon', data.payload);
                     break;
                 case 'getDetails':
-                    await this.createCommitDetailsPanel(data.payload.changeId);
+                    await this.createCommitDetailsPanel(
+                        data.payload.changeId,
+                        data.payload.changeIdShortest,
+                        data.payload.isDivergent,
+                        data.payload.changeIdOffset,
+                    );
                     break;
                 case 'new':
                     await vscode.commands.executeCommand('jj-view.new');
@@ -295,14 +300,28 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         });
     }
 
-    public async createCommitDetailsPanel(changeId: string) {
+    public async createCommitDetailsPanel(
+        changeId: string,
+        changeIdShortest?: string,
+        isDivergent?: boolean,
+        changeIdOffset?: number,
+    ) {
         const config = vscode.workspace.getConfiguration('jj-view');
         const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-        const shortId = shortenChangeId(changeId, minChangeIdLength);
+        const title = formatCommitTitle(
+            {
+                change_id: changeId,
+                change_id_shortest: changeIdShortest,
+                is_divergent: isDivergent,
+                change_id_offset: changeIdOffset,
+            },
+            minChangeIdLength,
+        );
+
         const uri = vscode.Uri.from({
             scheme: 'jj-commit',
             authority: 'commit',
-            path: `/Commit: ${shortId}`,
+            path: `/${title}`,
             query: `changeId=${changeId}`,
         });
 

--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -62,7 +62,7 @@ export function buildLogTemplate(schema: Record<string, JjTemplateField>): strin
 // Schema for JjLogEntry - defines how to serialize each field
 export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     commit_id: { type: 'string', expr: 'commit_id' },
-    change_id: { type: 'string', expr: 'change_id' },
+    change_id: { type: 'string', expr: 'if(divergent, change_id ++ "/" ++ change_offset, change_id)' },
     change_id_shortest: { type: 'string', expr: 'change_id.shortest()' },
     description: { type: 'json', expr: 'description' },
     author: {
@@ -97,6 +97,8 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     is_immutable: { type: 'raw', expr: 'immutable' },
     is_working_copy: { type: 'raw', expr: 'current_working_copy' },
     is_empty: { type: 'raw', expr: 'empty' },
+    is_divergent: { type: 'raw', expr: 'divergent' },
+    change_id_offset: { type: 'raw', expr: 'if(change_offset, change_offset, "null")' },
     parents: {
         type: 'stringArray',
         expr: 'parents',

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -42,6 +42,8 @@ export interface JjLogEntry {
     is_working_copy?: boolean;
     is_immutable?: boolean;
     is_empty?: boolean;
+    is_divergent?: boolean;
+    change_id_offset?: number;
     parents_immutable?: boolean[];
     conflict?: boolean;
     changes?: JjStatusEntry[];

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ElectronApplication, type Frame } from 'playwright';
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import { TestRepo } from '../test-repo';
+import { launchVSCode, focusJJLog, getLogWebview, triggerRefresh, hoverAndClick } from './e2e-helpers';
+
+/**
+ * Finds the webview frame containing the Commit Details panel.
+ * Reused from commit-details.spec.ts
+ */
+async function getDetailsWebview(page: Page): Promise<Frame> {
+    const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
+        for (const f of frames) {
+            try {
+                if (await f.locator('textarea').isVisible({ timeout: 50 })) {
+                    return f;
+                }
+                const nested = await findFrame(f.childFrames());
+                if (nested) return nested;
+            } catch (e) {}
+        }
+        return undefined;
+    };
+
+    let guestFrame: Frame | undefined;
+    await expect.poll(async () => {
+        guestFrame = await findFrame(page.frames());
+        return guestFrame;
+    }, {
+        timeout: 30000,
+        message: 'Could not find Commit Details webview frame',
+    }).toBeDefined();
+
+    await expect(guestFrame!.locator('textarea')).toBeVisible({ timeout: 10000 });
+    return guestFrame!;
+}
+
+test.describe('Divergent Commits E2E', () => {
+    let repo: TestRepo;
+    let app: ElectronApplication;
+    let page: Page;
+    let userDataDir: string;
+
+    test.beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        // 1. Create a commit (A version 1)
+        repo.writeFile('a.txt', 'content a');
+        repo.describe('commit A v1');
+        const commitIdV1 = repo.getCommitId('@');
+
+        // 2. Edit the message (creates A version 2)
+        repo.describe('commit A v2');
+        
+        // 3. Bookmark the old version to make it visible, creating divergence
+        repo.bookmark('zombie', commitIdV1);
+
+        const setup = await launchVSCode(repo);
+        app = setup.app;
+        page = setup.page;
+        userDataDir = setup.userDataDir;
+
+        await focusJJLog(page);
+    });
+
+    test.afterEach(async () => {
+        if (app) await app.close();
+        if (userDataDir) {
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+        }
+        if (repo) repo.dispose();
+    });
+
+    test('Visualizes divergence and allows resolving it', async () => {
+        const webview = await getLogWebview(page);
+
+        // 1. Verify graph visuals
+        // Both A v1 (zombie) and A v2 (@) should be visible
+        const rowV1 = webview.locator('.commit-row', { hasText: 'commit A v1' });
+        const rowV2 = webview.locator('.commit-row', { hasText: 'commit A v2' });
+        
+        await expect(rowV1).toBeVisible();
+        await expect(rowV2).toBeVisible();
+
+        // Verify purple suffix in graph for both
+        const suffix1 = rowV1.locator('.commit-id').locator('span', { hasText: /\/[012]/ });
+        const suffix2 = rowV2.locator('.commit-id').locator('span', { hasText: /\/[012]/ });
+        
+        await expect(suffix1).toBeVisible();
+        await expect(suffix2).toBeVisible();
+        
+        // Verify the (divergent) label is also visible in the description area
+        await expect(rowV1.getByText('(divergent)')).toBeVisible();
+        await expect(rowV2.getByText('(divergent)')).toBeVisible();
+
+        // 2. Verify Tab Title for A v2
+        await rowV2.click();
+        
+        const changeIdV2 = await rowV2.getAttribute('data-change-id'); // e.g. "uuid/0" or "uuid/1"
+        const [uuid, offset] = changeIdV2!.split('/');
+        const shortId = uuid.substring(0, 3);
+        
+        // Big Solidus is \u29F8
+        const tabTitle = `Commit: ${shortId}\u29F8${offset}`;
+        await expect(page.getByRole('tab', { name: tabTitle })).toBeVisible({
+            timeout: 15000,
+        });
+
+        // 3. Edit Description for A v2
+        const details = await getDetailsWebview(page);
+        const textarea = details.locator('textarea');
+        await textarea.fill('updated A v2 message');
+        
+        const saveButton = details.locator('button', { hasText: /Save Changes/ });
+        await saveButton.click();
+        
+        // Wait for it to save
+        await expect(details.locator('button', { hasText: 'Saved' })).toBeDisabled({ timeout: 15000 });
+
+        // Verify in repo
+        const desc2 = repo.getDescription(changeIdV2!);
+        expect(desc2).toBe('updated A v2 message');
+
+        // 4. Abandon the "zombie" commit (A v1) to resolve divergence
+        await focusJJLog(page);
+        
+        // Re-get webview because focus might refresh it
+        const webview2 = await getLogWebview(page);
+        const rowToAbandon = webview2.locator('.commit-row', { hasText: 'commit A v1' });
+        
+        await expect(rowToAbandon).toBeVisible();
+        await hoverAndClick(rowToAbandon, webview2.locator('.icon-button[title="Abandon Commit"]'));
+        
+        // 5. Verify divergence is resolved
+        await expect(async () => {
+            // Trigger refresh to ensure the backend update is picked up synchronously in the test
+            await triggerRefresh(page);
+
+            const finalWebview = await getLogWebview(page);
+            const remainingRows = finalWebview.locator('.commit-row', { hasText: 'updated A v2 message' });
+            await expect(remainingRows).toHaveCount(1);
+            
+            // Should NO LONGER have a slash in the ID area
+            const idArea = remainingRows.locator('.commit-id');
+            await expect(idArea.locator('span', { hasText: '/' })).toBeHidden();
+            
+            // Should NO LONGER have the (divergent) label
+            await expect(remainingRows.getByText('(divergent)')).toBeHidden();
+        }).toPass({ timeout: 20000 });
+    });
+});

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1274,4 +1274,38 @@ log = "none()"
         expect(hashes.size).toBe(1);
         expect(hashes.get(fileName)).toBe(expectedHash);
     });
+
+    test('getLog detects divergent commits and offsets', async () => {
+        // 1. Create a commit
+        repo.describe('version 1');
+        const commitIdV1 = repo.getCommitId('@');
+
+        // 2. Edit the commit message (creates V2)
+        repo.describe('version 2');
+        const commitIdV2 = repo.getCommitId('@');
+
+        // 3. Bookmark the old commit ID to make it visible
+        repo.bookmark('old-version', commitIdV1);
+
+        // Now we have two visible commits for the same change ID: commitIdV1 and commitIdV2
+        const logs = await jjService.getLog({ revision: 'all()' });
+
+        const v1Entry = logs.find((l) => l.commit_id === commitIdV1);
+        const v2Entry = logs.find((l) => l.commit_id === commitIdV2);
+
+        expect(v1Entry).toBeDefined();
+        expect(v2Entry).toBeDefined();
+
+        expect(v1Entry!.is_divergent).toBe(true);
+        expect(v2Entry!.is_divergent).toBe(true);
+
+        // Verification of combined change_id
+        expect(v1Entry!.change_id).toMatch(/\/\d+$/);
+        expect(v2Entry!.change_id).toMatch(/\/\d+$/);
+
+        // In this test setup, V1 gets offset 1 and V2 gets offset 0
+        expect(v1Entry!.change_id_offset).toBe(1);
+        expect(v2Entry!.change_id_offset).toBe(0);
+        expect(v1Entry!.change_id_offset).not.toBe(v2Entry!.change_id_offset);
+    });
 });

--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -9,6 +9,7 @@ import {
     shortenChangeId,
     getChangeIdDisplayLength,
     formatDisplayChangeId,
+    formatCommitTitle,
 } from '../utils/jj-utils';
 
 describe('JJ Utils', () => {
@@ -76,6 +77,49 @@ describe('JJ Utils', () => {
 
         it('should handle short full ID', () => {
             expect(formatDisplayChangeId('abc', 'abc', 8)).toBe('abc');
+        });
+    });
+
+    describe('formatCommitTitle', () => {
+        const fullId = 'abcdefghijklmnopqrstuvwxyz';
+
+        it('should use minLen if shortestId is missing', () => {
+            const commit = { change_id: fullId };
+            expect(formatCommitTitle(commit, 8)).toBe('Commit: abcdefgh');
+        });
+
+        it('should use shortestId length if it is longer than minLen', () => {
+            const commit = { change_id: fullId, change_id_shortest: 'abcd' };
+            expect(formatCommitTitle(commit, 1)).toBe('Commit: abcd');
+        });
+
+        it('should append offset for divergent commits', () => {
+            const commit = {
+                change_id: 'abc/1',
+                is_divergent: true,
+                change_id_offset: 1,
+            };
+            // Note: substring(0, 1) on "abc/1" is "a"
+            expect(formatCommitTitle(commit, 1)).toBe('Commit: a⧸1');
+        });
+
+        it('should truncate offset from base change_id even without splitting', () => {
+            const commit = {
+                change_id: 'vykwzknv/1',
+                is_divergent: true,
+                change_id_offset: 1,
+                change_id_shortest: 'vykw',
+            };
+            // displayLen = 4. "vykwzknv/1".substring(0, 4) = "vykw"
+            expect(formatCommitTitle(commit, 1)).toBe('Commit: vykw⧸1');
+        });
+
+        it('should handle regular commits with no offset', () => {
+            const commit = {
+                change_id: 'abcdef',
+                is_divergent: false,
+            };
+            expect(formatCommitTitle(commit, 8)).toBe('Commit: abcdef');
         });
     });
 });

--- a/src/utils/jj-utils.ts
+++ b/src/utils/jj-utils.ts
@@ -48,3 +48,16 @@ export function formatDisplayChangeId(changeId: string, shortestId: string | und
     const displayLen = getChangeIdDisplayLength(shortestId, minLen);
     return shortenChangeId(changeId, displayLen);
 }
+/**
+ * Formats a title for the commit details tab.
+ * Shortens the UUID part and appends the offset if divergent.
+ */
+export function formatCommitTitle(
+    commit: { change_id: string; change_id_shortest?: string; is_divergent?: boolean; change_id_offset?: number },
+    minLen: number,
+): string {
+    const displayLen = Math.max(minLen, commit.change_id_shortest?.length || 0);
+    const shortId = commit.change_id.substring(0, displayLen);
+    const offsetSuffix = commit.is_divergent ? `⧸${commit.change_id_offset}` : '';
+    return `Commit: ${shortId}${offsetSuffix}`;
+}

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -120,7 +120,13 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                             <CommitNode
                                 commit={commit}
                                 onClick={(modifiers) =>
-                                    onAction('select', { changeId: commit.change_id, ...modifiers })
+                                    onAction('select', {
+                                        changeId: commit.change_id,
+                                        changeIdShortest: commit.change_id_shortest,
+                                        isDivergent: commit.is_divergent,
+                                        changeIdOffset: commit.change_id_offset,
+                                        ...modifiers,
+                                    })
                                 }
                                 onAction={onAction}
                                 isSelected={isSelected}

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -79,6 +79,8 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
         }
     } else if (isConflict) {
         backgroundColor = 'color-mix(in srgb, transparent, var(--vscode-charts-red) 10%)';
+    } else if (commit.is_divergent) {
+        backgroundColor = 'color-mix(in srgb, transparent, var(--vscode-charts-purple) 10%)';
     }
 
     // Allow hover background even while dragging (buttons hidden by JSX check)
@@ -87,6 +89,8 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
         if (isSelected) {
         } else if (isConflict) {
             backgroundColor = 'color-mix(in srgb, transparent, var(--vscode-charts-red) 20%)';
+        } else if (commit.is_divergent) {
+            backgroundColor = 'color-mix(in srgb, transparent, var(--vscode-charts-purple) 20%)';
         } else {
             backgroundColor = 'var(--vscode-list-hoverBackground)';
         }
@@ -188,8 +192,8 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 style={{
                     marginRight: '8px',
                     flexShrink: 0,
-                    width: `${idDisplayLength}ch`,
                     minWidth: `${idDisplayLength}ch`,
+                    width: 'auto',
                     position: 'relative',
                     display: 'flex',
                     alignItems: 'center',
@@ -209,18 +213,30 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                         fontFamily: 'monospace', // Ensure ch units align with text
                     }}
                 >
-                    {commit.change_id_shortest ? (
-                        <>
-                            <span style={{ fontWeight: 'bold' }}>{commit.change_id_shortest}</span>
-                            {commit.change_id.length > commit.change_id_shortest.length && (
-                                <span style={{ opacity: 0.6 }}>
-                                    {commit.change_id.substring(commit.change_id_shortest.length, idDisplayLength)}
-                                </span>
-                            )}
-                        </>
-                    ) : (
-                        commit.change_id.substring(0, idDisplayLength)
-                    )}
+                    {(() => {
+                        const [idPart, offsetPart] = commit.change_id.split('/');
+                        const hasShortId = commit.change_id_shortest && idPart.startsWith(commit.change_id_shortest);
+                        
+                        return (
+                            <>
+                                {hasShortId ? (
+                                    <>
+                                        <span style={{ fontWeight: 'bold' }}>{commit.change_id_shortest}</span>
+                                        {idPart.length > commit.change_id_shortest.length && (
+                                            <span style={{ opacity: 0.6 }}>
+                                                {idPart.substring(commit.change_id_shortest.length, idDisplayLength)}
+                                            </span>
+                                        )}
+                                    </>
+                                ) : (
+                                    idPart.substring(0, idDisplayLength)
+                                )}
+                                {offsetPart && (
+                                    <span style={{ color: 'var(--vscode-charts-purple)' }}>/{offsetPart}</span>
+                                )}
+                            </>
+                        );
+                    })()}
                 </span>
 
                 {/* Overlay Actions */}
@@ -334,6 +350,11 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                             minWidth: 0, // Critical for text-overflow in flex children
                         }}
                     >
+                        {commit.is_divergent && (
+                            <span style={{ color: 'var(--vscode-charts-purple)', marginRight: '4px' }}>
+                                (divergent)
+                            </span>
+                        )}
                         {displayDescription}
                     </span>
 


### PR DESCRIPTION
This change adds comprehensive support for identifying and visualizing divergent commits in the JJ log.

Key updates:

- Added `is_divergent` and `change_id_offset` to the log entry schema and types.
- Updated `CommitNode` to highlight divergent commits with purple accents, a "(divergent)" label, and a slash-suffix for change IDs (e.g., `/1`).
- Improved commit details tab titles to include the divergence offset using the new `formatCommitTitle` utility.
- Added E2E and unit tests to verify divergence detection, visualization, and resolution flow.

Fixes #116 