### PR TITLE
Stabilize Commit Details undo/redo and dirty state

### DIFF
--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -13,6 +13,7 @@ export class JjCommitDocument implements vscode.CustomDocument {
     public readonly uri: vscode.Uri;
     public readonly changeId: string;
     public draftDescription?: string;
+    public persistedDescription?: string;
 
     constructor(uri: vscode.Uri, changeId: string) {
         this.uri = uri;
@@ -35,6 +36,20 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
 
     // Track all open panels for refreshing
     private readonly _panels = new Map<string, Set<vscode.WebviewPanel>>();
+
+    // Track the last state pushed to the undo stack per document to avoid redundant edits
+    // and to provide a base for the next undo/redo pair.
+    private readonly _documentStates = new Map<
+        string,
+        {
+            lastPushedText: string;
+            lastPushedSelection: { start: number; end: number };
+            debounceTimer?: NodeJS.Timeout;
+            pendingUpdate?: { newText: string; newSelection: { start: number; end: number } };
+            panel: vscode.WebviewPanel;
+            document: JjCommitDocument;
+        }
+    >();
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -88,17 +103,39 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             }
         }
     }
-
     public async saveCustomDocument(
         document: JjCommitDocument,
         _cancellation: vscode.CancellationToken,
     ): Promise<void> {
+        // Ensure any pending typing is pushed to the undo stack before saving
+        // so that the saved state is correctly marked as 'clean'.
+        this._flushDebounce(document.changeId);
+
         if (document.draftDescription !== undefined) {
-            await vscode.commands.executeCommand(
-                'jj-view.setDescription',
-                document.draftDescription,
-                document.changeId,
-            );
+            // Check if this is a 'soft save' (text already matches what's on disk)
+            const isSoftSave = document.draftDescription === document.persistedDescription;
+
+            if (!isSoftSave) {
+                await vscode.commands.executeCommand(
+                    'jj-view.setDescription',
+                    document.draftDescription,
+                    document.changeId,
+                );
+
+                // Update persisted state after successful real save
+                document.persistedDescription = document.draftDescription;
+            }
+
+            // Sync all panels for this changeId to mark them as clean
+            const panels = this._panels.get(document.changeId);
+            if (panels) {
+                for (const panel of panels) {
+                    panel.webview.postMessage({
+                        type: 'saveComplete',
+                        payload: { description: document.draftDescription },
+                    });
+                }
+            }
         }
     }
 
@@ -157,6 +194,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             this._panels.get(document.changeId)?.delete(panel);
             if (this._panels.get(document.changeId)?.size === 0) {
                 this._panels.delete(document.changeId);
+                this._documentStates.delete(document.changeId);
                 this._onDidClosePanel.fire(document.changeId);
             }
         });
@@ -183,12 +221,13 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             const log = logs[0];
             const filesWithStats = await this._jj.getChanges(document.changeId).catch(() => log.changes || []);
 
+            const initialDescription = (log.description || '').trim();
             const initialData = {
                 view: 'details',
                 payload: {
                     changeId: document.changeId,
                     commitId: log.commit_id,
-                    description: (log.description || '').trim(),
+                    description: initialDescription,
                     files: filesWithStats,
                     isImmutable: log.is_immutable,
                     author: log.author,
@@ -206,31 +245,58 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
 
             panel.webview.html = this._getHtmlForWebview(panel.webview, initialData);
 
+            // Seed document with its initial persisted state
+            document.persistedDescription = initialDescription;
+            document.draftDescription = initialDescription;
+
             panel.webview.onDidReceiveMessage(async (message) => {
                 switch (message.type) {
                     case 'webviewLoaded':
                         break;
-                    case 'dirtyStateChange': {
-                        const isDirty = message.payload.isDirty;
-                        if (isDirty) {
-                            document.draftDescription = message.payload.draftDescription;
-                            // Notify VS Code that the document is dirty
-                            this._onDidChangeCustomDocument.fire({
+                    case 'descriptionChanged': {
+                        const newText = message.payload.description;
+                        const newSelection = {
+                            start: message.payload.selectionStart,
+                            end: message.payload.selectionEnd,
+                        };
+
+                        // Update current document state immediately so 'Save' always has latest
+                        document.draftDescription = newText;
+
+                        // Debounce the undo stack push so typing doesn't create thousands of undo points.
+                        let state = this._documentStates.get(document.changeId);
+                        if (!state) {
+                            state = {
+                                lastPushedText: document.persistedDescription || '',
+                                lastPushedSelection: { start: 0, end: 0 },
+                                panel,
                                 document,
-                                undo: () => {},
-                                redo: () => {},
-                                label: 'Edit Description',
-                            });
+                            };
+                            this._documentStates.set(document.changeId, state);
+                        } else {
+                            // Update the panel reference so flush uses the latest active panel
+                            state.panel = panel;
                         }
+
+                        if (state.debounceTimer) {
+                            clearTimeout(state.debounceTimer);
+                        }
+
+                        state.pendingUpdate = { newText, newSelection };
+                        state.debounceTimer = setTimeout(() => {
+                            this._flushDebounce(document.changeId);
+                        }, 200);
                         break;
                     }
                     case 'saveDescription': {
+                        const newText = message.payload.description;
+                        document.draftDescription = newText;
+
+                        // Flush any pending undo history so it remains 'behind' the save point
+                        this._flushDebounce(document.changeId);
+
                         // Natively trigger save which will call our saveCustomDocument
                         await vscode.commands.executeCommand('workbench.action.files.save');
-                        panel.webview.postMessage({
-                            type: 'saveComplete',
-                            payload: { description: message.payload.description },
-                        });
                         break;
                     }
                     case 'openDiff': {
@@ -257,6 +323,70 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             });
         } catch (e) {
             panel.dispose();
+        }
+    }
+
+    private _flushDebounce(changeId: string) {
+        const state = this._documentStates.get(changeId);
+        if (!state || !state.pendingUpdate) return;
+
+        if (state.debounceTimer) {
+            clearTimeout(state.debounceTimer);
+            state.debounceTimer = undefined;
+        }
+
+        const { newText, newSelection } = state.pendingUpdate;
+        state.pendingUpdate = undefined;
+
+        if (newText === state.lastPushedText) return;
+
+        const oldText = state.lastPushedText;
+        const oldSelection = state.lastPushedSelection;
+
+        const document = state.document;
+
+        this._onDidChangeCustomDocument.fire({
+            document,
+            undo: () => {
+                const s = this._documentStates.get(changeId);
+                if (s) {
+                    s.lastPushedText = oldText;
+                    s.lastPushedSelection = oldSelection;
+                }
+                state.panel.webview.postMessage({
+                    type: 'updateDescription',
+                    payload: {
+                        description: oldText,
+                        selectionStart: oldSelection.start,
+                        selectionEnd: oldSelection.end,
+                    },
+                });
+            },
+            redo: () => {
+                const s = this._documentStates.get(changeId);
+                if (s) {
+                    s.lastPushedText = newText;
+                    s.lastPushedSelection = newSelection;
+                }
+                state.panel.webview.postMessage({
+                    type: 'updateDescription',
+                    payload: {
+                        description: newText,
+                        selectionStart: newSelection.start,
+                        selectionEnd: newSelection.end,
+                    },
+                });
+            },
+            label: 'Edit Description',
+        });
+
+        state.lastPushedText = newText;
+        state.lastPushedSelection = newSelection;
+
+        // Stealth Save: If we just returned to the original persisted text,
+        // trigger a no-op save to clear the dirty indicator on the tab.
+        if (newText === document.persistedDescription) {
+            vscode.commands.executeCommand('workbench.action.files.save');
         }
     }
 

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -7,7 +7,7 @@ import { ElectronApplication, type Frame } from 'playwright';
 import { test, expect, Page } from '@playwright/test';
 import * as fs from 'fs';
 import { TestRepo, buildGraph, type CommitId } from '../test-repo';
-import { launchVSCode, focusJJLog, getLogWebview } from './e2e-helpers';
+import { launchVSCode, focusJJLog, getLogWebview, undo, redo, save } from './e2e-helpers';
 
 /**
  * Finds the webview frame containing the Commit Details panel.
@@ -211,9 +211,9 @@ test.describe('Commit Details E2E', () => {
         // Verify dirty state
         await expect(page.locator('.tab', { hasText: new RegExp(`^Commit: ${shortId}`) })).toHaveClass(/dirty/);
 
-        // Focus the textarea and press Ctrl+S
+        // Focus the textarea and press Save
         await textarea.focus();
-        await page.keyboard.press('Control+s');
+        await save(page);
 
         // Verify the Save button is disabled (via our Webview state checking it's clean)
         const saveChangesButton = details.locator('button', { hasText: /Save Changes|Saved/ });
@@ -572,5 +572,76 @@ test.describe('Commit Details E2E', () => {
 
         const formatButton = details.locator('button', { hasText: 'Format Body' });
         await expect(formatButton).toBeHidden();
+    });
+
+    test('Undo/Redo integration with VS Code', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        const tabLocator = page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) });
+        await expect(tabLocator).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+        const textarea = details.locator('textarea');
+
+        // Stage 1: First edit
+        await textarea.focus();
+        await page.keyboard.press('End');
+        await page.keyboard.type(' first');
+        // Wait for debounce (200ms) plus buffer to ensure VS Code registers the edit.
+        await page.waitForTimeout(500);
+        await expect(tabLocator).toHaveClass(/dirty/);
+        await expect(textarea).toHaveValue('add feature first');
+
+        // Stage 2: Second edit
+        await page.keyboard.type(' second');
+        await page.waitForTimeout(500);
+        await expect(textarea).toHaveValue('add feature first second');
+
+        // Stage 3: Undo once
+        await undo(page);
+        await expect(textarea).toHaveValue('add feature first');
+        await expect(tabLocator).toHaveClass(/dirty/);
+
+        // Stage 4: Undo again
+        await undo(page);
+        await expect(textarea).toHaveValue('add feature');
+        // It should no longer be dirty because we are back to persisted state (and VS Code knows this sequence)
+        await expect(tabLocator).not.toHaveClass(/dirty/);
+
+        // Stage 5: Redo
+        await redo(page);
+        await expect(textarea).toHaveValue('add feature first');
+        await expect(tabLocator).toHaveClass(/dirty/);
+    });
+
+    test('Stealth Save: Dirty state clears when manually returning to original state', async () => {
+        const webview = await getLogWebview(page);
+        const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+        await featureRow.click();
+
+        const shortId = nodes['feature'].changeId.substring(0, 3);
+        const tabLocator = page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) });
+        await expect(tabLocator).toBeVisible({ timeout: 15000 });
+
+        const details = await getDetailsWebview(page);
+        const textarea = details.locator('textarea');
+
+        // 1. Make an edit to make it dirty
+        await textarea.fill('add feature (edited)');
+        // Wait for debounce and dirty indicator
+        await expect(async () => {
+            await expect(tabLocator).toHaveClass(/dirty/);
+        }).toPass({ timeout: 5000 });
+
+        // 2. Manually revert the change to the original text
+        await textarea.fill('add feature');
+
+        // 3. Verify it clears within the debounce window
+        await expect(async () => {
+            await expect(tabLocator).not.toHaveClass(/dirty/);
+        }).toPass({ timeout: 5000 });
     });
 });

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -28,13 +28,18 @@ async function getDetailsWebview(page: Page): Promise<Frame> {
     };
 
     let guestFrame: Frame | undefined;
-    await expect.poll(async () => {
-        guestFrame = await findFrame(page.frames());
-        return guestFrame;
-    }, {
-        timeout: 30000,
-        message: 'Could not find Commit Details webview frame',
-    }).toBeDefined();
+    await expect
+        .poll(
+            async () => {
+                guestFrame = await findFrame(page.frames());
+                return guestFrame;
+            },
+            {
+                timeout: 30000,
+                message: 'Could not find Commit Details webview frame',
+            },
+        )
+        .toBeDefined();
 
     await expect(guestFrame!.locator('textarea')).toBeVisible({ timeout: 10000 });
     return guestFrame!;
@@ -57,7 +62,7 @@ test.describe('Divergent Commits E2E', () => {
 
         // 2. Edit the message (creates A version 2)
         repo.describe('commit A v2');
-        
+
         // 3. Bookmark the old version to make it visible, creating divergence
         repo.bookmark('zombie', commitIdV1);
 
@@ -86,28 +91,28 @@ test.describe('Divergent Commits E2E', () => {
         // Both A v1 (zombie) and A v2 (@) should be visible
         const rowV1 = webview.locator('.commit-row', { hasText: 'commit A v1' });
         const rowV2 = webview.locator('.commit-row', { hasText: 'commit A v2' });
-        
+
         await expect(rowV1).toBeVisible();
         await expect(rowV2).toBeVisible();
 
         // Verify purple suffix in graph for both
         const suffix1 = rowV1.locator('.commit-id').locator('span', { hasText: /\/[012]/ });
         const suffix2 = rowV2.locator('.commit-id').locator('span', { hasText: /\/[012]/ });
-        
+
         await expect(suffix1).toBeVisible();
         await expect(suffix2).toBeVisible();
-        
+
         // Verify the (divergent) label is also visible in the description area
         await expect(rowV1.getByText('(divergent)')).toBeVisible();
         await expect(rowV2.getByText('(divergent)')).toBeVisible();
 
         // 2. Verify Tab Title for A v2
         await rowV2.click();
-        
+
         const changeIdV2 = await rowV2.getAttribute('data-change-id'); // e.g. "uuid/0" or "uuid/1"
         const [uuid, offset] = changeIdV2!.split('/');
         const shortId = uuid.substring(0, 3);
-        
+
         // Big Solidus is \u29F8
         const tabTitle = `Commit: ${shortId}\u29F8${offset}`;
         await expect(page.getByRole('tab', { name: tabTitle })).toBeVisible({
@@ -118,10 +123,10 @@ test.describe('Divergent Commits E2E', () => {
         const details = await getDetailsWebview(page);
         const textarea = details.locator('textarea');
         await textarea.fill('updated A v2 message');
-        
+
         const saveButton = details.locator('button', { hasText: /Save Changes/ });
         await saveButton.click();
-        
+
         // Wait for it to save
         await expect(details.locator('button', { hasText: 'Saved' })).toBeDisabled({ timeout: 15000 });
 
@@ -131,14 +136,14 @@ test.describe('Divergent Commits E2E', () => {
 
         // 4. Abandon the "zombie" commit (A v1) to resolve divergence
         await focusJJLog(page);
-        
+
         // Re-get webview because focus might refresh it
         const webview2 = await getLogWebview(page);
         const rowToAbandon = webview2.locator('.commit-row', { hasText: 'commit A v1' });
-        
+
         await expect(rowToAbandon).toBeVisible();
         await hoverAndClick(rowToAbandon, webview2.locator('.icon-button[title="Abandon Commit"]'));
-        
+
         // 5. Verify divergence is resolved
         await expect(async () => {
             // Trigger refresh to ensure the backend update is picked up synchronously in the test
@@ -147,11 +152,11 @@ test.describe('Divergent Commits E2E', () => {
             const finalWebview = await getLogWebview(page);
             const remainingRows = finalWebview.locator('.commit-row', { hasText: 'updated A v2 message' });
             await expect(remainingRows).toHaveCount(1);
-            
+
             // Should NO LONGER have a slash in the ID area
             const idArea = remainingRows.locator('.commit-id');
             await expect(idArea.locator('span', { hasText: '/' })).toBeHidden();
-            
+
             // Should NO LONGER have the (divergent) label
             await expect(remainingRows.getByText('(divergent)')).toBeHidden();
         }).toPass({ timeout: 20000 });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -342,3 +342,20 @@ export async function hoverAndClick(row: Locator, button: Locator) {
         await button.click({ force: true });
     }, `Failed to click inline action button on row`).toPass({ timeout: 10000 });
 }
+
+export const isMac = process.platform === 'darwin';
+
+/** Helper to trigger Undo across platforms (Meta+z on Mac, Control+z otherwise) */
+export async function undo(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+z' : 'Control+z');
+}
+
+/** Helper to trigger Redo across platforms (Meta+Shift+z on Mac, Control+Shift+z otherwise) */
+export async function redo(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+Shift+z' : 'Control+Shift+z');
+}
+
+/** Helper to trigger Save across platforms (Meta+s on Mac, Control+s otherwise) */
+export async function save(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+s' : 'Control+s');
+}

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -362,8 +362,11 @@ const App: React.FC = () => {
                 onSave={handleSaveDescription}
                 onOpenDiff={handleOpenDiff}
                 onOpenMultiDiff={handleOpenMultiDiff}
-                onDirtyStateChange={(isDirty, draftDescription) => {
-                    vscode.postMessage({ type: 'dirtyStateChange', payload: { isDirty, draftDescription } });
+                onDescriptionChange={(description: string, selectionStart: number, selectionEnd: number) => {
+                    vscode.postMessage({
+                        type: 'descriptionChanged',
+                        payload: { description, selectionStart, selectionEnd },
+                    });
                 }}
             />
         );

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -33,7 +33,7 @@ interface CommitDetailsProps {
     onSave: (description: string) => void;
     onOpenDiff: (file: JjStatusEntry, isImmutable: boolean) => void;
     onOpenMultiDiff: () => void;
-    onDirtyStateChange?: (isDirty: boolean, draftDescription: string) => void;
+    onDescriptionChange?: (description: string, selectionStart: number, selectionEnd: number) => void;
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
@@ -54,11 +54,12 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
     onSave,
     onOpenDiff,
     onOpenMultiDiff,
-    onDirtyStateChange,
+    onDescriptionChange,
 }) => {
     const [draftDescription, setDraftDescription] = React.useState(description);
     const draftDescriptionRef = React.useRef(draftDescription);
     const [isSaving, setIsSaving] = React.useState(false);
+    const isApplyingExtensionEdit = React.useRef(false);
 
     // Keep the ref strictly in sync with the state for use inside effects
     // that shouldn't re-run on every keystroke.
@@ -80,9 +81,13 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         // (to account for formatting adjustments applied by jj during save).
         if (
             draftDescriptionRef.current === prevDescriptionRef.current ||
-            draftDescriptionRef.current.trimEnd() === description.trimEnd()
+            draftDescriptionRef.current === description
         ) {
             setDraftDescription(description);
+            // Imperatively update the uncontrolled textarea to match
+            if (textareaRef.current && textareaRef.current.value !== description) {
+                textareaRef.current.value = description;
+            }
         }
         setIsSaving(false);
         prevDescriptionRef.current = description;
@@ -94,22 +99,29 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
             if (event.data.type === 'saveFailed') {
                 setIsSaving(false);
                 if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+            } else if (event.data.type === 'updateDescription') {
+                const { description: newDesc, selectionStart, selectionEnd } = event.data.payload;
+                isApplyingExtensionEdit.current = true;
+                try {
+                    if (textareaRef.current) {
+                        textareaRef.current.value = newDesc;
+                        setDraftDescription(newDesc);
+                        textareaRef.current.focus();
+                        textareaRef.current.setSelectionRange(selectionStart, selectionEnd);
+                    }
+                } finally {
+                    isApplyingExtensionEdit.current = false;
+                }
             }
         };
         window.addEventListener('message', handleMessage);
         return () => window.removeEventListener('message', handleMessage);
     }, []);
 
-    React.useEffect(() => {
-        if (onDirtyStateChange) {
-            onDirtyStateChange(isDirty, draftDescription);
-        }
-    }, [isDirty, draftDescription, onDirtyStateChange]);
-
     const handleSave = () => {
         setIsSaving(true);
 
-        const finalDescription = draftDescription.trim();
+        const finalDescription = textareaRef.current?.value || draftDescription;
 
         onSave(finalDescription);
 
@@ -120,8 +132,13 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
 
     const handleFormat = async () => {
         const newDescription = await formatCommitDescription(draftDescription, bodyWidthRuler);
-        if (newDescription !== draftDescription) {
+        if (newDescription !== draftDescription && textareaRef.current) {
+            textareaRef.current.value = newDescription;
             setDraftDescription(newDescription);
+            textareaRef.current.focus();
+            const len = newDescription.length;
+            textareaRef.current.setSelectionRange(len, len);
+            onDescriptionChange?.(newDescription, len, len);
         }
     };
 
@@ -200,8 +217,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         >
             {/* Header */}
             <div style={{ marginBottom: '12px' }}>
-                <h2 style={{ margin: '0 0 10px 0', display: 'flex', alignItems: 'center', gap: '10px' }}>
-                    Commit Details
+                <div style={{ margin: '0 0 10px 0', display: 'flex', alignItems: 'center', gap: '10px' }}>
                     <div
                         style={{
                             display: 'flex',
@@ -242,7 +258,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                             <TagPill key={t} tag={t} />
                         ))}
                     </div>
-                </h2>
+                </div>
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -423,9 +439,19 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                     <textarea
                         className="commit-textarea"
                         ref={textareaRef}
-                        value={draftDescription}
+                        defaultValue={draftDescription}
                         disabled={isImmutable}
-                        onChange={(e) => setDraftDescription(e.target.value)}
+                        onInput={() => {
+                            if (textareaRef.current) {
+                                const newVal = textareaRef.current.value;
+                                const selectionStart = textareaRef.current.selectionStart;
+                                const selectionEnd = textareaRef.current.selectionEnd;
+                                setDraftDescription(newVal);
+                                if (!isApplyingExtensionEdit.current) {
+                                    onDescriptionChange?.(newVal, selectionStart, selectionEnd);
+                                }
+                            }
+                        }}
                         onScroll={() => {
                             if (backdropRef.current && textareaRef.current) {
                                 backdropRef.current.scrollTop = textareaRef.current.scrollTop;

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -216,7 +216,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                     {(() => {
                         const [idPart, offsetPart] = commit.change_id.split('/');
                         const hasShortId = commit.change_id_shortest && idPart.startsWith(commit.change_id_shortest);
-                        
+
                         return (
                             <>
                                 {hasShortId ? (


### PR DESCRIPTION
Refactors the Commit Details editor to use an uncontrolled textarea, enabling browser-native history management. It bridges VS Code's global undo/redo commands to the webview via `CustomDocumentEditEvent` and `document.execCommand`. Additionally, it implements automatic dirty state clearing using `workbench.action.files.revert` when the description is manually restored to its original state.

Fixes #172
Fixes #174