### PR TITLE
Implement jj binary discovery and configuration

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -82,6 +82,21 @@ You MUST run individual test cases when writing a new test or debugging a broken
     # Example: npm run test:e2e -- scm.spec.ts
     ```
 
+### 4. Debugging E2E Tests (DOM Dumping)
+
+**Purpose:** When locators fail in E2E tests, it's often due to the complex, nested structure of VS Code (including shadow roots and iframes). Simply dumping the page content can help identify the correct selectors.
+
+**Common Strategy:**
+
+```typescript
+// Dump the entire page content as a string
+console.log(await page.content());
+
+// Or dump focused parts of the DOM if you suspect nested structures
+const dom = await page.evaluate(() => document.body.innerHTML);
+console.log(dom);
+```
+
 ## Mandatory Debugging Practice
 
 When writing a new test or investigating a failure:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.graphLabelAlignment`          | `"aligned"` | Controls the horizontal alignment of commit messages in the log view. Available options: `aligned`, `compact`.                                                                                                                                                                                       |
 | `jj-view.commit.titleWidthRuler`       | `50`        | Width at which to display a ruler in the commit details description editor for the title line.                                                                                                                                                                                                       |
 | `jj-view.commit.bodyWidthRuler`        | `72`        | Width at which to display a ruler in the commit details description editor for the body.                                                                                                                                                                                                             |
+| `jj-view.binaryPath`                  | `""`        | Optional absolute path to the 'jj' binary. If empty, the extension will search for it in your PATH                                                                                                                                                                     |
 | `jj-view.suppressGitColocationWarning` | `false`     | Suppress the warning to disable the built-in Git extension in colocated repositories.                                                                                                                                                                                                                |
 
 ## Advanced Configuration
@@ -188,7 +189,7 @@ On non-macOS platforms, we recommend installing [Watchman](https://facebook.gith
 
 ## Requirements
 
-- **Jujutsu (jj)**: The `jj` CLI must be installed and available in your system `PATH`.
+- **Jujutsu (jj)**: The `jj` CLI must be installed. By default, it must be available in your system `PATH`, but you can also configure a custom path in the extension settings.
     - [Installation Guide](https://docs.jj-vcs.dev/latest/install-and-setup)
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Suppress the warning to disable the built-in Git extension in colocated repositories."
+                },
+                "jj-view.binaryPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Optional absolute path to the 'jj' binary. If empty, the extension will search for it in your PATH."
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { checkGitColocation } from './git-colocation';
 
 import { JjService } from './jj-service';
+import { resolveJjBinary } from './utils/binary-utils';
 import { JjScmProvider } from './jj-scm-provider';
 import { JjDocumentContentProvider } from './jj-content-provider';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
@@ -59,6 +60,52 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(outputChannel);
 
     const jj = new JjService(workspaceRoot, (msg) => outputChannel.appendLine(msg));
+
+    // Resolve jj binary path and handle failure
+    const updateBinaryPath = async () => {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        const preferredPath = config.get<string>('binaryPath');
+
+        let resolvedPath: string | undefined;
+        let errorMessage: string | undefined;
+
+        try {
+            resolvedPath = await resolveJjBinary(preferredPath, workspaceRoot);
+            if (!resolvedPath) {
+                errorMessage = `Could not find 'jj' binary. Please ensure 'jj' is installed and in your PATH, or configure its path manually.`;
+            }
+        } catch (e: unknown) {
+            errorMessage = `Invalid 'jj' binary configuration: ${(e as Error).message}`;
+        }
+
+        if (resolvedPath) {
+            jj.binaryPath = resolvedPath;
+            outputChannel.appendLine(`[Extension] Using jj binary at: ${resolvedPath}`);
+        } else if (errorMessage) {
+            showBinaryError(errorMessage);
+        }
+    };
+
+    const showBinaryError = (message: string) => {
+        const CONFIGURE = 'Configure Path';
+        vscode.window.showErrorMessage(message, CONFIGURE).then((selection) => {
+            if (selection === CONFIGURE) {
+                vscode.commands.executeCommand('workbench.action.openSettings', 'jj-view.binaryPath');
+            }
+        });
+    };
+
+    updateBinaryPath();
+
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration(async (e) => {
+            if (e.affectsConfiguration('jj-view.binaryPath')) {
+                await updateBinaryPath();
+                scmProvider.refresh();
+            }
+        }),
+    );
+
     const gerritService = new GerritService(workspaceRoot, jj, outputChannel);
     context.subscriptions.push(gerritService);
 

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -34,6 +34,7 @@ export class JjService {
     constructor(
         public readonly workspaceRoot: string,
         public readonly logger: (message: string) => void = () => {},
+        public binaryPath: string = 'jj',
     ) {}
 
     private _repoRoot?: string;
@@ -208,7 +209,7 @@ export class JjService {
                     ...options,
                 };
 
-                cp.execFile('jj', allArgs, finalOptions, (err, stdout, stderr) => {
+                cp.execFile(this.binaryPath, allArgs, finalOptions, (err, stdout, stderr) => {
                     const duration = performance.now() - start;
                     const cachedInfo = options.useCachedSnapshot ? ' (cached)' : '';
                     this.logger(`[${duration.toFixed(0)}ms]${cachedInfo} ${commandStr}`);

--- a/src/test/e2e/binary-config.spec.ts
+++ b/src/test/e2e/binary-config.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { TestRepo } from '../test-repo';
+import { launchVSCode } from './e2e-helpers';
+
+test.describe('JJ Binary Configuration E2E', () => {
+    test('Shows error and opens settings for invalid binary path', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        const invalidPath = path.join(os.tmpdir(), 'non-existent-jj-binary');
+        const { app, page, userDataDir } = await launchVSCode(repo, {
+            'jj-view.binaryPath': invalidPath,
+        });
+
+        try {
+            // Un-hide notifications toast locally
+            await page.addStyleTag({
+                content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
+            });
+
+            // Wait for notification to appear. VS Code uses a button role for notification messages sometimes,
+            // or just text nodes. Let's look for the text directly.
+            const notification = page.locator('.notification-toast-container', {
+                hasText: `Invalid 'jj' binary configuration`,
+            });
+            await expect(notification).toBeVisible({ timeout: 15000 });
+
+            const configureButton = notification.getByRole('button', { name: 'Configure Path' });
+            await configureButton.click();
+
+            // Verify settings editor is open
+            await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible({ timeout: 15000 });
+
+            // Verify the 'Binary Path' setting item is visible and has the invalid path value
+            // (Standard VS Code settings verify pattern)
+            const settingItem = page.locator('.setting-item').filter({ hasText: 'Binary Path' });
+            await expect(settingItem).toBeVisible({ timeout: 10000 });
+            await expect(settingItem.locator('input')).toHaveValue(invalidPath);
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Shows error when jj binary is not found', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        // Launch with empty PATH and empty HOME to avoid discovery
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            { 'jj-view.binaryPath': '' }, // Ensure not set
+            { PATH: '', HOME: path.join(os.tmpdir(), 'jj-empty-home') },
+        );
+
+        try {
+            // Un-hide notifications toast locally
+            await page.addStyleTag({
+                content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
+            });
+
+            // Wait for notification
+            const notification = page.locator('.notification-toast-container', {
+                hasText: `Could not find 'jj' binary`,
+            });
+            await expect(notification).toBeVisible({ timeout: 15000 });
+
+            // Click Configure Path
+            const configureButton = notification.getByRole('button', { name: 'Configure Path' });
+            await configureButton.click();
+
+            // Verify settings
+            await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible({ timeout: 15000 });
+            const settingItem = page.locator('.setting-item').filter({ hasText: 'Binary Path' });
+            await expect(settingItem).toBeVisible({ timeout: 10000 });
+            // Since we set it to empty string in the setup, the UI should show an empty input
+            await expect(settingItem.locator('input')).toHaveValue('');
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+});

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -24,7 +24,11 @@ export interface VSCodeContext {
  * Initializes a user data directory with common settings and launches VS Code.
  * Renamed to launchVSCode to avoid confusion with local setup functions in specs.
  */
-export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
+export async function launchVSCode(
+    repo: TestRepo,
+    extraSettings: Record<string, unknown> = {},
+    extraEnv: Record<string, string | undefined> = {},
+): Promise<VSCodeContext> {
     const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-user-data-'));
     const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-extensions-'));
     const userSettingsDir = path.join(userDataDir, 'User');
@@ -52,6 +56,7 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
                 'extensions.autoCheckUpdates': false,
                 'extensions.autoUpdate': false,
                 'explorer.excludeGitIgnore': false,
+                ...extraSettings,
             },
             null,
             2,
@@ -123,9 +128,20 @@ export async function launchVSCode(repo: TestRepo): Promise<VSCodeContext> {
         args.push('--disable-extensions'); // Only disable other extensions when running from source
     }
 
+    const env = { ...process.env } as { [key: string]: string };
+    for (const key in extraEnv) {
+        const val = extraEnv[key];
+        if (val === undefined) {
+            delete env[key];
+        } else {
+            env[key] = val;
+        }
+    }
+
     const app = await electron.launch({
         executablePath: vscodePath,
         args,
+        env,
     });
 
     const page = await app.firstWindow();

--- a/src/test/utils/binary-utils.test.ts
+++ b/src/test/utils/binary-utils.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as cp from 'child_process';
+import { resolveJjBinary } from '../../utils/binary-utils';
+
+describe('binary-utils real-file tests', () => {
+    let tempDir: string;
+    let oldHome: string | undefined;
+    let oldPath: string | undefined;
+    let oldUserProfile: string | undefined;
+    let oldProgramFiles: string | undefined;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-binary-test-'));
+        oldHome = process.env.HOME;
+        oldPath = process.env.PATH;
+        oldUserProfile = process.env.USERPROFILE;
+        oldProgramFiles = process.env.ProgramFiles;
+    });
+
+    afterEach(() => {
+        if (oldHome !== undefined) process.env.HOME = oldHome;
+        else delete process.env.HOME;
+
+        if (oldPath !== undefined) process.env.PATH = oldPath;
+        else delete process.env.PATH;
+
+        if (oldUserProfile !== undefined) process.env.USERPROFILE = oldUserProfile;
+        else delete process.env.USERPROFILE;
+
+        if (oldProgramFiles !== undefined) process.env.ProgramFiles = oldProgramFiles;
+        else delete process.env.ProgramFiles;
+
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const createExecutable = (filePath: string, output: string = 'jj 0.1.0') => {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        
+        const goSourcePath = filePath + '.go';
+        const goSource = `
+package main
+import (
+    "fmt"
+    "os"
+)
+func main() {
+    if len(os.Args) > 1 && os.Args[1] == "--version" {
+        fmt.Println("${output}")
+    }
+}
+`;
+        fs.writeFileSync(goSourcePath, goSource);
+        cp.execFileSync('go', ['build', '-o', filePath, goSourcePath]);
+        fs.unlinkSync(goSourcePath);
+    };
+
+    test('resolveJjBinary returns absolute path if it exists and is working', async () => {
+        const binName = os.platform() === 'win32' ? 'jj.exe' : 'jj';
+        const binPath = path.join(tempDir, binName);
+        createExecutable(binPath);
+
+        const result = await resolveJjBinary(binPath);
+        expect(result).toBe(binPath);
+    });
+
+    test('resolveJjBinary throws if absolute path is not a working jj binary', async () => {
+        const binPath = path.join(tempDir, 'not-jj');
+        createExecutable(binPath, 'not jj');
+
+        await expect(resolveJjBinary(binPath)).rejects.toThrow("is not a valid 'jj' binary");
+    });
+
+    test('resolveJjBinary throws if absolute path does not exist', async () => {
+        const binPath = path.join(tempDir, 'non-existent-jj');
+        // No file created
+        await expect(resolveJjBinary(binPath)).rejects.toThrow("is not a valid 'jj' binary");
+    });
+
+    test('resolveJjBinary finds binary in PATH', async () => {
+        const binDir = path.join(tempDir, 'bin');
+        const binName = os.platform() === 'win32' ? 'jj.exe' : 'jj';
+        const binPath = path.join(binDir, binName);
+        createExecutable(binPath);
+
+        process.env.PATH = `${binDir}${path.delimiter}${oldPath}`;
+
+        const result = await resolveJjBinary();
+        // It returns 'jj' because it found it in PATH
+        expect(result).toBe('jj');
+    });
+
+    test('resolveJjBinary returns undefined if nowhere to be found', async () => {
+        // Clear everything
+        process.env.PATH = '';
+        const emptyHome = path.join(tempDir, 'empty-home');
+        fs.mkdirSync(emptyHome);
+
+        if (os.platform() === 'win32') {
+            process.env.USERPROFILE = emptyHome;
+        } else {
+            process.env.HOME = emptyHome;
+        }
+
+        const result = await resolveJjBinary();
+        expect(result).toBeUndefined();
+    });
+
+    test('resolveJjBinary resolves relative path from workspaceRoot', async () => {
+        const workspaceRoot = path.join(tempDir, 'workspace');
+        fs.mkdirSync(workspaceRoot);
+        const binName = os.platform() === 'win32' ? 'jj.exe' : 'jj';
+        const binPath = path.join(workspaceRoot, 'bin', binName);
+        createExecutable(binPath);
+
+        const result = await resolveJjBinary('./bin/' + binName, workspaceRoot);
+        expect(result).toBe(binPath);
+    });
+
+    test('resolveJjBinary throws if relative path provided but no workspaceRoot', async () => {
+        const relPath = './bin/jj';
+        await expect(resolveJjBinary(relPath, undefined)).rejects.toThrow(
+            `Could not resolve relative path: ${relPath}`,
+        );
+    });
+
+    test('resolveJjBinary falls back to discovery if preferredPath is empty or whitespace', async () => {
+        // Setup a binary in PATH so discovery succeeds
+        const binDir = path.join(tempDir, 'bin');
+        const binName = os.platform() === 'win32' ? 'jj.exe' : 'jj';
+        const binPath = path.join(binDir, binName);
+        createExecutable(binPath);
+        process.env.PATH = `${binDir}${path.delimiter}${oldPath}`;
+
+        // Case: empty string
+        const resultEmpty = await resolveJjBinary('');
+        expect(resultEmpty).toBe('jj');
+
+        // Case: whitespace
+        const resultWhitespace = await resolveJjBinary('   ');
+        expect(resultWhitespace).toBe('jj');
+    });
+});

--- a/src/utils/binary-utils.ts
+++ b/src/utils/binary-utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'path';
+import * as cp from 'child_process';
+
+/**
+ * Resolves the path to the 'jj' binary by verifying it through 'jj --version'.
+ *
+ * Logic:
+ * 1. If preferredPath is provided, verify it by running `${path} --version`.
+ * 2. If no path is provided, try running `jj --version` (letting the OS find it in PATH).
+ *
+ * Throws a descriptive error if preferredPath is set but invalid or fails the version check.
+ * Returns undefined if default discovery ('jj') fails.
+ */
+export async function resolveJjBinary(preferredPath?: string, workspaceRoot?: string): Promise<string | undefined> {
+    // 1. Check preferred path
+    if (preferredPath && preferredPath.trim().length > 0) {
+        const absolutePath = path.isAbsolute(preferredPath)
+            ? preferredPath
+            : workspaceRoot
+              ? path.resolve(workspaceRoot, preferredPath)
+              : undefined;
+
+        if (!absolutePath) {
+            throw new Error(`Could not resolve relative path: ${preferredPath}`);
+        }
+
+        const version = await getJjVersion(absolutePath);
+        if (!version) {
+            throw new Error(`'${preferredPath}' is not a valid 'jj' binary (could not get version).`);
+        }
+        return absolutePath;
+    }
+
+    // 2. Try default 'jj' (relies on PATH)
+    const version = await getJjVersion('jj');
+    if (version) {
+        return 'jj';
+    }
+
+    // If we've reached here, we haven't found a working jj.
+    return undefined;
+}
+
+/**
+ * Executes a 'jj --version' command to verify if a path points to a valid jj binary.
+ * Returns the version string (e.g., '0.14.0') if successful, or undefined otherwise.
+ */
+async function getJjVersion(binaryPath: string): Promise<string | undefined> {
+    return new Promise((resolve) => {
+        cp.execFile(binaryPath, ['--version'], { timeout: 2000 }, (err, stdout) => {
+            if (err) {
+                resolve(undefined);
+                return;
+            }
+
+            // Expected output format: "jj 0.39.0" or similar
+            const match = stdout.trim().match(/^jj\s+(\d+\.\d+\.\d+)/);
+            if (match) {
+                resolve(match[1]);
+            } else {
+                resolve(undefined);
+            }
+        });
+    });
+}

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -79,10 +79,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         // We only overwrite the draft if the user hasn't made any unsaved edits (the draft
         // matches the previous description), or if the only difference is trailing whitespace
         // (to account for formatting adjustments applied by jj during save).
-        if (
-            draftDescriptionRef.current === prevDescriptionRef.current ||
-            draftDescriptionRef.current === description
-        ) {
+        if (draftDescriptionRef.current === prevDescriptionRef.current || draftDescriptionRef.current === description) {
             setDraftDescription(description);
             // Imperatively update the uncontrolled textarea to match
             if (textareaRef.current && textareaRef.current.value !== description) {


### PR DESCRIPTION
Add jj binary configuration and validation

Introduces a new `jj-view.binaryPath` configuration setting to allow
manual specification of the `jj` binary location. The extension now
actively validates the binary on startup and displays an error
notification with a "Configure Path" link if `jj` cannot be found or is
invalid.

Key changes:

- Added `jj-view.binaryPath` setting to `package.json`.
- Implemented binary validation and discovery logic in
  `src/utils/binary-utils.ts`.
- Added startup error handling and configuration listeners in
  `src/extension.ts`.
- Integrated the resolved binary path into `JjService`.
- Added unit and E2E tests for the configuration flow.

Fixes #176