### PR TITLE
Fix Quick Diff for added and untracked files

### DIFF
--- a/src/commands/discard-change.ts
+++ b/src/commands/discard-change.ts
@@ -49,8 +49,8 @@ export async function discardChangeCommand(
     const change = changes[index];
 
     try {
-        const originalUri = scmProvider.provideOriginalResource(uri) as vscode.Uri;
-        if (!originalUri) {
+        const originalUri = await scmProvider.provideOriginalResource(uri);
+        if (!originalUri || !(originalUri instanceof vscode.Uri)) {
             throw new Error('Could not determine original resource');
         }
 

--- a/src/commands/squash-change.ts
+++ b/src/commands/squash-change.ts
@@ -84,9 +84,9 @@ export async function squashChangeCommand(
 
     const relPath = path.relative(jj.workspaceRoot, uri.fsPath);
 
-    const originalUri = scmProvider.provideOriginalResource(uri) as vscode.Uri;
+    const originalUri = scmProvider.provideOriginalResource(uri);
     let revision = '@';
-    if (originalUri && originalUri.query) {
+    if (originalUri && originalUri instanceof vscode.Uri && originalUri.query) {
         const queryParams = new URLSearchParams(originalUri.query);
         revision = queryParams.get('base') || '@';
     }

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -37,6 +37,7 @@ export class JjScmProvider implements vscode.Disposable {
     private _lastKnownCommitId: string = '';
     private _selectedCommitIds: string[] = [];
     private _currentEntry: JjLogEntry | undefined;
+    private _workingCopyStatuses = new Map<string, JjStatusEntry>();
 
     private _onDidChangeStatus = new vscode.EventEmitter<void>();
     readonly onDidChangeStatus: vscode.Event<void> = this._onDidChangeStatus.event;
@@ -311,6 +312,8 @@ export class JjScmProvider implements vscode.Disposable {
 
                 // Working Copy Changes
                 const changes = currentEntry?.changes || [];
+                this._workingCopyStatuses.clear();
+
                 if (currentEntry) {
                     const config = vscode.workspace.getConfiguration('jj-view');
                     const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
@@ -331,6 +334,7 @@ export class JjScmProvider implements vscode.Disposable {
                         multipleAncestors: ancestorsToDisplay.length > 1,
                     });
                     decorationMap.set(state.resourceUri.toString(), c);
+                    this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
                     return state;
                 });
 
@@ -587,6 +591,11 @@ export class JjScmProvider implements vscode.Disposable {
     }
 
     provideOriginalResource(uri: vscode.Uri): vscode.ProviderResult<vscode.Uri> {
+        const statusEntry = this._workingCopyStatuses.get(uri.fsPath);
+        if (!statusEntry || statusEntry.status === 'added') {
+            return undefined;
+        }
+
         const query = new URLSearchParams(uri.query);
         const revision = query.get('jj-revision') || '@';
         return uri.with({ scheme: 'jj-view', query: `base=${revision}&side=left` });

--- a/src/test/commands/discard-change.test.ts
+++ b/src/test/commands/discard-change.test.ts
@@ -22,69 +22,77 @@ const mockDocuments = new Map<
     }
 >();
 
-vi.mock('vscode', () => ({
-    Uri: {
-        file: (filePath: string) => ({
-            fsPath: filePath,
-            toString: () => `file://${filePath}`,
-            with: (params: { scheme: string; query: string }) => ({
-                scheme: params.scheme,
-                query: params.query,
-                fsPath: filePath,
-                toString: () => `${params.scheme}://${filePath}?${params.query}`,
-            }),
-        }),
-    },
-    Position: class {
+vi.mock('vscode', () => {
+    class MockUri {
         constructor(
-            public line: number,
-            public character: number,
+            public fsPath: string,
+            public scheme: string = 'file',
+            public query: string = '',
         ) {}
-    },
-    Range: class {
-        constructor(
-            public startLine: number | vscode.Position,
-            public startChar: number | vscode.Position,
-            public endLine?: number,
-            public endChar?: number,
-        ) {}
-    },
-    window: {
-        showErrorMessage: vi.fn(),
-    },
-    workspace: {
-        openTextDocument: vi.fn().mockImplementation((uri: { fsPath: string; scheme?: string }) => {
-            const doc = mockDocuments.get(uri.toString?.() ?? uri.fsPath);
-            if (doc) return Promise.resolve(doc);
-            // Fallback: read from filesystem
-            const content = fs.existsSync(uri.fsPath) ? fs.readFileSync(uri.fsPath, 'utf-8') : '';
-            const lines = content.split('\n');
-            return Promise.resolve({
-                getText: (range?: { startLine: number; startChar: number }) => {
-                    if (!range) return content;
-                    // Simplified range extraction
-                    return content;
-                },
-                lineAt: (line: number) => ({
-                    rangeIncludingLineBreak: {
-                        end: { line, character: (lines[line] || '').length + 1 },
+        static file(fsPath: string) {
+            return new MockUri(fsPath);
+        }
+        toString() {
+            return `${this.scheme}://${this.fsPath}${this.query ? '?' + this.query : ''}`;
+        }
+        with(params: { scheme?: string; query?: string }) {
+            return new MockUri(this.fsPath, params.scheme ?? this.scheme, params.query ?? this.query);
+        }
+    }
+
+    return {
+        Uri: MockUri,
+        Position: class {
+            constructor(
+                public line: number,
+                public character: number,
+            ) {}
+        },
+        Range: class {
+            constructor(
+                public startLine: number | vscode.Position,
+                public startChar: number | vscode.Position,
+                public endLine?: number,
+                public endChar?: number,
+            ) {}
+        },
+        window: {
+            showErrorMessage: vi.fn(),
+        },
+        workspace: {
+            openTextDocument: vi.fn().mockImplementation((uri: { fsPath: string; scheme?: string }) => {
+                const doc = mockDocuments.get(uri.toString?.() ?? uri.fsPath);
+                if (doc) return Promise.resolve(doc);
+                // Fallback: read from filesystem
+                const content = fs.existsSync(uri.fsPath) ? fs.readFileSync(uri.fsPath, 'utf-8') : '';
+                const lines = content.split('\n');
+                return Promise.resolve({
+                    getText: (range?: { startLine: number; startChar: number }) => {
+                        if (!range) return content;
+                        // Simplified range extraction
+                        return content;
                     },
-                }),
-                save: vi.fn().mockResolvedValue(true),
-            });
-        }),
-        applyEdit: vi.fn().mockResolvedValue(true),
-    },
-    WorkspaceEdit: class {
-        private edits: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }> = [];
-        replace(uri: vscode.Uri, range: vscode.Range, text: string) {
-            this.edits.push({ uri, range, text });
-        }
-        getEdits() {
-            return this.edits;
-        }
-    },
-}));
+                    lineAt: (line: number) => ({
+                        rangeIncludingLineBreak: {
+                            end: { line, character: (lines[line] || '').length + 1 },
+                        },
+                    }),
+                    save: vi.fn().mockResolvedValue(true),
+                });
+            }),
+            applyEdit: vi.fn().mockResolvedValue(true),
+        },
+        WorkspaceEdit: class {
+            private edits: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }> = [];
+            replace(uri: vscode.Uri, range: vscode.Range, text: string) {
+                this.edits.push({ uri, range, text });
+            }
+            getEdits() {
+                return this.edits;
+            }
+        },
+    };
+});
 
 describe('discardChangeCommand', () => {
     let repo: TestRepo;

--- a/src/test/provide-original-resource.integration.test.ts
+++ b/src/test/provide-original-resource.integration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { JjService } from '../jj-service';
+import { JjScmProvider } from '../jj-scm-provider';
+import { TestRepo, buildGraph } from './test-repo';
+import { createMock } from './test-utils';
+
+suite('JjScmProvider provideOriginalResource Integration Test', function () {
+    let jj: JjService;
+    let scmProvider: JjScmProvider;
+    let repo: TestRepo;
+
+    setup(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        const context = createMock<vscode.ExtensionContext>({
+            subscriptions: [],
+        });
+
+        jj = new JjService(repo.path);
+        const outputChannel = createMock<vscode.OutputChannel>({
+            appendLine: () => {},
+            append: () => {},
+            replace: () => {},
+            clear: () => {},
+            show: () => {},
+            hide: () => {},
+            dispose: () => {},
+            name: 'mock',
+        });
+        scmProvider = new JjScmProvider(context, jj, repo.path, outputChannel);
+    });
+
+    teardown(async () => {
+        if (scmProvider) {
+            scmProvider.dispose();
+        }
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+
+    test('returns undefined for added file', async () => {
+        const fileName = 'added.txt';
+        repo.writeFile(fileName, 'new content');
+        
+        await scmProvider.refresh({ forceSnapshot: true });
+
+        const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
+        const originalUri = scmProvider.provideOriginalResource(fileUri);
+
+        assert.strictEqual(originalUri, undefined, 'Should return undefined for added files');
+    });
+
+    test('returns undefined for untracked file', async () => {
+        // Create an ignored file
+        repo.writeFile('.jjignore', 'ignored.txt\n');
+        // Manually write file without repo.writeFile (which snapshots)
+        const ignoredPath = path.join(repo.path, 'ignored.txt');
+        require('fs').writeFileSync(ignoredPath, 'ignored content');
+
+        await scmProvider.refresh({ forceSnapshot: true });
+
+        const fileUri = vscode.Uri.file(ignoredPath);
+        const originalUri = scmProvider.provideOriginalResource(fileUri);
+
+        assert.strictEqual(originalUri, undefined, 'Should return undefined for untracked/ignored files');
+    });
+
+    test('returns jj-view URI for modified file', async () => {
+        const fileName = 'modified.txt';
+        const fileContentOriginal = 'original content\n';
+        const fileContentModified = 'modified content\n';
+
+        await buildGraph(repo, [
+            {
+                label: 'parent',
+                description: 'parent',
+                files: { [fileName]: fileContentOriginal },
+            },
+            {
+                parents: ['parent'],
+                files: { [fileName]: fileContentModified },
+                isWorkingCopy: true,
+            },
+        ]);
+
+        await scmProvider.refresh({ forceSnapshot: true });
+
+        const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
+        const originalUri = scmProvider.provideOriginalResource(fileUri) as vscode.Uri;
+
+        assert.ok(originalUri, 'Should return a URI for modified files');
+        assert.strictEqual(originalUri.scheme, 'jj-view', 'Scheme should be jj-view');
+        
+        const query = new URLSearchParams(originalUri.query);
+        assert.strictEqual(query.get('base'), '@', 'Base should be @ by default');
+        assert.strictEqual(query.get('side'), 'left', 'Side should be left');
+    });
+});

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -16,45 +16,37 @@ import { vi } from 'vitest';
 export function createVscodeMock(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     const base: Record<string, unknown> = {
         ProgressLocation: { Notification: 15 },
-        Uri: {
-            file: (fsPath: string) => {
-                return {
-                    fsPath,
-                    path: fsPath,
-                    scheme: 'file',
-                    query: '',
-                    with: function (change: { query?: string }) {
-                        return { ...this, ...change };
-                    },
-                };
-            },
-            from: (components: { scheme: string; path: string; query?: string }) => {
-                return {
-                    scheme: components.scheme,
-                    path: components.path,
-                    query: components.query || '',
-                    fsPath: components.path,
-                    with: function (change: { query?: string }) {
-                        return { ...this, ...change };
-                    },
-                };
-            },
-            parse: (uriString: string) => {
+        Uri: class MockUri {
+            constructor(
+                public fsPath: string,
+                public scheme: string = 'file',
+                public query: string = '',
+                public path: string = fsPath,
+            ) {}
+            static file(fsPath: string) {
+                return new MockUri(fsPath);
+            }
+            static from(components: { scheme: string; path: string; query?: string }) {
+                return new MockUri(components.path, components.scheme, components.query || '', components.path);
+            }
+            static parse(uriString: string) {
                 return { _isUriBaseCtorMock: true, value: uriString };
-            },
-            joinPath: (base: { path: string; scheme: string }, ...paths: string[]) => {
-                // formatted join
+            }
+            static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
                 const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
-                return {
-                    scheme: base.scheme,
-                    path: combined,
-                    fsPath: combined,
-                    query: '',
-                    with: function (change: { query?: string }) {
-                        return { ...this, ...change };
-                    },
-                };
-            },
+                return new MockUri(combined, base.scheme, '', combined);
+            }
+            toString() {
+                return `${this.scheme}://${this.fsPath}${this.query ? '?' + this.query : ''}`;
+            }
+            with(change: { scheme?: string; query?: string }) {
+                return new MockUri(
+                    this.fsPath,
+                    change.scheme ?? this.scheme,
+                    change.query ?? this.query,
+                    this.path,
+                );
+            }
         },
         env: {
             openExternal: vi.fn(),


### PR DESCRIPTION
This change prevents the editor from displaying full-file green "Added" decorations for newly added or untracked/ignored files.

Key changes:

- Implemented a status-aware `provideOriginalResource` in `JjScmProvider` that returns `undefined` when no base version exists.
- Refactored `discard-change` and `squash-change` commands to use safe type narrowing instead of unsafe casts.
- Added comprehensive integration tests to verify the new behavior.

Fixes #159
Fixes #165