### PR TITLE
Add @trivago/prettier-plugin-sort-imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,7 @@
     "semi": true,
     "singleQuote": true,
     "trailingComma": "all",
-    "printWidth": 120
+    "printWidth": 120,
+    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "importOrder": ["<THIRD_PARTY_MODULES>", "^[./]"]
 }

--- a/.vscode-test-activation.mjs
+++ b/.vscode-test-activation.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from '@vscode/test-cli';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-activation-user-data-'));
 const userDir = path.join(tmpDir, 'User');

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from '@vscode/test-cli';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
 
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-user-data-'));
 const userDir = path.join(tmpDir, 'User');

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import typescriptEslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
+import typescriptEslint from 'typescript-eslint';
 
 export default [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
             },
             "devDependencies": {
                 "@playwright/test": "^1.58.0",
+                "@trivago/prettier-plugin-sort-imports": "^6.0.2",
                 "@types/mocha": "^10.0.10",
                 "@types/node": "22.x",
                 "@types/parcel__watcher": "^2.0.5",
@@ -236,16 +237,64 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -256,6 +305,70 @@
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.0"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.0",
+                "@babel/generator": "^7.29.0",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.29.0",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -300,7 +413,6 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -375,15 +487,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
             "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "aix"
-            ],
+            "os": ["aix"],
             "engines": {
                 "node": ">=18"
             }
@@ -392,15 +500,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
             "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=18"
             }
@@ -409,15 +513,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
             "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=18"
             }
@@ -426,15 +526,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
             "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">=18"
             }
@@ -443,15 +539,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
             "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=18"
             }
@@ -460,15 +552,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
             "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">=18"
             }
@@ -477,15 +565,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
             "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -494,15 +578,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
             "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -511,15 +591,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
             "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -528,15 +604,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
             "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -545,15 +617,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
             "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -562,15 +630,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
             "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -579,15 +643,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
             "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-            "cpu": [
-                "mips64el"
-            ],
+            "cpu": ["mips64el"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -596,15 +656,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
             "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -613,15 +669,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
             "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -630,15 +682,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
             "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -647,15 +695,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
             "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">=18"
             }
@@ -664,15 +708,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
             "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -681,15 +721,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
             "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "netbsd"
-            ],
+            "os": ["netbsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -698,15 +734,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
             "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -715,15 +747,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
             "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "openbsd"
-            ],
+            "os": ["openbsd"],
             "engines": {
                 "node": ">=18"
             }
@@ -732,15 +760,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
             "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "openharmony"
-            ],
+            "os": ["openharmony"],
             "engines": {
                 "node": ">=18"
             }
@@ -749,15 +773,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
             "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "sunos"
-            ],
+            "os": ["sunos"],
             "engines": {
                 "node": ">=18"
             }
@@ -766,15 +786,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
             "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=18"
             }
@@ -783,15 +799,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
             "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=18"
             }
@@ -800,15 +812,11 @@
             "version": "0.27.2",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
             "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">=18"
             }
@@ -1242,15 +1250,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
             "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1259,15 +1263,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
             "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1276,15 +1276,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
             "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1293,15 +1289,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
             "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1310,15 +1302,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
             "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1327,15 +1315,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
             "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1344,15 +1328,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
             "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1361,15 +1341,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
             "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1378,15 +1354,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
             "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1395,15 +1367,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
             "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1412,9 +1380,7 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
             "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
-            "cpu": [
-                "wasm32"
-            ],
+            "cpu": ["wasm32"],
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1429,15 +1395,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
             "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1446,15 +1408,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
             "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1463,15 +1421,11 @@
             "version": "1.10.6",
             "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.10.6.tgz",
             "integrity": "sha512-5B1vXosIIBw1m2Rcnw62IIfH7W9s9f7H7Ma0rRuhT8HR4Xh8QCgw6NJSI2S2MCngsGktYnAhyUvs81b7efTyQw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10"
             }
@@ -1583,14 +1537,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
             "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
+            "os": ["android"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1603,14 +1553,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
             "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1623,14 +1569,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
             "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1643,14 +1585,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
             "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ],
+            "os": ["freebsd"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1663,14 +1601,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
             "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1683,14 +1617,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
             "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1703,14 +1633,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
             "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1723,14 +1649,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
             "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1743,14 +1665,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
             "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1763,14 +1681,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
             "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ],
+            "os": ["linux"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1783,14 +1697,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
             "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1803,14 +1713,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
             "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1823,14 +1729,10 @@
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
             "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ],
+            "os": ["win32"],
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -1888,309 +1790,221 @@
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
             "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
             "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ]
+            "os": ["android"]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
             "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
             "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
             "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "os": ["freebsd"]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
             "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "freebsd"
-            ]
+            "os": ["freebsd"]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
             "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
             "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
             "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
             "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
             "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
-            "cpu": [
-                "loong64"
-            ],
+            "cpu": ["loong64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
             "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
-            "cpu": [
-                "ppc64"
-            ],
+            "cpu": ["ppc64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
             "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
             "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
-            "cpu": [
-                "riscv64"
-            ],
+            "cpu": ["riscv64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
             "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
-            "cpu": [
-                "s390x"
-            ],
+            "cpu": ["s390x"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
             "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
             "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
             "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "openharmony"
-            ]
+            "os": ["openharmony"]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
             "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
             "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
-            "cpu": [
-                "ia32"
-            ],
+            "cpu": ["ia32"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
             "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
             "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@secretlint/config-creator": {
             "version": "10.2.2",
@@ -2557,6 +2371,47 @@
                 "@textlint/ast-node-types": "15.5.0"
             }
         },
+        "node_modules/@trivago/prettier-plugin-sort-imports": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.2.tgz",
+            "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/generator": "^7.28.0",
+                "@babel/parser": "^7.28.0",
+                "@babel/traverse": "^7.28.0",
+                "@babel/types": "^7.28.0",
+                "javascript-natural-sort": "^0.7.1",
+                "lodash-es": "^4.17.21",
+                "minimatch": "^9.0.0",
+                "parse-imports-exports": "^0.2.4"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "3.x",
+                "prettier": "2.x - 3.x",
+                "prettier-plugin-ember-template-tag": ">= 2.0.0",
+                "prettier-plugin-svelte": "3.x",
+                "svelte": "4.x || 5.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "prettier-plugin-ember-template-tag": {
+                    "optional": true
+                },
+                "prettier-plugin-svelte": {
+                    "optional": true
+                },
+                "svelte": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -2648,7 +2503,6 @@
             "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2676,7 +2530,6 @@
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2783,7 +2636,6 @@
             "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.50.1",
                 "@typescript-eslint/types": "8.50.1",
@@ -3112,8 +2964,7 @@
             "version": "0.0.44",
             "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.44.tgz",
             "integrity": "sha512-F7qPRumUK3EHjNdopfICLGRf3iNPoZQt+McTHAn4AlOWPB3W2kL4H0S7uqEqbyZ6rCxaeDjpAn3MCUnwTu/VJQ==",
-            "license": "CC-BY-4.0",
-            "peer": true
+            "license": "CC-BY-4.0"
         },
         "node_modules/@vscode/test-cli": {
             "version": "0.0.12",
@@ -3226,127 +3077,91 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
             "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "alpine"
-            ]
+            "os": ["alpine"]
         },
         "node_modules/@vscode/vsce-sign-alpine-x64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
             "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "alpine"
-            ]
+            "os": ["alpine"]
         },
         "node_modules/@vscode/vsce-sign-darwin-arm64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
             "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@vscode/vsce-sign-darwin-x64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
             "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "darwin"
-            ]
+            "os": ["darwin"]
         },
         "node_modules/@vscode/vsce-sign-linux-arm": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
             "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
-            "cpu": [
-                "arm"
-            ],
+            "cpu": ["arm"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@vscode/vsce-sign-linux-arm64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
             "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@vscode/vsce-sign-linux-x64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
             "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "linux"
-            ]
+            "os": ["linux"]
         },
         "node_modules/@vscode/vsce-sign-win32-arm64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
             "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
-            "cpu": [
-                "arm64"
-            ],
+            "cpu": ["arm64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@vscode/vsce-sign-win32-x64": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
             "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
-            "cpu": [
-                "x64"
-            ],
+            "cpu": ["x64"],
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "optional": true,
-            "os": [
-                "win32"
-            ]
+            "os": ["win32"]
         },
         "node_modules/@vscode/vsce/node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -3515,7 +3330,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5259,7 +5073,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5807,9 +5620,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -7055,6 +6866,13 @@
                 "@pkgjs/parseargs": "^0.11.0"
             }
         },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7083,6 +6901,19 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -7396,6 +7227,13 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
             "dev": true,
             "license": "MIT"
         },
@@ -8506,10 +8344,7 @@
             "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
             "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
             "dev": true,
-            "funding": [
-                "https://github.com/sponsors/sxzz",
-                "https://opencollective.com/debug"
-            ],
+            "funding": ["https://github.com/sponsors/sxzz", "https://opencollective.com/debug"],
             "license": "MIT"
         },
         "node_modules/once": {
@@ -8810,6 +8645,16 @@
             "integrity": "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA==",
             "license": "MIT"
         },
+        "node_modules/parse-imports-exports": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+            "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "parse-statements": "1.0.11"
+            }
+        },
         "node_modules/parse-json": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -8843,6 +8688,13 @@
             "bin": {
                 "semver": "bin/semver"
             }
+        },
+        "node_modules/parse-statements": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+            "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/parse5": {
             "version": "7.3.0",
@@ -9061,9 +8913,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "os": ["darwin"],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -9326,7 +9176,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9336,7 +9185,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -11336,7 +11184,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11701,7 +11548,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11930,7 +11776,6 @@
             "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -12024,7 +11869,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },

--- a/package.json
+++ b/package.json
@@ -12,12 +12,8 @@
     "engines": {
         "vscode": "^1.104.0"
     },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "workspaceContains:.jj"
-    ],
+    "categories": ["Other"],
+    "activationEvents": ["workspaceContains:.jj"],
     "main": "./dist/extension.js",
     "contributes": {
         "customEditors": [
@@ -58,10 +54,7 @@
                 "jj-view.fileWatcherMode": {
                     "type": "string",
                     "default": "polling",
-                    "enum": [
-                        "polling",
-                        "watch"
-                    ],
+                    "enum": ["polling", "watch"],
                     "enumDescriptions": [
                         "Use periodic status checks (default).",
                         "Use a file watcher (parcel-watcher) for efficient updates (only on changes)."
@@ -95,23 +88,13 @@
                 "jj-view.logTheme": {
                     "type": "string",
                     "default": "default",
-                    "enum": [
-                        "default",
-                        "oceanic",
-                        "sunset",
-                        "neon",
-                        "pastel",
-                        "monochrome"
-                    ],
+                    "enum": ["default", "oceanic", "sunset", "neon", "pastel", "monochrome"],
                     "description": "Color theme for the graph lanes in the JJ Log view."
                 },
                 "jj-view.graphLabelAlignment": {
                     "type": "string",
                     "default": "aligned",
-                    "enum": [
-                        "aligned",
-                        "compact"
-                    ],
+                    "enum": ["aligned", "compact"],
                     "enumDescriptions": [
                         "Keep commit messages aligned in a single column.",
                         "Place commit messages immediately to the right of their node."
@@ -564,6 +547,7 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.58.0",
+        "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/parcel__watcher": "^2.0.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({

--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
-import * as path from 'path';
+import { BackendType } from '@parcel/watcher';
 import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { DirectoryWatcher } from './directory-watcher';
 import { JjService } from './jj-service';
 import { Poller } from './poller';
-import { DirectoryWatcher } from './directory-watcher';
-import { BackendType } from '@parcel/watcher';
 
 export class ChangeDetectionManager implements vscode.Disposable {
     private _disposed = false;

--- a/src/commands/abandon.ts
+++ b/src/commands/abandon.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevision, isWorkingCopyResourceGroup, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     let revisions: string[] = [];

--- a/src/commands/absorb.ts
+++ b/src/commands/absorb.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { collectResourceStates, extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 
 export async function absorbCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {

--- a/src/commands/bookmark.ts
+++ b/src/commands/bookmark.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function setBookmarkCommand(
     scmProvider: JjScmProvider,

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { JjResourceState } from '../jj-scm-provider';
-import { ScmContextValue } from '../jj-context-keys';
-import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as vscode from 'vscode';
+import { ScmContextValue } from '../jj-context-keys';
+import { JjResourceState } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 
 // Internal type guards to keep the messy VS Code argument matching encapsulated

--- a/src/commands/commit-prompt.ts
+++ b/src/commands/commit-prompt.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export async function commitPromptCommand(scmProvider: JjScmProvider, jj: JjService) {

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export async function commitCommand(scmProvider: JjScmProvider, jj: JjService) {

--- a/src/commands/describe-prompt.ts
+++ b/src/commands/describe-prompt.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export async function describePromptCommand(scmProvider: JjScmProvider, jj: JjService) {

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function setDescriptionCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[] = []) {
     const message = typeof args[0] === 'string' ? args[0] : undefined;

--- a/src/commands/details.ts
+++ b/src/commands/details.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { extractRevision, showJjError } from './command-utils';
 import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import { extractRevision, showJjError } from './command-utils';
 
 export async function showDetailsCommand(logWebviewProvider: JjLogWebviewProvider, args: unknown[]) {
     const revision = extractRevision(args);

--- a/src/commands/discard-change.ts
+++ b/src/commands/discard-change.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
 import { showJjError } from './command-utils';

--- a/src/commands/duplicate.ts
+++ b/src/commands/duplicate.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function duplicateCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const revision = extractRevisions(args)[0];

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function editCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const revision = extractRevision(args);

--- a/src/commands/merge-editor.ts
+++ b/src/commands/merge-editor.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { JjScmProvider } from '../jj-scm-provider';
 import { collectResourceStates, showJjError } from './command-utils';
 

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError } from './command-utils';
 
 export interface MergeCommandArg {

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
 import * as path from 'path';
-import { JjService } from '../jj-service';
+import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { collectResourceStates, extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function moveToChildCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {

--- a/src/commands/multi-diff.ts
+++ b/src/commands/multi-diff.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
 import { createDiffUris } from '../uri-utils';

--- a/src/commands/new-after.ts
+++ b/src/commands/new-after.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function newAfterCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     let revisions: string[] = [];

--- a/src/commands/new-before.ts
+++ b/src/commands/new-before.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function newBeforeCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     let revisions: string[] = [];

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
-import { JjScmProvider } from '../jj-scm-provider';
 
 export async function newCommand(scmProvider: JjScmProvider, jj: JjService, args?: unknown[]) {
     // args might contain a revision if triggered from context menu "New child"

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 
 export async function openFileCommand(resourceState: vscode.SourceControlResourceState | undefined) {

--- a/src/commands/rebase.ts
+++ b/src/commands/rebase.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export interface CommitMenuContext {

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { JjScmProvider } from '../jj-scm-provider';
 import { showJjError } from './command-utils';
 

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { collectResourceStates, showJjError, withDelayedProgress } from './command-utils';
 
 export async function restoreCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjService } from '../jj-service';
 import { showJjError } from './command-utils';

--- a/src/commands/squash-change.ts
+++ b/src/commands/squash-change.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
 import * as path from 'path';
-import { JjService } from '../jj-service';
+import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { showJjError } from './command-utils';
 
 interface LineChange {

--- a/src/commands/squash-into.ts
+++ b/src/commands/squash-into.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { collectResourceStates, extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function squashIntoCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {

--- a/src/commands/squash.ts
+++ b/src/commands/squash.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs/promises';
-import { JjService } from '../jj-service';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { collectResourceStates, extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function squashCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {

--- a/src/commands/undo.ts
+++ b/src/commands/undo.ts
@@ -2,10 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { JjService } from '../jj-service';
 import { JjScmProvider } from '../jj-scm-provider';
-
+import { JjService } from '../jj-service';
 import { showJjError, withDelayedProgress } from './command-utils';
 
 export async function undoCommand(scmProvider: JjScmProvider, jj: JjService) {

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -2,11 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
-
 import { GerritService } from '../gerrit-service';
+import { JjService } from '../jj-service';
 import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function uploadCommand(

--- a/src/directory-watcher.ts
+++ b/src/directory-watcher.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { AsyncSubscription, BackendType, Event, subscribe } from '@parcel/watcher';
 import * as vscode from 'vscode';
-import { subscribe, AsyncSubscription, Event, BackendType } from '@parcel/watcher';
 
 export type DirectoryWatcherCallback = (events: Event[]) => void;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,53 +2,49 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-
+import { abandonCommand } from './commands/abandon';
+import { absorbCommand } from './commands/absorb';
+import { setBookmarkCommand } from './commands/bookmark';
+import { commitCommand } from './commands/commit';
+import { commitPromptCommand } from './commands/commit-prompt';
+import { setDescriptionCommand } from './commands/describe';
+import { describePromptCommand } from './commands/describe-prompt';
+import { showDetailsCommand } from './commands/details';
+import { discardChangeCommand } from './commands/discard-change';
+import { duplicateCommand } from './commands/duplicate';
+import { editCommand } from './commands/edit';
+import { MergeCommandArg, newMergeChangeCommand } from './commands/merge';
+import { openMergeEditorCommand } from './commands/merge-editor';
+import { moveToChildCommand, moveToParentInDiffCommand } from './commands/move';
+import { showMultiFileDiffCommand } from './commands/multi-diff';
+import { newCommand } from './commands/new';
+import { newAfterCommand } from './commands/new-after';
+import { newBeforeCommand } from './commands/new-before';
+import { openFileCommand } from './commands/open';
+import { CommitMenuContext, rebaseOntoSelectedCommand } from './commands/rebase';
+import { refreshCommand } from './commands/refresh';
+import { restoreCommand } from './commands/restore';
+import { showCurrentChangeCommand } from './commands/show';
+import { completeSquashCommand, squashCommand } from './commands/squash';
+import { squashChangeCommand } from './commands/squash-change';
+import { squashIntoCommand } from './commands/squash-into';
+import { undoCommand } from './commands/undo';
+import { uploadCommand } from './commands/upload';
+import { GerritService } from './gerrit-service';
 import { checkGitColocation } from './git-colocation';
-
-import { JjService } from './jj-service';
-import { resolveJjBinary } from './utils/binary-utils';
-import { JjScmProvider } from './jj-scm-provider';
+import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 import { JjDocumentContentProvider } from './jj-content-provider';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjLogWebviewProvider } from './jj-log-webview-provider';
-import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
-import { GerritService } from './gerrit-service';
-import { abandonCommand } from './commands/abandon';
-import { newMergeChangeCommand, MergeCommandArg } from './commands/merge';
-import { squashCommand, completeSquashCommand } from './commands/squash';
-import { squashIntoCommand } from './commands/squash-into';
-import { moveToChildCommand, moveToParentInDiffCommand } from './commands/move';
-import { restoreCommand } from './commands/restore';
-import { setDescriptionCommand } from './commands/describe';
-import { newCommand } from './commands/new';
-import { uploadCommand } from './commands/upload';
-import { discardChangeCommand } from './commands/discard-change';
-import { squashChangeCommand } from './commands/squash-change';
-import { setBookmarkCommand } from './commands/bookmark';
-import { absorbCommand } from './commands/absorb';
-import { newBeforeCommand } from './commands/new-before';
-import { newAfterCommand } from './commands/new-after';
+import { JjScmProvider } from './jj-scm-provider';
+import { JjService } from './jj-service';
+import { resolveJjBinary } from './utils/binary-utils';
 
 export interface Api {
     scmProvider: JjScmProvider;
     jj: JjService;
 }
-
-import { undoCommand } from './commands/undo';
-import { duplicateCommand } from './commands/duplicate';
-import { editCommand } from './commands/edit';
-import { showDetailsCommand } from './commands/details';
-import { showCurrentChangeCommand } from './commands/show';
-import { commitCommand } from './commands/commit';
-import { commitPromptCommand } from './commands/commit-prompt';
-import { describePromptCommand } from './commands/describe-prompt';
-import { rebaseOntoSelectedCommand, CommitMenuContext } from './commands/rebase';
-import { openMergeEditorCommand } from './commands/merge-editor';
-import { refreshCommand } from './commands/refresh';
-import { openFileCommand } from './commands/open';
-import { showMultiFileDiffCommand } from './commands/multi-diff';
 
 export function activate(context: vscode.ExtensionContext) {
     if (!vscode.workspace.workspaceFolders) {

--- a/src/gerrit-service.ts
+++ b/src/gerrit-service.ts
@@ -2,13 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs';
-
-import { GerritClInfo } from './jj-types';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { JjService } from './jj-service';
+import { GerritClInfo } from './jj-types';
 import { convertJjChangeIdToHex } from './utils/jj-utils';
 
 interface GerritFile {

--- a/src/git-colocation.ts
+++ b/src/git-colocation.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 
 /** Checks if the repository is git-colocated and prompts the user to disable the Git extension if necessary. */

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 import { createDiffUris } from './uri-utils';
 import { shortenChangeId } from './utils/jj-utils';

--- a/src/jj-content-provider.ts
+++ b/src/jj-content-provider.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjStatusEntry } from './jj-types';
 import { JjService } from './jj-service';
+import { JjStatusEntry } from './jj-types';
 
 export class JjDecorationProvider implements vscode.FileDecorationProvider {
     private readonly _onDidChangeFileDecorations: vscode.EventEmitter<vscode.Uri | vscode.Uri[] | undefined> =

--- a/src/jj-edit-fs-provider.ts
+++ b/src/jj-edit-fs-provider.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -2,15 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
-import { JjService } from './jj-service';
+import { GerritService } from './gerrit-service';
+import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 import { JjContextKey } from './jj-context-keys';
+import { JjService } from './jj-service';
 import { JjLogEntry } from './jj-types';
 import { formatCommitTitle } from './utils/jj-utils';
-import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
-
-import { GerritService } from './gerrit-service';
 
 export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'jj-view.logView';

--- a/src/jj-merge-provider.ts
+++ b/src/jj-merge-provider.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjService } from './jj-service';
 

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -2,22 +2,19 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
-import { JjService } from './jj-service';
-import { JjStatusEntry, JjLogEntry } from './jj-types';
-import { ChangeDetectionManager } from './change-detection-manager';
-
 import * as fs from 'fs/promises';
 import * as path from 'path';
-
+import * as vscode from 'vscode';
+import { ChangeDetectionManager } from './change-detection-manager';
+import { getErrorMessage } from './commands/command-utils';
+import { completeSquashCommand } from './commands/squash';
 import { JjDocumentContentProvider } from './jj-content-provider';
+import { JjContextKey, ScmContextValue } from './jj-context-keys';
+import { JjDecorationProvider } from './jj-decoration-provider';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjMergeContentProvider } from './jj-merge-provider';
-import { JjDecorationProvider } from './jj-decoration-provider';
-import { JjContextKey, ScmContextValue } from './jj-context-keys';
-import { completeSquashCommand } from './commands/squash';
-import { getErrorMessage } from './commands/command-utils';
+import { JjService } from './jj-service';
+import { JjLogEntry, JjStatusEntry } from './jj-types';
 import { RefreshScheduler } from './refresh-scheduler';
 import { createDiffUris } from './uri-utils';
 import { formatDisplayChangeId } from './utils/jj-utils';

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as cp from 'child_process';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
+import { LOG_ENTRY_SCHEMA, buildLogTemplate } from './jj-template-builder';
 import { JjLogEntry, JjStatusEntry } from './jj-types';
 import { PatchHelper, SelectionRange } from './patch-helper';
-import { buildLogTemplate, LOG_ENTRY_SCHEMA } from './jj-template-builder';
 
 export interface JjLogOptions {
     revision?: string;

--- a/src/patch-helper.ts
+++ b/src/patch-helper.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import parse from 'parse-diff';
 
 export interface SelectionRange {

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 
 /**

--- a/src/refresh-scheduler.ts
+++ b/src/refresh-scheduler.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 
 export class RefreshScheduler implements vscode.Disposable {

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { JjService } from '../jj-service';
+import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { TestRepo, buildGraph } from './test-repo';
 import { createMock } from './test-utils';
 

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs/promises';
-import { describe, it, beforeEach, afterEach, vi, expect, Mock, MockInstance } from 'vitest';
+import * as path from 'path';
+import { Mock, MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { ChangeDetectionManager } from '../change-detection-manager';
+import { DirectoryWatcher } from '../directory-watcher';
 import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
-import { DirectoryWatcher } from '../directory-watcher';
 
 // Mock VS Code
 const mockGetConfiguration = vi.fn();

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { withDelayedProgress } from '../commands/command-utils';
 

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -2,15 +2,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock, asMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { abandonCommand } from '../../commands/abandon';
+import { ScmContextValue } from '../../jj-context-keys';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { ScmContextValue } from '../../jj-context-keys';
-import * as vscode from 'vscode';
+import { asMock, createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import { absorbCommand } from '../../commands/absorb';
 import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { absorbCommand } from '../../commands/absorb';
 
 suite('Absorb Integration Test', function () {
     this.timeout(60000);

--- a/src/test/commands/absorb.test.ts
+++ b/src/test/commands/absorb.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import { absorbCommand } from '../../commands/absorb';
-import { JjService } from '../../jj-service';
 import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
 import { createMock } from '../test-utils';
 

--- a/src/test/commands/bookmark.test.ts
+++ b/src/test/commands/bookmark.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { setBookmarkCommand } from '../../commands/bookmark';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { createMock } from '../test-utils';
 
 // Mock QuickPick
 const { mockQuickPick } = vi.hoisted(() => ({

--- a/src/test/commands/commit-prompt.test.ts
+++ b/src/test/commands/commit-prompt.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import { commitPromptCommand } from '../../commands/commit-prompt';
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { TestRepo } from '../test-repo';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { commitPromptCommand } from '../../commands/commit-prompt';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/commit.test.ts
+++ b/src/test/commands/commit.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import { commitCommand } from '../../commands/commit';
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { TestRepo } from '../test-repo';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { commitCommand } from '../../commands/commit';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/describe-prompt.test.ts
+++ b/src/test/commands/describe-prompt.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import { describePromptCommand } from '../../commands/describe-prompt';
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { TestRepo } from '../test-repo';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { describePromptCommand } from '../../commands/describe-prompt';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { createMock } from '../test-utils';
 import { setDescriptionCommand } from '../../commands/describe';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/details.test.ts
+++ b/src/test/commands/details.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { showDetailsCommand } from '../../commands/details';
 import { JjLogWebviewProvider } from '../../jj-log-webview-provider';
 import { JjResourceState } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/discard-change.test.ts
+++ b/src/test/commands/discard-change.test.ts
@@ -2,15 +2,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import * as path from 'path';
 import * as fs from 'fs';
-import { discardChangeCommand } from '../../commands/discard-change';
-import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { discardChangeCommand } from '../../commands/discard-change';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
 
 // Track created documents for mocking
 const mockDocuments = new Map<

--- a/src/test/commands/duplicate.test.ts
+++ b/src/test/commands/duplicate.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { duplicateCommand } from '../../commands/duplicate';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/edit.test.ts
+++ b/src/test/commands/edit.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { editCommand } from '../../commands/edit';
+import { JjResourceState, JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider, JjResourceState } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/index-lock-error.test.ts
+++ b/src/test/commands/index-lock-error.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, afterEach, vi, Mock } from 'vitest';
-import { JjService } from '../../jj-service';
-import { showJjError } from '../../commands/command-utils';
-import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { Mock, afterEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { showJjError } from '../../commands/command-utils';
+import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
 
 vi.mock('vscode', async () => {

--- a/src/test/commands/merge-editor.test.ts
+++ b/src/test/commands/merge-editor.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock, asMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { openMergeEditorCommand } from '../../commands/merge-editor';
 import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { asMock, createMock } from '../test-utils';
 
 vi.mock('vscode', () => ({
     window: {

--- a/src/test/commands/merge.test.ts
+++ b/src/test/commands/merge.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock, asMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { newMergeChangeCommand } from '../../commands/merge';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { asMock, createMock } from '../test-utils';
 
 vi.mock('vscode', () => ({
     Uri: { file: (path: string) => ({ fsPath: path }) },

--- a/src/test/commands/move.test.ts
+++ b/src/test/commands/move.test.ts
@@ -2,15 +2,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { moveToChildCommand } from '../../commands/move';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/multi-diff.test.ts
+++ b/src/test/commands/multi-diff.test.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import { showMultiFileDiffCommand } from '../../commands/multi-diff';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';

--- a/src/test/commands/new-after.test.ts
+++ b/src/test/commands/new-after.test.ts
@@ -2,12 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { newAfterCommand } from '../../commands/new-after';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
 
 // Mock vscode

--- a/src/test/commands/new-before.test.ts
+++ b/src/test/commands/new-before.test.ts
@@ -2,12 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { newBeforeCommand } from '../../commands/new-before';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
 
 // Mock vscode

--- a/src/test/commands/new.test.ts
+++ b/src/test/commands/new.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { newCommand } from '../../commands/new';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, afterEach, vi } from 'vitest';
-import { openFileCommand } from '../../commands/open';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { openFileCommand } from '../../commands/open';
 import { createMock } from '../test-utils';
 
 vi.mock('vscode', () => {

--- a/src/test/commands/rebase.test.ts
+++ b/src/test/commands/rebase.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock, asMock } from '../test-utils';
-import { rebaseOntoSelectedCommand } from '../../commands/rebase';
-import { JjService } from '../../jj-service';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { TestRepo, buildGraph } from '../test-repo';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { rebaseOntoSelectedCommand } from '../../commands/rebase';
+import { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo, buildGraph } from '../test-repo';
+import { asMock, createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/refresh.test.ts
+++ b/src/test/commands/refresh.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock, asMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { refreshCommand } from '../../commands/refresh';
 import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { asMock, createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/restore.test.ts
+++ b/src/test/commands/restore.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { restoreCommand } from '../../commands/restore';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/show.test.ts
+++ b/src/test/commands/show.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { showCurrentChangeCommand } from '../../commands/show';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import * as vscode from 'vscode';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/squash-change.test.ts
+++ b/src/test/commands/squash-change.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { squashChangeCommand } from '../../commands/squash-change';
+import { JjDocumentContentProvider } from '../../jj-content-provider';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import { JjDocumentContentProvider } from '../../jj-content-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', () => ({
     Uri: {

--- a/src/test/commands/squash-into.test.ts
+++ b/src/test/commands/squash-into.test.ts
@@ -2,15 +2,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { squashIntoCommand } from '../../commands/squash-into';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {

--- a/src/test/commands/squash.test.ts
+++ b/src/test/commands/squash.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { squashCommand } from '../../commands/squash';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo, buildGraph } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
-import * as vscode from 'vscode';
+import { createMock } from '../test-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {

--- a/src/test/commands/undo.test.ts
+++ b/src/test/commands/undo.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createMock } from '../test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { undoCommand } from '../../commands/undo';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { JjScmProvider } from '../../jj-scm-provider';
+import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { uploadCommand } from '../../commands/upload';
-import { JjService } from '../../jj-service';
-import { GerritService } from '../../gerrit-service';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import { uploadCommand } from '../../commands/upload';
+import { GerritService } from '../../gerrit-service';
+import { JjService } from '../../jj-service';
 
 // Mock dependencies
 const mockConfig = {

--- a/src/test/directory-watcher.test.ts
+++ b/src/test/directory-watcher.test.ts
@@ -2,21 +2,19 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import * as parcelWatcher from '@parcel/watcher';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import * as path from 'path';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OutputChannel } from 'vscode';
 import { DirectoryWatcher } from '../directory-watcher';
 import { createMock } from './test-utils';
-import type { OutputChannel } from 'vscode';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('./vscode-mock');
     return createVscodeMock();
 });
-
-import * as parcelWatcher from '@parcel/watcher';
 
 vi.mock('@parcel/watcher', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@parcel/watcher')>();

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { ElectronApplication, type Frame } from 'playwright';
-import { test, expect, Page } from '@playwright/test';
+import { Page, expect, test } from '@playwright/test';
 import * as fs from 'fs';
-import { TestRepo, buildGraph, type CommitId } from '../test-repo';
-import { launchVSCode, focusJJLog, getLogWebview, undo, redo, save } from './e2e-helpers';
+import { ElectronApplication, type Frame } from 'playwright';
+import { type CommitId, TestRepo, buildGraph } from '../test-repo';
+import { focusJJLog, getLogWebview, launchVSCode, redo, save, undo } from './e2e-helpers';
 
 /**
  * Finds the webview frame containing the Commit Details panel.

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -2,19 +2,18 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { ElectronApplication } from 'playwright';
-import { test, expect, Page } from '@playwright/test';
+import { Page, expect, test } from '@playwright/test';
 import * as fs from 'fs';
-import { TestRepo, buildGraph, type CommitId } from '../test-repo';
+import { ElectronApplication } from 'playwright';
+import { type CommitId, TestRepo, buildGraph } from '../test-repo';
 import {
-    launchVSCode,
+    ROOT_ID,
+    entry,
+    expectTree,
     focusJJLog,
     getLogWebview,
-    expectTree,
-    entry,
+    launchVSCode,
     rightClickAndSelect,
-    ROOT_ID,
     selectCommits,
     triggerRefresh,
 } from './e2e-helpers';
@@ -350,10 +349,11 @@ test.describe('JJ Log Context Menu E2E', () => {
             await page.keyboard.press('Enter');
 
             // Verification: bookmark pill should appear in the webview
-            await expect(commit1Row.locator('.bookmark-pill', { hasText: 'my-bookmark' })).toBeVisible({ timeout: 10000 });
+            await expect(commit1Row.locator('.bookmark-pill', { hasText: 'my-bookmark' })).toBeVisible({
+                timeout: 10000,
+            });
         }).toPass({ timeout: 30000 });
     });
-
 
     test('Absorb', async () => {
         const commit1Id = nodes['commit1'].changeId;

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { ElectronApplication, type Frame } from 'playwright';
-import { test, expect, Page } from '@playwright/test';
+import { Page, expect, test } from '@playwright/test';
 import * as fs from 'fs';
+import { ElectronApplication, type Frame } from 'playwright';
 import { TestRepo } from '../test-repo';
-import { launchVSCode, focusJJLog, getLogWebview, triggerRefresh, hoverAndClick } from './e2e-helpers';
+import { focusJJLog, getLogWebview, hoverAndClick, launchVSCode, triggerRefresh } from './e2e-helpers';
 
 /**
  * Finds the webview frame containing the Commit Details panel.

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { _electron as electron, Page, type Frame, ElectronApplication } from 'playwright';
-import { expect, Locator } from '@playwright/test';
-import * as path from 'path';
+import { Locator, expect } from '@playwright/test';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
+import { ElectronApplication, type Frame, Page, _electron as electron } from 'playwright';
 import { TestRepo } from '../test-repo';
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 
 export const ROOT_ID = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
 

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import { TestRepo, buildGraph } from '../test-repo';
-import { launchVSCode, focusJJLog, getLogWebview, expectTree, entry, ROOT_ID } from './e2e-helpers';
+import { ROOT_ID, entry, expectTree, focusJJLog, getLogWebview, launchVSCode } from './e2e-helpers';
 
 test.describe('JJ Log Pane E2E', () => {
     test('Webview Initialization & Rendering', async () => {

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { TestRepo, buildGraph } from '../test-repo';
-import { launchVSCode, focusSCM, hoverAndClick, expectTree, entry, ROOT_ID } from './e2e-helpers';
+import { ROOT_ID, entry, expectTree, focusSCM, hoverAndClick, launchVSCode } from './e2e-helpers';
 
 test.describe('SCM Pane E2E', () => {
     test('Displays correct groups and populates SCM input', async () => {
@@ -160,7 +159,6 @@ test.describe('SCM Pane E2E', () => {
                     expect(repo.getDescription('@').trim()).toBe('Commit via keyboard');
                 }).toPass({ timeout: 5000 });
             }).toPass({ timeout: 10000 });
-
 
             // Commit with Ctrl+Enter
             await scmInputRow.click();

--- a/src/test/extension.integration.test.ts
+++ b/src/test/extension.integration.test.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Api } from '../extension';

--- a/src/test/fake-gerrit-server.ts
+++ b/src/test/fake-gerrit-server.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { GerritChange } from '../gerrit-service';
 
 export class FakeGerritServer {

--- a/src/test/format-utils.test.ts
+++ b/src/test/format-utils.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { formatCommitDescription } from '../utils/format-utils';
 
 function trimLiteral(str: string): string {

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -2,15 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'; // Vitest
-import * as vscode from 'vscode';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+// Vitest
+import * as vscode from 'vscode';
 import { GerritService } from '../gerrit-service';
 import { JjService } from '../jj-service';
-import { TestRepo } from './test-repo';
 import { FakeGerritServer } from './fake-gerrit-server';
+import { TestRepo } from './test-repo';
 
 // Mock VS Code
 const mockConfig = {

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { GerritService } from '../gerrit-service';
 import { JjService } from '../jj-service';
-import { TestRepo } from './test-repo';
 import { JjLogEntry } from '../jj-types';
+import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
 
 vi.mock('vscode', () => ({

--- a/src/test/git-colocation.integration.test.ts
+++ b/src/test/git-colocation.integration.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
-import * as sinon from 'sinon';
 import * as cp from 'child_process';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
 import { checkGitColocation } from '../git-colocation';
-import { TestRepo } from './test-repo';
 import { JjService } from '../jj-service';
+import { TestRepo } from './test-repo';
 
 suite('Git Colocation Integration Test Suite', () => {
     let repo: TestRepo;

--- a/src/test/global-teardown.ts
+++ b/src/test/global-teardown.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -2,9 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService } from '../jj-service';
 import { computeGraphLayout } from '../webview/graph-compute';
 import { TestRepo, buildGraph } from './test-repo';

--- a/src/test/jj-decoration-provider.test.ts
+++ b/src/test/jj-decoration-provider.test.ts
@@ -2,12 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+// sort-imports-ignore (needed so that we can import after `vscode` is mocked)
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { accessPrivate, createMock } from './test-utils';
-import { JjStatusEntry } from '../jj-types'; // Retained as it's used
 import { JjService } from '../jj-service';
+import { JjStatusEntry } from '../jj-types';
+import { accessPrivate, createMock } from './test-utils';
 
 // Mock vscode
 vi.mock('vscode', () => {

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
-import { createMock, accessPrivate } from './test-utils';
+import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ Decoration Integration Test', function () {
     let scmProvider: JjScmProvider;

--- a/src/test/jj-merge-provider.integration.test.ts
+++ b/src/test/jj-merge-provider.integration.test.ts
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as path from 'path';
-import { JjService } from '../jj-service';
+import * as vscode from 'vscode';
 import { JjMergeContentProvider } from '../jj-merge-provider';
+import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
 
 suite('JJ Merge Provider Integration Test', function () {

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -2,19 +2,18 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as fs from 'fs';
-import * as path from 'path';
 import * as fsp from 'fs/promises';
-import { JjService } from '../jj-service';
-import { JjScmProvider } from '../jj-scm-provider';
-import { ScmContextValue } from '../jj-context-keys';
-import { squashCommand, completeSquashCommand } from '../commands/squash';
+import * as path from 'path';
+import * as vscode from 'vscode';
 import { moveToChildCommand, moveToParentInDiffCommand } from '../commands/move';
+import { completeSquashCommand, squashCommand } from '../commands/squash';
+import { ScmContextValue } from '../jj-context-keys';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { TestRepo, buildGraph } from './test-repo';
-import { createMock, accessPrivate } from './test-utils';
+import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ SCM Provider Integration Test', function () {
     let jj: JjService;

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { JjService } from '../jj-service';
 import { TestRepo, buildGraph } from './test-repo';
 

--- a/src/test/jj-service-timeout.test.ts
+++ b/src/test/jj-service-timeout.test.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { JjService } from '../jj-service';
 import * as cp from 'child_process';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { JjService } from '../jj-service';
 
 // Mock child_process to control execution and simulate hangs
 vi.mock('child_process');

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as cp from 'child_process';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService } from '../jj-service';
 import { TestRepo, buildGraph } from './test-repo';
 

--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
     convertJjChangeIdToHex,
-    shortenChangeId,
-    getChangeIdDisplayLength,
-    formatDisplayChangeId,
     formatCommitTitle,
+    formatDisplayChangeId,
+    getChangeIdDisplayLength,
+    shortenChangeId,
 } from '../utils/jj-utils';
 
 describe('JJ Utils', () => {

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { JjService } from '../jj-service';
-import { JjScmProvider } from '../jj-scm-provider';
 import { ScmContextValue } from '../jj-context-keys';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
-import { createMock, accessPrivate } from './test-utils';
+import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ SCM Visibility Integration Test', function () {
     let jj: JjService;

--- a/src/test/layout-utils.test.ts
+++ b/src/test/layout-utils.test.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect } from 'vitest';
-import { computeGap, computeMaxShortestIdLength, computeGraphAreaWidth } from '../webview/layout-utils';
+import { describe, expect, it } from 'vitest';
+import { computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../webview/layout-utils';
 
 describe('Layout Utils', () => {
     describe('computeGap', () => {

--- a/src/test/patch-helper.test.ts
+++ b/src/test/patch-helper.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { PatchHelper, SelectionRange } from '../patch-helper';
 
 // Helper to create range

--- a/src/test/person-info.test.ts
+++ b/src/test/person-info.test.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { describe, expect, it } from 'vitest';
 import { getPersonDisplayStrings, getRelativeTimeString } from '../webview/components/PersonInfo';
 

--- a/src/test/poller.test.ts
+++ b/src/test/poller.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Poller } from '../poller';
 
 describe('Poller', () => {

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { JjService } from '../jj-service';
-import { JjScmProvider } from '../jj-scm-provider';
-import { JjDocumentContentProvider } from '../jj-content-provider';
+import * as vscode from 'vscode';
 import { discardChangeCommand } from '../commands/discard-change';
 import { squashChangeCommand } from '../commands/squash-change';
+import { JjDocumentContentProvider } from '../jj-content-provider';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
 import { TestRepo, buildGraph } from './test-repo';
 import { createMock } from './test-utils';
 

--- a/src/test/refresh-scheduler.test.ts
+++ b/src/test/refresh-scheduler.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { type Mock, afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { RefreshScheduler } from '../refresh-scheduler';
 
 // Hoisted mock for vscode

--- a/src/test/screenshots/generate.spec.ts
+++ b/src/test/screenshots/generate.spec.ts
@@ -2,14 +2,13 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { _electron as electron } from 'playwright';
 import { test } from '@playwright/test';
-import * as path from 'path';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as fs from 'fs';
 import * as os from 'os';
+import * as path from 'path';
+import { _electron as electron } from 'playwright';
 import { TestRepo, buildGraph } from '../test-repo';
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 
 /**
  * Playwright test to generate high-quality screenshots for the README.

--- a/src/test/scripts.test.ts
+++ b/src/test/scripts.test.ts
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, expect, test, beforeAll, afterAll } from 'vitest';
-import * as path from 'path';
-import * as fs from 'fs/promises';
 import { execFile } from 'child_process';
-import { promisify } from 'util';
+import * as fs from 'fs/promises';
 import * as os from 'os';
+import * as path from 'path';
+import { promisify } from 'util';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 const execFileAsync = promisify(execFile);
 

--- a/src/test/selection-utils.test.ts
+++ b/src/test/selection-utils.test.ts
@@ -2,8 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { calculateNextSelection, hasImmutableSelection } from '../webview/utils/selection-utils';
 
 describe('selection-utils', () => {

--- a/src/test/subdirectory-mapping.test.ts
+++ b/src/test/subdirectory-mapping.test.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
 

--- a/src/test/suite/menu-filter.test.ts
+++ b/src/test/suite/menu-filter.test.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect } from 'vitest';
-import { filterMenuActions, MenuAction } from '../../common/menu-filter';
+import { describe, expect, test } from 'vitest';
+import { MenuAction, filterMenuActions } from '../../common/menu-filter';
 
 describe('filterMenuActions', () => {
     const actions: MenuAction[] = [

--- a/src/test/terminal-detection.test.ts
+++ b/src/test/terminal-detection.test.ts
@@ -2,17 +2,18 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+// sort-imports-ignore (needed so that we can import after `vscode` is mocked)
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import { handleTerminalExecution } from '../extension';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('./vscode-mock');
     return createVscodeMock();
 });
 
-import { handleTerminalExecution } from '../extension';
+// Import after mock
 import type { GerritService } from '../gerrit-service';
-import type * as vscode from 'vscode';
 
 describe('handleTerminalExecution', () => {
     let gerritService: { forceRefresh: ReturnType<typeof vi.fn>; requestRefreshWithBackoffs: ReturnType<typeof vi.fn> };

--- a/src/test/test-repo.test.ts
+++ b/src/test/test-repo.test.ts
@@ -2,10 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { TestRepo, buildGraph } from './test-repo';
 import * as cp from 'child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TestRepo, buildGraph } from './test-repo';
 
 describe('TestRepo', () => {
     let repo: TestRepo;

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
 import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 export class TestRepo {
     public readonly path: string;

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { Mock } from 'vitest';
 import { SinonStub } from 'sinon';
+import { Mock } from 'vitest';
 
 export /**
  * Creates a partial mock of type T.

--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -2,11 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, it, expect, vi } from 'vitest';
-
-import { createDiffUris } from '../uri-utils';
+import { describe, expect, it, vi } from 'vitest';
 import { JjStatusEntry } from '../jj-types';
+import { createDiffUris } from '../uri-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { vi } from 'vitest';
 
 /**

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -2,23 +2,21 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-
-import { JjService } from '../jj-service';
-import { JjScmProvider } from '../jj-scm-provider';
-import { JjLogWebviewProvider } from '../jj-log-webview-provider';
-import { GerritService } from '../gerrit-service';
+import * as vscode from 'vscode';
 import { abandonCommand } from '../commands/abandon';
-import { squashCommand } from '../commands/squash';
-import { newCommand } from '../commands/new';
 import { editCommand } from '../commands/edit';
+import { newCommand } from '../commands/new';
+import { squashCommand } from '../commands/squash';
 import { undoCommand } from '../commands/undo';
-import { TestRepo } from './test-repo';
-import { createMock, asSinonStub } from './test-utils';
+import { GerritService } from '../gerrit-service';
 import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
+import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
+import { TestRepo } from './test-repo';
+import { asSinonStub, createMock } from './test-utils';
 
 suite('Webview Commands End-to-End Integration Test', function () {
     let jj: JjService;

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -2,16 +2,14 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-
-import { JjService } from '../jj-service';
-import { JjLogWebviewProvider } from '../jj-log-webview-provider';
 import { GerritService } from '../gerrit-service';
+import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
+import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import { JjService } from '../jj-service';
 import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
-import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 
 function createMockWebviewView() {
     let visibilityListener: (e: void) => void | undefined;

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -2,16 +2,15 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as assert from 'assert';
-import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { JjService } from '../jj-service';
-import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import * as vscode from 'vscode';
 import { GerritService } from '../gerrit-service';
-import { TestRepo } from './test-repo';
-import { createMock, asSinonStub } from './test-utils';
 import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
+import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import { JjService } from '../jj-service';
+import { TestRepo } from './test-repo';
+import { asSinonStub, createMock } from './test-utils';
 
 suite('Webview Selection Integration Test', function () {
     let jj: JjService;

--- a/src/test/write-op-timeout.test.ts
+++ b/src/test/write-op-timeout.test.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as cp from 'child_process';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { JjService } from '../jj-service';
 
 vi.mock('child_process');

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as vscode from 'vscode';
 import { JjStatusEntry } from './jj-types';
 

--- a/src/utils/format-utils.ts
+++ b/src/utils/format-utils.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import * as prettier from 'prettier/standalone';
 import * as markdownPlugin from 'prettier/plugins/markdown';
+import * as prettier from 'prettier/standalone';
 
 export async function formatCommitDescription(description: string, bodyWidthRuler: number): Promise<string> {
     // Separate the title, any empty lines immediately following it, and the content body.

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -2,20 +2,18 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { DndContext, DragOverlay, MouseSensor, TouchSensor, pointerWithin, useSensor, useSensors } from '@dnd-kit/core';
 import * as React from 'react';
-import { DndContext, DragOverlay, MouseSensor, TouchSensor, useSensor, useSensors, pointerWithin } from '@dnd-kit/core';
+import { JjStatusEntry } from '../jj-types';
+import { BookmarkPill } from './components/Bookmark';
+import { CommitDetails } from './components/CommitDetails';
+import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
+import { snapToCursorLeft } from './utils/modifiers';
+import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
 
 // Define the vscode API from the global scope (see global.d.ts)
 const vscode = window.acquireVsCodeApi();
-
-import { CommitDetails } from './components/CommitDetails';
-import { BookmarkPill } from './components/Bookmark';
-import { CommitDragPreview } from './components/CommitDragPreview';
-import { snapToCursorLeft } from './utils/modifiers';
-import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
-import { JjStatusEntry } from '../jj-types';
 
 const App: React.FC = () => {
     // Initial State from Window (injected by provider)
@@ -408,8 +406,8 @@ const App: React.FC = () => {
                         graphLabelAlignment={graphLabelAlignment}
                     />
                 </div>
-                {/* 
-                  snapCenterToCursor ensures the preview is always centered on the mouse, 
+                {/*
+                  snapCenterToCursor ensures the preview is always centered on the mouse,
                   regardless of where the user grabbed the original wide row.
                 */}
                 <DragOverlay

--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import React from 'react';
 import { useDraggable } from '@dnd-kit/core';
+import React from 'react';
 import { JjBookmark } from '../../jj-types';
 
 export const BasePill: React.FC<{

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
-import { formatCommitDescription } from '../../utils/format-utils';
 import { JjStatusEntry } from '../../jj-types';
-import { BookmarkPill, BasePill, TagPill } from './Bookmark';
+import { formatCommitDescription } from '../../utils/format-utils';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
+import { BasePill, BookmarkPill, TagPill } from './Bookmark';
 import { PersonInfo } from './PersonInfo';
 
 interface CommitDetailsProps {

--- a/src/webview/components/CommitDragPreview.tsx
+++ b/src/webview/components/CommitDragPreview.tsx
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
 import { getChangeIdDisplayLength, shortenChangeId } from '../../utils/jj-utils';
 

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -2,12 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
 import { computeGraphLayout } from '../graph-compute';
+import { computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
+import { ActionPayload, CommitNode } from './CommitNode';
 import { GraphRail } from './GraphRail';
-import { CommitNode, ActionPayload } from './CommitNode';
-import { computeGap, computeMaxShortestIdLength, computeGraphAreaWidth } from '../layout-utils';
 
 interface CommitGraphProps {
     commits: any[];

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -2,13 +2,12 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import React from 'react';
-import { useDroppable, useDraggable, useDndContext } from '@dnd-kit/core';
-
-import { IconButton } from './IconButton';
+// Needs to be available in types or duplicated.
+import { GerritClInfo } from '../../jj-types';
 import { BookmarkPill, DraggableBookmark } from './Bookmark';
-import { GerritClInfo } from '../../jj-types'; // Import GerritClInfo (needs to be available in types or duplicated)
+import { IconButton } from './IconButton';
 
 // Exported for DragOverlay in App.tsx
 export { BookmarkPill } from './Bookmark';

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
-import { GraphNode, GraphEdge } from '../graph-model';
+import { GraphEdge, GraphNode } from '../graph-model';
 
 interface GraphRailProps {
     nodes: GraphNode[];

--- a/src/webview/components/IconButton.tsx
+++ b/src/webview/components/IconButton.tsx
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
 
 interface IconButtonProps {

--- a/src/webview/components/PersonInfo.tsx
+++ b/src/webview/components/PersonInfo.tsx
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as React from 'react';
 
 export interface PersonInfoProps {

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -2,9 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import { GraphLayout, GraphNode, GraphEdge } from './graph-model';
 import { JjLogEntry } from '../jj-types';
+import { GraphEdge, GraphLayout, GraphNode } from './graph-model';
 
 function getColor(lane: number): string {
     return `var(--jj-lane-${lane % 7})`;

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { JjLogEntry } from '../jj-types';
 
 export interface GraphNode {

--- a/src/webview/index.tsx
+++ b/src/webview/index.tsx
@@ -2,11 +2,10 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import '@vscode-elements/elements';
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
-import '@vscode-elements/elements';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {

--- a/src/webview/layout-utils.ts
+++ b/src/webview/layout-utils.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { getChangeIdDisplayLength } from '../utils/jj-utils';
 
 /**

--- a/src/webview/utils/modifiers.ts
+++ b/src/webview/utils/modifiers.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { Modifier } from '@dnd-kit/core';
 
 // Custom modifier to snap the left edge of the preview to the cursor

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
Notable files:

- `src/test/jj-decoration-provider.test.ts` needed to disable sort ordering so that `vscode` could be mocked first.
- `src/test/terminal-detection.test.ts` used to have imports after `vscode` as mocked, but not sure if that's important.
- `src/test/directory-watcher.test.ts` used to have an import after `vscode` was mocked, but not sure if that's important.

Formatted all files with `npm run format`.

Thanks for the multi-diff view! It was absolutely a game changer for me to review all of this.

Also not sure if you want any other ordering rules. For example you could choose to sort Node built-ins before third-party modules, such that `fs`, `os`, and `path` are sorted before `@vscode/test-cli` in `.vscode-test-activation.mjs`, for example. Or you could want to sort all names with a `@` prefix after. Or you could want to have case-insensitive sorting. See other options at https://github.com/trivago/prettier-plugin-sort-imports?tab=readme-ov-file#apis.