### PR TITLE
fix: make selected text readable in commit details editor

### DIFF
--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -483,7 +483,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                     />
                     <style>{`
                         .commit-textarea::selection {
-                            color: transparent !important;
+                            color: var(--vscode-input-foreground) !important;
                             background-color: var(--vscode-editor-selectionBackground) !important;
                         }
                         .btn-dirty .codicon-save {


### PR DESCRIPTION
The textarea in the commit message editor uses a backdrop overlay pattern where the textarea text is transparent and the backdrop renders the actual visible text with syntax highlighting. When text was selected, the ::selection pseudo-element kept `color: transparent`, so the selection highlight obscured the backdrop text and left nothing readable.

Switch the selection text color to `var(--vscode-input-foreground)` so the textarea's own text becomes visible when selected.

Fixes #178