### PR TITLE
fix: support non-standard jj version strings

### DIFF
--- a/src/test/utils/binary-utils.test.ts
+++ b/src/test/utils/binary-utils.test.ts
@@ -146,4 +146,14 @@ func main() {
         const resultWhitespace = await resolveJjBinary('   ');
         expect(resultWhitespace).toBe('jj');
     });
+
+    test('resolveJjBinary handles non-standard version strings', async () => {
+        const binName = os.platform() === 'win32' ? 'jj-non-standard.exe' : 'jj-non-standard';
+        const binPath = path.join(tempDir, binName);
+        const versionString = 'jj 0.35-dev';
+        createExecutable(binPath, versionString);
+
+        const result = await resolveJjBinary(binPath);
+        expect(result).toBe(binPath);
+    });
 });

--- a/src/utils/binary-utils.ts
+++ b/src/utils/binary-utils.ts
@@ -57,8 +57,8 @@ async function getJjVersion(binaryPath: string): Promise<string | undefined> {
                 return;
             }
 
-            // Expected output format: "jj 0.39.0" or similar
-            const match = stdout.trim().match(/^jj\s+(\d+\.\d+\.\d+)/);
+            // Expected output format: "jj 0.39.0" or "jj 0.35.0-6dfd142d5583"
+            const match = stdout.trim().match(/^jj\s+(.+)$/);
             if (match) {
                 resolve(match[1]);
             } else {


### PR DESCRIPTION
Update the jj binary version check to be less restrictive, allowing non-standard version strings (e.g., development builds like '0.35-dev'). Previously, only strict semantic versions were accepted.

Includes a new test case in binary-utils.test.ts to verify compatibility.

Fixes #186