### PR TITLE
ci: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,23 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v5
               with:
                   version: 10
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'
 
             - name: Install Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@v6
               with:
                   go-version: '1.21'
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Set up Go stable
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@v6
               with:
                   go-version: stable
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,17 +10,17 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v5
               with:
                   version: 10
 
             - name: Install Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'pnpm'


### PR DESCRIPTION
Updates actions/checkout, actions/setup-node, actions/setup-go, and pnpm/action-setup to their latest versions that support Node.js 24. This resolves the deprecation warnings currently appearing in CI jobs.