### PR TITLE
feat: Resolve nearest visible ancestors for history gaps

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -6,7 +6,7 @@ import * as cp from 'child_process';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { LOG_ENTRY_SCHEMA, buildLogTemplate } from './jj-template-builder';
+import { LOG_ENTRY_SCHEMA, buildLogTemplate, CHANGE_ID_EXPR } from './jj-template-builder';
 import { JjLogEntry, JjStatusEntry } from './jj-types';
 import { PatchHelper, SelectionRange } from './patch-helper';
 
@@ -14,6 +14,7 @@ export interface JjLogOptions {
     revision?: string;
     limit?: number;
     omitChanges?: boolean;
+    includeNearestVisibleAncestors?: boolean;
 }
 
 // Safety timeout: if a mutation takes longer than this, unblock file watcher
@@ -264,28 +265,26 @@ export class JjService {
     }
 
     async getLog(options: JjLogOptions = {}): Promise<JjLogEntry[]> {
-        const { revision, limit, omitChanges } = options;
+        const { revision, limit, omitChanges, includeNearestVisibleAncestors } = options;
 
         let schema = LOG_ENTRY_SCHEMA;
         if (omitChanges) {
             schema = { ...LOG_ENTRY_SCHEMA };
-            delete schema['changes'];
+            delete schema.changes;
         }
 
         const args = ['-T', buildLogTemplate(schema)];
         if (revision) {
             args.push('-r', revision);
         }
-        if (limit) {
+
+        if (limit !== undefined) {
             args.push('-n', limit.toString());
-        } else if (!revision) {
-            // Safety: If no revision is specified (default view), limit to 200 entries
-            // to prevent buffer overflows and UI performance issues on huge repos.
-            args.push('-n', '200');
         }
 
         const output = await this.run('log', args, { useCachedSnapshot: true, label: 'getLog' });
         const entries: JjLogEntry[] = [];
+        const visibleIds = new Set<string>();
 
         for (const line of output.trim().split('\n')) {
             if (!line) {
@@ -297,13 +296,81 @@ export class JjService {
             }
             const jsonPart = line.substring(jsonStart);
             try {
-                const raw = JSON.parse(jsonPart);
-                entries.push(raw as JjLogEntry);
+                const entry = JSON.parse(jsonPart) as JjLogEntry;
+                entries.push(entry);
+                visibleIds.add(entry.change_id);
             } catch (e) {
                 console.error('Failed to parse log entry:', line, e);
             }
         }
+
+        if (includeNearestVisibleAncestors) {
+            await this._resolveNearestVisibleAncestors(entries, visibleIds, revision);
+        }
+
         return entries;
+    }
+
+    private async _resolveNearestVisibleAncestors(
+        entries: JjLogEntry[],
+        visibleIds: Set<string>,
+        revision?: string,
+    ): Promise<void> {
+        // Determine the search set for nearest ancestors.
+        // If an explicit revision was provided, we use that.
+        // Otherwise, we default to the configured log revset (or a safe fallback).
+        let searchSet = revision;
+        if (!searchSet) {
+            try {
+                searchSet = await this.run('config', ['get', 'revsets.log'], {
+                    useCachedSnapshot: true,
+                    label: 'getLog:revsets.log',
+                });
+            } catch {
+                searchSet = 'present(@) | ancestors(immutable_heads().., 2) | trunk()';
+            }
+        }
+
+        const followUps: Promise<void>[] = [];
+        for (const entry of entries) {
+            const parentChangeIds = entry.parent_change_ids || [];
+            const hasMissingParents = parentChangeIds.some((p) => !visibleIds.has(p));
+            if (!hasMissingParents) {
+                entry.nearest_visible_ancestors = parentChangeIds;
+                continue;
+            }
+
+            // Some parents are not in the current log slice. Find the nearest ones in the search set.
+            // We use the same change ID expression for the output to ensure consistency.
+            followUps.push(
+                (async () => {
+                    try {
+                        const results = await this.run(
+                            'log',
+                            [
+                                '-r',
+                                `heads(::(${entry.change_id}-) & (${searchSet}))`,
+                                '--no-graph',
+                                '-T',
+                                CHANGE_ID_EXPR + ' ++ "\\n"',
+                            ],
+                            { useCachedSnapshot: true, label: `nearestAncestors:${entry.change_id}` },
+                        );
+                        entry.nearest_visible_ancestors = results
+                            .split('\n')
+                            .map((l) => l.trim())
+                            .filter(Boolean);
+                    } catch (e) {
+                        this.logger(`Warning: failed to fetch nearest ancestors for ${entry.change_id}: ${e}`);
+                        entry.nearest_visible_ancestors = [];
+                    }
+                })(),
+            );
+        }
+
+        if (followUps.length > 0) {
+            await Promise.all(followUps);
+        }
     }
 
     async getLogIds(options: JjLogOptions = {}): Promise<string[]> {

--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -58,11 +58,14 @@ export function buildLogTemplate(schema: Record<string, JjTemplateField>): strin
     });
     return `"{" ++ ${parts.join(' ++ ", " ++ ')} ++ "}\\n"`;
 }
+export const CHANGE_ID_EXPR = 'if(divergent, change_id ++ "/" ++ change_offset, change_id)';
+export const CHANGE_ID_ITEM_EXPR =
+    'if(item.divergent(), item.change_id() ++ "/" ++ item.change_offset(), item.change_id())';
 
 // Schema for JjLogEntry - defines how to serialize each field
 export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     commit_id: { type: 'string', expr: 'commit_id' },
-    change_id: { type: 'string', expr: 'if(divergent, change_id ++ "/" ++ change_offset, change_id)' },
+    change_id: { type: 'string', expr: CHANGE_ID_EXPR },
     change_id_shortest: { type: 'string', expr: 'change_id.shortest()' },
     description: { type: 'json', expr: 'description' },
     author: {
@@ -108,6 +111,11 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
         type: 'stringArray',
         expr: 'parents',
         itemExpr: 'item.commit_id()',
+    },
+    parent_change_ids: {
+        type: 'stringArray',
+        expr: 'parents',
+        itemExpr: CHANGE_ID_ITEM_EXPR,
     },
     parents_immutable: {
         type: 'rawArray',

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -37,6 +37,8 @@ export interface JjLogEntry {
         timestamp: string;
     };
     parents: string[];
+    parent_change_ids?: string[];
+    nearest_visible_ancestors?: string[];
     bookmarks?: JjBookmark[];
     tags?: string[];
     working_copies?: string[];

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -603,6 +603,49 @@ log = "none()"
         expect(log.change_id_shortest!.length).toBeLessThan(log.change_id.length);
     });
 
+    test('getLog populates nearest_visible_ancestors with gaps', async () => {
+        // Setup: A -> B -> C -> D
+        const ids = await buildGraph(repo, [
+            { label: 'A', description: 'commit A' },
+            { label: 'B', parents: ['A'], description: 'commit B' },
+            { label: 'C', parents: ['B'], description: 'commit C' },
+            { label: 'D', parents: ['C'], description: 'commit D' },
+        ]);
+
+        const idA = ids['A'].changeId;
+        const idD = ids['D'].changeId;
+
+        // Fetch only A and D. B and C are "missing".
+        // Nearest visible ancestor of D in (A|D) should be A.
+        const logs = await jjService.getLog({
+            revision: `(${idA} | ${idD})`,
+            includeNearestVisibleAncestors: true,
+        });
+
+        const logD = logs.find((l) => l.change_id === idD);
+        const logA = logs.find((l) => l.change_id === idA);
+
+        expect(logD).toBeDefined();
+        expect(logA).toBeDefined();
+
+        // Immediate parent of D is C
+        expect(logD!.parents).toContain(ids['C'].commitId);
+        expect(logD!.parent_change_ids).toContain(ids['C'].changeId);
+
+        // Nearest visible ancestor of D in (A|D) is A
+        expect(logD!.nearest_visible_ancestors).toContain(idA);
+        expect(logD!.nearest_visible_ancestors?.length).toBe(1);
+
+        // A's nearest visible ancestors should be empty (no ancestors in (A|D))
+        expect(logA!.nearest_visible_ancestors?.length).toBe(0);
+    });
+
+    test('getLog does not populate nearest_visible_ancestors by default', async () => {
+        repo.describe('test');
+        const [log] = await jjService.getLog({ revision: '@' });
+        expect(log.nearest_visible_ancestors).toBeUndefined();
+    });
+
     test('getLog detects empty status correctly', async () => {
         const filePath = path.join(repo.path, 'not-empty.txt');
         fs.writeFileSync(filePath, 'content');


### PR DESCRIPTION
Implements a new capability in `JjService` to identify the most recent ancestors of a commit that are present within the current log's visibility set. This enables the UI to correctly route graph edges across "gaps" in history where intermediate commits are elided. This is in prep for addressing #87

Key changes:

- Added `nearest_visible_ancestors` and `parent_change_ids` to the log entry schema and types.
- Implemented `_resolveNearestVisibleAncestors` in `JjService` to fetch ancestor change IDs via recursive `jj log` lookups.
- Enhanced `getLog` with an opt-in `includeNearestVisibleAncestors` flag.
- Added unit tests verifying ancestor resolution in both contiguous and gapped history slices.