### PR TITLE
feat: Implement visual graph elision for history gaps

### DIFF
--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -222,7 +222,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
                 // Default jj log (usually local heads/roots)
                 const logStart = performance.now();
-                commits = await this._jj.getLog({ omitChanges: true });
+                commits = await this._jj.getLog({ omitChanges: true, includeNearestVisibleAncestors: true });
                 const logDuration = performance.now() - logStart;
                 this.outputChannel?.appendLine(
                     `[JjLogWebviewProvider] jj log took ${logDuration.toFixed(0)}ms, found ${commits.length} commits`,

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -10,10 +10,11 @@ import { TestRepo, buildGraph } from './test-repo';
 // Helper: ASCII renderer to verify layout against jj log output
 function renderToAscii(
     layout: {
-        nodes: { x: number; y: number; commitId: string }[];
+        nodes: { x: number; y: number; changeId: string }[];
         rows: {
             commit_id: string;
             parents: string[];
+            nearest_visible_ancestors?: string[];
             is_current_working_copy?: boolean;
             change_id: string;
             description: string;
@@ -23,8 +24,8 @@ function renderToAscii(
     headId: string,
 ): string {
     const rows: string[] = [];
-    const nodesById = new Map<string, { x: number; y: number; commitId: string }>(
-        layout.nodes.map((n) => [n.commitId, n]),
+    const nodesById = new Map<string, { x: number; y: number; changeId: string }>(
+        layout.nodes.map((n) => [n.changeId, n]),
     );
 
     // Calculate maximum width (number of lanes) used by any node or edge
@@ -35,7 +36,7 @@ function renderToAscii(
 
     for (let i = 0; i < layout.rows.length; i++) {
         const log = layout.rows[i];
-        const node = nodesById.get(log.commit_id);
+        const node = nodesById.get(log.change_id);
         if (!node) {
             continue;
         }
@@ -55,7 +56,7 @@ function renderToAscii(
             let symbol = ' ';
             if (node.x === x) {
                 symbol = '○';
-                if (log.parents.length === 0) {
+                if ((log.nearest_visible_ancestors || log.parents).length === 0) {
                     symbol = '◆';
                 }
                 if (log.is_current_working_copy || log.change_id === headId) {
@@ -104,7 +105,7 @@ function renderToAscii(
 
         rows.push(`${finalStr}  ${log.change_id.substring(0, 8)} ${log.description.split('\n')[0]}`.trimEnd());
 
-        if (log.parents.length === 0) {
+        if ((log.nearest_visible_ancestors || log.parents).length === 0) {
             continue; // No spacer rows needed after a root commit.
         }
 
@@ -115,7 +116,8 @@ function renderToAscii(
 
             // In jj log, if an empty child is connecting to the root commit, it skips the second spacer row
             // to save vertical space.
-            const isStraightToRoot = nextLog.parents.length === 0 && log.description === '';
+            const isStraightToRoot =
+                (nextLog.nearest_visible_ancestors || nextLog.parents).length === 0 && log.description === '';
             const spacerCount = isStraightToRoot ? 1 : 2;
 
             for (let s = 0; s < spacerCount; s++) {
@@ -275,7 +277,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'c2', description: 'C2', parents: ['c1'], isCurrentWorkingCopy: true },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const nodes = layout.nodes;
@@ -333,7 +335,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'child2', description: 'Child2', parents: ['parent'] },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const nodes = layout.nodes;
@@ -386,7 +388,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'merge', description: 'MergeChild', parents: ['p1', 'p2'] },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const mergeNode = layout.nodes.find((n) => logs[n.y].description.includes('MergeChild'));
@@ -441,7 +443,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'head', description: 'tqlynzyq', parents: ['vpm'], isCurrentWorkingCopy: true },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         // NOTE: We need to manually calculate headId because renderToAscii relied on it being in scope/verified.
@@ -511,7 +513,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'wc', description: 'WC', parents: ['main'], isCurrentWorkingCopy: true },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const headLog = logs.find((l) => l.is_current_working_copy);
@@ -545,7 +547,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         ]);
 
         const jjService = new JjService(repo.path);
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const headLog = logs.find((l) => l.is_current_working_copy);
@@ -572,7 +574,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'c', description: 'C', parents: ['p'], isCurrentWorkingCopy: true },
         ]);
 
-        const logs = await jjService.getLog();
+        const logs = await jjService.getLog({ includeNearestVisibleAncestors: true });
         const layout = computeGraphLayout(logs);
 
         const headLog = logs.find((l) => l.is_current_working_copy);
@@ -608,7 +610,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
             { label: 'wr', description: 'wr', parents: ['ux'], isCurrentWorkingCopy: true },
         ]);
 
-        const layout = computeGraphLayout(await jjService.getLog());
+        const layout = computeGraphLayout(await jjService.getLog({ includeNearestVisibleAncestors: true }));
         const headId = layout.nodes[0].changeId;
 
         const userTemplate = 'change_id.shortest(8) ++ " " ++ description ++ "\\n\\n"';
@@ -616,5 +618,40 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         const generatedOutput = renderToAscii(layout, headId).trim();
 
         expect(generatedOutput).toBe(expectedOutput);
+    });
+
+    test('History Elision Marker', async () => {
+        // Setup:
+        // A -> B -> C
+        // if we log {A, C}, the edge from C -> A should be elided.
+        await buildGraph(repo, [
+            { label: 'a', description: 'A' },
+            { label: 'b', description: 'B', parents: ['a'] },
+            { label: 'c', description: 'C', parents: ['b'] },
+        ]);
+
+        const allLogs = await jjService.getLog({});
+        const aLog = allLogs.find((l) => l.description.trim() === 'A');
+        const cLog = allLogs.find((l) => l.description.trim() === 'C');
+
+        expect(aLog).toBeDefined();
+        expect(cLog).toBeDefined();
+
+        // Manually simulate a gap by passing C and A but not B.
+        // We need to ensure C's nearest_visible_ancestors correctly points to A.
+        const cEntry = { ...cLog!, nearest_visible_ancestors: [aLog!.change_id] };
+        const logs = [cEntry, aLog!];
+
+        const layout = computeGraphLayout(logs);
+
+        const cNode = layout.nodes.find((n) => n.changeId === cLog!.change_id);
+        const aNode = layout.nodes.find((n) => n.changeId === aLog!.change_id);
+
+        expect(cNode).toBeDefined();
+        expect(aNode).toBeDefined();
+
+        const edge = layout.edges.find((e) => e.y1 === cNode!.y && e.y2 === aNode!.y);
+        expect(edge).toBeDefined();
+        expect(edge!.isElided).toBe(true);
     });
 });

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -87,7 +87,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     const graphAreaWidth = computeGraphAreaWidth(layout.width, LANE_WIDTH, LEFT_MARGIN, GAP);
 
     return (
-        <div className="commit-graph" style={{ position: 'relative' }}>
+        <div className="commit-graph" style={{ position: 'relative', paddingBottom: '20px' }}>
             {/* SVG Graph Overlay */}
             <GraphRail
                 nodes={layout.nodes}

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -20,6 +20,7 @@ const CX = W / 2;
 const CY_OFFSET = ROW_HEADER_HEIGHT / 2; // Graph is centered in the primary line (14px)
 const LEFT_MARGIN = 12; // Shift graph right to prevent clipping of halos
 const R = 8; // Max radius (W/2) for smooth curves
+const BOTTOM_PADDING = 20; // Extra room for trailing elision markers at the bottom
 
 export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, height, rowOffsets, selectedNodes }) => {
     // Layering: Leftmost lanes (lower x) should render visually on TOP.
@@ -44,7 +45,9 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
 
         const ex = x2 * W + CX + LEFT_MARGIN;
         // End Y
-        const ey = (rowOffsets[y2] || 0) + CY_OFFSET;
+        const isTrailing = y2 === rowOffsets.length - 1;
+        // Trailing edges extend 12px past the last row before being "broken" by the tilde
+        const ey = (rowOffsets[y2] || 0) + (isTrailing ? 12 : CY_OFFSET);
 
         let d = '';
 
@@ -61,7 +64,7 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
                 midY = rowOffsets[cY];
             } else {
                 // If it curves offscreen, use ey but subtract the offset to get the row boundary
-                midY = ey - CY_OFFSET;
+                midY = isTrailing ? ey : ey - CY_OFFSET;
             }
 
             // Direction for horizontal
@@ -98,16 +101,41 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
             }
         }
 
+        const ElisionMarker = () => {
+            if (!edge.isElided) return null;
+
+            // Simple pixel midpoint measures the total gap accurately.
+            const visualMid = (sy + ey) / 2;
+            let mx = sx;
+            let my = visualMid;
+
+            if (isTrailing) {
+                // For trailing edges, put it at the very end of the extended edge
+                mx = ex;
+                my = ey - 2;
+            }
+
+            return (
+                <g key={`elision-${index}`} transform={`translate(${mx}, ${my})`}>
+                    {/* Background cutout to create a clean gap in the colored line */}
+                    <rect x="-5" y="-6" width="10" height="12" fill="var(--vscode-sideBar-background)" />
+                    {/* Tilde marker ~ in disabled gray */}
+                    <path
+                        d="M -4,1 C -4,-2 -1,-2 0,0 C 1,2 4,2 4,-1"
+                        stroke="var(--vscode-descriptionForeground)"
+                        strokeWidth="2"
+                        fill="none"
+                        strokeLinecap="round"
+                    />
+                </g>
+            );
+        };
+
         return (
-            <path
-                key={`edge-${index}`}
-                d={d}
-                stroke={color}
-                strokeWidth="2"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            />
+            <React.Fragment key={`edge-group-${index}`}>
+                <path d={d} stroke={color} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                <ElisionMarker />
+            </React.Fragment>
         );
     };
 
@@ -221,8 +249,8 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
 
     // Determine graph SVG dimensions
     const svgWidth = width * W + LEFT_MARGIN + W; // Width + margin + extra buffer
-    // SVG Height is now passed in explicitly based on total row height
-    const svgHeight = height;
+    // SVG Height includes padding for trailing markers
+    const svgHeight = height + BOTTOM_PADDING;
 
     return (
         <svg

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -14,24 +14,27 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
     // The input 'commits' array is already sorted by 'jj log' (graph order).
     // We trust this order implicitly.
     const allCommits = new Map<string, JjLogEntry>();
-    commits.forEach((c) => allCommits.set(c.commit_id, c));
-
-    // Use input order directly.
-    // We don't need sorting or ancestry checks because jj has already done it.
-    const sortedRows = commits;
+    commits.forEach((c) => allCommits.set(c.change_id, c));
 
     // Layout Logic
     const nodes: GraphNode[] = [];
     const edges: GraphEdge[] = [];
-    const pendingEdges: { x1: number; y1: number; targetCommitId: string; targetLane: number; color: string }[] = [];
+    const pendingEdges: {
+        x1: number;
+        y1: number;
+        targetChangeId: string;
+        targetLane: number;
+        color: string;
+        isElided?: boolean;
+    }[] = [];
     const lanes: (string | null)[] = [];
     const nodeMap = new Map<string, GraphNode>();
 
-    sortedRows.forEach((commit, rowIndex) => {
-        const commitId = commit.commit_id;
+    commits.forEach((commit, rowIndex) => {
+        const changeId = commit.change_id;
 
         // 1. Determine my lane
-        let nodeLane = lanes.indexOf(commitId);
+        let nodeLane = lanes.indexOf(changeId);
         if (nodeLane === -1) {
             nodeLane = lanes.indexOf(null);
             if (nodeLane === -1) {
@@ -42,8 +45,8 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
         // 2. Create Node
         const nodeColor = getColor(nodeLane);
         const node: GraphNode = {
-            commitId,
-            changeId: commit.change_id,
+            commitId: commit.commit_id,
+            changeId,
             x: nodeLane,
             y: rowIndex,
             color: nodeColor,
@@ -54,23 +57,25 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
             isImmutable: commit.is_immutable,
         };
         nodes.push(node);
-        nodeMap.set(commitId, node);
+        nodeMap.set(changeId, node);
 
         // 3. Update Lanes (Clear self and overlapping)
         lanes[nodeLane] = null;
         for (let i = 0; i < lanes.length; i++) {
-            if (lanes[i] === commitId) {
+            if (lanes[i] === changeId) {
                 lanes[i] = null;
             }
         }
 
         // 4. Handle Parents (Assign Lanes & Create Edges)
-        const parents = commit.parents || [];
+        // We exclusively use nearest_visible_ancestors (change IDs).
+        const ancestors = commit.nearest_visible_ancestors || [];
+        const directParents = new Set(commit.parent_change_ids || []);
         const allocated = new Set<number>();
         allocated.add(nodeLane);
 
-        if (parents.length > 0) {
-            const p0 = parents[0];
+        if (ancestors.length > 0) {
+            const p0 = ancestors[0];
             let p0Lane = lanes.indexOf(p0);
             if (p0Lane === -1) {
                 p0Lane = nodeLane;
@@ -84,21 +89,21 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
                 p0Lane = nodeLane;
             } else {
                 // p0 already occupies a lower lane, so nodeLane is now free.
-                // Allow secondary parents to inherit it (e.g. merge's second
-                // parent continues straight down through the node's lane).
+                // Allow secondary parents to inherit it.
                 allocated.delete(nodeLane);
             }
             pendingEdges.push({
                 x1: nodeLane,
                 y1: rowIndex,
-                targetCommitId: p0,
+                targetChangeId: p0,
                 targetLane: p0Lane,
                 color: nodeColor,
+                isElided: !directParents.has(p0),
             });
         }
 
-        for (let i = 1; i < parents.length; i++) {
-            const p = parents[i];
+        for (let i = 1; i < ancestors.length; i++) {
+            const p = ancestors[i];
             let pLane = lanes.indexOf(p);
 
             if (pLane === -1) {
@@ -124,35 +129,44 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
             pendingEdges.push({
                 x1: nodeLane,
                 y1: rowIndex,
-                targetCommitId: p,
+                targetChangeId: p,
                 targetLane: pLane,
                 color: getColor(pLane),
+                isElided: !directParents.has(p),
+            });
+        }
+
+        // 4b. No visible ancestors for non-root: create trailing elided edge
+        if (ancestors.length === 0 && directParents.size > 0) {
+            pendingEdges.push({
+                x1: nodeLane,
+                y1: rowIndex,
+                targetChangeId: 'unresolved-elision', // Dummy ID for trailing edge
+                targetLane: nodeLane,
+                color: nodeColor,
+                isElided: true,
             });
         }
     });
 
     // 5. Resolve Edges
     pendingEdges.forEach((pe) => {
-        const target = nodeMap.get(pe.targetCommitId);
+        const target = nodeMap.get(pe.targetChangeId);
         let targetX: number;
         let targetY: number;
+        let isJoining: boolean = false;
 
-        let isJoining = false;
         if (target) {
             targetY = target.y;
             // Cross-lane edges (pe.x1 !== pe.targetLane) are "joining" an existing
             // vertical line in pe.targetLane. They should merge into that lane, not
             // chase the target if it later moved to a different lane.
             // Same-lane edges (pe.x1 === pe.targetLane) "own" the lane and follow
-            // the target to its final position (e.g. when a later sibling rebalances
-            // the parent leftward).
+            // the target to its final position.
             targetX = pe.x1 !== pe.targetLane ? pe.targetLane : target.x;
 
             // For joining edges where the target moved lanes (targetX !== target.x),
-            // cap y2 at the curveY of the "owning" edge — the edge that travels
-            // vertically through pe.targetLane and then curves to target.x.
-            // This prevents the joining edge from drawing a vertical line past
-            // where the lane actually curves away.
+            // cap y2 at the curveY of the "owning" edge.
             if (targetX !== target.x) {
                 const ownerEdge = edges.find((e) => e.x1 === pe.targetLane && e.x2 === target.x && e.y2 === target.y);
 
@@ -163,14 +177,12 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
             }
         } else {
             targetX = pe.targetLane;
-            targetY = sortedRows.length;
+            targetY = commits.length;
         }
 
         let curveY = targetY;
         if (pe.x1 !== targetX) {
             // For joining edges, also check the target lane for blocking nodes.
-            // Owning edges only check their source lane — they travel vertically
-            // through the source lane and curve at the end.
             const checkTargetLane = pe.x1 !== pe.targetLane;
             for (let y = pe.y1 + 1; y < targetY; y++) {
                 if (nodes[y] && (nodes[y].x === pe.x1 || (checkTargetLane && nodes[y].x === targetX))) {
@@ -189,6 +201,7 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
             color: pe.color,
             type: 'parent',
             isJoining,
+            isElided: pe.isElided || target === undefined,
         });
     });
 
@@ -197,5 +210,5 @@ export function computeGraphLayout(commits: JjLogEntry[]): GraphLayout {
         nodes.reduce((max, n) => Math.max(max, n.x + 1), 0),
     );
 
-    return { nodes, edges, width, height: sortedRows.length, rows: sortedRows };
+    return { nodes, edges, width, height: commits.length, rows: commits };
 }

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -26,6 +26,7 @@ export interface GraphEdge {
     color: string;
     type: 'parent' | 'merge'; // 'parent' usually means from Child -> Parent (Vertical/Fork). 'merge' means incoming?
     isJoining?: boolean; // True if this edge seamlessly merges into another edge's trunk
+    isElided?: boolean; // True if this edge connects to a non-direct ancestor (history gap)
 }
 
 export interface GraphLayout {


### PR DESCRIPTION
Integrates `nearest_visible_ancestors` from the `jj` log to correctly route ancestry edges across elided commits. This change introduces a visual tilde (`~`) marker on elided edges to signify gaps in the displayed history and adds support for trailing edges that extend beyond the visible working set.

Key changes:

- Refactored `graph-compute` to use `change_id` for layout tracking and `nearest_visible_ancestors` for edge routing.
- Implemented `ElisionMarker` in `GraphRail` to render tildes on elided and trailing edges.
- Added automated tests to verify elision logic and edge cases like root commits and history gaps.

Fixes #87
Fixes #88