### PR TITLE
test: stabilize SCM E2E tests and cleanup comments

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run_tests
-description: Explains how to write and run tests in the jj-view repository, detailing the test suites, their purposes, and how to filter test runs down to single test cases.
+description: Explains how to write and run tests in the jj-view repository, detailing the test suites, their purposes, and how to filter test runs down to single test cases. You must read this before editing or debuggins tests.
 ---
 
 # Testing in JJ View
@@ -26,13 +26,13 @@ You MUST run individual test cases when writing a new test or debugging a broken
 
 - **Run a single test case (Recommended):** Use the `-t` flag with the test name (you may also include the filename to narrow it down further).
     ```bash
-    pnpm test:unit -- <filename> -t "<test name>"
-    # Example: pnpm test:unit -- merge-editor.test.ts -t "should open merge editor"
+    pnpm test:unit <filename> -t "<test name>"
+    # Example: pnpm test:unit merge-editor.test.ts -t "should open merge editor"
     ```
 - **Run a specific test file:** Pass part of the filename.
     ```bash
-    pnpm test:unit -- <filename>
-    # Example: pnpm test:unit -- merge-editor
+    pnpm test:unit <filename>
+    # Example: pnpm test:unit merge-editor
     ```
 
 ### 2. Integration Tests (VS Code Test Electron)
@@ -60,7 +60,7 @@ You MUST run individual test cases when writing a new test or debugging a broken
     pnpm test:integration --grep "<test case name>"
     # Example: pnpm test:integration --grep "should register commands"
     ```
-    _(Note: `vscode-test` passes arguments to Mocha under the hood. For `pnpm`, you can pass these flags directly if they are not picked up by pnpm itself, or use `--` to be safe: `pnpm test:integration -- --grep "pattern"`)_
+    _(Note: `vscode-test` passes arguments to Mocha under the hood. For `pnpm`, you can pass these flags directly if they are not picked up by pnpm itself, or use `--` to be safe: `pnpm test:integration --grep "pattern"`)_
 
 ### 3. End-to-End (E2E) Tests (Playwright)
 
@@ -75,16 +75,19 @@ You MUST run individual test cases when writing a new test or debugging a broken
 **Filtering:**
 You MUST run individual test cases when writing a new test or debugging a broken test.
 
-- **Run a single test case (Very Strongly Recommended):** Use the `-g` flag for grep along with the filename.
+- **Run a single test case (Required):** Use the `-g` flag for grep. 
+  You can also provide the filename to narrow it down further, but just using `-g` with a unique pattern is often more convenient.
   When debugging a flaky test, append `--repeat-each 5 --max-failures 1` to run it multiple times and fail fast.
     ```bash
-    pnpm test:e2e -- <filename> -g "<test-name>" [--repeat-each 5 --max-failures 1]
-    # Example: pnpm test:e2e -- scm.spec.ts -g "squash button visibility"
+    pnpm test:e2e [-g "<test-name>"] [<filename>] [--repeat-each 5 --max-failures 1]
+    # Examples:
+    # pnpm test:e2e -g "Additional Actions"
+    # pnpm test:e2e scm.spec.ts -g "squash"
     ```
 - **Run a specific test file:** Pass the filename.
     ```bash
-    pnpm test:e2e -- <filename>
-    # Example: pnpm test:e2e -- scm.spec.ts
+    pnpm test:e2e <filename>
+    # Example: pnpm test:e2e scm.spec.ts
     ```
 
 ### 4. Debugging E2E Tests (DOM Dumping)

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -374,3 +374,29 @@ export async function redo(page: Page) {
 export async function save(page: Page) {
     await page.keyboard.press(isMac ? 'Meta+s' : 'Control+s');
 }
+
+/**
+ * Robustly sets the description in the SCM input field.
+ * Uses Playwright's .fill() most of the time, but includes
+ * explicit validation to prevent partial/mangled entries.
+ */
+export async function setScmDescription(page: Page, description: string) {
+    const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+
+    await expect(async () => {
+        // 1. Ensure the SCM input is visible and focused
+        await scmInputRow.click();
+        const textbox = scmInputRow.getByRole('textbox');
+        await expect(textbox).toBeVisible({ timeout: 2000 });
+
+        // 2. Clear the input
+        await page.keyboard.press('Control+A');
+        await page.keyboard.press('Backspace');
+
+        // 3. Set the description
+        await page.keyboard.insertText(description);
+
+        // 4. Validate the text EXACTLY matches the requested description.
+        await expect(scmInputRow).toHaveText(description, { timeout: 2000 });
+    }, `Failed to set SCM description to "${description}" reliably`).toPass({ timeout: 15000 });
+}

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { TestRepo, buildGraph } from '../test-repo';
-import { ROOT_ID, entry, expectTree, focusSCM, hoverAndClick, launchVSCode } from './e2e-helpers';
+import { ROOT_ID, entry, expectTree, focusSCM, hoverAndClick, launchVSCode, setScmDescription } from './e2e-helpers';
 
 test.describe('SCM Pane E2E', () => {
     test('Displays correct groups and populates SCM input', async () => {
@@ -43,7 +43,7 @@ test.describe('SCM Pane E2E', () => {
             await expect(mergeConflictsHeader).toBeVisible();
             await expect(workingCopyHeader).toBeVisible();
 
-            // Verify ancestor groups (merge commit is empty, so we see its parents @-2^1 and @-2^2)
+            // Verify ancestor groups (merge commit is empty, showing parents @-2^1 and @-2^2)
             await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({ timeout: 5000 });
             await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible();
 
@@ -75,25 +75,17 @@ test.describe('SCM Pane E2E', () => {
             const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
             await scmInputRow.click(); // Focus the editor
 
-            // Set Description and Commit with retry logic for stability
+            // Set Description and Commit with robust helper
+            await setScmDescription(page, 'Updated description explicitly');
+
+            // Commit using button inside the Source Control view title bar
+            const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
+            await commitButton.click();
+
+            // Wait for description to appear in log (indicating commit success)
             await expect(async () => {
-                await scmInputRow.click();
-                await page.keyboard.press('Control+A');
-                await page.keyboard.press('Backspace');
-                await page.keyboard.insertText('Updated description explicitly');
-
-                // Verify UI reflects the text before clicking commit to ensure synchronization
-                await expect(scmInputRow).toContainText('Updated description explicitly', { timeout: 2000 });
-
-                // Commit using button inside the Source Control view title bar
-                const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
-                await commitButton.click();
-
-                // Wait for description to appear in log (indicating commit success)
-                await expect(async () => {
-                    expect(repo.log()).toContain('Updated description explicitly');
-                }).toPass({ timeout: 5000 });
-            }).toPass({ timeout: 15000 });
+                expect(repo.log()).toContain('Updated description explicitly');
+            }).toPass({ timeout: 5000 });
 
             // Ensure wait for SCM refresh before next action
             await expect(scmInputRow).not.toContainText('Updated description explicitly', { timeout: 10000 });
@@ -135,40 +127,26 @@ test.describe('SCM Pane E2E', () => {
             await focusSCM(page);
             const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
 
-            // Set Description with Ctrl+S
+            // Set Description and Save with Control+S
             await expect(async () => {
-                await scmInputRow.click();
-                await page.keyboard.press('Control+A');
-                await page.keyboard.press('Backspace');
-                await page.keyboard.insertText('Using keyboard shortcuts');
+                await setScmDescription(page, 'Using keyboard shortcuts');
                 await page.keyboard.press('Control+S');
 
-                // Wait for input to be stable (doesn't change back to what it was)
+                // Wait for input to be stable (picked up by the backend)
                 expect(repo.getDescription('@').trim()).toBe('Using keyboard shortcuts');
-            }).toPass({ timeout: 10000 });
+            }).toPass({ timeout: 15000 });
 
-            // Set Description to trigger commit
+            // Set Description and Commit with Control+Enter
             await expect(async () => {
-                await scmInputRow.click();
-                await page.keyboard.press('Control+A');
-                await page.keyboard.press('Backspace');
-                await page.keyboard.insertText('Commit via keyboard');
-                await page.keyboard.press('Control+S');
+                await setScmDescription(page, 'Commit via keyboard');
+                await page.keyboard.press('Control+Enter');
 
-                await expect(async () => {
-                    expect(repo.getDescription('@').trim()).toBe('Commit via keyboard');
-                }).toPass({ timeout: 5000 });
-            }).toPass({ timeout: 10000 });
-
-            // Commit with Ctrl+Enter
-            await scmInputRow.click();
-            await page.keyboard.press('Control+Enter');
-
-            // Wait for commit to appear in log
-            await expect(async () => {
+                // Wait for it to be committed and appear in log
                 const log = repo.log();
                 expect(log).toContain('Commit via keyboard');
-            }).toPass({ timeout: 5000 });
+            }).toPass({ timeout: 15000 });
+
+            // Wait for input to clear in UI
 
             // Wait for input to clear in UI
             await expect(scmInputRow).not.toContainText('Commit via keyboard', { timeout: 10000 });
@@ -271,7 +249,7 @@ test.describe('SCM Pane E2E', () => {
 
             // File-Level Squash (file.txt)
             // Hover over file.txt in Working Copy and click Squash into Parent
-            // It shares the same codicon-arrow-down icon as the group squash action
+            // file.txt and the group squash action share the same codicon-arrow-down icon
             const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
             // Use role and more flexible title matching for reliability across VS Code versions
             const squashFileIcon = wcFileRow.getByRole('button', { name: /Squash into (Parent|Ancestor)/ }).first();
@@ -292,8 +270,7 @@ test.describe('SCM Pane E2E', () => {
             // Wait for Diff Editor
             await page.waitForSelector('.monaco-diff-editor');
 
-            // In VS Code, diff editors have left and right.
-            // We want to edit the right side (working copy).
+            // Edit the right side of the diff editor (the working copy)
             const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
             await rightEditor.click();
 
@@ -325,15 +302,9 @@ test.describe('SCM Pane E2E', () => {
                 expect(content).toBe('edited from diff');
             }).toPass({ timeout: 20000 });
 
-            // Squash Into Ancestor (file.txt)
-            // Need a setup with a grandparent. Let's create one on the fly.
-            // Oh wait, `initial` is the parent of `wc`. Let's use `initial` as the grandparent.
-            // Actually, we need to commit `wc` to make a parent, then create a new `wc` on top.
+            // Create a chain (initial -> wc_commit -> new_wc) to verify squash into a non-immediate ancestor
             await focusSCM(page);
-            const scmInputRow2 = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow2.click();
-            await page.keyboard.press('Control+A');
-            await page.keyboard.insertText('commit wc');
+            await setScmDescription(page, 'commit wc');
             await page.keyboard.press('Control+Enter');
 
             await expect(async () => {
@@ -356,7 +327,7 @@ test.describe('SCM Pane E2E', () => {
             const squashIcon = newWcFileRow.getByRole('button', { name: 'Squash into Parent', exact: true }).first();
             await expect(squashIcon).toBeVisible();
 
-            // The squashInto action should be visible because we have two mutable ancestors (the previous wc commit, and initial).
+            // The squashInto action should be visible since there are two mutable ancestors
             const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash into Ancestor/ }).first();
             await hoverAndClick(newWcFileRow, squashIntoIcon);
 
@@ -433,12 +404,15 @@ test.describe('SCM Pane E2E', () => {
             const detailsIcon = ancestorRow
                 .locator('.action-item', { has: page.locator('.codicon-list-selection') })
                 .first();
-            await hoverAndClick(ancestorRow, detailsIcon);
 
-            // Assert that the Commit Details panel opened (it opens as an editor tab)
-            await expect(page.getByRole('tab', { name: /^Commit: / })).toBeVisible({ timeout: 5000 });
+            // Assert that the Commit Details panel opens (it opens as an editor tab)
+            // Use toPass to retry the entire Open Details sequence in case the icon/click was missed during SCM refresh.
+            await expect(async () => {
+                await hoverAndClick(ancestorRow, detailsIcon);
+                await expect(page.getByRole('tab', { name: /^Commit: / })).toBeVisible({ timeout: 5000 });
+            }).toPass({ timeout: 20000 });
 
-            // Ensure we switch focus back to SCM View if needed, though sidebar might still be visible
+            // Return focus to SCM View
             await focusSCM(page);
 
             // 3. Move to Child (Pull from Ancestor)


### PR DESCRIPTION
Introduces a robust `setScmDescription` helper in `e2e-helpers.ts` to replace fragile manual keyboard sequences in SCM tests. This helper uses a retry-wrapped clear-and-type strategy with explicit validation to prevent partial description entries that were causing CI flakiness.

Additionally, performs a pass over `scm.spec.ts` to refine "stream of consciousness" comments into a more concise and professional technical style.