### PR TITLE
Refactor upload command logic for better flexibility

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -13,29 +13,27 @@ export async function uploadCommand(
     args: unknown[],
     outputChannel: vscode.OutputChannel,
 ): Promise<void> {
-    const revision = extractRevision(args) || '@';
+    const revision = extractRevision(args);
     const config = vscode.workspace.getConfiguration('jj-view');
     const customCommand = config.get<string>('uploadCommand');
     const hasCustomCommand = !!(customCommand && customCommand.trim().length > 0);
     try {
-        let args: string[] = [];
+        let commandStr = '';
         if (hasCustomCommand) {
-            args = customCommand!.trim().split(/\s+/);
+            commandStr = customCommand!.trim();
         } else {
             const isGerrit = await gerrit.isGerrit();
-            if (isGerrit) {
-                args = ['gerrit', 'upload'];
-            } else {
-                args = ['git', 'push'];
-            }
+            commandStr = isGerrit ? 'gerrit upload' : 'git push';
         }
 
-        if (args.length === 0) {
+        if (commandStr.length === 0) {
             vscode.window.showErrorMessage('Invalid upload command configuration.');
             return;
         }
 
-        await withDelayedProgress(`Uploading revision ${revision.substring(0, 8)}...`, jj.upload(args, revision));
+        const [subcommand, ...commandArgs] = commandStr.split(/\s+/);
+        const title = revision ? `Uploading revision ${revision.substring(0, 8)}...` : 'Uploading...';
+        await withDelayedProgress(title, jj.upload(revision, subcommand, ...commandArgs));
 
         gerrit.requestRefreshWithBackoffs();
         vscode.window.setStatusBarMessage('Upload successful', 3000);

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -961,8 +961,12 @@ export class JjService {
         return this.run('diff', ['--git', '-r', revision, relativePath], { useCachedSnapshot: true });
     }
 
-    async upload(commandArgs: string[], revision: string): Promise<string> {
-        return this.run(commandArgs[0], [...commandArgs.slice(1), '-r', revision], {
+    async upload(revision: string | undefined, command: string, ...args: string[]): Promise<string> {
+        const finalArgs = [...args];
+        if (revision) {
+            finalArgs.push('-r', revision);
+        }
+        return this.run(command, finalArgs, {
             isMutation: true,
             timeout: UPLOAD_TIMEOUT_MS,
         });

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -51,7 +51,7 @@ describe('uploadCommand', () => {
         await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         // Should use the custom command
-        expect(jjService.upload).toHaveBeenCalledWith(['git', 'push', '--force'], 'rev-123');
+        expect(jjService.upload).toHaveBeenCalledWith('rev-123', 'git', 'push', '--force');
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
@@ -61,7 +61,7 @@ describe('uploadCommand', () => {
         await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         // Default for non-Gerrit is git push
-        expect(jjService.upload).toHaveBeenCalledWith(['git', 'push'], 'rev-123');
+        expect(jjService.upload).toHaveBeenCalledWith('rev-123', 'git', 'push');
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
@@ -71,7 +71,7 @@ describe('uploadCommand', () => {
         // This simulates the webview payload: { changeId: 'rev-object' }
         await uploadCommand(jjService, gerritService, [{ changeId: 'rev-object' }], mockOutputChannel);
 
-        expect(jjService.upload).toHaveBeenCalledWith(['git', 'push'], 'rev-object');
+        expect(jjService.upload).toHaveBeenCalledWith('rev-object', 'git', 'push');
     });
 
     test('suggests configuration when upload fails and no custom command set', async () => {

--- a/src/test/jj-service-timeout.test.ts
+++ b/src/test/jj-service-timeout.test.ts
@@ -29,7 +29,7 @@ describe('JjService Timeout Tests', () => {
             return {} as cp.ChildProcess;
         });
 
-        const uploadPromise = jjService.upload(['git', 'push'], '@');
+        const uploadPromise = jjService.upload('@', 'git', 'push');
 
         // Advance 2 minutes - should still be pending (upload timeout is 6 mins)
         // We use advanceTimersByTimeAsync to ensure pending timers are processed

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1378,4 +1378,28 @@ log = "none()"
         expect(currentWcEntry!.change_id).toBe(currentWcId);
         expect(currentWcEntry!.working_copies).toContain('default@');
     });
+
+    describe('upload', () => {
+        test('upload with revision includes -r flag', async () => {
+            try {
+                // In a test repo without remotes, jj git push -r <bad-rev> should fail with a revision error
+                await jjService.upload('non-existent-rev', 'git', 'push');
+                expect.fail('Should have failed due to non-existent revision');
+            } catch (e: unknown) {
+                if (e instanceof Error) {
+                    // This confirms the -r flag was passed because jj is complaining about the specific revision string
+                    expect(e.message).toContain('non-existent-rev');
+                } else {
+                    throw e;
+                }
+            }
+        });
+
+        test('upload without revision omits -r flag', async () => {
+            // In a test repo, jj git push (without remotes) should naturally succeed or fail
+            // without a revision-specific error if our change successfully omitted the -r flag.
+            await jjService.upload(undefined, 'git', 'push');
+        });
+    });
 });
+


### PR DESCRIPTION
Refactors the `uploadCommand` and `JjService.upload` to support more dynamic command execution. The revision flag (`-r`) is now conditionally applied only when a revision is explicitly provided, allowing jj to handle default revision selection. This change also cleans up how custom upload commands are parsed and executed, and adds unit tests to verify the conditional flag logic and general upload behavior.

#180