### PR TITLE
fix: align bookmarks and status pills vertically

### DIFF
--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -115,6 +115,8 @@ export const DraggableBookmark: React.FC<{ bookmark: JjBookmark }> = ({ bookmark
         cursor: isDragging ? 'grabbing' : 'grab',
         opacity: isDragging ? 0.3 : 1, // Show pending state
         filter: isDragging ? 'grayscale(100%)' : 'none',
+        display: 'inline-flex',
+        alignItems: 'center',
     };
 
     return (

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -219,6 +219,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                             display: 'flex',
                             gap: '6px',
                             flexWrap: 'wrap',
+                            alignItems: 'center',
                             fontSize: '11px',
                             fontWeight: 'normal',
                         }}

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -359,7 +359,9 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                     </span>
 
                     {/* Right-aligned Bookmarks */}
-                    <span style={{ display: 'flex', marginLeft: 'auto', flexShrink: 0, gap: '4px' }}>
+                    <span
+                        style={{ display: 'flex', marginLeft: 'auto', flexShrink: 0, gap: '4px', alignItems: 'center' }}
+                    >
                         {commit.bookmarks &&
                             commit.bookmarks.map((bookmark: any) => (
                                 <DraggableBookmark


### PR DESCRIPTION
Apply consistent flex centering to bookmark and status pill containers in the webview. This ensures that draggable local bookmarks, remote bookmarks, and status badges (Immutable, Empty, Conflicted) are all correctly aligned vertically in both the commit log and detail views.

Fixes #201