### PR TITLE
test: Stabilize E2E tests for Settings editor

### DIFF
--- a/src/test/e2e/binary-config.spec.ts
+++ b/src/test/e2e/binary-config.spec.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { TestRepo } from '../test-repo';
-import { launchVSCode } from './e2e-helpers';
+import { expectSettingsOpen, launchVSCode } from './e2e-helpers';
 
 test.describe('JJ Binary Configuration E2E', () => {
     test('Shows error and opens settings for invalid binary path', async () => {
@@ -35,13 +35,8 @@ test.describe('JJ Binary Configuration E2E', () => {
             const configureButton = notification.getByRole('button', { name: 'Configure Path' });
             await configureButton.click();
 
-            // Verify settings editor is open
-            await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible({ timeout: 15000 });
-
-            // Verify the 'Binary Path' setting item is visible and has the invalid path value
-            // (Standard VS Code settings verify pattern)
-            const settingItem = page.locator('.setting-item').filter({ hasText: 'Binary Path' });
-            await expect(settingItem).toBeVisible({ timeout: 10000 });
+            // Verify settings editor is open and find the Binary Path setting
+            const settingItem = await expectSettingsOpen(page, 'Binary Path');
             await expect(settingItem.locator('input')).toHaveValue(invalidPath);
         } finally {
             await app.close();
@@ -80,9 +75,8 @@ test.describe('JJ Binary Configuration E2E', () => {
             await configureButton.click();
 
             // Verify settings
-            await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible({ timeout: 15000 });
-            const settingItem = page.locator('.setting-item').filter({ hasText: 'Binary Path' });
-            await expect(settingItem).toBeVisible({ timeout: 10000 });
+            const settingItem = await expectSettingsOpen(page, 'Binary Path');
+
             // Since we set it to empty string in the setup, the UI should show an empty input
             await expect(settingItem.locator('input')).toHaveValue('');
         } finally {

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -6,7 +6,15 @@ import { Page, expect, test } from '@playwright/test';
 import * as fs from 'fs';
 import { ElectronApplication, type Frame } from 'playwright';
 import { type CommitId, TestRepo, buildGraph } from '../test-repo';
-import { focusJJLog, getLogWebview, launchVSCode, redo, save, undo } from './e2e-helpers';
+import {
+    expectSettingsOpen,
+    focusJJLog,
+    getLogWebview,
+    launchVSCode,
+    redo,
+    save,
+    undo,
+} from './e2e-helpers';
 
 /**
  * Finds the webview frame containing the Commit Details panel.
@@ -443,15 +451,11 @@ test.describe('Commit Details E2E', () => {
         await settingsLink.click();
 
         // The VS Code Settings tab should open
-        await expect(page.getByRole('tab', { name: 'Settings' })).toBeVisible({ timeout: 15000 });
+        const titleItem = await expectSettingsOpen(page, 'Title Width Ruler');
+        await expect(titleItem.locator('input')).toHaveValue('50');
 
-        // Also verify the settings are actually filtered and showing our custom setting
-        // And check their default values (50 and 72)
-        const titleInput = page.locator('.setting-item').filter({ hasText: 'Title Width Ruler' }).locator('input');
-        await expect(titleInput).toHaveValue('50');
-
-        const bodyInput = page.locator('.setting-item').filter({ hasText: 'Body Width Ruler' }).locator('input');
-        await expect(bodyInput).toHaveValue('72');
+        const bodyItem = await expectSettingsOpen(page, 'Body Width Ruler');
+        await expect(bodyItem.locator('input')).toHaveValue('72');
     });
 
     test('Displays pills and person info correctly', async () => {

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -376,6 +376,27 @@ export async function save(page: Page) {
 }
 
 /**
+ * Robustly waits for the Settings editor to be open and visible.
+ * Handles both traditional tab-based and newer modal-based layouts.
+ * Returns the locator for the specific setting item.
+ */
+export async function expectSettingsOpen(page: Page, settingName: string | RegExp): Promise<Locator> {
+    let settingItem: Locator | undefined;
+    await expect(async () => {
+        // Look for the settings editor container which is common to both layouts
+        const editor = page.locator('.settings-editor');
+        await expect(editor).toBeVisible({ timeout: 5000 });
+
+        // The settings editor can be slow to filter or render the item.
+        // We search for a .setting-item that contains the text
+        settingItem = page.locator('.setting-item').filter({ hasText: settingName });
+        await expect(settingItem.first()).toBeVisible({ timeout: 5000 });
+    }, `Failed to find Settings editor or specified setting "${settingName}"`).toPass({ timeout: 20000 });
+
+    return settingItem!.first();
+}
+
+/**
  * Robustly sets the description in the SCM input field.
  * Uses Playwright's .fill() most of the time, but includes
  * explicit validation to prevent partial/mangled entries.


### PR DESCRIPTION
Introduces a robust `expectSettingsOpen` helper in `e2e-helpers.ts` that handles both traditional tab-based and newer modal-based Settings layouts.

The helper ensures the Settings editor is visible and verifies that a specific setting item is rendered before the test continues, preventing race conditions in CI where search results may take a moment to appear.

Updated `binary-config.spec.ts` and `commit-details.spec.ts` to use this new pattern.