### PR TITLE
chore parallelize CI workflow and optimize test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,8 @@ on:
             - main
 
 jobs:
-    build:
-        permissions:
-            contents: write
-        strategy:
-            matrix:
-                os: [ubuntu-latest, macos-latest, windows-latest]
-        runs-on: ${{ matrix.os }}
+    prepare:
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -45,51 +40,218 @@ jobs:
               with:
                   tool: jj-cli
 
+            - name: Verify Environment
+              run: |
+                  go version
+                  jj --version
+                  which jj
+
             - name: Install Dependencies
               run: pnpm install --frozen-lockfile
 
             - name: Lint
-              if: runner.os == 'Linux'
               run: pnpm lint
 
             - name: Check Types
-              if: runner.os == 'Linux'
               run: pnpm check-types
 
-            - name: Build Extension (Verification)
-              run: pnpm build
+            - name: Build Extension
+              run: node esbuild.js
+
+            - name: Build Tests
+              run: pnpm build:tests
 
             - name: Package Extension
-              if: runner.os == 'Linux'
               run: pnpm package --out jj-view.vsix
 
             - name: Verify VSIX Contents
-              if: runner.os == 'Linux'
               run: pnpm exec ts-node scripts/verify-vsix.ts jj-view.vsix
+
+            - name: Upload Build Artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: build-outputs
+                  path: |
+                      dist/
+                      out/
+                      jj-view.vsix
+                  retention-days: 1
+
+    unit-tests:
+        needs: prepare
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  version: 10
+
+            - name: Install Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: 'pnpm'
+
+            - name: Install Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version: '1.21'
+
+            - name: Install jj (Jujutsu)
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: jj-cli
+
+            - name: Verify Environment
+              run: |
+                  go version
+                  jj --version
+                  which jj
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Download Build Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: build-outputs
+                  path: .
 
             - name: Run Unit Tests
               run: pnpm test:unit
 
+    integration-tests:
+        needs: prepare
+        strategy:
+            matrix:
+                os: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  version: 10
+
+            - name: Install Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: 'pnpm'
+
+            - name: Install Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version: '1.21'
+
+            - name: Install jj (Jujutsu)
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: jj-cli
+
+            - name: Verify Environment
+              run: |
+                  go version
+                  jj --version
+                  which jj
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Download Build Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: build-outputs
+                  path: .
+
             - name: Run Integration Tests (Linux)
               if: runner.os == 'Linux'
-              run: xvfb-run -a pnpm test:integration
+              run: xvfb-run -a pnpm exec vscode-test --config .vscode-test.mjs && xvfb-run -a pnpm exec vscode-test --config .vscode-test-activation.mjs
 
             - name: Run Integration Tests (macOS/Windows)
               if: runner.os != 'Linux'
-              run: pnpm test:integration
+              run: |
+                  pnpm exec vscode-test --config .vscode-test.mjs
+                  pnpm exec vscode-test --config .vscode-test-activation.mjs
 
-            - name: Install Playwright Browsers & Dependencies
-              if: runner.os == 'Linux'
+    e2e-tests:
+        needs: prepare
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v5
+              with:
+                  version: 10
+
+            - name: Install Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: 'pnpm'
+
+            - name: Install Go
+              uses: actions/setup-go@v6
+              with:
+                  go-version: '1.21'
+
+            - name: Install jj (Jujutsu)
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: jj-cli
+
+            - name: Verify Environment
+              run: |
+                  go version
+                  jj --version
+                  which jj
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Download Build Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: build-outputs
+                  path: .
+
+            - name: Install Playwright Chromium
               run: pnpm playwright install --with-deps chromium
 
-            - name: Run E2E Tests (Linux)
-              if: runner.os == 'Linux'
+            - name: Run E2E Tests
               env:
                   VSIX_PATH: jj-view.vsix
-              run: xvfb-run -a pnpm test:e2e
+              run: xvfb-run -a pnpm exec playwright test -c playwright.e2e.config.ts
+
+    release:
+        needs: [unit-tests, integration-tests, e2e-tests]
+        runs-on: ubuntu-latest
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name != 'pull_request'
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Download Build Artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: build-outputs
+                  path: .
 
             - name: Generate Release Info
-              if: runner.os == 'Linux'
               id: release_info
               run: |
                   VERSION=$(jq -r .version package.json)
@@ -123,15 +285,14 @@ jobs:
                   echo "" >> $GITHUB_OUTPUT
                   echo "EOF" >> $GITHUB_OUTPUT
 
-            - name: Upload Artifact
-              if: runner.os == 'Linux'
+            - name: Upload Persistent Artifact
               uses: actions/upload-artifact@v4
               with:
-                  name: jj-view-extension
+                  name: jj-view-extension-packaged
                   path: ${{ steps.release_info.outputs.vsix_name }}
 
             - name: Update Prerelease
-              if: runner.os == 'Linux' && github.ref == 'refs/heads/main'
+              if: github.ref == 'refs/heads/main'
               uses: softprops/action-gh-release@v1
               with:
                   tag_name: prerelease
@@ -142,7 +303,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Release
-              if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux'
+              if: startsWith(github.ref, 'refs/tags/v')
               uses: softprops/action-gh-release@v1
               with:
                   files: ${{ steps.release_info.outputs.vsix_name }}

--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
     testDir: './src/test/e2e',
+    globalSetup: require.resolve('./src/test/e2e/global-setup'),
     timeout: 60000,
     expect: {
         timeout: 10000,

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -106,14 +106,13 @@ export async function launchVSCode(
         if (!fs.existsSync(vsixPath)) {
             throw new Error(`VSIX_PATH is set but file does not exist: ${vsixPath}`);
         }
-
         // Import utilities from @vscode/test-electron to find the CLI path
         const { resolveCliPathFromVSCodeExecutablePath } = await import('@vscode/test-electron');
         const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodePath);
 
         // Install the extension via CLI
         const { spawnSync } = await import('child_process');
-        console.log(`Installing VSIX from ${vsixPath}...`);
+        console.log(`Installing VSIX from ${vsixPath} using CLI ${cliPath}...`);
         const result = spawnSync(cliPath, ['--install-extension', vsixPath, '--extensions-dir', extensionsDir], {
             encoding: 'utf-8',
             stdio: 'inherit',

--- a/src/test/e2e/global-setup.ts
+++ b/src/test/e2e/global-setup.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+
+/**
+ * Downloads and unzips VS Code sequentially before Playwright spawns parallel
+ * worker threads, preventing race conditions (e.g., 'tar: Cannot mkdir') when
+ * multiple workers attempt to extract the archive to the same directory.
+ */
+async function globalSetup() {
+    process.stdout.write('Downloading and unzipping VS Code (Global Setup)...\n');
+    await downloadAndUnzipVSCode();
+    process.stdout.write('VS Code download complete.\n');
+}
+
+export default globalSetup;

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -27,8 +27,9 @@ export class TestRepo {
     // and prevent arbitrary command execution in tests.
     private exec(args: string[], options: { trim?: boolean; suppressStderr?: boolean } = {}) {
         const env = { ...process.env, JJ_CONFIG: '' };
+        const jjBinary = 'jj';
         try {
-            const output = cp.execFileSync('jj', ['--quiet', ...args], {
+            const output = cp.execFileSync(jjBinary, ['--quiet', ...args], {
                 cwd: this.path,
                 encoding: 'utf-8',
                 env,
@@ -36,14 +37,31 @@ export class TestRepo {
             });
             return options.trim !== false ? output.trim() : output;
         } catch (e: unknown) {
-            const err = e as { stdout?: Buffer; stderr?: Buffer };
+            const err = e as {
+                stdout?: Buffer;
+                stderr?: Buffer;
+                code?: string;
+                status?: number;
+                path?: string;
+                message?: string;
+            };
             const stderr = err.stderr?.toString() || '';
+
+            // Handle "Command not found" specifically
+            if (err.code === 'ENOENT') {
+                const pathEnv = process.env.PATH || 'undefined';
+                throw new Error(
+                    `Could not find '${jjBinary}' binary in PATH.\n` +
+                        `Current PATH: ${pathEnv}\n` +
+                        `Check if jj is installed and available in the environment.`,
+                );
+            }
 
             // If the working copy is stale, try again with --ignore-working-copy
             // if we haven't already tried it.
             if (stderr.toLowerCase().includes('working copy is stale') && !args.includes('--ignore-working-copy')) {
                 try {
-                    const output = cp.execFileSync('jj', ['--quiet', '--ignore-working-copy', ...args], {
+                    const output = cp.execFileSync(jjBinary, ['--quiet', '--ignore-working-copy', ...args], {
                         cwd: this.path,
                         encoding: 'utf-8',
                         env,
@@ -56,8 +74,13 @@ export class TestRepo {
             }
 
             // Re-throw with stdout/stderr for easier debugging
+            const stdout = err.stdout?.toString() || 'undefined';
             throw new Error(
-                `Command failed: jj ${args.join(' ')}\nStdout: ${err.stdout?.toString()}\nStderr: ${stderr}`,
+                `Command failed: jj ${args.join(' ')}\n` +
+                    `Status: ${err.status}\n` +
+                    `Stdout: ${stdout}\n` +
+                    `Stderr: ${stderr}\n` +
+                    `Raw Error: ${err.message}`,
             );
         }
     }


### PR DESCRIPTION
Decomposes the monolithic CI "build" job into a multi-stage pipeline: 'prepare', 'unit-tests', 'integration-tests', 'e2e-tests', and 'release'. This restructuring enables concurrent execution of test suites while ensuring the extension is only built and linted once. Build artifacts (dist/, out/, and VSIX) are now shared across jobs via GitHub Action artifacts, significantly reducing overall CI wall-clock time and preventing redundant compilation.