### PR TITLE
chore: tidy up playwright test output and test infrastructure

### DIFF
--- a/playwright.e2e.config.ts
+++ b/playwright.e2e.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     expect: {
         timeout: 10000,
     },
-    reporter: 'line',
+    reporter: 'list',
     use: {
         trace: 'on-first-retry',
     },

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Locator, expect } from '@playwright/test';
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { SilentReporter, downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -85,7 +85,7 @@ export async function launchVSCode(
     );
 
     const extensionPath = path.resolve(__dirname, '../../../../');
-    const vscodePath = await downloadAndUnzipVSCode();
+    const vscodePath = await downloadAndUnzipVSCode({ reporter: new SilentReporter() });
 
     const args = [
         repo.path,

--- a/src/test/screenshots/generate.spec.ts
+++ b/src/test/screenshots/generate.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { test } from '@playwright/test';
-import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { SilentReporter, downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -119,7 +119,7 @@ if __name__ == "__main__":
 
     // 2. Launch VS Code
     const extensionPath = path.resolve(__dirname, '../../../');
-    const vscodePath = await downloadAndUnzipVSCode();
+    const vscodePath = await downloadAndUnzipVSCode({ reporter: new SilentReporter() });
     const executablePath = vscodePath;
 
     // Launch with strict isolation

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -327,6 +327,7 @@ export interface CommitId {
 
 export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): Promise<Record<string, CommitId>> {
     const labelToId: Record<string, CommitId> = {};
+    const metadataOps: { type: 'bookmark' | 'tag', name: string, changeId: string }[] = [];
 
     // Helper to resolve parents
     const resolveParents = (parents?: string[]): string[] => {
@@ -349,9 +350,6 @@ export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): P
             }
         }
 
-        // Snapshot changes so they become part of the commit
-        // 'jj new' automatically snapshots the *previous* WC, but here we are in the WC of the *current* commit we just created with 'new'
-
         // Capture ID
         const changeId = repo.getChangeId('@');
         const commitId = repo.getCommitId('@');
@@ -359,18 +357,30 @@ export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): P
             labelToId[commit.label] = { changeId, commitId };
         }
 
-        // Apply bookmarks
+        // Collect bookmarks for later application
         if (commit.bookmarks) {
             for (const bookmark of commit.bookmarks) {
-                repo.bookmark(bookmark, '@');
+                metadataOps.push({ type: 'bookmark', name: bookmark, changeId });
             }
         }
 
-        // Apply tags
+        // Collect tags for later application
         if (commit.tags) {
             for (const tag of commit.tags) {
-                repo.tag(tag, '@');
+                metadataOps.push({ type: 'tag', name: tag, changeId });
             }
+        }
+    }
+
+    // Apply metadata (tags and bookmarks) to specific IDs.
+    // This is done after the initial graph construction loop so that 
+    // metadata operations (which might make commits immutable) don't 
+    // affect the working copy commit (@) during construction.
+    for (const op of metadataOps) {
+        if (op.type === 'bookmark') {
+            repo.bookmark(op.name, op.changeId);
+        } else if (op.type === 'tag') {
+            repo.tag(op.name, op.changeId);
         }
     }
 


### PR DESCRIPTION
This change focuses on improving the developer experience and CI reliability by cleaning up test-related output and refactoring test helpers:

- Uses `SilentReporter` for VS Code downloads in E2E tests and screenshot generation to reduce log noise.
- Switches Playwright E2E configuration to use the `linelist` reporter.
- Refactors `TestRepo.buildGraph` to apply bookmarks and tags after the initial graph construction, preventing metadata operations from interfering with the working copy state during test setup.