### PR TITLE
fix: adjust compact graph label alignment to prevent overlaps

### DIFF
--- a/src/test/layout-utils.test.ts
+++ b/src/test/layout-utils.test.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../webview/layout-utils';
+import { computeCompactRowMaxX, computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../webview/layout-utils';
+import { GraphLayout } from '../webview/graph-model';
+import { JjLogEntry } from '../jj-types';
+import { createMock } from './test-utils';
 
 describe('Layout Utils', () => {
     describe('computeGap', () => {
@@ -47,6 +50,56 @@ describe('Layout Utils', () => {
             // graphWidth * laneWidth + leftMargin + gap
             // 2 * 16 + 12 + 10 = 32 + 12 + 10 = 54
             expect(computeGraphAreaWidth(2, 16, 12, 10)).toBe(54);
+        });
+    });
+
+    describe('computeCompactRowMaxX', () => {
+        it('should account for node positions', () => {
+            const layout: GraphLayout = {
+                nodes: [
+                    { commitId: 'c1', changeId: 'c1', x: 0, y: 0, color: 'red', isCurrentWorkingCopy: false },
+                ],
+                edges: [],
+                width: 3,
+                height: 1,
+                rows: [createMock<JjLogEntry>({})],
+            };
+            const result = computeCompactRowMaxX(layout);
+            expect(result).toEqual([0]);
+        });
+
+        it('should account for vertical edges passing through rows', () => {
+            const layout: GraphLayout = {
+                nodes: [
+                    { commitId: 'c1', changeId: 'c1', x: 0, y: 0, color: 'red', isCurrentWorkingCopy: false },
+                ],
+                edges: [{ x1: 2, y1: 0, x2: 2, y2: 2, curveY: 2, type: 'parent', color: 'green' }],
+                width: 3,
+                height: 3,
+                rows: [createMock<JjLogEntry>({}), createMock<JjLogEntry>({}), createMock<JjLogEntry>({})],
+            };
+            const result = computeCompactRowMaxX(layout);
+            // Edge at x1=2 for y=0,1. Edge at x2=2 for y=2.
+            expect(result).toEqual([2, 2, 2]);
+        });
+
+        it('should ignore curved segments when determining max lane', () => {
+            const layout: GraphLayout = {
+                nodes: [
+                    { commitId: 'c1', changeId: 'c1', x: 0, y: 0, color: 'red', isCurrentWorkingCopy: false },
+                ],
+                edges: [
+                    { x1: 4, y1: 0, x2: 0, y2: 2, curveY: 2, type: 'parent', color: 'green' },
+                ],
+                width: 6,
+                height: 3,
+                rows: [createMock<JjLogEntry>({}), createMock<JjLogEntry>({}), createMock<JjLogEntry>({})],
+            };
+            const result = computeCompactRowMaxX(layout);
+            // Node at row 0: x=0. Edge at row 0: y<curveY -> x1=4. max=4.
+            // Edge at row 1: y<curveY -> x1=4. max=4.
+            // Edge at row 2: y>=curveY -> x2=0. max=0.
+            expect(result).toEqual([4, 4, 0]);
         });
     });
 });

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -4,7 +4,7 @@
  */
 import * as React from 'react';
 import { computeGraphLayout } from '../graph-compute';
-import { computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
+import { computeCompactRowMaxX, computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
 import { ActionPayload, CommitNode } from './CommitNode';
 import { GraphRail } from './GraphRail';
 
@@ -43,12 +43,13 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             return undefined;
         }
         const map = new Map<string, number>();
+        const rowMaxX = computeCompactRowMaxX(layout);
         layout.nodes.forEach((n) => {
-            const padding = computeGraphAreaWidth(n.x + 1, LANE_WIDTH, LEFT_MARGIN, GAP);
+            const padding = computeGraphAreaWidth(rowMaxX[n.y] + 1, LANE_WIDTH, LEFT_MARGIN, GAP);
             map.set(n.commitId, padding);
         });
         return map;
-    }, [layout.nodes, graphLabelAlignment]);
+    }, [layout, graphLabelAlignment, GAP, LANE_WIDTH, LEFT_MARGIN]);
 
     // Calculate Row Offsets
     // This allows us to have variable height rows while keeping the graph aligned.

--- a/src/webview/layout-utils.ts
+++ b/src/webview/layout-utils.ts
@@ -3,6 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { getChangeIdDisplayLength } from '../utils/jj-utils';
+import { GraphLayout } from './graph-model';
+
+/**
+ * Calculates the maximum lane index occupied by any graph element (node or edge) in each row.
+ * This is used for 'compact' label alignment to push text securely to the right of all lanes.
+ *
+ * The rule is: No text is ever drawn to the left of an edge passing through its row center.
+ * Crucially, horizontal curves exist in the space *between* rows. Therefore, an edge is
+ * completely at `x1` above its curve row, and completely at `x2` at/below its curve row.
+ */
+export function computeCompactRowMaxX(layout: GraphLayout): number[] {
+    const rowMaxX = new Array(layout.rows.length).fill(0);
+
+    for (const { x, y } of layout.nodes) {
+        if (y >= 0 && y < rowMaxX.length) rowMaxX[y] = Math.max(rowMaxX[y], x);
+    }
+
+    for (const e of layout.edges) {
+        const cY = e.curveY ?? e.y2;
+        for (let y = Math.max(0, e.y1); y <= e.y2 && y < rowMaxX.length; y++) {
+            // If the row center is above the curve, it is at x1.
+            // If the row center is at or below the curve, it has already curved to x2.
+            rowMaxX[y] = Math.max(rowMaxX[y], y < cY ? e.x1 : e.x2);
+        }
+    }
+
+    return rowMaxX;
+}
 
 /**
  * Calculates the gap between the commit graph and the text content based on font size.


### PR DESCRIPTION
This change implements a more accurate padding calculation for the 'compact' graph alignment. By correctly identifying which vertical lanes actually pass through a row center and ignoring horizontal curve segments that occupy the space between rows, we achieve a tighter layout that guarantees labels never overlap with vertical graph edges.

Fixes #209

<img width="297" height="517" alt="image" src="https://github.com/user-attachments/assets/89ca88c4-b407-4289-9aad-2649cfd7f8ed" />
