### PR TITLE
fix: ensure undo is before redo in JJ Log title

### DIFF
--- a/package.json
+++ b/package.json
@@ -343,27 +343,27 @@
             "view/title": [
                 {
                     "command": "jj-view.undo",
-                    "group": "navigation",
+                    "group": "navigation@1",
                     "when": "view == jj-view.logView"
                 },
                 {
                     "command": "jj-view.redo",
-                    "group": "navigation",
+                    "group": "navigation@2",
                     "when": "view == jj-view.logView"
                 },
                 {
                     "command": "jj-view.abandon",
-                    "group": "navigation",
+                    "group": "navigation@3",
                     "when": "view == jj-view.logView && jj.selection.allowAbandon"
                 },
                 {
                     "command": "jj-view.newMergeChange",
-                    "group": "navigation",
+                    "group": "navigation@4",
                     "when": "view == jj-view.logView && jj.selection.allowMerge"
                 },
                 {
                     "command": "jj-view.newBefore",
-                    "group": "navigation",
+                    "group": "navigation@5",
                     "when": "view == jj-view.logView && jj.selection.allowNewBefore"
                 }
             ],


### PR DESCRIPTION
Explicitly set navigation indices for JJ Log title actions to guarantee that Undo (navigation@1) appears before Redo (navigation@2), and fixes  the order for other selection-aware buttons.