### PR TITLE
Implement elision rows for history gaps

### DIFF
--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -4,51 +4,64 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService } from '../jj-service';
+import { JjLogEntry } from '../jj-types';
 import { computeGraphLayout } from '../webview/graph-compute';
+import { GraphLayout, GraphNode } from '../webview/graph-model';
 import { TestRepo, buildGraph } from './test-repo';
 
 // Helper: ASCII renderer to verify layout against jj log output
-function renderToAscii(
-    layout: {
-        nodes: { x: number; y: number; changeId: string }[];
-        rows: {
-            commit_id: string;
-            parents: string[];
-            nearest_visible_ancestors?: string[];
-            is_current_working_copy?: boolean;
-            change_id: string;
-            description: string;
-        }[];
-        edges: { x1: number; y1: number; x2: number; y2: number; curveY?: number; isJoining?: boolean }[];
-    },
-    headId: string,
-): string {
+function renderToAscii(layout: GraphLayout, headId: string): string {
     const rows: string[] = [];
-    const nodesById = new Map<string, { x: number; y: number; changeId: string }>(
-        layout.nodes.map((n) => [n.changeId, n]),
-    );
+    const nodesById = new Map<string, GraphNode>(layout.nodes.map((n: GraphNode) => [n.changeId, n]));
 
-    // Calculate maximum width (number of lanes) used by any node or edge
-    let width = Math.max(1, ...layout.nodes.map((n) => n.x + 1));
+    let width = Math.max(1, ...layout.nodes.map((n: GraphNode) => n.x + 1));
     for (const e of layout.edges) {
         width = Math.max(width, e.x1 + 1, e.x2 + 1);
     }
 
+    const edgeRoutes = layout.edges.map((e) => {
+        if (e.x1 === e.x2) return { ...e, yBend: e.y1 }; // Straight
+
+        // jj log curves around row offsets. It typically curves just before the target
+        // row `curveY`, so visual yBend is exactly midway above curveY
+        return { ...e, yBend: (e.curveY ?? e.y2) - 0.5 };
+    });
+
     for (let i = 0; i < layout.rows.length; i++) {
-        const log = layout.rows[i];
+        const row = layout.rows[i];
+
+        if ('type' in row && row.type === 'elision') {
+            // 0. Elision Row (~)
+            let lineStr = '';
+            for (let x = 0; x < width; x++) {
+                let symbol = ' ';
+                const hasEdge = edgeRoutes.some((e) => {
+                    const isOurElision = e.isElided && e.y1 === i - 1 && (e.x1 === x || e.x2 === x);
+                    if (isOurElision) {
+                        symbol = '~';
+                        return true;
+                    }
+                    if (e.x1 === e.x2) {
+                        return e.x1 === x && e.y1 < i && e.y2 > i;
+                    } else {
+                        if (x === e.x1 && i < e.yBend && i > e.y1) return true;
+                        if (x === e.x2 && i > e.yBend && i < e.y2 && !e.isJoining) return true;
+                        return false;
+                    }
+                });
+                if (hasEdge && symbol === ' ') symbol = '│';
+                lineStr += symbol;
+                if (x < width - 1) lineStr += ' ';
+            }
+            rows.push(lineStr.trimEnd());
+            continue;
+        }
+
+        const log = row as JjLogEntry;
         const node = nodesById.get(log.change_id);
         if (!node) {
             continue;
         }
-
-        // Pre-calculate yBend for all non-straight edges early, so both Commit Row and Spacer Rows can use it.
-        const edgeRoutes = layout.edges.map((e) => {
-            if (e.x1 === e.x2) return { ...e, yBend: e.y1 }; // Straight
-
-            // jj log curves around row offsets. It typically curves just before the target
-            // row `curveY`, so visual yBend is exactly midway above curveY
-            return { ...e, yBend: (e.curveY ?? e.y2) - 0.5 };
-        });
 
         // 1. Commit Row
         let lineStr = '';
@@ -111,7 +124,12 @@ function renderToAscii(
 
         // 2. Spacer Rows (2 lines)
         if (i < layout.rows.length - 1) {
-            const nextLog = layout.rows[i + 1];
+            const nextRow = layout.rows[i + 1];
+            if ('type' in nextRow && nextRow.type === 'elision') {
+                continue; // Skip spacers if an elision row follows
+            }
+
+            const nextLog = nextRow as JjLogEntry;
             const yMid = node.y + 0.5;
 
             // In jj log, if an empty child is connecting to the root commit, it skips the second spacer row

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -375,7 +375,10 @@ const App: React.FC = () => {
     }
 
     return (
-        <div className={`app-container theme-${theme}`}>
+        <div
+            className={`app-container theme-${theme}`}
+            style={{ '--commit-left-padding': '6px' } as React.CSSProperties}
+        >
             <DndContext
                 sensors={sensors}
                 collisionDetection={pointerWithin}

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -3,7 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from 'react';
+import { JjLogEntry } from '../../jj-types';
 import { computeGraphLayout } from '../graph-compute';
+import {
+    LANE_WIDTH,
+    ROW_HEIGHT_NORMAL,
+    ROW_HEIGHT_EXPANDED,
+    ROW_HEIGHT_ELISION,
+    LEFT_MARGIN,
+    COMMIT_ROW_PADDING_LEFT,
+} from '../layout-constants';
 import { computeCompactRowMaxX, computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
 import { ActionPayload, CommitNode } from './CommitNode';
 import { GraphRail } from './GraphRail';
@@ -25,13 +34,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     graphLabelAlignment = 'aligned',
     theme = 'default',
 }) => {
-    // Width of a lane in pixels
-    const LANE_WIDTH = 16;
-    const ROW_HEIGHT_NORMAL = 28;
-    const ROW_HEIGHT_EXPANDED = 44; // Reduced to 44px (28 top - 6 overlap + 22 bottom)
-
     // Total graph width calculation
-    const LEFT_MARGIN = 12; // Match GraphRail
     // Dynamic sizing based on font
     // Fallback to 13px if not available
     const fontSize = typeof document !== 'undefined' ? parseInt(getComputedStyle(document.body).fontSize) || 13 : 13;
@@ -44,11 +47,11 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
         if (graphLabelAlignment !== 'compact') {
             return undefined;
         }
-        const map = new Map<string, number>();
+        const map = new Map<number, number>();
         const rowMaxX = computeCompactRowMaxX(layout);
-        layout.nodes.forEach((n) => {
-            const padding = computeGraphAreaWidth(rowMaxX[n.y] + 1, LANE_WIDTH, LEFT_MARGIN, GAP);
-            map.set(n.commitId, padding);
+        rowMaxX.forEach((maxX, y) => {
+            const padding = computeGraphAreaWidth(maxX + 1, LANE_WIDTH, LEFT_MARGIN, GAP);
+            map.set(y, padding);
         });
         return map;
     }, [layout, graphLabelAlignment, GAP, LANE_WIDTH, LEFT_MARGIN]);
@@ -59,10 +62,16 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
         let currentOffset = 0;
         const offsets: number[] = [];
 
-        displayRows.forEach((commit) => {
+        displayRows.forEach((row) => {
             offsets.push(currentOffset);
             // Height logic matching the renderer in CommitNode
-            const height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
+            let height: number;
+            if ('type' in row && row.type === 'elision') {
+                height = ROW_HEIGHT_ELISION;
+            } else {
+                const commit = row as JjLogEntry;
+                height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
+            }
             currentOffset += height;
         });
 
@@ -89,6 +98,38 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     // Padding-left for the text area
     const graphAreaWidth = computeGraphAreaWidth(layout.width, LANE_WIDTH, LEFT_MARGIN, GAP);
 
+    const renderElisionRow = (i: number, isLastRow: boolean) => {
+        // Offset to match the start of the Change ID in CommitNode
+        const graphOffset = compactPaddingMap?.get(i) ?? graphAreaWidth;
+        const paddingLeft = graphOffset + COMMIT_ROW_PADDING_LEFT;
+
+        return (
+            <div
+                key={`elision-${i}`}
+                style={{
+                    height: ROW_HEIGHT_ELISION,
+                    paddingLeft,
+                    display: 'flex',
+                    alignItems: 'center',
+                }}
+            >
+                {!isLastRow && (
+                    <div
+                        style={{
+                            flexGrow: 1,
+                            height: '4px',
+                            background:
+                                'linear-gradient(to right, var(--vscode-descriptionForeground) 0%, transparent 80%)',
+                            opacity: 0.1,
+                            marginRight: '20px',
+                            borderRadius: '2px',
+                        }}
+                    />
+                )}
+            </div>
+        );
+    };
+
     return (
         <div className="commit-graph" style={{ position: 'relative', paddingBottom: '20px' }}>
             {/* SVG Graph Overlay */}
@@ -98,15 +139,22 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                 width={layout.width}
                 height={totalHeight}
                 rowOffsets={rowOffsets}
+                rows={displayRows}
                 selectedNodes={selectedCommitIds}
             />
 
             {/* Commit List (Text) */}
             <div style={{ position: 'relative', zIndex: 1 }}>
-                {displayRows.map((commit) => {
+                {displayRows.map((row, i) => {
+                    const isLastRow = i === displayRows.length - 1;
+                    if (row && 'type' in row && row.type === 'elision') {
+                        return renderElisionRow(i, isLastRow);
+                    }
+
+                    const commit = row as JjLogEntry;
                     const isSelected = selectedCommitIds?.has(commit.change_id);
                     const height = commit.gerritCl ? ROW_HEIGHT_EXPANDED : ROW_HEIGHT_NORMAL;
-                    const paddingLeft = compactPaddingMap?.get(commit.commit_id) ?? graphAreaWidth;
+                    const paddingLeft = compactPaddingMap?.get(i) ?? graphAreaWidth;
                     return (
                         <div
                             key={commit.commit_id}

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -6,6 +6,7 @@ import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import React from 'react';
 // Needs to be available in types or duplicated.
 import { GerritClInfo } from '../../jj-types';
+import { COMMIT_ROW_PADDING_LEFT } from '../layout-constants';
 import { BookmarkPill, DraggableBookmark, TagPill, WorkspacePill } from './Bookmark';
 import { IconButton } from './IconButton';
 
@@ -182,7 +183,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 outlineOffset: '-2px',
                 touchAction: 'none',
                 minWidth: 0,
-                paddingLeft: '6px',
+                paddingLeft: COMMIT_ROW_PADDING_LEFT,
                 paddingTop: '0',
             }}
         >

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from 'react';
-import { GraphEdge, GraphNode } from '../graph-model';
+import { GraphEdge, GraphNode, GraphRow } from '../graph-model';
+import { LANE_WIDTH, ROW_HEIGHT_ELISION, LEFT_MARGIN, LANE_CENTER_X, ROW_CENTER_Y } from '../layout-constants';
 
 interface GraphRailProps {
     nodes: GraphNode[];
@@ -11,18 +12,26 @@ interface GraphRailProps {
     width: number; // in lanes
     height: number; // total height in pixels
     rowOffsets: number[]; // Exact Y position for each row index
+    rows: GraphRow[];
     selectedNodes?: Set<string>;
 }
 
-const W = 16;
-const ROW_HEADER_HEIGHT = 28; // The "primary" line height where the graph lives
-const CX = W / 2;
-const CY_OFFSET = ROW_HEADER_HEIGHT / 2; // Graph is centered in the primary line (14px)
-const LEFT_MARGIN = 12; // Shift graph right to prevent clipping of halos
+const W = LANE_WIDTH;
+const CX = LANE_CENTER_X;
+const CY_OFFSET = ROW_CENTER_Y;
+const ELISION_ROW_HEIGHT = ROW_HEIGHT_ELISION;
 const R = 8; // Max radius (W/2) for smooth curves
 const BOTTOM_PADDING = 20; // Extra room for trailing elision markers at the bottom
 
-export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, height, rowOffsets, selectedNodes }) => {
+export const GraphRail: React.FC<GraphRailProps> = ({
+    nodes,
+    edges,
+    width,
+    height,
+    rowOffsets,
+    rows,
+    selectedNodes,
+}) => {
     // Layering: Leftmost lanes (lower x) should render visually on TOP.
     // SVG renders elements in order, so the last element appears on top.
     // Therefore, we want lower x values to come LAST in the array.
@@ -45,9 +54,23 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
 
         const ex = x2 * W + CX + LEFT_MARGIN;
         // End Y
-        const isTrailing = y2 === rowOffsets.length - 1;
-        // Trailing edges extend 12px past the last row before being "broken" by the tilde
-        const ey = (rowOffsets[y2] || 0) + (isTrailing ? 12 : CY_OFFSET);
+        const isTrailing = y2 >= rows.length;
+        // Trailing edges extend past the last row. If the last row is an elision row, they should end there.
+        const lastRowIndex = rows.length - 1;
+        const isLastRowElision =
+            rows[lastRowIndex] && 'type' in rows[lastRowIndex] && rows[lastRowIndex].type === 'elision';
+
+        let ey: number;
+        if (isTrailing) {
+            if (isLastRowElision) {
+                // End in the middle of the elision row
+                ey = (rowOffsets[lastRowIndex] || 0) + ELISION_ROW_HEIGHT / 2;
+            } else {
+                ey = (rowOffsets[y2] || rowOffsets[lastRowIndex] || 0) + 12;
+            }
+        } else {
+            ey = (rowOffsets[y2] || 0) + CY_OFFSET;
+        }
 
         let d = '';
 
@@ -104,16 +127,21 @@ export const GraphRail: React.FC<GraphRailProps> = ({ nodes, edges, width, heigh
         const ElisionMarker = () => {
             if (!edge.isElided) return null;
 
-            // Simple pixel midpoint measures the total gap accurately.
-            const visualMid = (sy + ey) / 2;
-            let mx = sx;
-            let my = visualMid;
-
-            if (isTrailing) {
-                // For trailing edges, put it at the very end of the extended edge
-                mx = ex;
-                my = ey - 2;
+            // Find the elision row for this edge.
+            // It should be either y1 + 1 (standard elision after child)
+            // or the last row (if it's a trailing edge).
+            let elisionRowIndex = -1;
+            const nextRow = rows[y1 + 1];
+            if (nextRow && 'type' in nextRow && nextRow.type === 'elision') {
+                elisionRowIndex = y1 + 1;
+            } else if (isTrailing && isLastRowElision) {
+                elisionRowIndex = lastRowIndex;
             }
+
+            if (elisionRowIndex === -1) return null;
+
+            const mx = sx;
+            const my = rowOffsets[elisionRowIndex] + ELISION_ROW_HEIGHT / 2;
 
             return (
                 <g key={`elision-${index}`} transform={`translate(${mx}, ${my})`}>

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { JjLogEntry } from '../jj-types';
-import { GraphEdge, GraphLayout, GraphNode } from './graph-model';
+import { GraphEdge, GraphLayout, GraphNode, GraphRow } from './graph-model';
 import { getColor } from './themes.generated';
 
 export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'default'): GraphLayout {
@@ -13,8 +13,27 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
     const allCommits = new Map<string, JjLogEntry>();
     commits.forEach((c) => allCommits.set(c.change_id, c));
 
+    // Pre-calculate display rows and commit-to-row mapping
+    const displayRows: GraphRow[] = [];
+    const commitToRowIndex = new Map<string, number>();
+
+    commits.forEach((commit) => {
+        const rowIndex = displayRows.length;
+        displayRows.push(commit);
+        commitToRowIndex.set(commit.change_id, rowIndex);
+
+        const ancestors = commit.nearest_visible_ancestors || [];
+        const directParents = new Set(commit.parent_change_ids || []);
+        const hasElision =
+            ancestors.some((p) => !directParents.has(p)) || (ancestors.length === 0 && directParents.size > 0);
+
+        if (hasElision) {
+            displayRows.push({ type: 'elision' });
+        }
+    });
+
     // Layout Logic
-    const nodes: GraphNode[] = [];
+    const nodes: GraphNode[] = []; // Sparse array indexed by rowIndex
     const edges: GraphEdge[] = [];
     const pendingEdges: {
         x1: number;
@@ -27,8 +46,9 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
     const lanes: (string | null)[] = [];
     const nodeMap = new Map<string, GraphNode>();
 
-    commits.forEach((commit, rowIndex) => {
+    commits.forEach((commit) => {
         const changeId = commit.change_id;
+        const rowIndex = commitToRowIndex.get(changeId)!;
 
         // 1. Determine my lane
         let nodeLane = lanes.indexOf(changeId);
@@ -53,7 +73,7 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
             isEmpty: commit.is_empty,
             isImmutable: commit.is_immutable,
         };
-        nodes.push(node);
+        nodes[rowIndex] = node;
         nodeMap.set(changeId, node);
 
         // 3. Update Lanes (Clear self and overlapping)
@@ -174,7 +194,7 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
             }
         } else {
             targetX = pe.targetLane;
-            targetY = commits.length;
+            targetY = displayRows.length;
         }
 
         let curveY = targetY;
@@ -207,5 +227,11 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
         nodes.reduce((max, n) => Math.max(max, n.x + 1), 0),
     );
 
-    return { nodes, edges, width, height: commits.length, rows: commits };
+    return {
+        nodes: nodes.filter((n) => !!n), // Flatten sparse array for layout output
+        edges,
+        width,
+        height: displayRows.length,
+        rows: displayRows,
+    };
 }

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -29,10 +29,16 @@ export interface GraphEdge {
     isElided?: boolean; // True if this edge connects to a non-direct ancestor (history gap)
 }
 
+export interface ElisionRow {
+    type: 'elision';
+}
+
+export type GraphRow = JjLogEntry | ElisionRow;
+
 export interface GraphLayout {
     nodes: GraphNode[];
     edges: GraphEdge[];
     width: number;
     height: number;
-    rows: JjLogEntry[]; // The commits in display order
+    rows: GraphRow[]; // The commits and spacer rows in display order
 }

--- a/src/webview/layout-constants.ts
+++ b/src/webview/layout-constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared layout constants for the CommitGraph webview.
+ * Centralizing these ensures that the SVG graph and the HTML text rows
+ * stay perfectly synchronized in height and horizontal positioning.
+ */
+
+export const LANE_WIDTH = 16;
+export const ROW_HEIGHT_NORMAL = 28;
+export const ROW_HEIGHT_EXPANDED = 44;
+export const ROW_HEIGHT_ELISION = 10;
+export const LEFT_MARGIN = 12;
+export const COMMIT_ROW_PADDING_LEFT = 6;
+
+// Derived constants
+export const LANE_CENTER_X = LANE_WIDTH / 2;
+export const ROW_CENTER_Y = ROW_HEIGHT_NORMAL / 2;


### PR DESCRIPTION
Introduces a visual indicator for elided history in the log graph. Calculates gaps where nearest visible ancestors are not direct parents and inserts "elision" rows into the graph layout.

Key changes:
- Centralizes layout dimensions in `layout-constants.ts` to ensure perfect synchronization between SVG and HTML elements.
- Updates `computeGraphLayout` to detect history gaps and generate `GraphRow` objects that include `ElisionRow` markers.
- Implements `renderElisionRow` in `CommitGraph` with a subtle gradient line and updates `GraphRail` to render tildes (~) on elided edges.
- Refactors the compact alignment map to be row-indexed, ensuring consistent text positioning across all row types.
- Enhances ASCII test rendering to support and verify elision symbols.

Addresses https://github.com/brychanrobot/jj-view/issues/87#issuecomment-4184031526

<img width="129" height="192" alt="image" src="https://github.com/user-attachments/assets/a4384d82-b898-4022-a514-d9e355f0cd96" />
