### PR TITLE
fix: support op_heads change detection in secondary jj workspaces

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -134,17 +134,25 @@ export class ChangeDetectionManager implements vscode.Disposable {
         } catch {
             return;
         }
-        const opHeadsPath = path.join(repoRoot, '.jj', 'repo', 'op_heads');
 
-        // Skip if directory does not exist
+        // Handle non-default workspaces where .jj/repo might be a file containing a path
+        const repoStorePath = await this.resolveRepoStorePath(repoRoot);
+        if (this._disposed) return;
+
+        const opHeadsPath = path.join(repoStorePath, 'op_heads');
+
+        // Final check that the directory exists and we have a real path
+        let realOpHeadsPath: string;
         try {
-            await fs.access(opHeadsPath);
+            realOpHeadsPath = await fs.realpath(opHeadsPath);
         } catch {
             return;
         }
 
+        if (this._disposed) return;
+
         this._opHeadsWatcher = new DirectoryWatcher(
-            opHeadsPath,
+            realOpHeadsPath,
             () => {
                 if (this.hasActiveOrRecentWrites) {
                     return;
@@ -160,6 +168,20 @@ export class ChangeDetectionManager implements vscode.Disposable {
         this._opHeadsWatcher.start().catch((err) => {
             this.outputChannel.appendLine(`Failed to start op_heads watcher: ${err}`);
         });
+    }
+
+    private async resolveRepoStorePath(workspaceRoot: string): Promise<string> {
+        const repoPath = path.join(workspaceRoot, '.jj', 'repo');
+        try {
+            const stats = await fs.lstat(repoPath);
+            if (stats.isFile()) {
+                const content = await fs.readFile(repoPath, 'utf8');
+                return path.resolve(path.dirname(repoPath), content.trim());
+            }
+            return await fs.realpath(repoPath);
+        } catch {
+            return repoPath;
+        }
     }
 
     private async startWorkingCopyWatching() {
@@ -191,6 +213,8 @@ export class ChangeDetectionManager implements vscode.Disposable {
         }
 
         const [gitIgnores, gitModules] = await Promise.all([this.getGitIgnorePatterns(), this.getGitModulesPatterns()]);
+        if (this._disposed) return;
+
         const ignore = ['.git', '.jj', '.vscode-test', 'node_modules', ...gitIgnores, ...gitModules];
 
         this._workingCopyWatcher = new DirectoryWatcher(

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -240,15 +240,39 @@ describe('ChangeDetectionManager', () => {
             // Wait for op_heads watcher to start
             await waitForLog('OpHeads Watcher] Started');
 
-            // Trigger an op_heads change
-            const opHeadsPath = path.join(repo.path, '.jj', 'repo', 'op_heads', 'new_head');
-            await fs.writeFile(opHeadsPath, 'commitid');
+            // Trigger an op_heads change using a separate TestRepo instance
+            // (Simulates an external jj operation)
+            const triggeringRepo = new TestRepo(repo.path);
+            triggeringRepo.new([], 'trigger refresh');
 
             // Wait for event
             await vi.waitFor(
                 () => {
                     const found = triggerRefreshSpy.mock.calls.some((call) => call[0].reason === 'jj operation');
                     expect(found, 'Trigger refresh for jj operation was not called').toBe(true);
+                },
+                { timeout: 10000, interval: 100 },
+            );
+        });
+
+        it('handles op_heads changes in non-default workspace', async () => {
+            const secondRepo = repo.workspaceAdd('second_workspace');
+            const secondJj = new JjService(secondRepo.path);
+
+            changeManager = new ChangeDetectionManager(secondRepo.path, secondJj, outputChannel, triggerRefreshSpy);
+
+            // Wait for op_heads watcher to start
+            await waitForLog('OpHeads Watcher] Started');
+
+            // Trigger an op_heads change in the second workspace using the secondary TestRepo instance
+            // (Acts as an external operation from the perspective of the ChangeDetectionManager's JjService)
+            secondRepo.new([], 'trigger refresh');
+
+            // Wait for event
+            await vi.waitFor(
+                () => {
+                    const found = triggerRefreshSpy.mock.calls.some((call) => call[0].reason === 'jj operation');
+                    expect(found, 'Trigger refresh for jj operation was not called in second workspace').toBe(true);
                 },
                 { timeout: 10000, interval: 100 },
             );

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -294,7 +294,7 @@ export class TestRepo {
         return output.trim() === 'true';
     }
 
-    workspaceAdd(name: string, revision?: string): string {
+    workspaceAdd(name: string, revision?: string): TestRepo {
         const workspacePath = path.join(this.path, name);
         fs.mkdirSync(workspacePath, { recursive: true });
         const args = ['workspace', 'add', workspacePath];
@@ -302,7 +302,7 @@ export class TestRepo {
             args.push('-r', revision);
         }
         this.exec(args);
-        return workspacePath;
+        return new TestRepo(workspacePath);
     }
 
     gitImport() {


### PR DESCRIPTION
In multi-workspace Jujutsu setups, the `.jj/repo` path is often a file link rather than a directory, which previously caused the `op_heads` watcher to fail with `ENOTDIR` errors.

This change ensures the repository store path is correctly resolved from these links before initializing the file watcher. To support this fix, `TestRepo` was enhanced to return new repository instances from `workspaceAdd`, enabling more realistic, command-based regression tests that simulate external CLI operations in shared-store environments.

Fixes #218