### PR TITLE
fix: trigger SCM refresh on upload

### DIFF
--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -4,10 +4,12 @@
  */
 import * as vscode from 'vscode';
 import { GerritService } from '../gerrit-service';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
 export async function uploadCommand(
+    scmProvider: JjScmProvider,
     jj: JjService,
     gerrit: GerritService,
     args: unknown[],
@@ -35,6 +37,7 @@ export async function uploadCommand(
         const title = revision ? `Uploading revision ${revision.substring(0, 8)}...` : 'Uploading...';
         await withDelayedProgress(title, jj.upload(revision, subcommand, ...commandArgs));
 
+        await scmProvider.refresh();
         gerrit.requestRefreshWithBackoffs();
         vscode.window.setStatusBarMessage('Upload successful', 3000);
     } catch (e: unknown) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -250,7 +250,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.upload', async (...args: unknown[]) => {
-            await uploadCommand(jj, gerritService, args, outputChannel);
+            await uploadCommand(scmProvider, jj, gerritService, args, outputChannel);
         }),
     );
 
@@ -321,7 +321,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Detect terminal 'jj upload' commands and trigger immediate Gerrit refresh
     context.subscriptions.push(
         vscode.window.onDidEndTerminalShellExecution((event) => {
-            handleTerminalExecution(event.execution.commandLine.value, gerritService, outputChannel);
+            handleTerminalExecution(event.execution.commandLine.value, gerritService, outputChannel, scmProvider);
         }),
     );
 
@@ -390,11 +390,13 @@ export function handleTerminalExecution(
     commandLine: string,
     gerritService: GerritService,
     outputChannel: vscode.OutputChannel,
+    scmProvider: JjScmProvider,
 ): boolean {
     const cmd = commandLine.trim();
     if (cmd.startsWith('jj') && cmd.includes('upload')) {
         outputChannel.appendLine(`[Extension] Detected terminal upload: "${cmd}"`);
         gerritService.requestRefreshWithBackoffs();
+        scmProvider.refresh();
         return true;
     }
     return false;

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -6,7 +6,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { uploadCommand } from '../../commands/upload';
 import { GerritService } from '../../gerrit-service';
+import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
+import { createMock } from '../test-utils';
 
 // Mock dependencies
 const mockConfig = {
@@ -29,15 +31,19 @@ describe('uploadCommand', () => {
     let jjService: JjService;
 
     let gerritService: GerritService;
+    let scmProvider: JjScmProvider;
     let mockOutputChannel: vscode.OutputChannel;
 
     beforeEach(() => {
-        jjService = { upload: vi.fn() } as unknown as JjService;
-        gerritService = {
+        jjService = createMock<JjService>({ upload: vi.fn() });
+        gerritService = createMock<GerritService>({
             isGerrit: vi.fn().mockResolvedValue(false),
             requestRefreshWithBackoffs: vi.fn(),
-        } as unknown as GerritService;
-        mockOutputChannel = { appendLine: vi.fn(), show: vi.fn() } as unknown as vscode.OutputChannel;
+        });
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn().mockResolvedValue(undefined),
+        });
+        mockOutputChannel = createMock<vscode.OutputChannel>({ appendLine: vi.fn(), show: vi.fn() });
         mockConfig.get.mockReset();
     });
 
@@ -48,20 +54,22 @@ describe('uploadCommand', () => {
             return undefined;
         });
 
-        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
+        await uploadCommand(scmProvider, jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         // Should use the custom command
         expect(jjService.upload).toHaveBeenCalledWith('rev-123', 'git', 'push', '--force');
+        expect(scmProvider.refresh).toHaveBeenCalled();
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
     test('falls back to default when custom command is empty', async () => {
         mockConfig.get.mockReturnValue(undefined);
 
-        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
+        await uploadCommand(scmProvider, jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         // Default for non-Gerrit is git push
         expect(jjService.upload).toHaveBeenCalledWith('rev-123', 'git', 'push');
+        expect(scmProvider.refresh).toHaveBeenCalled();
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
@@ -69,7 +77,7 @@ describe('uploadCommand', () => {
         mockConfig.get.mockReturnValue(undefined);
 
         // This simulates the webview payload: { changeId: 'rev-object' }
-        await uploadCommand(jjService, gerritService, [{ changeId: 'rev-object' }], mockOutputChannel);
+        await uploadCommand(scmProvider, jjService, gerritService, [{ changeId: 'rev-object' }], mockOutputChannel);
 
         expect(jjService.upload).toHaveBeenCalledWith('rev-object', 'git', 'push');
     });
@@ -86,7 +94,7 @@ describe('uploadCommand', () => {
         ) => Thenable<string | undefined>;
         vi.mocked(showErrorMessage).mockResolvedValue('Configure Upload...');
 
-        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
+        await uploadCommand(scmProvider, jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('Upload failed: upload failed'),
@@ -113,7 +121,7 @@ describe('uploadCommand', () => {
         ) => Thenable<string | undefined>;
         vi.mocked(showErrorMessage).mockResolvedValue('Show Log');
 
-        await uploadCommand(jjService, gerritService, ['rev-123'], mockOutputChannel);
+        await uploadCommand(scmProvider, jjService, gerritService, ['rev-123'], mockOutputChannel);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('Upload failed: upload failed'),

--- a/src/test/terminal-detection.test.ts
+++ b/src/test/terminal-detection.test.ts
@@ -14,48 +14,48 @@ vi.mock('vscode', async () => {
 
 // Import after mock
 import type { GerritService } from '../gerrit-service';
+import type { JjScmProvider } from '../jj-scm-provider';
+import { createMock } from './test-utils';
 
 describe('handleTerminalExecution', () => {
-    let gerritService: { forceRefresh: ReturnType<typeof vi.fn>; requestRefreshWithBackoffs: ReturnType<typeof vi.fn> };
-    let outputChannel: { appendLine: ReturnType<typeof vi.fn> };
+    let gerritService: GerritService;
+    let outputChannel: vscode.OutputChannel;
+    let scmProvider: JjScmProvider;
 
     beforeEach(() => {
-        gerritService = {
+        gerritService = createMock<GerritService>({
             forceRefresh: vi.fn(),
             requestRefreshWithBackoffs: vi.fn(),
-        };
-        outputChannel = { appendLine: vi.fn() };
+        });
+        outputChannel = createMock<vscode.OutputChannel>({ appendLine: vi.fn() });
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn().mockResolvedValue(undefined),
+        });
     });
 
     it('detects "jj upload" and schedules staggered refreshes', () => {
-        const result = handleTerminalExecution(
-            'jj upload',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
-        );
+        const result = handleTerminalExecution('jj upload', gerritService, outputChannel, scmProvider);
 
         expect(result).toBe(true);
-
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
+        expect(scmProvider.refresh).toHaveBeenCalled();
     });
 
     it('detects "jj gerrit upload" with arguments', () => {
         const result = handleTerminalExecution(
             'jj gerrit upload --change abc123',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
+            gerritService,
+            outputChannel,
+            scmProvider,
         );
 
         expect(result).toBe(true);
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
+        expect(scmProvider.refresh).toHaveBeenCalled();
     });
 
     it('ignores non-jj commands', () => {
-        const result = handleTerminalExecution(
-            'git push origin main',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
-        );
+        const result = handleTerminalExecution('git push origin main', gerritService, outputChannel, scmProvider);
 
         expect(result).toBe(false);
         expect(gerritService.requestRefreshWithBackoffs).not.toHaveBeenCalled();
@@ -63,33 +63,22 @@ describe('handleTerminalExecution', () => {
     });
 
     it('ignores jj commands without upload', () => {
-        const result = handleTerminalExecution(
-            'jj log --revisions @',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
-        );
+        const result = handleTerminalExecution('jj log --revisions @', gerritService, outputChannel, scmProvider);
 
         expect(result).toBe(false);
         expect(gerritService.requestRefreshWithBackoffs).not.toHaveBeenCalled();
     });
 
     it('handles leading whitespace in command', () => {
-        const result = handleTerminalExecution(
-            '  jj upload  ',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
-        );
+        const result = handleTerminalExecution('  jj upload  ', gerritService, outputChannel, scmProvider);
 
         expect(result).toBe(true);
         expect(gerritService.requestRefreshWithBackoffs).toHaveBeenCalled();
+        expect(scmProvider.refresh).toHaveBeenCalled();
     });
 
     it('logs detected upload command', () => {
-        handleTerminalExecution(
-            'jj upload',
-            gerritService as unknown as GerritService,
-            outputChannel as unknown as vscode.OutputChannel,
-        );
+        handleTerminalExecution('jj upload', gerritService, outputChannel, scmProvider);
 
         expect(outputChannel.appendLine).toHaveBeenCalledWith('[Extension] Detected terminal upload: "jj upload"');
     });


### PR DESCRIPTION
Ensures the SCM provider and log view are refreshed after a successful upload to reflect any file or bookmark changes. This applies to both the extension's upload command and terminal-based uploads.