### PR TITLE
feat: Add workspace management (forget and delete)

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,6 +341,18 @@
                 "title": "Add Workspace",
                 "category": "JJ View",
                 "icon": "$(jj-icon-workspace-add)"
+            },
+            {
+                "command": "jj-view.workspaceForget",
+                "title": "Forget Workspace",
+                "category": "JJ View",
+                "icon": "$(close)"
+            },
+            {
+                "command": "jj-view.workspaceDelete",
+                "title": "Delete Workspace Directory",
+                "category": "JJ View",
+                "icon": "$(trash)"
             }
         ],
         "keybindings": [
@@ -391,6 +403,16 @@
                 }
             ],
             "webview/context": [
+                {
+                    "command": "jj-view.workspaceForget",
+                    "when": "webviewSection == 'workspace'",
+                    "group": "1_workspace@1"
+                },
+                {
+                    "command": "jj-view.workspaceDelete",
+                    "when": "webviewSection == 'workspace'",
+                    "group": "1_workspace@2"
+                },
                 {
                     "command": "jj-view.showMultiFileDiff",
                     "when": "webviewSection == 'commit'",

--- a/src/commands/workspace-add.ts
+++ b/src/commands/workspace-add.ts
@@ -60,6 +60,7 @@ export async function workspaceAddCommand(scmProvider: JjScmProvider, jj: JjServ
                 await jj.workspaceAdd(destination, workspaceName);
             },
         );
+        await scmProvider.refresh();
 
         // 5. Success notification with "Open" action
         const OPEN = 'Open Workspace';
@@ -72,8 +73,6 @@ export async function workspaceAddCommand(scmProvider: JjScmProvider, jj: JjServ
             const uri = vscode.Uri.file(destination);
             await vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
         }
-
-        await scmProvider.refresh();
     } catch (e) {
         const message = getErrorMessage(e);
         vscode.window.showErrorMessage(`Failed to create workspace: ${message}`);

--- a/src/commands/workspace-delete.ts
+++ b/src/commands/workspace-delete.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
+import { getErrorMessage } from './command-utils';
+import { resolveWorkspaceName } from './workspace-utils';
+
+export async function workspaceDeleteCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    const workspaceName = await resolveWorkspaceName(jj, args);
+    if (!workspaceName) {
+        return;
+    }
+
+    const YES = 'Yes, Delete Workspace';
+    const result = await vscode.window.showWarningMessage(
+        `Are you sure you want to forget AND delete the directory for workspace "${workspaceName}"? This action cannot be undone.`,
+        { modal: true },
+        YES,
+    );
+
+    if (result !== YES) {
+        return;
+    }
+
+    try {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Deleting workspace "${workspaceName}"...`,
+                cancellable: false,
+            },
+            async () => {
+                let dirPath: string | undefined;
+                try {
+                    dirPath = await jj.getWorkspaceRoot(workspaceName);
+                } catch (e) {
+                    throw new Error(`Failed to find directory for workspace "${workspaceName}"`);
+                }
+
+                await jj.workspaceForget(workspaceName);
+
+                if (dirPath) {
+                    await fs.promises.rm(dirPath, { recursive: true, force: true });
+                }
+            },
+        );
+        scmProvider.refresh();
+    } catch (e) {
+        const message = getErrorMessage(e);
+        vscode.window.showErrorMessage(`Failed to delete workspace: ${message}`);
+        scmProvider.outputChannel.appendLine(`[Error] Workspace delete failed: ${message}`);
+    }
+}

--- a/src/commands/workspace-forget.ts
+++ b/src/commands/workspace-forget.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+import { JjScmProvider } from '../jj-scm-provider';
+import { JjService } from '../jj-service';
+import { getErrorMessage } from './command-utils';
+import { resolveWorkspaceName } from './workspace-utils';
+
+export async function workspaceForgetCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    const workspaceName = await resolveWorkspaceName(jj, args);
+    if (!workspaceName) {
+        return;
+    }
+
+    const YES = 'Yes, Forget Workspace';
+    const result = await vscode.window.showWarningMessage(
+        `Are you sure you want to forget the workspace "${workspaceName}"? This will untrack it but will not delete the directory from disk.`,
+        { modal: true },
+        YES,
+    );
+
+    if (result !== YES) {
+        return;
+    }
+
+    try {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Forgetting workspace "${workspaceName}"...`,
+                cancellable: false,
+            },
+            async () => {
+                await jj.workspaceForget(workspaceName);
+            },
+        );
+        scmProvider.refresh();
+    } catch (e) {
+        const message = getErrorMessage(e);
+        vscode.window.showErrorMessage(`Failed to forget workspace: ${message}`);
+        scmProvider.outputChannel.appendLine(`[Error] Workspace forget failed: ${message}`);
+    }
+}

--- a/src/commands/workspace-utils.ts
+++ b/src/commands/workspace-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+import { JjService } from '../jj-service';
+
+/**
+ * Resolves a workspace name from command arguments or by prompting the user with a QuickPick.
+ *
+ * @param jj The Jujutsu service instance.
+ * @param args The command arguments (expected to contain { workspaceName: string } if from a context menu).
+ * @returns The resolved workspace name, or undefined if the user cancelled or no workspaces were found.
+ */
+export async function resolveWorkspaceName(jj: JjService, args: unknown[]): Promise<string | undefined> {
+    // 1. Try to extract from args (context menu case)
+    const arg = args[0];
+    if (arg && typeof arg === 'object' && 'workspaceName' in arg && typeof arg.workspaceName === 'string') {
+        return arg.workspaceName;
+    }
+
+    // 2. Prompt with QuickPick (command palette case)
+    const workspaces = await jj.getWorkspaces();
+
+    if (workspaces.length === 0) {
+        vscode.window.showErrorMessage('No workspaces found in this repository.');
+        return undefined;
+    }
+
+    if (workspaces.length === 1) {
+        return workspaces[0];
+    }
+
+    const selection = await vscode.window.showQuickPick(workspaces, {
+        placeHolder: 'Select a workspace to operate on',
+        title: 'Workspace Action',
+    });
+
+    return selection;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ import { squashIntoCommand } from './commands/squash-into';
 import { undoCommand } from './commands/undo';
 import { uploadCommand } from './commands/upload';
 import { workspaceAddCommand } from './commands/workspace-add';
+import { workspaceDeleteCommand } from './commands/workspace-delete';
+import { workspaceForgetCommand } from './commands/workspace-forget';
 import { GerritService } from './gerrit-service';
 import { checkGitColocation } from './git-colocation';
 import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
@@ -380,6 +382,18 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.workspaceAdd', async () => {
             await workspaceAddCommand(scmProvider, jj);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.workspaceForget', async (...args: unknown[]) => {
+            await workspaceForgetCommand(scmProvider, jj, args);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.workspaceDelete', async (...args: unknown[]) => {
+            await workspaceDeleteCommand(scmProvider, jj, args);
         }),
     );
 

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -836,6 +836,33 @@ export class JjService {
         return this.run('workspace', ['add', ...args], { isMutation: true, label: 'workspaceAdd' });
     }
 
+    async workspaceForget(workspaceName: string): Promise<void> {
+        await this.run('workspace', ['forget', workspaceName], { isMutation: true, label: 'workspaceForget' });
+    }
+
+    async getWorkspaces(): Promise<string[]> {
+        const output = await this.run('workspace', ['list', '-T', 'name ++ "\\n"'], {
+            useCachedSnapshot: true,
+            label: 'getWorkspaces',
+        });
+        return output
+            .split('\n')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+    }
+
+    async getWorkspaceRoot(workspaceName?: string): Promise<string> {
+        const args = [];
+        if (workspaceName) {
+            args.push('--name', workspaceName);
+        }
+        const output = await this.run('workspace', ['root', ...args], {
+            useCachedSnapshot: true,
+            label: 'getWorkspaceRoot',
+        });
+        return output.trim();
+    }
+
     async getFileContent(
         filePath: string,
         revision: string = '@',

--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -102,7 +102,7 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     working_copies: {
         type: 'stringArray',
         expr: 'working_copies',
-        itemExpr: 'item',
+        itemExpr: 'item.name()',
     },
     is_empty: { type: 'raw', expr: 'empty' },
     is_divergent: { type: 'raw', expr: 'divergent' },

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -27,6 +27,7 @@ export async function launchVSCode(
     repo: TestRepo,
     extraSettings: Record<string, unknown> = {},
     extraEnv: Record<string, string | undefined> = {},
+    showNotifications = false,
 ): Promise<VSCodeContext> {
     const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-user-data-'));
     const extensionsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-extensions-'));
@@ -49,8 +50,8 @@ export async function launchVSCode(
                 'jj-view.fileWatcherMode': 'watch',
                 'jj-view.minChangeIdLength': 3,
                 'telemetry.telemetryLevel': 'off',
-                'workbench.notification.displayMode': 'hidden',
-                'notifications.showDoNotDisturb': true,
+                'workbench.notification.displayMode': showNotifications ? 'default' : 'hidden',
+                'notifications.showDoNotDisturb': !showNotifications,
                 'update.mode': 'none',
                 'extensions.autoCheckUpdates': false,
                 'extensions.autoUpdate': false,
@@ -155,10 +156,12 @@ export async function launchVSCode(
     // Wait for the workbench to be ready
     await expect(page.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
 
-    // Hide notification toasts via CSS. Error-level toasts (e.g. "failed to load
+    // Hide notification toasts via CSS unless requested. Error-level toasts (e.g. "failed to load
     // extension") bypass VS Code's Do Not Disturb / displayMode settings and can
     // overlay buttons, causing click interception in tests.
-    await page.addStyleTag({ content: '.notifications-toasts { display: none !important; }' });
+    if (!showNotifications) {
+        await page.addStyleTag({ content: '.notifications-toasts { display: none !important; }' });
+    }
 
     return { app, page, userDataDir };
 }
@@ -419,4 +422,36 @@ export async function setScmDescription(page: Page, description: string) {
         // 4. Validate the text EXACTLY matches the requested description.
         await expect(scmInputRow).toHaveText(description, { timeout: 2000 });
     }, `Failed to set SCM description to "${description}" reliably`).toPass({ timeout: 15000 });
+}
+
+/**
+ * Clicks a button in the JJ Log title bar by its name.
+ */
+export async function clickLogTitleButton(page: Page, name: string) {
+    const header = page.locator('.pane-header', { hasText: 'JJ Log' }).first();
+    const button = header.getByRole('button', { name });
+    await expect(button).toBeVisible({ timeout: 10000 });
+    await button.click();
+}
+
+/**
+ * Clicks a button within a notification toast.
+ */
+export async function clickNotificationButton(page: Page, actionLabel: string) {
+    await expect(async () => {
+        const toast = page.locator('.notifications-toasts .notification-toast');
+        const button = toast.getByRole('button', { name: actionLabel });
+        await expect(button).toBeVisible({ timeout: 2000 });
+        await button.click();
+    }, `Failed to click notification button "${actionLabel}"`).toPass({ timeout: 15000 });
+}
+
+/**
+ * Waits for the VS Code QuickInput widget to be visible and returns the input locator.
+ */
+export async function waitForQuickInput(page: Page): Promise<Locator> {
+    const quickInput = page.locator('.quick-input-widget');
+    const input = quickInput.locator('input.input');
+    await expect(input).toBeVisible({ timeout: 10000 });
+    return input;
 }

--- a/src/test/e2e/workspace.spec.ts
+++ b/src/test/e2e/workspace.spec.ts
@@ -4,10 +4,19 @@
  */
 import { expect, test } from '@playwright/test';
 import * as fs from 'fs';
+import * as path from 'path';
 import { TestRepo, buildGraph } from '../test-repo';
-import { focusJJLog, getLogWebview, launchVSCode } from './e2e-helpers';
+import {
+    clickLogTitleButton,
+    clickNotificationButton,
+    focusJJLog,
+    getLogWebview,
+    launchVSCode,
+    rightClickAndSelect,
+    waitForQuickInput,
+} from './e2e-helpers';
 
-test.describe('Workspace Labels E2E', () => {
+test.describe('Workspace Management E2E', () => {
     test('Shows workspace labels for multiple workspaces', async () => {
         const repo = new TestRepo();
         repo.init();
@@ -43,6 +52,119 @@ test.describe('Workspace Labels E2E', () => {
             // 'repo2@' should be on its own working copy (created by workspace add)
             const repo2Pill = webview.locator('.bookmark-pill', { hasText: new RegExp(`${workspaceName}.*@`) });
             await expect(repo2Pill).toBeVisible();
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Add Workspace via title bar action', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        // Use a unique name to avoid any potential (though unlikely) collisions
+        const workspaceName = `ws-${Date.now()}`;
+
+        // Enable notifications for this test so we can click "Open Workspace"
+        const { app, page, userDataDir } = await launchVSCode(repo, {}, {}, true);
+
+        try {
+            await focusJJLog(page);
+
+            // 1. Click Add Workspace in Title Bar
+            await clickLogTitleButton(page, 'Add Workspace');
+
+            // 2. Type name and Enter
+            const input = await waitForQuickInput(page);
+            await input.fill(workspaceName);
+            await page.keyboard.press('Enter');
+
+            // 3. Verify workspace pill appears in webview
+            const webview = await getLogWebview(page);
+            await expect(webview.locator('.bookmark-pill', { hasText: workspaceName })).toBeVisible({ timeout: 20000 });
+
+            // 4. Click "Open Workspace" in the notification and verify a new window opens
+            const nextWindowPromise = app.waitForEvent('window');
+            await clickNotificationButton(page, 'Open Workspace');
+            const newPage = await nextWindowPromise;
+
+            // Wait for workbench to load in new window
+            await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
+
+            // On Linux, the window title should contain the folder name
+            await expect.poll(async () => await newPage.title(), { timeout: 10000 }).toContain(workspaceName);
+
+            // 5. Verify in jj
+            const workspaces = repo.getLog('all()', 'working_copies.map(|w| w.name()).join("\\n")');
+            expect(workspaces).toContain(workspaceName);
+        } catch (e) {
+            throw e;
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Forget and Delete Workspace via context menu', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        const forgetWs = 'forget-me';
+        const deleteWs = 'delete-me';
+
+        // Add both workspaces info the .workspaces directory to match extension default
+        const workspacesRelativeDir = '.workspaces';
+        repo.workspaceAdd(path.join(workspacesRelativeDir, forgetWs));
+        repo.workspaceAdd(path.join(workspacesRelativeDir, deleteWs));
+
+        const forgetWsPath = path.resolve(repo.path, workspacesRelativeDir, forgetWs);
+        const deleteWsPath = path.resolve(repo.path, workspacesRelativeDir, deleteWs);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            const webview = await getLogWebview(page);
+
+            // 1. Forget Workspace
+            const forgetPill = webview.locator('.bookmark-pill', { hasText: forgetWs });
+            await expect(forgetPill).toBeVisible();
+
+            await rightClickAndSelect(page, forgetPill, 'Forget Workspace');
+
+            // Confirm warning dialog
+            const forgetBtn = page.getByRole('button', { name: 'Yes, Forget Workspace' });
+            await expect(forgetBtn, 'Forget confirmation button should be visible').toBeVisible({ timeout: 5000 });
+            await forgetBtn.click();
+
+            await expect(forgetPill).not.toBeVisible({ timeout: 15000 });
+
+            const stillExists = fs.existsSync(forgetWsPath);
+            expect(stillExists, `Directory ${forgetWsPath} should still exist after forget`).toBe(true);
+
+            // 2. Delete Workspace
+            const deletePill = webview.locator('.bookmark-pill', { hasText: deleteWs });
+            await expect(deletePill).toBeVisible();
+
+            await rightClickAndSelect(page, deletePill, 'Delete Workspace Directory');
+
+            // Confirm warning dialog
+            const deleteBtn = page.getByRole('button', { name: 'Yes, Delete Workspace' });
+            await expect(deleteBtn, 'Delete confirmation button should be visible').toBeVisible({ timeout: 5000 });
+            await deleteBtn.click();
+
+            await expect(deletePill).not.toBeVisible({ timeout: 15000 });
+
+            const gone = !fs.existsSync(deleteWsPath);
+            expect(gone, `Directory ${deleteWsPath} should be removed after delete`).toBe(true);
+        } catch (e) {
+            throw e;
         } finally {
             await app.close();
             try {

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -141,8 +141,47 @@ log = "none()"
             expect(fs.existsSync(path.join(wsPath, '.jj'))).toBe(true);
 
             // Verify it shows up in workspace list
-            const output = cp.execFileSync('jj', ['workspace', 'list'], { cwd: repo.path, encoding: 'utf-8' });
+            const output = repo.listWorkspaces();
             expect(output).toContain('new_ws');
+        });
+
+        test('getWorkspaceRoot returns correct paths', async () => {
+            // 1. Current workspace
+            const currentRoot = await jjService.getWorkspaceRoot();
+            expect(fs.realpathSync.native(currentRoot)).toBe(fs.realpathSync.native(repo.path));
+
+            // 2. Secondary workspace
+            const wsPath = path.join(repo.path, 'ws_for_root');
+            await jjService.workspaceAdd(wsPath, 'ws_for_root');
+            const wsRoot = await jjService.getWorkspaceRoot('ws_for_root');
+            expect(fs.realpathSync.native(wsRoot)).toBe(fs.realpathSync.native(wsPath));
+        });
+
+        test('workspaceForget removes workspace from tracking', async () => {
+            const wsPath = path.join(repo.path, 'ws_to_forget');
+            await jjService.workspaceAdd(wsPath, 'ws_to_forget');
+
+            // Verify it exists in list
+            let output = repo.listWorkspaces();
+            expect(output).toContain('ws_to_forget');
+
+            // Forget it
+            await jjService.workspaceForget('ws_to_forget');
+
+            // Verify it's gone from list
+            output = repo.listWorkspaces();
+            expect(output).not.toContain('ws_to_forget');
+
+            // Directory should still exist (jj forget doesnt delete path)
+            expect(fs.existsSync(wsPath)).toBe(true);
+        });
+
+        test('getWorkspaces returns all workspace names', async () => {
+            await jjService.workspaceAdd(path.join(repo.path, 'ws1'), 'ws1');
+            await jjService.workspaceAdd(path.join(repo.path, 'ws2'), 'ws2');
+
+            const workspaces = await jjService.getWorkspaces();
+            expect(workspaces.sort()).toEqual(['default', 'ws1', 'ws2']);
         });
 
         test('creates a new change with parent', async () => {
@@ -1412,7 +1451,7 @@ log = "none()"
         const currentWcEntry = logs.find((l) => l.is_current_working_copy);
         expect(currentWcEntry).toBeDefined();
         expect(currentWcEntry!.change_id).toBe(currentWcId);
-        expect(currentWcEntry!.working_copies).toContain('default@');
+        expect(currentWcEntry!.working_copies).toContain('default');
     });
 
     describe('upload', () => {

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -308,6 +308,10 @@ export class TestRepo {
     gitImport() {
         this.exec(['git', 'import']);
     }
+
+    listWorkspaces(): string {
+        return this.exec(['workspace', 'list']);
+    }
 }
 
 export interface CommitDefinition {

--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -87,16 +87,25 @@ export const WorkspacePill: React.FC<{ workspace: string; style?: React.CSSPrope
     const borderColor = `color-mix(in srgb, ${accentColor}, transparent 50%)`;
 
     return (
-        <BasePill
-            style={{
-                backgroundColor,
-                color: accentColor,
-                border: `1px solid ${borderColor}`,
-                ...style,
-            }}
+        <span
+            data-vscode-context={JSON.stringify({
+                webviewSection: 'workspace',
+                workspaceName: workspace,
+                preventDefaultContextMenuItems: true,
+            })}
+            style={{ display: 'inline-flex', alignItems: 'center' }}
         >
-            {workspace}
-        </BasePill>
+            <BasePill
+                style={{
+                    backgroundColor,
+                    color: accentColor,
+                    border: `1px solid ${borderColor}`,
+                    ...style,
+                }}
+            >
+                {workspace}@
+            </BasePill>
+        </span>
     );
 };
 


### PR DESCRIPTION
This change adds support for forgetting and deleting workspaces directly from the UI.

- Adds `Forget Workspace` and `Delete Workspace Directory` commands.
- Implements a custom context menu for workspace pills in the Log View webview.
- Adds comprehensive E2E and unit tests for the new workspace management features.
- Improves the 'Add Workspace' command with better post-creation workflow and notifications.