### PR TITLE
fix: implement robust directory deletion for workspace removal

### DIFF
--- a/src/commands/workspace-delete.ts
+++ b/src/commands/workspace-delete.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { JjScmProvider } from '../jj-scm-provider';
@@ -42,9 +43,8 @@ export async function workspaceDeleteCommand(scmProvider: JjScmProvider, jj: JjS
                 }
 
                 await jj.workspaceForget(workspaceName);
-
                 if (dirPath) {
-                    await fs.promises.rm(dirPath, { recursive: true, force: true });
+                    await rmRecursive(dirPath);
                 }
             },
         );
@@ -54,4 +54,41 @@ export async function workspaceDeleteCommand(scmProvider: JjScmProvider, jj: JjS
         vscode.window.showErrorMessage(`Failed to delete workspace: ${message}`);
         scmProvider.outputChannel.appendLine(`[Error] Workspace delete failed: ${message}`);
     }
+}
+
+/**
+ * Robustly deletes a directory. Falls back to the system `rm` command on
+ * Linux/macOS when Node's fs.rm fails, which can happen because Electron
+ * patches the fs module to intercept .asar paths inside VS Code installations.
+ */
+async function rmRecursive(dirPath: string) {
+    try {
+        await withTimeout(fs.promises.rm(dirPath, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }));
+    } catch {
+        if (process.platform === 'win32') {
+            await execAsync('cmd.exe', ['/c', 'rd', '/s', '/q', dirPath]);
+        } else {
+            await execAsync('rm', ['-rf', dirPath]);
+        }
+    }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms = 5000): Promise<T> {
+    let timeoutId: NodeJS.Timeout;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('Timed out')), ms);
+    });
+    return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeoutId));
+}
+
+function execAsync(command: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+        cp.execFile(command, args, (err) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    });
 }


### PR DESCRIPTION
Introduces a resilient directory cleanup mechanism in the workspace deletion command to handle filesystem race conditions and file locks.

The new `rmRecursive` utility combines Node.js `fs.promises.rm` with a retry strategy and a 5-second timeout. If the standard removal fails—as can happen in Electron-based environments due to patched `fs` behavior—it falls back to native system commands (`rm -rf` or `rd`) to ensure the workspace directory is successfully removed.