### PR TITLE
Gracefully handle deleted files in SCM view

### DIFF
--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -8,7 +8,6 @@ import { createDiffUris } from '../uri-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {
-    // await import('./vscode-mock'); // this was redundant
     const { createVscodeMock } = await import('./vscode-mock');
     return await createVscodeMock({});
 });
@@ -73,5 +72,96 @@ describe('createDiffUris', () => {
         expect(rightUri.path).toBe('/root/new.txt');
         expect(rightUri.query).toContain('base=rev1');
         expect(rightUri.query).toContain('side=right');
+    });
+
+    it('handles removed files in working copy correctly', () => {
+        const entry: JjStatusEntry = {
+            path: 'deleted.txt',
+            status: 'removed',
+        };
+        const revision = '@';
+
+        const { leftUri, rightUri } = createDiffUris(entry, revision, root);
+
+        expect(leftUri.scheme).toBe('jj-view');
+        expect(leftUri.path).toBe('/root/deleted.txt');
+        expect(leftUri.query).toContain('base=@');
+        expect(leftUri.query).toContain('side=left');
+
+        // DESIRED FIX: Removed files in working copy should use jj-view scheme for right side
+        // to avoid "File not found" errors in VS Code.
+        expect(rightUri.scheme).toBe('jj-view');
+        expect(rightUri.path).toBe('/root/deleted.txt');
+        expect(rightUri.query).toContain('base=@');
+        expect(rightUri.query).toContain('side=right');
+    });
+
+    it('handles deleted status in working copy correctly', () => {
+        const entry: JjStatusEntry = {
+            path: 'deleted.txt',
+            status: 'deleted',
+        };
+        const revision = '@';
+
+        const { rightUri } = createDiffUris(entry, revision, root);
+
+        expect(rightUri.scheme).toBe('jj-view');
+        expect(rightUri.query).toContain('side=right');
+    });
+
+    it('handles removed files in ancestors correctly', () => {
+        const entry: JjStatusEntry = {
+            path: 'deleted.txt',
+            status: 'removed',
+        };
+        const revision = 'rev1';
+
+        const { leftUri, rightUri } = createDiffUris(entry, revision, root);
+
+        expect(leftUri.scheme).toBe('jj-view');
+        expect(rightUri.scheme).toBe('jj-view');
+        expect(rightUri.query).toContain('side=right');
+    });
+
+    it('handles added files in working copy correctly', () => {
+        const entry: JjStatusEntry = {
+            path: 'new.txt',
+            status: 'added',
+        };
+        const revision = '@';
+
+        const { leftUri, rightUri } = createDiffUris(entry, revision, root);
+
+        expect(leftUri.scheme).toBe('jj-view');
+        expect(leftUri.query).toContain('side=left');
+        expect(rightUri.scheme).toBe('file');
+    });
+
+    it('handles copied files correctly', () => {
+        const entry: JjStatusEntry = {
+            path: 'copy.txt',
+            oldPath: 'original.txt',
+            status: 'copied',
+        };
+        const revision = 'rev1';
+
+        const { leftUri, rightUri } = createDiffUris(entry, revision, root);
+
+        expect(leftUri.path).toBe('/root/original.txt');
+        expect(rightUri.path).toBe('/root/copy.txt');
+    });
+
+    it('detects working copy via options.workingCopyChangeId', () => {
+        const entry: JjStatusEntry = {
+            path: 'file.txt',
+            status: 'modified',
+        };
+        // Revision is a commit ID, but it matches the working copy change ID
+        const revision = 'commit-123';
+        const { rightUri } = createDiffUris(entry, revision, root, {
+            workingCopyChangeId: 'commit-123',
+        });
+
+        expect(rightUri.scheme).toBe('file');
     });
 });

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -29,7 +29,14 @@ export function createDiffUris(
     });
 
     let rightUri: vscode.Uri;
-    if (isCurrentWorkingCopy) {
+    const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
+    if (isDeleted) {
+        rightUri = vscode.Uri.from({
+            scheme: 'jj-view',
+            path: resourceUri.path,
+            query: `base=${revision}&side=right`,
+        });
+    } else if (isCurrentWorkingCopy) {
         rightUri = resourceUri;
     } else if (options.editable) {
         // Editable: use jj-edit scheme backed by FileSystemProvider


### PR DESCRIPTION
Previously, clicking a deleted file in the SCM view caused a 'file not found' error because the extension looked for the file on disk. We now use the virtual scheme for deleted files, allowing them to show a proper diff even when the physical file is gone.

Fixes #239