### PR TITLE
feat: show correct icons for deleted and copied files in Commit Details

### DIFF
--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -627,8 +627,10 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
 function getFileIcon(status: string): string {
     switch (status) {
         case 'added':
+        case 'copied':
             return 'diff-added';
         case 'removed':
+        case 'deleted':
             return 'diff-removed';
         case 'modified':
             return 'diff-modified';
@@ -642,8 +644,10 @@ function getFileIcon(status: string): string {
 function getFileColor(status: string): string {
     switch (status) {
         case 'added':
+        case 'copied':
             return 'var(--vscode-gitDecoration-addedResourceForeground)';
         case 'removed':
+        case 'deleted':
             return 'var(--vscode-gitDecoration-deletedResourceForeground)';
         case 'modified':
             return 'var(--vscode-gitDecoration-modifiedResourceForeground)';


### PR DESCRIPTION
Updates the Commit Details webview to explicitly handle the 'deleted' and 'copied' statuses. This ensures deleted files show the 'diff-removed' icon (red) and copied files show the 'diff-added' icon (green) instead of falling back to generic styles.

Fixes #238