### PR TITLE
chore: decouple format and license checks from lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -611,7 +611,7 @@
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "pnpm build && pnpm build:tests && pnpm lint",
         "check-types": "tsc --noEmit",
-        "lint": "pnpm format && eslint src && pnpm check-license",
+        "lint": "eslint src",
         "check-license": "go run github.com/google/addlicense@v1.1.1 -check -s=only -ignore='node_modules/**' -ignore='dist/**' -ignore='out/**' -ignore='coverage/**' -ignore='.vscode-test/**' -ignore='.jj/**' -ignore='media/custom-icons/**' -ignore='pnpm-lock.yaml' **",
         "fix-license": "go run github.com/google/addlicense@v1.1.1 -s=only -ignore='node_modules/**' -ignore='dist/**' -ignore='out/**' -ignore='coverage/**' -ignore='.vscode-test/**' -ignore='.jj/**' -ignore='media/custom-icons/**' -ignore='pnpm-lock.yaml' **",
         "format": "prettier --write .",

--- a/tooling/jj/repo-config.toml
+++ b/tooling/jj/repo-config.toml
@@ -14,6 +14,17 @@ patterns = [
     "glob:'**/*.css'",
 ]
 
+[fix.tools.addlicense]
+command = ["go", "run", "github.com/google/addlicense@v1.1.1", "-s=only", "$path"]
+patterns = [
+    "glob:'**/*.ts'",
+    "glob:'**/*.tsx'",
+    "glob:'**/*.js'",
+    "glob:'**/*.jsx'",
+    "glob:'**/*.css'",
+]
+
+
 [[--scope]]
 --when.environments = ["ANTIGRAVITY_AGENT"]
 [--scope.ui]


### PR DESCRIPTION
- Removed pnpm format and pnpm check-license from the lint script in package.json to avoid side effects during linting.
- Added addlicense to fix.tools in tooling/jj/repo-config.toml to support the jj fix workflow for license headers.