### PR TITLE
feat: hide log hover buttons via right-click

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
             },
             {
                 "command": "jj-view.squash",
-                "title": "Squash into Parent",
+                "title": "Squash",
                 "category": "JJ View",
                 "icon": "$(arrow-down)"
             },
@@ -353,6 +353,66 @@
                 "title": "Delete Workspace Directory",
                 "category": "JJ View",
                 "icon": "$(trash)"
+            },
+            {
+                "command": "jj-view.hideCommitAction.newChild",
+                "title": "Hide 'New Child'",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.hideCommitAction.edit",
+                "title": "Hide 'Edit'",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.hideCommitAction.squash",
+                "title": "Hide 'Squash'",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.hideCommitAction.abandon",
+                "title": "Hide 'Abandon'",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.newChild.on",
+                "title": "● New Child",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.newChild.off",
+                "title": "○ New Child",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.edit.on",
+                "title": "● Edit",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.edit.off",
+                "title": "○ Edit",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.squash.on",
+                "title": "● Squash",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.squash.off",
+                "title": "○ Squash",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.abandon.on",
+                "title": "● Abandon",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.abandon.off",
+                "title": "○ Abandon",
+                "category": "JJ View"
             }
         ],
         "keybindings": [
@@ -420,58 +480,118 @@
                 },
                 {
                     "command": "jj-view.new",
-                    "when": "webviewSection == 'commit' && canNewChild",
+                    "when": "webviewSection == 'commit' && jj.canNewChild",
                     "group": "2_edit@1"
                 },
                 {
                     "command": "jj-view.newBefore",
-                    "when": "webviewSection == 'commit' && canNewBefore",
+                    "when": "webviewSection == 'commit' && jj.canNewBefore",
                     "group": "2_edit@2"
                 },
                 {
                     "command": "jj-view.newAfter",
-                    "when": "webviewSection == 'commit' && canNewAfter",
+                    "when": "webviewSection == 'commit' && jj.canNewAfter",
                     "group": "2_edit@3"
                 },
                 {
                     "command": "jj-view.edit",
-                    "when": "webviewSection == 'commit' && canEdit",
+                    "when": "webviewSection == 'commit' && jj.canEdit",
                     "group": "2_edit@4"
                 },
                 {
                     "command": "jj-view.duplicate",
-                    "when": "webviewSection == 'commit' && canDuplicate",
+                    "when": "webviewSection == 'commit' && jj.canDuplicate",
                     "group": "4_changes@1"
                 },
                 {
                     "command": "jj-view.abandon",
-                    "when": "webviewSection == 'commit' && canAbandon",
+                    "when": "webviewSection == 'commit' && jj.canAbandon",
                     "group": "4_changes@2"
                 },
                 {
                     "command": "jj-view.absorb",
-                    "when": "webviewSection == 'commit' && canAbsorb",
+                    "when": "webviewSection == 'commit' && jj.canAbsorb",
                     "group": "4_changes@3"
                 },
                 {
                     "command": "jj-view.upload",
-                    "when": "webviewSection == 'commit' && canUpload",
+                    "when": "webviewSection == 'commit' && jj.canUpload",
                     "group": "3_bookmark@2"
                 },
                 {
                     "command": "jj-view.rebaseOntoSelected",
-                    "when": "webviewSection == 'commit' && canRebaseOnto",
+                    "when": "webviewSection == 'commit' && jj.canRebaseOnto",
                     "group": "5_rebase@1"
                 },
                 {
                     "command": "jj-view.newMergeChange",
-                    "when": "webviewSection == 'commit' && canMerge",
+                    "when": "webviewSection == 'commit' && jj.canMerge",
                     "group": "5_rebase@2"
                 },
                 {
                     "command": "jj-view.setBookmark",
                     "when": "webviewSection == 'commit'",
                     "group": "3_bookmark@1"
+                },
+                {
+                    "command": "jj-view.hideCommitAction.newChild",
+                    "when": "webviewSection == 'commitAction' && jj.actionId == 'newChild' && jj.newChildVisible",
+                    "group": "9_visibility_1_hide"
+                },
+                {
+                    "command": "jj-view.hideCommitAction.edit",
+                    "when": "webviewSection == 'commitAction' && jj.actionId == 'edit' && jj.editVisible",
+                    "group": "9_visibility_1_hide"
+                },
+                {
+                    "command": "jj-view.hideCommitAction.squash",
+                    "when": "webviewSection == 'commitAction' && jj.actionId == 'squash' && jj.squashVisible",
+                    "group": "9_visibility_1_hide"
+                },
+                {
+                    "command": "jj-view.hideCommitAction.abandon",
+                    "when": "webviewSection == 'commitAction' && jj.actionId == 'abandon' && jj.abandonVisible",
+                    "group": "9_visibility_1_hide"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.newChild.on",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.newChild",
+                    "group": "9_visibility_2_toggle@1"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.newChild.off",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.newChild",
+                    "group": "9_visibility_2_toggle@1"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.edit.on",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.edit",
+                    "group": "9_visibility_2_toggle@2"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.edit.off",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.edit",
+                    "group": "9_visibility_2_toggle@2"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.squash.on",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.squash",
+                    "group": "9_visibility_2_toggle@3"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.squash.off",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.squash",
+                    "group": "9_visibility_2_toggle@3"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.abandon.on",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.abandon",
+                    "group": "9_visibility_2_toggle@4"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.abandon.off",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.abandon",
+                    "group": "9_visibility_2_toggle@4"
                 }
             ],
             "scm/title": [

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -23,28 +23,28 @@ function hasResourceStates(arg: unknown): arg is { resourceStates: unknown[] } {
     return Array.isArray(obj.resourceStates);
 }
 
-function hasRevision(arg: unknown): arg is { revision: string } {
-    if (typeof arg !== 'object' || arg === null || !('revision' in arg)) {
+function hasRevision(arg: unknown): arg is { revision: string } | { 'jj.revision': string } {
+    if (typeof arg !== 'object' || arg === null) {
         return false;
     }
-    const obj = arg as { revision: unknown };
-    return typeof obj.revision === 'string';
+    const obj = arg as Record<string, unknown>;
+    return typeof obj.revision === 'string' || typeof obj['jj.revision'] === 'string';
 }
 
-function hasCommitId(arg: unknown): arg is { commitId: string } {
-    if (typeof arg !== 'object' || arg === null || !('commitId' in arg)) {
+function hasCommitId(arg: unknown): arg is { commitId: string } | { 'jj.commitId': string } {
+    if (typeof arg !== 'object' || arg === null) {
         return false;
     }
-    const obj = arg as { commitId: unknown };
-    return typeof obj.commitId === 'string';
+    const obj = arg as Record<string, unknown>;
+    return typeof obj.commitId === 'string' || typeof obj['jj.commitId'] === 'string';
 }
 
-function hasChangeId(arg: unknown): arg is { changeId: string } {
-    if (typeof arg !== 'object' || arg === null || !('changeId' in arg)) {
+function hasChangeId(arg: unknown): arg is { changeId: string } | { 'jj.changeId': string } {
+    if (typeof arg !== 'object' || arg === null) {
         return false;
     }
-    const obj = arg as { changeId: unknown };
-    return typeof obj.changeId === 'string';
+    const obj = arg as Record<string, unknown>;
+    return typeof obj.changeId === 'string' || typeof obj['jj.changeId'] === 'string';
 }
 
 /**
@@ -112,17 +112,20 @@ export function extractRevisions(args: unknown[]): string[] {
         }
 
         if (hasRevision(arg)) {
-            revisions.push(arg.revision);
+            const val = 'revision' in arg ? arg.revision : arg['jj.revision'];
+            revisions.push(val);
             continue;
         }
 
         if (hasChangeId(arg)) {
-            revisions.push(arg.changeId);
+            const val = 'changeId' in arg ? arg.changeId : arg['jj.changeId'];
+            revisions.push(val);
             continue;
         }
 
         if (hasCommitId(arg)) {
-            revisions.push(arg.commitId);
+            const val = 'commitId' in arg ? arg.commitId : arg['jj.commitId'];
+            revisions.push(val);
             continue;
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjLogWebviewProvider } from './jj-log-webview-provider';
 import { JjScmProvider } from './jj-scm-provider';
 import { JjService } from './jj-service';
+import { TOGGLEABLE_COMMIT_ACTIONS } from './jj-types';
 import { JjViewFileSystemProvider } from './jj-view-fs-provider';
 import { resolveJjBinary } from './utils/binary-utils';
 
@@ -299,6 +300,7 @@ export function activate(context: vscode.ExtensionContext) {
         (ids) => {
             scmProvider.handleSelectionChange(ids);
         },
+        context,
         outputChannel,
     );
     context.subscriptions.push(
@@ -352,6 +354,20 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(undoCmd);
     context.subscriptions.push(redoCmd);
     context.subscriptions.push(rebaseOntoSelectedCmd);
+
+    for (const actionId of TOGGLEABLE_COMMIT_ACTIONS) {
+        context.subscriptions.push(
+            vscode.commands.registerCommand(`jj-view.hideCommitAction.${actionId}`, () =>
+                logWebviewProvider.toggleActionVisibility(actionId),
+            ),
+            vscode.commands.registerCommand(`jj-view.toggleCommitAction.${actionId}.on`, () =>
+                logWebviewProvider.toggleActionVisibility(actionId),
+            ),
+            vscode.commands.registerCommand(`jj-view.toggleCommitAction.${actionId}.off`, () =>
+                logWebviewProvider.toggleActionVisibility(actionId),
+            ),
+        );
+    }
 
     context.subscriptions.push(disposable);
     context.subscriptions.push(newCmd);

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -7,13 +7,14 @@ import { GerritService } from './gerrit-service';
 import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
 import { JjContextKey } from './jj-context-keys';
 import { JjService } from './jj-service';
-import { JjLogEntry } from './jj-types';
+import { JjLogEntry, TOGGLEABLE_COMMIT_ACTIONS, ToggleableCommitAction } from './jj-types';
 import { formatCommitTitle } from './utils/jj-utils';
 
 export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'jj-view.logView';
     private _view?: vscode.WebviewView;
     private _cachedCommits: JjLogEntry[] = [];
+    private readonly _hiddenActionsKey = 'jj-view.hiddenCommitActions';
 
     constructor(
         private readonly _extensionUri: vscode.Uri,
@@ -21,6 +22,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         private readonly _gerrit: GerritService,
         private readonly _commitDetailsProvider: JjCommitDetailsEditorProvider,
         private readonly _onSelectionChange: (commits: string[]) => void,
+        private readonly _context: vscode.ExtensionContext,
         public readonly outputChannel?: vscode.OutputChannel, // Optional
     ) {
         // Gerrit updates only need to re-render, not re-fetch jj log
@@ -38,6 +40,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 payload: { changeId },
             });
         });
+
+        this._updateContextKeys();
     }
 
     public get jj(): JjService {
@@ -66,12 +70,14 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 const config = vscode.workspace.getConfiguration('jj-view');
                 const currentTheme = config.get<string>('logTheme', 'default');
                 const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
+                const hiddenActions = this._getHiddenActions();
                 webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
                     view: 'graph',
                     payload: {
                         commits: this._cachedCommits,
                         theme: currentTheme,
                         graphLabelAlignment,
+                        hiddenActions,
                     },
                 });
             }
@@ -80,12 +86,14 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const config = vscode.workspace.getConfiguration('jj-view');
         const initialTheme = config.get<string>('logTheme', 'default');
         const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
+        const hiddenActions = this._getHiddenActions();
         webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
             view: 'graph',
             payload: {
                 commits: this._cachedCommits,
                 theme: initialTheme,
                 graphLabelAlignment,
+                hiddenActions,
             },
         });
 
@@ -301,7 +309,40 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             minChangeIdLength,
             theme: logTheme,
             graphLabelAlignment,
+            hiddenActions: this._getHiddenActions(),
         });
+    }
+
+    private _getHiddenActions(): string[] {
+        return this._context.globalState.get<string[]>(this._hiddenActionsKey, []);
+    }
+
+    public async toggleActionVisibility(actionId: ToggleableCommitAction) {
+        const hidden = new Set(this._getHiddenActions());
+        if (hidden.has(actionId)) {
+            hidden.delete(actionId);
+        } else {
+            hidden.add(actionId);
+        }
+        const newHidden = Array.from(hidden);
+        await this._context.globalState.update(this._hiddenActionsKey, newHidden);
+
+        this._updateContextKeys();
+
+        this._view?.webview.postMessage({
+            type: 'updateHiddenActions',
+            payload: { hiddenActions: newHidden },
+        });
+    }
+
+    private _updateContextKeys() {
+        const hiddenActions = this._getHiddenActions();
+        const hidden = new Set(hiddenActions);
+        for (const actionId of TOGGLEABLE_COMMIT_ACTIONS) {
+            const key = `jj.commitActionVisible.${actionId}`;
+            const value = !hidden.has(actionId);
+            vscode.commands.executeCommand('setContext', key, value);
+        }
     }
 
     public async createCommitDetailsPanel(

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -62,3 +62,46 @@ export interface JjStatusEntry {
     deletions?: number;
     conflicted?: boolean;
 }
+
+export type CommitAction = 'newChild' | 'edit' | 'squash' | 'abandon' | 'openGerrit' | 'upload';
+
+export const TOGGLEABLE_COMMIT_ACTIONS = ['newChild', 'edit', 'squash', 'abandon'] as const;
+export type ToggleableCommitAction = (typeof TOGGLEABLE_COMMIT_ACTIONS)[number];
+
+export interface ActionPayload {
+    changeId: string;
+    isImmutable?: boolean;
+    url?: string;
+    multiSelect?: boolean;
+    changeIdShortest?: string;
+    isDivergent?: boolean;
+    changeIdOffset?: number;
+}
+
+/** Payload for the initial webview load */
+export interface WebviewPayload {
+    commits?: JjLogEntry[];
+    minChangeIdLength?: number;
+    theme?: string;
+    graphLabelAlignment?: string;
+    hiddenActions?: CommitAction[];
+    // Details fields
+    changeId?: string;
+    commitId?: string;
+    description?: string;
+    files?: JjStatusEntry[];
+    isImmutable?: boolean;
+    isEmpty?: boolean;
+    isConflict?: boolean;
+    author?: { name: string; email: string; timestamp: string };
+    committer?: { name: string; email: string; timestamp: string };
+    bookmarks?: JjBookmark[];
+    tags?: string[];
+    titleWidthRuler?: number;
+    bodyWidthRuler?: number;
+}
+
+export interface WebviewInitialData {
+    view: 'graph' | 'details';
+    payload?: WebviewPayload;
+}

--- a/src/test/commit-utils.test.ts
+++ b/src/test/commit-utils.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { JjService } from '../jj-service';
+import { CommitAction, JjLogEntry } from '../jj-types';
+import { computeCommitActions } from '../webview/utils/commit-utils';
+import { buildGraph, TestRepo } from './test-repo';
+
+describe('computeCommitActions', () => {
+    let repo: TestRepo;
+    let jj: JjService;
+
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path);
+    });
+
+    afterEach(() => {
+        repo.dispose();
+    });
+
+    async function getCommit(revision: string): Promise<JjLogEntry> {
+        const log = await jj.getLog({ revision });
+        return log[0];
+    }
+
+    it('should show all actions when everything is mutable and nothing is hidden', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'A', parents: ['root()'] },
+            { label: 'B', parents: ['A'] },
+        ]);
+        const commit = await getCommit(ids.B.changeId);
+
+        const hiddenActions = new Set<CommitAction>();
+        const result = computeCommitActions(commit, hiddenActions, false, false, 0, false);
+
+        expect(result.visibleActions).toEqual({
+            newChild: true,
+            edit: true,
+            squash: true,
+            abandon: true,
+        });
+        expect(result.vscodeContext['jj.canEdit']).toBe(true);
+        expect(result.vscodeContext['jj.canAbandon']).toBe(true);
+    });
+
+    it('should hide immutable actions', async () => {
+        // Root is immutable
+        const commit = await getCommit('root()');
+        const hiddenActions = new Set<CommitAction>();
+        const result = computeCommitActions(commit, hiddenActions, true, false, 0, false);
+
+        expect(result.visibleActions.edit).toBe(false);
+        expect(result.visibleActions.abandon).toBe(false);
+        expect(result.vscodeContext['jj.canEdit']).toBe(false);
+        expect(result.vscodeContext['jj.canAbandon']).toBe(false);
+    });
+
+    it('should respect hiddenActions', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'A', parents: ['root()'] },
+            { label: 'B', parents: ['A'] },
+        ]);
+        const commit = await getCommit(ids.B.changeId);
+
+        const hiddenActions = new Set<CommitAction>(['newChild', 'squash']);
+        const result = computeCommitActions(commit, hiddenActions, false, false, 0, false);
+
+        expect(result.visibleActions.newChild).toBe(false);
+        expect(result.visibleActions.squash).toBe(false);
+        expect(result.visibleActions.edit).toBe(true);
+        expect(result.visibleActions.abandon).toBe(true);
+    });
+
+    it('should only allow squash if there is exactly one mutable parent', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'A', parents: ['root()'] },
+            { label: 'B', parents: ['A'] },
+            { label: 'C', parents: ['root()'] },
+            { label: 'Merge', parents: ['A', 'C'] },
+        ]);
+
+        // Child of root (one immutable parent)
+        const commitA = await getCommit(ids.A.changeId);
+        const result1 = computeCommitActions(commitA, new Set(), false, false, 0, false);
+        expect(result1.visibleActions.squash).toBe(false);
+
+        // Child of mutable (one mutable parent)
+        const commitB = await getCommit(ids.B.changeId);
+        const result2 = computeCommitActions(commitB, new Set(), false, false, 0, false);
+        expect(result2.visibleActions.squash).toBe(true);
+
+        // Merge commit (two parents)
+        const commitMerge = await getCommit(ids.Merge.changeId);
+        const result3 = computeCommitActions(commitMerge, new Set(), false, false, 0, false);
+        expect(result3.visibleActions.squash).toBe(false);
+    });
+
+    it('should handle selection states correctly', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+
+        // Single selection
+        const result1 = computeCommitActions(commit, new Set(), false, true, 1, false);
+        expect(result1.vscodeContext.viewItem).toBe('jj-commit-selected');
+        expect(result1.vscodeContext['jj.canEdit']).toBe(true);
+
+        // Multi selection
+        const result2 = computeCommitActions(commit, new Set(), false, true, 2, false);
+        expect(result2.vscodeContext['jj.canEdit']).toBe(false);
+        expect(result2.vscodeContext['jj.canMerge']).toBe(true);
+    });
+
+    it('should prevent rebase onto self', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+
+        const result = computeCommitActions(commit, new Set(), false, true, 1, false);
+        expect(result.vscodeContext['jj.canRebaseOnto']).toBe(false);
+    });
+
+    it('should allow rebase onto selection when not selected', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+
+        const result = computeCommitActions(commit, new Set(), false, false, 1, false);
+        expect(result.vscodeContext['jj.canRebaseOnto']).toBe(true);
+    });
+
+    it('should only allow absorb if at least one parent is mutable', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'A', parents: ['root()'] },
+            { label: 'B', parents: ['A'] },
+        ]);
+
+        // Parent is root (immutable)
+        const commitA = await getCommit(ids.A.changeId);
+        const result1 = computeCommitActions(commitA, new Set(), false, false, 0, false);
+        expect(result1.vscodeContext['jj.canAbsorb']).toBe(false);
+
+        // Parent is mutable
+        const commitB = await getCommit(ids.B.changeId);
+        const result2 = computeCommitActions(commitB, new Set(), false, false, 0, false);
+        expect(result2.vscodeContext['jj.canAbsorb']).toBe(true);
+    });
+
+    it('should restrict canAbsorb and canEdit to single selection', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'A', parents: ['root()'] },
+            { label: 'B', parents: ['A'] },
+        ]);
+        const commit = await getCommit(ids.B.changeId);
+
+        // Selected in multi-selection
+        const result1 = computeCommitActions(commit, new Set(), false, true, 2, false);
+        expect(result1.vscodeContext['jj.canEdit']).toBe(false);
+        expect(result1.vscodeContext['jj.canAbsorb']).toBe(false);
+
+        // Unselected while others are selected
+        const result2 = computeCommitActions(commit, new Set(), false, false, 2, false);
+        expect(result2.vscodeContext['jj.canEdit']).toBe(true);
+        expect(result2.vscodeContext['jj.canAbsorb']).toBe(true);
+    });
+
+    it('should disable multi-item actions if selection contains immutable commits', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+
+        // Selection has immutable commit (e.g. root)
+        const result = computeCommitActions(commit, new Set(), false, true, 2, true);
+
+        expect(result.vscodeContext['jj.canAbandon']).toBe(false);
+        expect(result.vscodeContext['jj.canNewBefore']).toBe(false);
+        expect(result.vscodeContext['jj.canNewAfter']).toBe(false);
+    });
+
+    it('should handle canNewChild and canDuplicate in single-item context', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+
+        // Single selection
+        const result1 = computeCommitActions(commit, new Set(), false, true, 1, false);
+        expect(result1.vscodeContext['jj.canNewChild']).toBe(true);
+        expect(result1.vscodeContext['jj.canDuplicate']).toBe(true);
+
+        // Multi selection
+        const result2 = computeCommitActions(commit, new Set(), false, true, 2, false);
+        expect(result2.vscodeContext['jj.canNewChild']).toBe(false);
+        expect(result2.vscodeContext['jj.canDuplicate']).toBe(false);
+    });
+});

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -141,7 +141,7 @@ test.describe('Divergent Commits E2E', () => {
         const rowToAbandon = webview2.locator('.commit-row', { hasText: 'commit A v1' });
 
         await expect(rowToAbandon).toBeVisible();
-        await hoverAndClick(rowToAbandon, webview2.locator('.icon-button[title="Abandon Commit"]'));
+        await hoverAndClick(rowToAbandon, webview2.locator('.icon-button[title="Abandon"]'));
 
         // 5. Verify divergence is resolved
         await expect(async () => {

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -205,7 +205,7 @@ test.describe('JJ Log Pane E2E', () => {
             ]);
 
             // 3. Squash the child into branch
-            await clickLogAction(page, { changeId: childId }, 'Squash into Parent');
+            await clickLogAction(page, { changeId: childId }, 'Squash');
 
             // After squash: child is gone. branch has its changes.
             await expectTree(repo, [
@@ -216,7 +216,7 @@ test.describe('JJ Log Pane E2E', () => {
             ]);
 
             // 4. Abandon the branch commit
-            await clickLogAction(page, { changeId: branchId }, 'Abandon Commit');
+            await clickLogAction(page, { changeId: branchId }, 'Abandon');
 
             // After abandon branch: branch is gone. wc (child of branch) becomes child of initial.
             // Tree: [wc, initial(@)]

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -248,11 +248,10 @@ test.describe('SCM Pane E2E', () => {
             }).toPass({ timeout: 5000 });
 
             // File-Level Squash (file.txt)
-            // Hover over file.txt in Working Copy and click Squash into Parent
+            // Hover over file.txt in Working Copy and click Squash
             // file.txt and the group squash action share the same codicon-arrow-down icon
             const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
-            // Use role and more flexible title matching for reliability across VS Code versions
-            const squashFileIcon = wcFileRow.getByRole('button', { name: /Squash into (Parent|Ancestor)/ }).first();
+            const squashFileIcon = wcFileRow.getByRole('button', { name: 'Squash', exact: true }).first();
             await hoverAndClick(wcFileRow, squashFileIcon);
 
             // Assert via repo that file.txt changes were squashed into the parent commit
@@ -324,7 +323,7 @@ test.describe('SCM Pane E2E', () => {
 
             // Hover to reveal inline actions
             await newWcFileRow.hover();
-            const squashIcon = newWcFileRow.getByRole('button', { name: 'Squash into Parent', exact: true }).first();
+            const squashIcon = newWcFileRow.getByRole('button', { name: 'Squash', exact: true }).first();
             await expect(squashIcon).toBeVisible();
 
             // The squashInto action should be visible since there are two mutable ancestors

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -684,6 +684,13 @@ suite('JJ SCM Provider Integration Test', function () {
                 gerritService,
                 commitDetailsProvider,
                 () => {},
+                createMock<vscode.ExtensionContext>({
+                    globalState: createMock<vscode.ExtensionContext['globalState']>({
+                        get: () => [],
+                        update: () => Promise.resolve(),
+                        setKeysForSync: () => {},
+                    }),
+                }),
                 scmProvider.outputChannel,
             );
 

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -72,7 +72,15 @@ suite('Webview Commands End-to-End Integration Test', function () {
                 getScoped: () => createMock<vscode.EnvironmentVariableCollection>({}),
             }),
             extensionMode: vscode.ExtensionMode.Test,
-            // Add other props if needed by JjScmProvider constructor
+            globalState: createMock<vscode.ExtensionContext['globalState']>({
+                get: () => [],
+                update: () => Promise.resolve(),
+                setKeysForSync: () => {},
+            }),
+            workspaceState: createMock<vscode.ExtensionContext['workspaceState']>({
+                get: () => undefined,
+                update: () => Promise.resolve(),
+            }),
         });
 
         scm = new JjScmProvider(mockContext, jj, repo.path, outputChannel);
@@ -95,6 +103,7 @@ suite('Webview Commands End-to-End Integration Test', function () {
             gerritService,
             commitDetailsProvider,
             () => {},
+            mockContext,
             scm.outputChannel,
         );
 

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -71,6 +71,13 @@ suite('Webview Initialization Integration Test', function () {
             gerritService,
             commitDetailsProvider,
             () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
             outputChannel,
         );
     });

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -71,6 +71,13 @@ suite('Webview Selection Integration Test', function () {
             gerritService,
             commitDetailsProvider,
             () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
             outputChannel,
         );
 

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -82,6 +82,13 @@ suite('Webview Visibility Integration Test', function () {
             gerritService,
             commitDetailsProvider,
             () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
             outputChannel,
         );
     });

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -2,9 +2,20 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { DndContext, DragOverlay, MouseSensor, TouchSensor, pointerWithin, useSensor, useSensors } from '@dnd-kit/core';
+import {
+    DndContext,
+    DragEndEvent,
+    DragOverlay,
+    DragStartEvent,
+    MouseSensor,
+    TouchSensor,
+    pointerWithin,
+    useSensor,
+    useSensors,
+} from '@dnd-kit/core';
 import * as React from 'react';
-import { JjStatusEntry } from '../jj-types';
+import { ActionPayload, JjLogEntry, JjStatusEntry, WebviewPayload } from '../jj-types';
+import { CommitAction } from '../jj-types';
 import { BookmarkPill } from './components/Bookmark';
 import { CommitDetails } from './components/CommitDetails';
 import { CommitDragPreview } from './components/CommitDragPreview';
@@ -15,19 +26,23 @@ import { calculateNextSelection, hasImmutableSelection } from './utils/selection
 // Define the vscode API from the global scope (see global.d.ts)
 const vscode = window.acquireVsCodeApi();
 
+type DragItem =
+    | { type: 'bookmark'; name: string; remote?: string }
+    | (JjLogEntry & { type: 'commit'; changeId: string });
+
 const App: React.FC = () => {
     // Initial State from Window (injected by provider)
     const initialData = window.vscodeInitialData;
     const initialView = initialData?.view || 'graph';
 
     const [view] = React.useState<'graph' | 'details'>(initialView);
-    const [commits, setCommits] = React.useState<any[]>((initialData?.payload as any)?.commits || []);
+    const [commits, setCommits] = React.useState<JjLogEntry[]>(initialData?.payload?.commits || []);
     const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>(
-        (initialData?.payload as any)?.minChangeIdLength || 1,
+        initialData?.payload?.minChangeIdLength || 1,
     );
     const [theme, setTheme] = React.useState<string>(initialData?.payload?.theme || 'default');
     const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>(
-        (initialData?.payload as any)?.graphLabelAlignment || 'aligned',
+        initialData?.payload?.graphLabelAlignment || 'aligned',
     );
     // Use ref to access latest commits in event listeners without triggering re-effects
     const commitsRef = React.useRef(commits);
@@ -36,15 +51,18 @@ const App: React.FC = () => {
     }, [commits]);
 
     const [loading, setLoading] = React.useState(
-        initialView === 'graph' && !((initialData?.payload as any)?.commits?.length > 0),
+        initialView === 'graph' && !(initialData?.payload?.commits && initialData.payload.commits.length > 0),
     ); // Only load graph if in graph mode and no initial commits
     const [selectedCommitIds, setSelectedCommitIds] = React.useState<Set<string>>(new Set());
+    const [hiddenActions, setHiddenActions] = React.useState<Set<CommitAction>>(
+        new Set(initialData?.payload?.hiddenActions || []),
+    );
 
     // Details State
-    const [detailsCommit, setDetailsCommit] = React.useState<any>(initialData?.payload || null);
+    const [detailsCommit, setDetailsCommit] = React.useState<WebviewPayload | null>(initialData?.payload || null);
 
     // Drag State
-    const [activeDragItem, setActiveDragItem] = React.useState<any | null>(null);
+    const [activeDragItem, setActiveDragItem] = React.useState<DragItem | null>(null);
     const [isCtrlPressed, setIsCtrlPressed] = React.useState(false);
 
     // Configure sensors with activation constraint to prevent accidental drags on click
@@ -108,6 +126,9 @@ const App: React.FC = () => {
                         if (message.graphLabelAlignment !== undefined) {
                             setGraphLabelAlignment(message.graphLabelAlignment);
                         }
+                        if (message.hiddenActions !== undefined) {
+                            setHiddenActions(new Set(message.hiddenActions));
+                        }
                         setLoading(false);
 
                         // Validate current selection against new commits list
@@ -115,7 +136,7 @@ const App: React.FC = () => {
                             if (prevIds.size === 0) return prevIds;
 
                             const validIds = Array.from(prevIds).filter((id) =>
-                                message.commits.some((c: any) => c.change_id === id),
+                                message.commits.some((c: JjLogEntry) => c.change_id === id),
                             );
 
                             if (validIds.length !== prevIds.size) {
@@ -143,7 +164,7 @@ const App: React.FC = () => {
                     break;
                 case 'saveComplete':
                     if (view === 'details') {
-                        setDetailsCommit((prev: any) =>
+                        setDetailsCommit((prev) =>
                             prev ? { ...prev, description: message.payload.description } : prev,
                         );
                     }
@@ -179,6 +200,9 @@ const App: React.FC = () => {
                         return prevIds;
                     });
                     break;
+                case 'updateHiddenActions':
+                    setHiddenActions(new Set(message.payload.hiddenActions));
+                    break;
             }
         };
 
@@ -192,12 +216,12 @@ const App: React.FC = () => {
         };
     }, [view]);
 
-    const handleGraphAction = (action: string, payload: any) => {
+    const handleGraphAction = (action: string, payload: ActionPayload) => {
         if (action === 'select') {
             const { changeId, multiSelect } = payload;
 
             // 1. Calculate new selection state
-            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, multiSelect);
+            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, !!multiSelect);
 
             // 2. Update visual selection state
             setSelectedCommitIds(nextSelectedIds);
@@ -263,24 +287,24 @@ const App: React.FC = () => {
         }
     };
 
-    const handleDragStart = (event: any) => {
-        setActiveDragItem(event.active.data.current);
+    const handleDragStart = (event: DragStartEvent) => {
+        setActiveDragItem(event.active.data.current as DragItem);
     };
 
-    const handleDragEnd = (event: any) => {
+    const handleDragEnd = (event: DragEndEvent) => {
         const { active, over } = event;
         setActiveDragItem(null);
 
-        if (!over || active.id === over.id) {
+        if (!over || active.id === over.id || !active.data.current || !over.data.current) {
             return;
         }
 
-        const activeType = active.data.current?.type;
+        const activeType = (active.data.current as DragItem).type;
 
         if (activeType === 'bookmark') {
             // bookmark-NAME -> NAME
-            const bookmarkName = active.data.current.name;
-            const bookmarkRemote = active.data.current.remote;
+            const bookmarkName = (active.data.current as DragItem & { type: 'bookmark' }).name;
+            const bookmarkRemote = (active.data.current as DragItem & { type: 'bookmark' }).remote;
             // commit-ID -> ID
             const targetChangeId = over.data.current.changeId;
 
@@ -288,7 +312,7 @@ const App: React.FC = () => {
             setCommits((prevCommits) => {
                 // Check if move is actually needed (and find source)
                 const sourceCommit = prevCommits.find((c) =>
-                    c.bookmarks?.some((b: any) => b.name === bookmarkName && b.remote === bookmarkRemote),
+                    c.bookmarks?.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote),
                 );
 
                 if (!sourceCommit || sourceCommit.change_id === targetChangeId) {
@@ -299,9 +323,9 @@ const App: React.FC = () => {
                     let newBookmarks = commit.bookmarks || [];
 
                     // Remove from source
-                    if (newBookmarks.some((b: any) => b.name === bookmarkName && b.remote === bookmarkRemote)) {
+                    if (newBookmarks.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote)) {
                         newBookmarks = newBookmarks.filter(
-                            (b: any) => !(b.name === bookmarkName && b.remote === bookmarkRemote),
+                            (b) => !(b.name === bookmarkName && b.remote === bookmarkRemote),
                         );
                     }
 
@@ -325,7 +349,7 @@ const App: React.FC = () => {
                 payload: { bookmark: bookmarkName, targetChangeId },
             });
         } else if (activeType === 'commit') {
-            const sourceChangeId = active.data.current.changeId;
+            const sourceChangeId = (active.data.current as DragItem & { type: 'commit' }).changeId;
             const targetChangeId = over.data.current.changeId;
 
             // Detect modifier keys from the activator event or our state
@@ -343,11 +367,11 @@ const App: React.FC = () => {
     if (view === 'details' && detailsCommit) {
         return (
             <CommitDetails
-                changeId={detailsCommit.changeId}
-                commitId={detailsCommit.commitId}
-                description={detailsCommit.description}
-                files={detailsCommit.files}
-                isImmutable={detailsCommit.isImmutable}
+                changeId={detailsCommit.changeId || ''}
+                commitId={detailsCommit.commitId || ''}
+                description={detailsCommit.description || ''}
+                files={detailsCommit.files || []}
+                isImmutable={detailsCommit.isImmutable || false}
                 isEmpty={detailsCommit.isEmpty}
                 isConflict={detailsCommit.isConflict}
                 author={detailsCommit.author}
@@ -408,6 +432,7 @@ const App: React.FC = () => {
                         minChangeIdLength={minChangeIdLength}
                         graphLabelAlignment={graphLabelAlignment}
                         theme={theme}
+                        hiddenActions={hiddenActions}
                     />
                 </div>
                 {/*

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from 'react';
-import { JjLogEntry } from '../../jj-types';
+import { ActionPayload, CommitAction, JjLogEntry } from '../../jj-types';
 import { computeGraphLayout } from '../graph-compute';
 import {
     LANE_WIDTH,
@@ -14,7 +14,7 @@ import {
     COMMIT_ROW_PADDING_LEFT,
 } from '../layout-constants';
 import { computeCompactRowMaxX, computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
-import { ActionPayload, CommitNode } from './CommitNode';
+import { CommitNode } from './CommitNode';
 import { GraphRail } from './GraphRail';
 
 interface CommitGraphProps {
@@ -24,6 +24,7 @@ interface CommitGraphProps {
     minChangeIdLength: number;
     graphLabelAlignment?: string;
     theme?: string;
+    hiddenActions?: Set<CommitAction>;
 }
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
@@ -33,6 +34,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     minChangeIdLength,
     graphLabelAlignment = 'aligned',
     theme = 'default',
+    hiddenActions,
 }) => {
     // Total graph width calculation
     // Dynamic sizing based on font
@@ -183,6 +185,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                                 selectionCount={selectedCommitIds?.size || 0}
                                 hasImmutableSelection={hasImmutableSelection}
                                 idDisplayLength={maxShortestIdLength}
+                                hiddenActions={hiddenActions}
                             />
                         </div>
                     );

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -5,47 +5,48 @@
 import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import React from 'react';
 // Needs to be available in types or duplicated.
-import { GerritClInfo } from '../../jj-types';
+import { ActionPayload, CommitAction, JjLogEntry } from '../../jj-types';
 import { COMMIT_ROW_PADDING_LEFT } from '../layout-constants';
+import { computeCommitActions } from '../utils/commit-utils';
 import { BookmarkPill, DraggableBookmark, TagPill, WorkspacePill } from './Bookmark';
 import { IconButton } from './IconButton';
 
 // Exported for DragOverlay in App.tsx
 export { BookmarkPill } from './Bookmark';
 
-// Shared payload for all actions
-export interface ActionPayload {
-    changeId: string;
-    isImmutable?: boolean;
-    url?: string;
-    multiSelect?: boolean;
-    [key: string]: unknown;
-}
-
 interface CommitNodeProps {
-    commit: any;
+    commit: JjLogEntry;
     onClick: (modifiers: { multiSelect: boolean }) => void;
     onAction: (action: string, payload: ActionPayload) => void;
     isSelected?: boolean;
     selectionCount: number;
     hasImmutableSelection: boolean;
-    idDisplayLength?: number;
+    idDisplayLength: number;
+    hiddenActions?: Set<CommitAction>;
 }
 
 export const CommitNode: React.FC<CommitNodeProps> = ({
     commit,
     onClick,
     onAction,
-    isSelected,
+    isSelected = false,
     selectionCount,
     hasImmutableSelection,
-    idDisplayLength = 8, // Default fallback
+    idDisplayLength,
+    hiddenActions = new Set(),
 }) => {
+    const isImmutable = commit.is_immutable || false;
     const isCurrentWorkingCopy = commit.is_current_working_copy;
-    const isImmutable = commit.is_immutable;
     const isConflict = commit.conflict;
     const isEmpty = commit.is_empty;
-    const gerritCl = commit.gerritCl as GerritClInfo | undefined;
+    const gerritCl = commit.gerritCl;
+
+    // Memoized Visibility and Context Keys
+    const { visibleActions, vscodeContext } = React.useMemo(
+        () =>
+            computeCommitActions(commit, hiddenActions, isImmutable, isSelected, selectionCount, hasImmutableSelection),
+        [commit, hiddenActions, isImmutable, isSelected, selectionCount, hasImmutableSelection],
+    );
 
     const { setNodeRef, listeners, attributes, isDragging } = useDraggable({
         id: `commit-${commit.change_id}`,
@@ -132,36 +133,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
             data-change-id={commit.change_id}
             data-selected={isSelected}
             data-hovered={isHovered}
-            data-vscode-context={JSON.stringify({
-                webviewSection: 'commit',
-                viewItem: isSelected ? 'jj-commit-selected' : 'jj-commit',
-                commitId: commit.commit_id,
-                changeId: commit.change_id,
-
-                // Abandon, New Before, and New After supported on multi-selection, but also on unselected items
-                canAbandon: !isImmutable && (!isSelected || !hasImmutableSelection),
-                canNewBefore: !isImmutable && (!isSelected || !hasImmutableSelection),
-                canNewAfter: !isSelected || !hasImmutableSelection,
-                canUpload: !isImmutable && (!isSelected || !hasImmutableSelection),
-
-                // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
-                canEdit: !isImmutable && (!isSelected || selectionCount <= 1),
-                canDuplicate: !isSelected || selectionCount <= 1,
-                canNewChild: !isSelected || selectionCount <= 1,
-
-                // Rebase source must be mutable, and we rebase ONTO the current selection
-                canRebaseOnto: !isImmutable && !isSelected && selectionCount > 0,
-
-                // Merge requires multiple items selected
-                canMerge: isSelected && selectionCount > 1,
-
-                // Absorb requires at least one mutable parent and single-item context
-                canAbsorb:
-                    commit.parents_immutable?.some((immutable: boolean) => !immutable) &&
-                    (!isSelected || selectionCount <= 1),
-
-                preventDefaultContextMenuItems: true,
-            })}
+            data-vscode-context={JSON.stringify(vscodeContext)}
             onClick={(e) => {
                 const multiSelect = e.ctrlKey || e.metaKey;
                 onClick({ multiSelect });
@@ -216,16 +188,17 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 >
                     {(() => {
                         const [idPart, offsetPart] = commit.change_id.split('/');
-                        const hasShortId = commit.change_id_shortest && idPart.startsWith(commit.change_id_shortest);
+                        const shortId = commit.change_id_shortest;
+                        const hasShortId = shortId && idPart.startsWith(shortId);
 
                         return (
                             <>
                                 {hasShortId ? (
                                     <>
-                                        <span style={{ fontWeight: 'bold' }}>{commit.change_id_shortest}</span>
-                                        {idPart.length > commit.change_id_shortest.length && (
+                                        <span style={{ fontWeight: 'bold' }}>{shortId}</span>
+                                        {idPart.length > shortId.length && (
                                             <span style={{ opacity: 0.6 }}>
-                                                {idPart.substring(commit.change_id_shortest.length, idDisplayLength)}
+                                                {idPart.substring(shortId.length, idDisplayLength)}
                                             </span>
                                         )}
                                     </>
@@ -243,6 +216,14 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 {/* Overlay Actions */}
                 {isHovered && !active && !(selectionCount > 1) && (
                     <div
+                        data-vscode-context={JSON.stringify({
+                            webviewSection: 'commitActions',
+                            'jj.newChildVisible': visibleActions.newChild,
+                            'jj.editVisible': visibleActions.edit,
+                            'jj.squashVisible': visibleActions.squash,
+                            'jj.abandonVisible': visibleActions.abandon,
+                            preventDefaultContextMenuItems: true,
+                        })}
                         style={{
                             position: 'absolute',
                             left: '0',
@@ -263,16 +244,23 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                             paddingLeft: '0',
                         }}
                     >
-                        <IconButton
-                            title="New Child"
-                            icon="codicon-plus"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onAction('newChild', { changeId: commit.change_id });
-                            }}
-                        />
+                        {visibleActions.newChild && (
+                            <IconButton
+                                title="New Child"
+                                icon="codicon-plus"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAction('newChild', { changeId: commit.change_id });
+                                }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'newChild',
+                                    actionTitle: 'New Child',
+                                }}
+                            />
+                        )}
 
-                        {!isImmutable && (
+                        {visibleActions.edit && (
                             <IconButton
                                 title="Edit Commit"
                                 icon="codicon-edit"
@@ -280,30 +268,42 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                     e.stopPropagation();
                                     onAction('edit', { changeId: commit.change_id });
                                 }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'edit',
+                                    actionTitle: 'Edit',
+                                }}
                             />
                         )}
 
-                        {commit.parents_immutable &&
-                            commit.parents_immutable.length === 1 &&
-                            !commit.parents_immutable[0] && (
-                                <IconButton
-                                    title="Squash into Parent"
-                                    icon="codicon-arrow-down"
-                                    onClick={(e) => {
-                                        console.log('[Webview] Squash clicked for:', commit.change_id);
-                                        e.stopPropagation();
-                                        onAction('squash', { changeId: commit.change_id });
-                                    }}
-                                />
-                            )}
-
-                        {!isImmutable && (
+                        {visibleActions.squash && (
                             <IconButton
-                                title="Abandon Commit"
+                                title="Squash"
+                                icon="codicon-arrow-down"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAction('squash', { changeId: commit.change_id });
+                                }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'squash',
+                                    actionTitle: 'Squash',
+                                }}
+                            />
+                        )}
+
+                        {visibleActions.abandon && (
+                            <IconButton
+                                title="Abandon"
                                 icon="codicon-trash"
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     onAction('abandon', { changeId: commit.change_id });
+                                }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'abandon',
+                                    actionTitle: 'Abandon',
                                 }}
                             />
                         )}

--- a/src/webview/components/IconButton.tsx
+++ b/src/webview/components/IconButton.tsx
@@ -8,11 +8,18 @@ interface IconButtonProps {
     onClick: (e: React.MouseEvent) => void;
     title: string;
     icon: string; // codicon class name, e.g., 'codicon-plus'
+    contextData?: Record<string, unknown>; // Data for data-vscode-context
 }
 
-export const IconButton: React.FC<IconButtonProps> = ({ onClick, title, icon }) => {
+export const IconButton: React.FC<IconButtonProps> = ({ onClick, title, icon, contextData }) => {
     return (
-        <div className="icon-button" role="button" title={title} onClick={onClick}>
+        <div
+            className="icon-button"
+            role="button"
+            title={title}
+            onClick={onClick}
+            data-vscode-context={contextData ? JSON.stringify(contextData) : undefined}
+        >
             <span className={`codicon ${icon}`}></span>
         </div>
     );

--- a/src/webview/global.d.ts
+++ b/src/webview/global.d.ts
@@ -1,3 +1,5 @@
+import { WebviewInitialData } from '../jj-types';
+
 /**
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
@@ -9,13 +11,7 @@ export {};
 declare global {
     interface Window {
         vscode: unknown;
-        vscodeInitialData?: {
-            view: 'graph' | 'details';
-            payload?: {
-                theme?: string;
-                [key: string]: unknown;
-            };
-        };
+        vscodeInitialData?: WebviewInitialData;
         acquireVsCodeApi: () => {
             postMessage: (message: { type: string; payload?: unknown }) => void;
             setState: (state: unknown) => void;

--- a/src/webview/utils/commit-utils.ts
+++ b/src/webview/utils/commit-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { CommitAction, JjLogEntry } from '../../jj-types';
+
+export interface CommitActionStates {
+    newChild: boolean;
+    edit: boolean;
+    squash: boolean;
+    abandon: boolean;
+}
+
+/**
+ * Computes the visibility and context key states for a commit node.
+ * Extracted from CommitNode.tsx to allow unit testing of the visibility logic.
+ */
+export function computeCommitActions(
+    commit: JjLogEntry,
+    hiddenActions: Set<CommitAction>,
+    isImmutable: boolean,
+    isSelected: boolean,
+    selectionCount: number,
+    hasImmutableSelection: boolean,
+): { visibleActions: CommitActionStates; vscodeContext: Record<string, unknown> } {
+    const visibleActions: CommitActionStates = {
+        newChild: !hiddenActions.has('newChild'),
+        edit: !isImmutable && !hiddenActions.has('edit'),
+        squash: !hiddenActions.has('squash') && commit.parents_immutable?.length === 1 && !commit.parents_immutable[0],
+        abandon: !isImmutable && !hiddenActions.has('abandon'),
+    };
+
+    const vscodeContext = {
+        webviewSection: 'commit',
+        'jj.newChildVisible': visibleActions.newChild,
+        'jj.editVisible': visibleActions.edit,
+        'jj.squashVisible': visibleActions.squash,
+        'jj.abandonVisible': visibleActions.abandon,
+        viewItem: isSelected ? 'jj-commit-selected' : 'jj-commit',
+        commitId: commit.commit_id,
+        changeId: commit.change_id,
+
+        // Abandon, New Before, and New After supported on multi-selection, but also on unselected items
+        'jj.canAbandon': !isImmutable && (!isSelected || !hasImmutableSelection),
+        'jj.canNewBefore': !isImmutable && (!isSelected || !hasImmutableSelection),
+        'jj.canNewAfter': !isSelected || !hasImmutableSelection,
+        'jj.canUpload': !isImmutable && (!isSelected || !hasImmutableSelection),
+
+        // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
+        'jj.canEdit': !isImmutable && (!isSelected || selectionCount <= 1),
+        'jj.canDuplicate': !isSelected || selectionCount <= 1,
+        'jj.canNewChild': !isSelected || selectionCount <= 1,
+
+        // Rebase source must be mutable, and we rebase ONTO the current selection
+        'jj.canRebaseOnto': !isImmutable && !isSelected && selectionCount > 0,
+
+        // Merge requires multiple items selected
+        'jj.canMerge': isSelected && selectionCount > 1,
+
+        // Absorb requires at least one mutable parent and single-item context
+        'jj.canAbsorb':
+            commit.parents_immutable?.some((immutable: boolean) => !immutable) && (!isSelected || selectionCount <= 1),
+
+        preventDefaultContextMenuItems: true,
+    };
+
+    return { visibleActions, vscodeContext };
+}

--- a/src/webview/utils/selection-utils.ts
+++ b/src/webview/utils/selection-utils.ts
@@ -10,7 +10,7 @@
 // Basic interface for what we need from a commit
 export interface SelectableCommit {
     change_id: string;
-    is_immutable: boolean;
+    is_immutable?: boolean;
 }
 
 /**

--- a/tooling/jj/repo-config.toml
+++ b/tooling/jj/repo-config.toml
@@ -14,17 +14,6 @@ patterns = [
     "glob:'**/*.css'",
 ]
 
-[fix.tools.addlicense]
-command = ["go", "run", "github.com/google/addlicense@v1.1.1", "-s=only", "$path"]
-patterns = [
-    "glob:'**/*.ts'",
-    "glob:'**/*.tsx'",
-    "glob:'**/*.js'",
-    "glob:'**/*.jsx'",
-    "glob:'**/*.css'",
-]
-
-
 [[--scope]]
 --when.environments = ["ANTIGRAVITY_AGENT"]
 [--scope.ui]


### PR DESCRIPTION
Implement the ability to hide commit hover actions via a right-click context menu, matching the native VS Code behavior. This also refactors action visibility logic into a testable utility and enables context menus for webview buttons.

#235, #152, #149