### PR TITLE
fix: Handle serialization of atypical workspace names in getLog

### DIFF
--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -100,9 +100,9 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     is_immutable: { type: 'raw', expr: 'immutable' },
     is_current_working_copy: { type: 'raw', expr: 'current_working_copy' },
     working_copies: {
-        type: 'stringArray',
+        type: 'rawArray',
         expr: 'working_copies',
-        itemExpr: 'item.name()',
+        itemExpr: 'item.name().escape_json()',
     },
     is_empty: { type: 'raw', expr: 'empty' },
     is_divergent: { type: 'raw', expr: 'divergent' },

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1323,6 +1323,17 @@ log = "none()"
         expect(parent.description.trim()).toBe('my commit message');
     });
 
+    test('getLog handles atypical workspace names', async () => {
+        const alphaRepo = repo.workspaceAdd('alpha:1.0', undefined, path.join(repo.path, 'alpha_1.0'));
+        alphaRepo.new();
+
+        const logEntries = await jjService.getLog({ revision: alphaRepo.getWorkingCopyId() });
+
+        expect(logEntries.length).toBeGreaterThan(0);
+        const head = logEntries[0];
+        expect(head.working_copies).toContain('alpha:1.0');
+    });
+
     test('getBookmarks returns bookmark names', async () => {
         repo.bookmark('feature-a', '@');
         repo.bookmark('feature-b', '@');

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -294,15 +294,18 @@ export class TestRepo {
         return output.trim() === 'true';
     }
 
-    workspaceAdd(name: string, revision?: string): TestRepo {
-        const workspacePath = path.join(this.path, name);
-        fs.mkdirSync(workspacePath, { recursive: true });
-        const args = ['workspace', 'add', workspacePath];
+    workspaceAdd(name: string, revision?: string, workspacePath?: string): TestRepo {
+        const resolvedPath = workspacePath || path.join(this.path, name);
+        fs.mkdirSync(resolvedPath, { recursive: true });
+        const args = ['workspace', 'add', resolvedPath];
         if (revision) {
             args.push('-r', revision);
         }
+        if (workspacePath) {
+            args.push('--name', name);
+        }
         this.exec(args);
-        return new TestRepo(workspacePath);
+        return new TestRepo(resolvedPath);
     }
 
     gitImport() {


### PR DESCRIPTION
[RefSymbol](https://docs.jj-vcs.dev/latest/templates/#refsymbol-type) will surround name in quotes when it does not contain a valid identifier. This is enforced by JJ for bookmarks / tags but not for Workspace names. This results in commits getting dropped from JJ log if tracked by a workspace with such a name e.g. "alpha:1.0"

This fix uses escape_json() to ensure that the name is always an escaped string. Also adds a test case to check the new behaviour.