### PR TITLE
fix: refactor commit graph layout to use renderdag

### DIFF
--- a/package.json
+++ b/package.json
@@ -783,7 +783,9 @@
         "parse-diff": "^0.11.1",
         "prettier": "^3.8.1",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "renderdag-ts": "git+https://github.com/brychanrobot/renderdag-ts.git",
+        "ts-pattern": "^5.9.0"
     },
     "pnpm": {
         "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,13 +31,19 @@ importers:
         version: 0.11.1
       prettier:
         specifier: ^3.8.1
-        version: 3.8.1
+        version: 3.8.3
       react:
         specifier: ^19.2.3
         version: 19.2.3
       react-dom:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
+      renderdag-ts:
+        specifier: git+https://github.com/brychanrobot/renderdag-ts.git
+        version: https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12
@@ -2601,8 +2607,8 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2684,6 +2690,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  renderdag-ts@https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c:
+    resolution: {tarball: https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c}
+    version: 1.0.0
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3099,6 +3109,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6010,7 +6023,7 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   proc-log@5.0.0: {}
 
@@ -6122,6 +6135,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  renderdag-ts@https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c: {}
 
   require-directory@2.1.1: {}
 
@@ -6633,6 +6648,8 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-pattern@5.9.0: {}
 
   tslib@2.8.1: {}
 

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService } from '../jj-service';
 import type { JjLogEntry } from '../jj-types';
 import { computeGraphLayout } from '../webview/graph-compute';
-import type { GraphLayout, GraphNode } from '../webview/graph-model';
+import { type GraphLayout, type GraphNode, isElisionRow } from '../webview/graph-model';
 import { buildGraph, TestRepo } from './test-repo';
 
 // Helper: ASCII renderer to verify layout against jj log output
@@ -14,19 +14,50 @@ function renderToAscii(layout: GraphLayout, headId: string): string {
     const rows: string[] = [];
     const nodesById = new Map<string, GraphNode>(layout.nodes.map((n: GraphNode) => [n.changeId, n]));
 
-    let width = Math.max(1, ...layout.nodes.map((n: GraphNode) => n.x + 1));
-    for (const e of layout.edges) {
-        width = Math.max(width, e.x1 + 1, e.x2 + 1);
-    }
+    const width = layout.width;
+
+    const childDegree = new Map<string, number>();
+    const parentDegree = new Map<string, number>();
+
+    layout.rows.forEach((row) => {
+        if (!isElisionRow(row)) {
+            const parents = row.nearest_visible_ancestors || row.parent_change_ids || [];
+            if (parents.length > 1) {
+                childDegree.set(row.change_id, parents.length);
+            }
+            parents.forEach((p) => {
+                parentDegree.set(p, (parentDegree.get(p) || 0) + 1);
+            });
+        }
+    });
 
     const edgeRoutes = layout.edges.map((e) => {
-        if (e.x1 === e.x2) {
-            return { ...e, yBend: e.y1 }; // Straight
+        const p1 = e.points[0];
+        const p2 = e.points[e.points.length - 1];
+        const x1 = p1.x;
+        const x2 = p2.x;
+
+        const parts = e.id.split('->');
+        const childId = parts[0];
+        const parentId = parts[1];
+        const cleanChildId = childId.startsWith('elided-') ? childId.substring(7) : childId;
+        const cleanParentId = parentId.startsWith('elided-') ? parentId.substring(7) : parentId;
+
+        const childNode = nodesById.get(cleanChildId);
+        const parentNode = nodesById.get(cleanParentId);
+
+        const y1 = childNode ? childNode.y : Math.floor(p1.y);
+        const y2 = parentNode ? parentNode.y : Math.floor(p2.y);
+
+        let yBend = y1;
+        for (let j = 1; j < e.points.length; j++) {
+            if (e.points[j].x !== x1) {
+                yBend = e.points[j].y;
+                break;
+            }
         }
 
-        // jj log curves around row offsets. It typically curves just before the target
-        // row `curveY`, so visual yBend is exactly midway above curveY
-        return { ...e, yBend: (e.curveY ?? e.y2) - 0.5 };
+        return { ...e, x1, y1, x2, y2, yBend };
     });
 
     for (let i = 0; i < layout.rows.length; i++) {
@@ -155,7 +186,6 @@ function renderToAscii(layout: GraphLayout, headId: string): string {
             }
 
             const nextLog = nextRow as JjLogEntry;
-            const yMid = node.y + 0.5;
 
             // In jj log, if an empty child is connecting to the root commit, it skips the second spacer row
             // to save vertical space.
@@ -165,134 +195,211 @@ function renderToAscii(layout: GraphLayout, headId: string): string {
 
             for (let s = 0; s < spacerCount; s++) {
                 let spacerStr = '';
-                const isCurveRow = s === 0;
-                const rowIsMerge = false;
-                let rowIsFork = false;
-                if (isCurveRow) {
-                    // Check if any edge is curving at this yMid
-                    const bendingEdge = edgeRoutes.find((e) => e.x1 !== e.x2 && e.yBend === yMid);
+                // Both spacer rows query at the link-row y-coordinate (node.y + 0.5).
+                // Edge points use this exact coordinate for horizontal transitions.
+                const yQ = node.y + 0.5;
 
-                    if (bendingEdge) {
-                        if (bendingEdge.x1 > bendingEdge.x2) {
-                            // Lane N merging to Lane < N
-
-                            // Let's check if there is ALSO a straight connection passing down Lane N at yMid.
-                            const laneContinues = edgeRoutes.some(
-                                (e) =>
-                                    e.x1 === bendingEdge.x1 &&
-                                    e.y1 <= yMid - 0.5 &&
-                                    ((e.x2 === bendingEdge.x1 && e.y2 > yMid) ||
-                                        (e.x2 !== bendingEdge.x1 && e.yBend > yMid)),
-                            );
-
-                            // Build the spacer string column by column
-                            for (let x = 0; x < width; x++) {
-                                if (x === bendingEdge.x2) {
-                                    // Target lane (left side of the fork/merge)
-                                    spacerStr += laneContinues ? '╭' : '├';
-                                } else if (x > bendingEdge.x2 && x < bendingEdge.x1) {
-                                    // Intermediate lanes get crossed over
-                                    spacerStr += '─';
-                                } else if (x === bendingEdge.x1) {
-                                    // Source lane (right side)
-                                    spacerStr += laneContinues ? '┤' : '╯';
-                                } else {
-                                    // Lanes not involved in the bend
-                                    const hasVertical = edgeRoutes.some((e) => {
-                                        if (e.x1 === e.x2) {
-                                            return (
-                                                e.x1 === x && Math.min(e.y1, e.y2) < yMid && Math.max(e.y1, e.y2) > yMid
-                                            );
-                                        } else {
-                                            if (x === e.x1 && yMid < e.yBend && yMid > e.y1) {
-                                                return true;
-                                            }
-                                            if (x === e.x2 && yMid > e.yBend && yMid < e.y2) {
-                                                return true;
-                                            }
-                                            return false;
-                                        }
-                                    });
-                                    spacerStr += hasVertical ? '│' : ' ';
-                                }
-                                if (x < width - 1) {
-                                    if (x >= bendingEdge.x2 && x < bendingEdge.x1) {
-                                        spacerStr += '─';
-                                    } else {
-                                        spacerStr += ' ';
+                for (let x = 0; x < width; x++) {
+                    // For the second spacer row (s=1), only show vertical pass-throughs.
+                    if (s === 1) {
+                        let hasDown = false;
+                        edgeRoutes.forEach((e) => {
+                            if (e.y1 > yQ || e.y2 < yQ) {
+                                return;
+                            }
+                            for (let j = 0; j < e.points.length - 1; j++) {
+                                const pA = e.points[j];
+                                const pB = e.points[j + 1];
+                                if (pA.x === x && pB.x === x) {
+                                    if (Math.min(pA.y, pB.y) <= yQ && Math.max(pA.y, pB.y) > yQ) {
+                                        hasDown = true;
                                     }
                                 }
-                            }
-                            rowIsFork = true; // Handled both fork and merge in the builder above
-                        } else {
-                            // Lane N branching from Lane < N (for completeness, e.g. ╭─┤ on the right)
-                            // jj log usually pulls left, so this is rare natively but good for correctness.
-                            const laneContinues = edgeRoutes.some(
-                                (e) =>
-                                    e.x1 === bendingEdge.x1 &&
-                                    e.y1 <= yMid - 0.5 &&
-                                    ((e.x2 === bendingEdge.x1 && e.y2 > yMid) ||
-                                        (e.x2 !== bendingEdge.x1 && e.yBend > yMid)),
-                            );
-
-                            for (let x = 0; x < width; x++) {
-                                if (x === bendingEdge.x1) {
-                                    spacerStr += laneContinues ? '├' : '╰';
-                                } else if (x > bendingEdge.x1 && x < bendingEdge.x2) {
-                                    spacerStr += '─';
-                                } else if (x === bendingEdge.x2) {
-                                    spacerStr += laneContinues ? '╮' : '┤';
-                                } else {
-                                    const hasVertical = edgeRoutes.some((e) => {
-                                        if (e.x1 === e.x2) {
-                                            return (
-                                                e.x1 === x && Math.min(e.y1, e.y2) < yMid && Math.max(e.y1, e.y2) > yMid
-                                            );
-                                        } else {
-                                            if (x === e.x1 && yMid < e.yBend && yMid > e.y1) {
-                                                return true;
-                                            }
-                                            if (x === e.x2 && yMid > e.yBend && yMid < e.y2) {
-                                                return true;
-                                            }
-                                            return false;
-                                        }
-                                    });
-                                    spacerStr += hasVertical ? '│' : ' ';
-                                }
-                                if (x < width - 1) {
-                                    if (x >= bendingEdge.x1 && x < bendingEdge.x2) {
-                                        spacerStr += '─';
-                                    } else {
-                                        spacerStr += ' ';
-                                    }
-                                }
-                            }
-                            rowIsFork = true;
-                        }
-                    }
-                }
-
-                if (!rowIsMerge && !rowIsFork) {
-                    for (let x = 0; x < width; x++) {
-                        const hasVertical = edgeRoutes.some((e) => {
-                            if (e.x1 === e.x2) {
-                                return e.x1 === x && Math.min(e.y1, e.y2) < yMid && Math.max(e.y1, e.y2) > yMid;
-                            } else {
-                                // Diagonal edge: occupies x1 before yBend, and x2 after yBend
-                                if (x === e.x1 && yMid < e.yBend && yMid > e.y1) {
-                                    return true;
-                                }
-                                if (x === e.x2 && yMid >= e.yBend && yMid < e.y2 && !e.isJoining) {
-                                    return true;
-                                }
-                                return false;
                             }
                         });
-                        spacerStr += hasVertical ? '│' : ' ';
+                        spacerStr += hasDown ? '│' : ' ';
                         if (x < width - 1) {
                             spacerStr += ' ';
                         }
+                        continue;
+                    }
+
+                    // First spacer row (s=0): detect up/down/left/right at each cell.
+                    let up = false;
+                    let down = false;
+                    let left = false;
+                    let right = false;
+
+                    edgeRoutes.forEach((e) => {
+                        if (e.y1 > yQ || e.y2 < yQ) {
+                            return;
+                        }
+
+                        for (let j = 0; j < e.points.length - 1; j++) {
+                            const pA = e.points[j];
+                            const pB = e.points[j + 1];
+
+                            // Vertical segments at this column
+                            if (pA.x === x && pB.x === x) {
+                                if (Math.min(pA.y, pB.y) < yQ && Math.max(pA.y, pB.y) >= yQ) {
+                                    up = true;
+                                }
+                                if (Math.min(pA.y, pB.y) <= yQ && Math.max(pA.y, pB.y) > yQ) {
+                                    down = true;
+                                }
+                            }
+
+                            // Horizontal segments at yQ
+                            if (pA.y === yQ && pB.y === yQ) {
+                                const minX = Math.min(pA.x, pB.x);
+                                const maxX = Math.max(pA.x, pB.x);
+                                if (minX < x && maxX >= x) {
+                                    left = true;
+                                }
+                                if (minX <= x && maxX > x) {
+                                    right = true;
+                                }
+                            }
+                        }
+                    });
+
+                    // Calculate independent vertical based on symmetric geometric rules:
+                    // A curved symbol (╭ or ╮) is used instead of a T-junction (├ or ┤)
+                    // ONLY when it's the target of a curve whose source lane continues.
+                    let hasIndependentVertical = true;
+
+                    if (right && !left) {
+                        // Left Endpoint: check if it's the target of a leftward curve whose source continues.
+                        edgeRoutes.forEach((e) => {
+                            if (e.y1 > yQ || e.y2 < yQ) {
+                                return;
+                            }
+                            const childX = e.points[0].x;
+                            if (childX > x) {
+                                // Must actually have a horizontal segment at yQ touching x
+                                const hasHorizAtX = e.points.some((p) => p.y === yQ && p.x === x);
+                                if (!hasHorizAtX) {
+                                    return;
+                                }
+
+                                // Found a leftward curve from childX to x.
+                                // Now check if the lane at childX continues below yQ.
+                                const sourceContinues = edgeRoutes.some((e_other) => {
+                                    if (e_other.y1 > yQ || e_other.y2 < yQ) {
+                                        return false;
+                                    }
+                                    if (e_other === e) {
+                                        return false;
+                                    }
+                                    for (let j = 0; j < e_other.points.length - 1; j++) {
+                                        const pA = e_other.points[j];
+                                        const pB = e_other.points[j + 1];
+                                        if (
+                                            pA.x === childX &&
+                                            pB.x === childX &&
+                                            Math.min(pA.y, pB.y) <= yQ &&
+                                            Math.max(pA.y, pB.y) > yQ
+                                        ) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                });
+                                if (sourceContinues) {
+                                    hasIndependentVertical = false;
+                                }
+                            }
+                        });
+                    } else if (left && !right) {
+                        // Right Endpoint: check if it's the target of a rightward curve whose source continues.
+                        edgeRoutes.forEach((e) => {
+                            if (e.y1 > yQ || e.y2 < yQ) {
+                                return;
+                            }
+                            const childX = e.points[0].x;
+                            if (childX < x) {
+                                // Must actually have a horizontal segment at yQ touching x
+                                const hasHorizAtX = e.points.some((p) => p.y === yQ && p.x === x);
+                                if (!hasHorizAtX) {
+                                    return;
+                                }
+
+                                // Found a rightward curve from childX to x.
+                                // Now check if the lane at childX continues below yQ.
+                                const sourceContinues = edgeRoutes.some((e_other) => {
+                                    if (e_other.y1 > yQ || e_other.y2 < yQ) {
+                                        return false;
+                                    }
+                                    if (e_other === e) {
+                                        return false;
+                                    }
+                                    for (let j = 0; j < e_other.points.length - 1; j++) {
+                                        const pA = e_other.points[j];
+                                        const pB = e_other.points[j + 1];
+                                        if (
+                                            pA.x === childX &&
+                                            pB.x === childX &&
+                                            Math.min(pA.y, pB.y) <= yQ &&
+                                            Math.max(pA.y, pB.y) > yQ
+                                        ) {
+                                            return true;
+                                        }
+                                    }
+                                    return false;
+                                });
+                                if (sourceContinues) {
+                                    hasIndependentVertical = false;
+                                }
+                            }
+                        });
+                    }
+
+                    let symbol = ' ';
+                    if (up && down && !left && !right) {
+                        symbol = '│';
+                    } else if (left && right) {
+                        symbol = '─';
+                    } else if (up && down && right && !left) {
+                        symbol = hasIndependentVertical ? '├' : '╭';
+                    } else if (up && down && left && !right) {
+                        symbol = hasIndependentVertical ? '┤' : '╮';
+                    } else if (!up && down && !left && right) {
+                        symbol = '╭';
+                    } else if (!up && down && left && !right) {
+                        symbol = '╮';
+                    } else if (up && !down && !left && right) {
+                        symbol = '╰';
+                    } else if (up && !down && left && !right) {
+                        symbol = '╯';
+                    } else if ((up || down) && !left && !right) {
+                        symbol = '│';
+                    } else if (!up && !down && (left || right)) {
+                        symbol = '─';
+                    }
+
+                    spacerStr += symbol;
+
+                    if (x < width - 1) {
+                        let spaceHasHoriz = false;
+                        edgeRoutes.forEach((e) => {
+                            if (e.y1 > yQ || e.y2 < yQ) {
+                                return;
+                            }
+                            for (let j = 0; j < e.points.length - 1; j++) {
+                                const pA = e.points[j];
+                                const pB = e.points[j + 1];
+                                if (
+                                    pA.y === yQ &&
+                                    pB.y === yQ &&
+                                    Math.min(pA.x, pB.x) <= x &&
+                                    Math.max(pA.x, pB.x) >= x + 1
+                                ) {
+                                    spaceHasHoriz = true;
+                                    break;
+                                }
+                            }
+                        });
+                        spacerStr += spaceHasHoriz ? '─' : ' ';
                     }
                 }
                 rows.push(spacerStr.trimEnd());
@@ -359,13 +466,17 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         // Check edges
         const edges = layout.edges;
         // Edge C2->C1
-        const edge21 = edges.find((e) => e.y1 === forC2?.y && e.y2 === forC1?.y);
+        const edge21 = edges.find(
+            (e) => Math.floor(e.points[0].y) === forC2?.y && Math.floor(e.points[e.points.length - 1].y) === forC1?.y,
+        );
         expect(edge21).toBeDefined();
-        expect(edge21?.x1).toBe(0);
-        expect(edge21?.x2).toBe(0);
+        expect(edge21?.points[0].x).toBe(0);
+        expect(edge21?.points[edge21.points.length - 1].x).toBe(0);
 
         // Edge C1->Root
-        const edge10 = edges.find((e) => e.y1 === forC1?.y && e.y2 === root?.y);
+        const edge10 = edges.find(
+            (e) => Math.floor(e.points[0].y) === forC1?.y && Math.floor(e.points[e.points.length - 1].y) === root?.y,
+        );
         expect(edge10).toBeDefined();
     });
 
@@ -411,10 +522,16 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
 
         // Edges from children to parent
         const edge1 = layout.edges.find(
-            (e) => (e.y1 === child1?.y && e.y2 === parent?.y) || (e.y2 === child1?.y && e.y1 === parent?.y),
+            (e) =>
+                (Math.floor(e.points[0].y) === child1?.y &&
+                    Math.floor(e.points[e.points.length - 1].y) === parent?.y) ||
+                (Math.floor(e.points[e.points.length - 1].y) === child1?.y && Math.floor(e.points[0].y) === parent?.y),
         );
         const edge2 = layout.edges.find(
-            (e) => (e.y1 === child2?.y && e.y2 === parent?.y) || (e.y2 === child2?.y && e.y1 === parent?.y),
+            (e) =>
+                (Math.floor(e.points[0].y) === child2?.y &&
+                    Math.floor(e.points[e.points.length - 1].y) === parent?.y) ||
+                (Math.floor(e.points[e.points.length - 1].y) === child2?.y && Math.floor(e.points[0].y) === parent?.y),
         );
         expect(edge1).toBeDefined();
         expect(edge2).toBeDefined();
@@ -455,8 +572,14 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         expect(p2Node).toBeDefined();
 
         // Merge should connect to P1 and P2
-        const e1 = layout.edges.find((e) => e.y1 === mergeNode?.y && e.y2 === p1Node?.y);
-        const e2 = layout.edges.find((e) => e.y1 === mergeNode?.y && e.y2 === p2Node?.y);
+        const e1 = layout.edges.find(
+            (e) =>
+                Math.floor(e.points[0].y) === mergeNode?.y && Math.floor(e.points[e.points.length - 1].y) === p1Node?.y,
+        );
+        const e2 = layout.edges.find(
+            (e) =>
+                Math.floor(e.points[0].y) === mergeNode?.y && Math.floor(e.points[e.points.length - 1].y) === p2Node?.y,
+        );
 
         expect(e1).toBeDefined();
         expect(e2).toBeDefined();
@@ -706,7 +829,9 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         expect(cNode).toBeDefined();
         expect(aNode).toBeDefined();
 
-        const edge = layout.edges.find((e) => e.y1 === cNode?.y && e.y2 === aNode?.y);
+        const edge = layout.edges.find(
+            (e) => Math.floor(e.points[0].y) === cNode?.y && Math.floor(e.points[e.points.length - 1].y) === aNode?.y,
+        );
         expect(edge).toBeDefined();
         expect(edge?.isElided).toBe(true);
     });

--- a/src/test/layout-utils.test.ts
+++ b/src/test/layout-utils.test.ts
@@ -74,7 +74,18 @@ describe('Layout Utils', () => {
         it('should account for vertical edges passing through rows', () => {
             const layout: GraphLayout = {
                 nodes: [{ commitId: 'c1', changeId: 'c1', x: 0, y: 0, color: 'red', isCurrentWorkingCopy: false }],
-                edges: [{ x1: 2, y1: 0, x2: 2, y2: 2, curveY: 2, type: 'parent', color: 'green' }],
+                edges: [
+                    {
+                        id: 'e1',
+                        points: [
+                            { type: 'node', x: 2, y: 0 },
+                            { type: 'node', x: 2, y: 1 },
+                            { type: 'node', x: 2, y: 2 },
+                        ],
+                        type: 'parent',
+                        color: 'green',
+                    },
+                ],
                 width: 3,
                 height: 3,
                 rows: [createMock<JjLogEntry>({}), createMock<JjLogEntry>({}), createMock<JjLogEntry>({})],
@@ -84,19 +95,55 @@ describe('Layout Utils', () => {
             expect(result).toEqual([2, 2, 2]);
         });
 
-        it('should ignore curved segments when determining max lane', () => {
+        it('should account for curved segments correctly', () => {
             const layout: GraphLayout = {
                 nodes: [{ commitId: 'c1', changeId: 'c1', x: 0, y: 0, color: 'red', isCurrentWorkingCopy: false }],
-                edges: [{ x1: 4, y1: 0, x2: 0, y2: 2, curveY: 2, type: 'parent', color: 'green' }],
+                edges: [
+                    {
+                        id: 'e1',
+                        points: [
+                            { type: 'node', x: 4, y: 0 },
+                            { type: 'node', x: 4, y: 1 },
+                            { type: 'link', x: 4, y: 1.5 },
+                            { type: 'link', x: 0, y: 1.5 },
+                            { type: 'node', x: 0, y: 2 },
+                        ],
+                        type: 'parent',
+                        color: 'green',
+                    },
+                ],
                 width: 6,
                 height: 3,
                 rows: [createMock<JjLogEntry>({}), createMock<JjLogEntry>({}), createMock<JjLogEntry>({})],
             };
             const result = computeCompactRowMaxX(layout);
-            // Node at row 0: x=0. Edge at row 0: y<curveY -> x1=4. max=4.
-            // Edge at row 1: y<curveY -> x1=4. max=4.
-            // Edge at row 2: y>=curveY -> x2=0. max=0.
+            // Node at row 0: x=0. Edge at row 0: x=4. max=4.
+            // Edge at row 1: x=4. max=4.
+            // Edge at row 2: x=0. max=0.
             expect(result).toEqual([4, 4, 0]);
+        });
+
+        it('should account for intermediate rows without explicit points', () => {
+            const layout: GraphLayout = {
+                nodes: [],
+                edges: [
+                    {
+                        id: 'e1',
+                        points: [
+                            { type: 'node', x: 5, y: 5 },
+                            { type: 'link', x: 1, y: 2.5 },
+                            { type: 'node', x: 1, y: 2 },
+                        ],
+                        type: 'parent',
+                        color: 'green',
+                    },
+                ],
+                width: 6,
+                height: 6,
+                rows: Array.from({ length: 6 }, () => createMock<JjLogEntry>({})),
+            };
+            const result = computeCompactRowMaxX(layout);
+            expect(result).toEqual([0, 0, 1, 5, 5, 5]);
         });
     });
 });

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import type { ActionPayload, CommitAction, JjLogEntry } from '../../jj-types';
 import { computeGraphLayout } from '../graph-compute';
+import { isElisionRow } from '../graph-model';
 import {
     COMMIT_ROW_PADDING_LEFT,
     LANE_WIDTH,
@@ -69,7 +70,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             offsets.push(currentOffset);
             // Height logic matching the renderer in CommitNode
             let height: number;
-            if ('type' in row && row.type === 'elision') {
+            if (isElisionRow(row)) {
                 height = ROW_HEIGHT_ELISION;
             } else {
                 const commit = row as JjLogEntry;
@@ -140,6 +141,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             <GraphRail
                 nodes={layout.nodes}
                 edges={layout.edges}
+                terminations={layout.terminations}
                 width={layout.width}
                 height={totalHeight}
                 rowOffsets={rowOffsets}
@@ -151,7 +153,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
             <div style={{ position: 'relative', zIndex: 1 }} role="listbox" aria-label="Commit List">
                 {displayRows.map((row, i) => {
                     const isLastRow = i === displayRows.length - 1;
-                    if (row && 'type' in row && row.type === 'elision') {
+                    if (isElisionRow(row)) {
                         return renderElisionRow(i, isLastRow);
                     }
 

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -3,12 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from 'react';
-import type { GraphEdge, GraphNode, GraphRow } from '../graph-model';
-import { LANE_CENTER_X, LANE_WIDTH, LEFT_MARGIN, ROW_CENTER_Y, ROW_HEIGHT_ELISION } from '../layout-constants';
+import { match } from 'ts-pattern';
+import type { GraphEdge, GraphNode, GraphPoint, GraphRow } from '../graph-model';
+import { isElisionRow } from '../graph-model';
+import {
+    LANE_CENTER_X,
+    LANE_WIDTH,
+    LEFT_MARGIN,
+    ROW_CENTER_Y,
+    ROW_HEIGHT_ELISION,
+    ROW_HEIGHT_NORMAL,
+} from '../layout-constants';
 
 interface GraphRailProps {
     nodes: GraphNode[];
     edges: GraphEdge[];
+    terminations?: { x: number; y: number }[];
     width: number; // in lanes
     height: number; // total height in pixels
     rowOffsets: number[]; // Exact Y position for each row index
@@ -26,6 +36,7 @@ const BOTTOM_PADDING = 20; // Extra room for trailing elision markers at the bot
 export const GraphRail: React.FC<GraphRailProps> = ({
     nodes,
     edges,
+    terminations,
     width,
     height,
     rowOffsets,
@@ -40,142 +51,150 @@ export const GraphRail: React.FC<GraphRailProps> = ({
     //    This ensures lines extending further to the right (higher max) render underneath
     //    lines that stay strictly in the leftmost lane.
     const sortedEdges = React.useMemo(() => {
-        return [...edges].sort((a, b) => {
-            return Math.min(b.x1, b.x2) - Math.min(a.x1, a.x2) || Math.max(b.x1, b.x2) - Math.max(a.x1, a.x2);
+        const edgesWithBounds = edges.map((edge) => {
+            let minX = Number.MAX_SAFE_INTEGER;
+            let maxX = Number.MIN_SAFE_INTEGER;
+            for (let i = 0; i < edge.points.length; i++) {
+                const x = edge.points[i].x;
+                if (x < minX) {
+                    minX = x;
+                }
+                if (x > maxX) {
+                    maxX = x;
+                }
+            }
+            return { edge, minX, maxX };
         });
+        return edgesWithBounds.sort((a, b) => b.minX - a.minX || b.maxX - a.maxX).map((item) => item.edge);
     }, [edges]);
+
+    const getLayoutRowPixelY = React.useCallback(
+        (point: GraphPoint): number => {
+            const commitIndex = Math.floor(point.y);
+            const isLinkRow = match(point)
+                .with({ type: 'link' }, () => true)
+                .with({ type: 'node' }, () => false)
+                .exhaustive();
+
+            const topY = rowOffsets[commitIndex] || 0;
+            const row = rows[commitIndex];
+            const isElision = isElisionRow(row);
+            const thisCYOffset = isElision ? ROW_HEIGHT_ELISION / 2 : ROW_HEIGHT_NORMAL / 2;
+
+            if (isLinkRow) {
+                const nextRow = rows[commitIndex + 1];
+                const nextIsElision = isElisionRow(nextRow);
+                const nextCYOffset = nextIsElision ? ROW_HEIGHT_ELISION / 2 : ROW_HEIGHT_NORMAL / 2;
+
+                const bottomY = rowOffsets[commitIndex + 1] || topY + ROW_HEIGHT_NORMAL;
+                const thisCY = topY + thisCYOffset;
+                const nextCY = bottomY + nextCYOffset;
+                return thisCY + (nextCY - thisCY) / 2;
+            } else {
+                return topY + thisCYOffset;
+            }
+        },
+        [rowOffsets, rows],
+    );
+
+    const getPixelX = (lane: number) => lane * W + CX + LEFT_MARGIN;
 
     // Render Edges
     const renderEdge = (edge: GraphEdge, index: number) => {
-        const { x1, y1, x2, y2, color } = edge;
-        const sx = x1 * W + CX + LEFT_MARGIN;
-        // Start Y is based on row offset + centering in header
-        const sy = (rowOffsets[y1] || 0) + CY_OFFSET;
+        const { points, color } = edge;
+        if (!points || points.length < 2) {
+            return null;
+        }
 
-        const ex = x2 * W + CX + LEFT_MARGIN;
-        // End Y
-        const isTrailing = y2 >= rows.length;
-        // Trailing edges extend past the last row. If the last row is an elision row, they should end there.
-        const lastRowIndex = rows.length - 1;
-        const isLastRowElision =
-            rows[lastRowIndex] && 'type' in rows[lastRowIndex] && rows[lastRowIndex].type === 'elision';
+        // Apply trailing extension logic to the very last point
+        const displayPoints = [...points];
+        const lastP = displayPoints[displayPoints.length - 1];
+        const isTrailing = lastP.y >= rows.length;
 
-        let ey: number;
+        let trailingY = getLayoutRowPixelY(lastP);
         if (isTrailing) {
+            const lastRowIndex = rows.length - 1;
+            const isLastRowElision = isElisionRow(rows[lastRowIndex]);
+
             if (isLastRowElision) {
-                // End in the middle of the elision row
-                ey = (rowOffsets[lastRowIndex] || 0) + ELISION_ROW_HEIGHT / 2;
+                trailingY = (rowOffsets[lastRowIndex] || 0) + ELISION_ROW_HEIGHT / 2;
             } else {
-                ey = (rowOffsets[y2] || rowOffsets[lastRowIndex] || 0) + 12;
-            }
-        } else {
-            ey = (rowOffsets[y2] || 0) + CY_OFFSET;
-        }
-
-        let d = '';
-
-        if (x1 === x2) {
-            // Straight Vertical
-            d = `M ${sx} ${sy} L ${ex} ${ey}`;
-        } else {
-            // Rail Routing
-            const cY = edge.curveY ?? y2;
-            let midY: number;
-
-            if (rowOffsets[cY] !== undefined) {
-                // S-curve crosses boundary right above the curve row
-                midY = rowOffsets[cY];
-            } else {
-                // If it curves offscreen, use ey but subtract the offset to get the row boundary
-                midY = isTrailing ? ey : ey - CY_OFFSET;
-            }
-
-            // Direction for horizontal
-            const dirX = x2 > x1 ? 1 : -1;
-
-            // Start -> Vertical to Turn
-            d += `M ${sx} ${sy}`;
-            d += ` L ${sx} ${midY - R}`;
-
-            // Curve 1 (Vertical to Horizontal)
-
-            // Quadratic Bezier (Q): Q control-point-x control-point-y end-x end-y
-            // Start: (sx, midY - R)
-            // Control: (sx, midY) - Corner
-            // End: (sx + R*dirX, midY)
-            d += ` Q ${sx} ${midY} ${sx + R * dirX} ${midY}`;
-
-            // Horizontal Line
-            // If adjacent lanes (delta=1), len = W = 2*R.
-            // start + 2*R*dirX = start + W*dirX = ex.
-            // So horizontal segment is length 0. Perfect S.
-            // If delta > 1, straight line exists.
-            d += ` L ${ex - R * dirX} ${midY}`;
-
-            // Curve 2 (Horizontal to Vertical)
-            // Start: (ex - R*dirX, midY)
-            // Control: (ex, midY)
-            // End: (ex, midY + R)
-            d += ` Q ${ex} ${midY} ${ex} ${midY + R}`;
-
-            if (!edge.isJoining) {
-                // Vertical to End
-                d += ` L ${ex} ${ey}`;
+                trailingY = (rowOffsets[lastRowIndex] || 0) + CY_OFFSET + (edge.isElided ? 24 : 12);
             }
         }
 
-        const ElisionMarker = () => {
-            if (!edge.isElided) {
-                return null;
+        let d = `M ${getPixelX(displayPoints[0].x)} ${getLayoutRowPixelY(displayPoints[0])} `;
+
+        for (let j = 1; j < displayPoints.length - 1; j++) {
+            const prev = displayPoints[j - 1];
+            const curr = displayPoints[j];
+            const next = displayPoints[j + 1];
+
+            const px = getPixelX(prev.x);
+            const py = getLayoutRowPixelY(prev);
+            const cx = getPixelX(curr.x);
+            const cy = getLayoutRowPixelY(curr);
+
+            const nx = getPixelX(next.x);
+            let ny = getLayoutRowPixelY(next);
+            if (j + 1 === displayPoints.length - 1 && isTrailing) {
+                ny = trailingY;
             }
 
-            // Find the elision row for this edge.
-            // It should be either y1 + 1 (standard elision after child)
-            // or the last row (if it's a trailing edge).
-            let elisionRowIndex = -1;
-            const nextRow = rows[y1 + 1];
-            if (nextRow && 'type' in nextRow && nextRow.type === 'elision') {
-                elisionRowIndex = y1 + 1;
-            } else if (isTrailing && isLastRowElision) {
-                elisionRowIndex = lastRowIndex;
+            // Universal orthogonal rounded corner algorithm
+            const dx1 = cx - px;
+            const dy1 = cy - py;
+            const len1 = Math.sqrt(dx1 * dx1 + dy1 * dy1);
+
+            const dx2 = nx - cx;
+            const dy2 = ny - cy;
+            const len2 = Math.sqrt(dx2 * dx2 + dy2 * dy2);
+
+            // Radius cannot be larger than half the shortest segment
+            const r = Math.min(R, len1 / 2, len2 / 2);
+
+            if (r === 0) {
+                d += `L ${cx} ${cy} `;
+                continue;
             }
 
-            if (elisionRowIndex === -1) {
-                return null;
-            }
+            const ux = cx === px ? 0 : px < cx ? -1 : 1;
+            const uy = cy === py ? 0 : py < cy ? -1 : 1;
+            const startX = cx + ux * r;
+            const startY = cy + uy * r;
 
-            const mx = sx;
-            const my = rowOffsets[elisionRowIndex] + ELISION_ROW_HEIGHT / 2;
+            const vx = nx === cx ? 0 : cx < nx ? 1 : -1;
+            const vy = ny === cy ? 0 : cy < ny ? 1 : -1;
+            const endX = cx + vx * r;
+            const endY = cy + vy * r;
 
-            return (
-                <g key={`elision-${index}`} transform={`translate(${mx}, ${my})`}>
-                    {/* Background cutout to create a clean gap in the colored line */}
-                    <rect x="-5" y="-6" width="10" height="12" fill="var(--vscode-sideBar-background)" />
-                    {/* Tilde marker ~ in disabled gray */}
-                    <path
-                        d="M -4,1 C -4,-2 -1,-2 0,0 C 1,2 4,2 4,-1"
-                        stroke="var(--vscode-descriptionForeground)"
-                        strokeWidth="2"
-                        fill="none"
-                        strokeLinecap="round"
-                    />
-                </g>
-            );
-        };
+            d += `L ${startX} ${startY} `;
+            d += `Q ${cx} ${cy} ${endX} ${endY} `;
+        }
+
+        // Final segment
+        const last = displayPoints[displayPoints.length - 1];
+        const finalX = getPixelX(last.x);
+        const finalY = isTrailing ? trailingY : getLayoutRowPixelY(last);
+        d += `L ${finalX} ${finalY} `;
 
         return (
-            <React.Fragment key={`edge-group-${index}`}>
-                <path d={d} stroke={color} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
-                <ElisionMarker />
-            </React.Fragment>
+            <path
+                key={`edge-${index}`}
+                d={d}
+                stroke={color}
+                strokeWidth="2"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
         );
     };
 
     // Render Nodes
     const renderNode = (node: GraphNode) => {
-        const cx = node.x * W + CX + LEFT_MARGIN;
-        // Node Y is strictly based on the offset table
-        const cy = (rowOffsets[node.y] || 0) + CY_OFFSET;
+        const cx = getPixelX(node.x);
+        const cy = getLayoutRowPixelY({ type: 'node', x: node.x, y: node.y });
 
         const isSelected = selectedNodes?.has(node.changeId);
 
@@ -292,6 +311,25 @@ export const GraphRail: React.FC<GraphRailProps> = ({
             style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none', zIndex: 0 }}
         >
             {sortedEdges.map((edge, i) => renderEdge(edge, i))}
+            {terminations?.map((term) => {
+                const mx = getPixelX(term.x);
+                const my =
+                    term.y >= rows.length
+                        ? (rowOffsets[rows.length - 1] || 0) + CY_OFFSET + 24
+                        : getLayoutRowPixelY({ type: 'node', x: term.x, y: term.y });
+                return (
+                    <g key={`term-${term.x}-${term.y}`} transform={`translate(${mx}, ${my})`}>
+                        <rect x="-5" y="-6" width="10" height="12" fill="var(--vscode-sideBar-background)" />
+                        <path
+                            d="M -4,1 C -4,-2 -1,-2 0,0 C 1,2 4,2 4,-1"
+                            stroke="var(--vscode-descriptionForeground)"
+                            strokeWidth="2"
+                            fill="none"
+                            strokeLinecap="round"
+                        />
+                    </g>
+                );
+            })}
             {nodes.map((node) => renderNode(node))}
         </svg>
     );

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -2,239 +2,277 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import { type Ancestor, GraphRowRenderer, NodeLine } from 'renderdag-ts';
+import { match } from 'ts-pattern';
 import type { JjLogEntry } from '../jj-types';
-import type { GraphEdge, GraphLayout, GraphNode, GraphRow } from './graph-model';
+import type { GraphEdge, GraphLayout, GraphNode, GraphPoint, GraphRow } from './graph-model';
+import { isElisionRow } from './graph-model';
 import { getColor } from './themes.generated';
 
+function cleanupPoints(points: GraphPoint[]): GraphPoint[] {
+    if (points.length <= 2) {
+        return points;
+    }
+    const result: GraphPoint[] = [points[0]];
+    for (let i = 1; i < points.length - 1; i++) {
+        const prev = result[result.length - 1];
+        const curr = points[i];
+        const next = points[i + 1];
+
+        const isCollinear = (prev.x === curr.x && curr.x === next.x) || (prev.y === curr.y && curr.y === next.y);
+
+        if (!isCollinear) {
+            result.push(curr);
+        }
+    }
+    result.push(points[points.length - 1]);
+    return result;
+}
+
+interface ActiveEdge {
+    edge: GraphEdge;
+    targetChangeId: string;
+    currentLane: number;
+    maxLane: number;
+}
+
+/**
+ * Computes the graph layout using renderdag-ts.
+ * We use a single coordinate system where each commit i spans one row with fractional links:
+ * - nodeY = i (Node placement row)
+ * - linkY = i + 0.5 (Link/Transition row)
+ */
 export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'default'): GraphLayout {
-    // 1. Build Unique Nodes and Edges
-    // The input 'commits' array is already sorted by 'jj log' (graph order).
-    // We trust this order implicitly.
-    const allCommits = new Map<string, JjLogEntry>();
-    commits.forEach((c) => {
-        allCommits.set(c.change_id, c);
-    });
+    const headLog = commits.find((l) => l.is_current_working_copy);
+    const headId = headLog ? headLog.change_id : '';
 
-    // Pre-calculate display rows and commit-to-row mapping
     const displayRows: GraphRow[] = [];
-    const commitToRowIndex = new Map<string, number>();
 
     commits.forEach((commit) => {
-        const rowIndex = displayRows.length;
         displayRows.push(commit);
-        commitToRowIndex.set(commit.change_id, rowIndex);
 
-        const ancestors = commit.nearest_visible_ancestors || [];
+        const parents = commit.nearest_visible_ancestors || commit.parent_change_ids || [];
         const directParents = new Set(commit.parent_change_ids || []);
-        const hasElision =
-            ancestors.some((p) => !directParents.has(p)) || (ancestors.length === 0 && directParents.size > 0);
-
-        if (hasElision) {
-            displayRows.push({ type: 'elision' });
-        }
-    });
-
-    // Layout Logic
-    const nodes: GraphNode[] = []; // Sparse array indexed by rowIndex
-    const edges: GraphEdge[] = [];
-    const pendingEdges: {
-        x1: number;
-        y1: number;
-        targetChangeId: string;
-        targetLane: number;
-        color: string;
-        isElided?: boolean;
-    }[] = [];
-    const lanes: (string | null)[] = [];
-    const nodeMap = new Map<string, GraphNode>();
-
-    commits.forEach((commit) => {
-        const changeId = commit.change_id;
-        // biome-ignore lint/style/noNonNullAssertion: changeId is guaranteed to be in the map by previous pass
-        const rowIndex = commitToRowIndex.get(changeId)!;
-
-        // 1. Determine my lane
-        let nodeLane = lanes.indexOf(changeId);
-        if (nodeLane === -1) {
-            nodeLane = lanes.indexOf(null);
-            if (nodeLane === -1) {
-                nodeLane = lanes.length;
+        parents.forEach((p) => {
+            if (!directParents.has(p)) {
+                displayRows.push({ type: 'elision', targetId: p });
             }
-        }
-
-        // 2. Create Node
-        const nodeColor = getColor(nodeLane, themeName);
-        const node: GraphNode = {
-            commitId: commit.commit_id,
-            changeId,
-            x: nodeLane,
-            y: rowIndex,
-            color: nodeColor,
-            isCurrentWorkingCopy: !!commit.is_current_working_copy,
-            workingCopies: commit.working_copies,
-            conflict: commit.conflict,
-            isEmpty: commit.is_empty,
-            isImmutable: commit.is_immutable,
-        };
-        nodes[rowIndex] = node;
-        nodeMap.set(changeId, node);
-
-        // 3. Update Lanes (Clear self and overlapping)
-        lanes[nodeLane] = null;
-        for (let i = 0; i < lanes.length; i++) {
-            if (lanes[i] === changeId) {
-                lanes[i] = null;
-            }
-        }
-
-        // 4. Handle Parents (Assign Lanes & Create Edges)
-        // We exclusively use nearest_visible_ancestors (change IDs).
-        const ancestors = commit.nearest_visible_ancestors || [];
-        const directParents = new Set(commit.parent_change_ids || []);
-        const allocated = new Set<number>();
-        allocated.add(nodeLane);
-
-        if (ancestors.length > 0) {
-            const p0 = ancestors[0];
-            let p0Lane = lanes.indexOf(p0);
-            if (p0Lane === -1) {
-                p0Lane = nodeLane;
-                lanes[nodeLane] = p0;
-            } else if (p0Lane > nodeLane) {
-                // Parent was assigned a higher lane by a sibling branch.
-                // Move it to the child's (now-free) lane so converging branches
-                // collapse to the leftmost lane, matching `jj log` behavior.
-                lanes[p0Lane] = null;
-                lanes[nodeLane] = p0;
-                p0Lane = nodeLane;
-            } else {
-                // p0 already occupies a lower lane, so nodeLane is now free.
-                // Allow secondary parents to inherit it.
-                allocated.delete(nodeLane);
-            }
-            pendingEdges.push({
-                x1: nodeLane,
-                y1: rowIndex,
-                targetChangeId: p0,
-                targetLane: p0Lane,
-                color: nodeColor,
-                isElided: !directParents.has(p0),
-            });
-        }
-
-        for (let i = 1; i < ancestors.length; i++) {
-            const p = ancestors[i];
-            let pLane = lanes.indexOf(p);
-
-            if (pLane === -1) {
-                let free = -1;
-                for (let k = 0; k < lanes.length; k++) {
-                    if (lanes[k] === null && !allocated.has(k)) {
-                        free = k;
-                        break;
-                    }
-                }
-                if (free === -1) {
-                    let cand = lanes.length;
-                    while (allocated.has(cand)) {
-                        cand++;
-                    }
-                    free = cand;
-                }
-                pLane = free;
-                lanes[free] = p;
-                allocated.add(free);
-            }
-
-            pendingEdges.push({
-                x1: nodeLane,
-                y1: rowIndex,
-                targetChangeId: p,
-                targetLane: pLane,
-                color: getColor(pLane, themeName),
-                isElided: !directParents.has(p),
-            });
-        }
-
-        // 4b. No visible ancestors for non-root: create trailing elided edge
-        if (ancestors.length === 0 && directParents.size > 0) {
-            pendingEdges.push({
-                x1: nodeLane,
-                y1: rowIndex,
-                targetChangeId: 'unresolved-elision', // Dummy ID for trailing edge
-                targetLane: nodeLane,
-                color: nodeColor,
-                isElided: true,
-            });
-        }
-    });
-
-    // 5. Resolve Edges
-    pendingEdges.forEach((pe) => {
-        const target = nodeMap.get(pe.targetChangeId);
-        let targetX: number;
-        let targetY: number;
-        let isJoining: boolean = false;
-
-        if (target) {
-            targetY = target.y;
-            // Cross-lane edges (pe.x1 !== pe.targetLane) are "joining" an existing
-            // vertical line in pe.targetLane. They should merge into that lane, not
-            // chase the target if it later moved to a different lane.
-            // Same-lane edges (pe.x1 === pe.targetLane) "own" the lane and follow
-            // the target to its final position.
-            targetX = pe.x1 !== pe.targetLane ? pe.targetLane : target.x;
-
-            // For joining edges where the target moved lanes (targetX !== target.x),
-            // cap y2 at the curveY of the "owning" edge.
-            if (targetX !== target.x) {
-                const ownerEdge = edges.find((e) => e.x1 === pe.targetLane && e.x2 === target.x && e.y2 === target.y);
-
-                if (ownerEdge) {
-                    targetY = ownerEdge.curveY ?? ownerEdge.y2;
-                    isJoining = true;
-                }
-            }
-        } else {
-            targetX = pe.targetLane;
-            targetY = displayRows.length;
-        }
-
-        let curveY = targetY;
-        if (pe.x1 !== targetX) {
-            // For joining edges, also check the target lane for blocking nodes.
-            const checkTargetLane = pe.x1 !== pe.targetLane;
-            for (let y = pe.y1 + 1; y < targetY; y++) {
-                if (nodes[y] && (nodes[y].x === pe.x1 || (checkTargetLane && nodes[y].x === targetX))) {
-                    curveY = y;
-                    break;
-                }
-            }
-        }
-
-        edges.push({
-            x1: pe.x1,
-            y1: pe.y1,
-            x2: targetX,
-            y2: targetY,
-            curveY,
-            color: pe.color,
-            type: 'parent',
-            isJoining,
-            isElided: pe.isElided || target === undefined,
         });
     });
 
+    const renderer = new GraphRowRenderer<string>();
+
+    const commitToRowIndex = new Map<string, number>();
+    displayRows.forEach((row, i) => {
+        if (!isElisionRow(row)) {
+            commitToRowIndex.set(row.change_id, i);
+        }
+    });
+
+    const nodes: GraphNode[] = [];
+    const edges: GraphEdge[] = [];
+    const terminations: { x: number; y: number }[] = [];
+    let activeEdges: ActiveEdge[] = [];
+    let maxColumns = 0;
+
+    displayRows.forEach((row, rowIndex) => {
+        const nodeY = rowIndex;
+        const linkY = rowIndex + 0.5;
+
+        const { changeId, renderParents, glyph, message, parents, directParents } = match(row)
+            .with({ type: 'elision' }, (elision) => ({
+                changeId: `elided-${elision.targetId}`,
+                renderParents: [{ type: 'Parent', id: elision.targetId }] as Ancestor<string>[],
+                glyph: '',
+                message: '',
+                parents: [elision.targetId],
+                directParents: new Set<string>(),
+            }))
+            .otherwise((commit) => {
+                const parents = commit.nearest_visible_ancestors || commit.parent_change_ids || [];
+                const directParents = new Set(commit.parent_change_ids || []);
+                const renderParents = parents.map((p) => {
+                    if (!directParents.has(p)) {
+                        return { type: 'Parent', id: `elided-${p}` };
+                    }
+                    return { type: 'Parent', id: p };
+                }) as Ancestor<string>[];
+
+                return {
+                    changeId: commit.change_id,
+                    renderParents,
+                    glyph: commit.change_id === headId ? '@' : '○',
+                    message: commit.description || '',
+                    parents,
+                    directParents,
+                };
+            });
+
+        const rowData = renderer.nextRow(changeId, renderParents, glyph, message);
+        maxColumns = Math.max(maxColumns, renderer.activeColumns ? renderer.activeColumns.length : 0);
+
+        // 1. Determine current node position
+        const nodeLane = rowData.nodeLine.indexOf(NodeLine.Node);
+        if (nodeLane === -1) {
+            return;
+        }
+
+        if (isElisionRow(row)) {
+            // It's a synthetic elision row! Record its termination marker
+            terminations.push({ x: nodeLane, y: nodeY });
+        }
+
+        const nodeColor = getColor(nodeLane, themeName);
+        if (!isElisionRow(row)) {
+            const commit = row as JjLogEntry;
+            nodes.push({
+                commitId: commit.commit_id,
+                changeId: commit.change_id,
+                x: nodeLane,
+                y: nodeY,
+                color: nodeColor,
+                isCurrentWorkingCopy: !!commit.is_current_working_copy,
+                workingCopies: commit.working_copies,
+                conflict: commit.conflict,
+                isEmpty: commit.is_empty,
+                isImmutable: commit.is_immutable,
+            });
+        }
+
+        // 2. Process vertical segments through the node row (nodeY)
+        activeEdges.forEach((ae) => {
+            ae.edge.points.push({ type: 'node', x: ae.currentLane, y: nodeY });
+        }); // 3. Terminate edges that reached this node or continue if it's an elision
+        if (isElisionRow(row)) {
+            activeEdges.forEach((ae) => {
+                if (ae.targetChangeId === changeId) {
+                    ae.targetChangeId = row.targetId;
+                    ae.edge.isElided = true;
+                    if (ae.currentLane !== nodeLane) {
+                        ae.edge.points.push({ type: 'node', x: nodeLane, y: nodeY });
+                        ae.currentLane = nodeLane;
+                    }
+                }
+            });
+        } else {
+            activeEdges = activeEdges.filter((ae) => {
+                if (ae.targetChangeId === changeId) {
+                    if (ae.currentLane !== nodeLane) {
+                        ae.edge.points.push({ type: 'node', x: nodeLane, y: nodeY });
+                        ae.maxLane = Math.max(ae.maxLane, nodeLane);
+                        ae.edge.color = getColor(ae.maxLane, themeName);
+                    }
+                    edges.push(ae.edge);
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        // 4. Process horizontal segments and transitions in the link row (linkY)
+        const nextActiveColumns = renderer.activeColumns;
+
+        activeEdges.forEach((ae) => {
+            const nextLane = nextActiveColumns.findIndex(
+                (col) =>
+                    (col.type === 'Parent' || col.type === 'Ancestor' || col.type === 'Reserved') &&
+                    col.id === ae.targetChangeId,
+            );
+
+            if (nextLane !== -1) {
+                if (nextLane !== ae.currentLane) {
+                    ae.edge.points.push({ type: 'link', x: ae.currentLane, y: linkY });
+                    ae.edge.points.push({ type: 'link', x: nextLane, y: linkY });
+                    ae.currentLane = nextLane;
+                    ae.maxLane = Math.max(ae.maxLane, nextLane);
+                    ae.edge.color = getColor(ae.maxLane, themeName);
+                } else {
+                    ae.edge.points.push({ type: 'link', x: ae.currentLane, y: linkY });
+                }
+            }
+        });
+
+        // 5. Spawn new edges for parents (only for real commits!)
+        if (!isElisionRow(row)) {
+            const actualParents = parents.map((p) => {
+                if (!directParents.has(p)) {
+                    return `elided-${p}`;
+                }
+                return p;
+            });
+
+            actualParents.forEach((pId) => {
+                const pLane = nextActiveColumns.findIndex(
+                    (col) =>
+                        (col.type === 'Parent' || col.type === 'Ancestor' || col.type === 'Reserved') && col.id === pId,
+                );
+
+                if (pLane !== -1) {
+                    const maxLane = Math.max(nodeLane, pLane);
+                    const color = getColor(maxLane, themeName);
+
+                    const newEdge: GraphEdge = {
+                        id: `${changeId}->${pId}`,
+                        type: 'parent',
+                        color,
+                        isElided: pId.startsWith('elided-'),
+                        points: [
+                            { type: 'node', x: nodeLane, y: nodeY },
+                            { type: 'link', x: nodeLane, y: linkY },
+                            { type: 'link', x: pLane, y: linkY },
+                        ],
+                    };
+
+                    activeEdges.push({
+                        edge: newEdge,
+                        targetChangeId: pId,
+                        currentLane: pLane,
+                        maxLane,
+                    });
+                }
+            });
+        }
+
+        // 6. Handle elision trailing markers (anonymous roots)
+        if (parents.length === 0 && directParents.size > 0) {
+            edges.push({
+                id: `${changeId}->unresolved-elision`,
+                type: 'parent',
+                color: nodeColor,
+                isElided: true,
+                points: [
+                    { type: 'node', x: nodeLane, y: nodeY },
+                    { type: 'node', x: nodeLane, y: nodeY + 1 },
+                ],
+            });
+            terminations.push({ x: nodeLane, y: nodeY + 1 });
+        }
+    });
+
+    // Terminate remaining active edges (history continues below)
+    activeEdges.forEach((ae) => {
+        ae.edge.points.push({ type: 'node', x: ae.currentLane, y: displayRows.length });
+        ae.maxLane = Math.max(ae.maxLane, ae.currentLane);
+        ae.edge.color = getColor(ae.maxLane, themeName);
+        edges.push(ae.edge);
+    });
+
+    const cleanedEdges = edges.map((e) => ({
+        ...e,
+        points: cleanupPoints(e.points),
+    }));
+
     const width = Math.max(
-        lanes.length,
-        nodes.reduce((max, n) => Math.max(max, n.x + 1), 0),
+        maxColumns,
+        nodes.reduce((max, n) => Math.max(max, n ? n.x + 1 : 0), 0),
     );
 
     return {
-        nodes: nodes.filter((n) => !!n), // Flatten sparse array for layout output
-        edges,
+        nodes,
+        edges: cleanedEdges,
+        terminations,
         width,
-        height: displayRows.length,
+        height: displayRows.length, // Total layout rows
         rows: displayRows,
     };
 }

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import { match } from 'ts-pattern';
 import type { JjLogEntry } from '../jj-types';
 
 export interface GraphNode {
@@ -17,27 +18,46 @@ export interface GraphNode {
     isImmutable?: boolean;
 }
 
+export interface NodePoint {
+    type: 'node';
+    x: number; // Lane index
+    y: number; // Row index
+}
+
+export interface LinkPoint {
+    type: 'link';
+    x: number; // Lane index
+    y: number; // Row index
+}
+
+export type GraphPoint = NodePoint | LinkPoint;
+
 export interface GraphEdge {
-    x1: number;
-    y1: number;
-    x2: number;
-    y2: number;
-    curveY?: number; // Row index where the line bends horizontally
+    id: string;
+    points: GraphPoint[]; // The series of points forming the path
     color: string;
-    type: 'parent' | 'merge'; // 'parent' usually means from Child -> Parent (Vertical/Fork). 'merge' means incoming?
-    isJoining?: boolean; // True if this edge seamlessly merges into another edge's trunk
+    type: 'parent';
     isElided?: boolean; // True if this edge connects to a non-direct ancestor (history gap)
+    isJoining?: boolean; // True if this edge is joining another lane
 }
 
 export interface ElisionRow {
     type: 'elision';
+    targetId: string;
 }
 
 export type GraphRow = JjLogEntry | ElisionRow;
 
+export function isElisionRow(row: GraphRow): row is ElisionRow {
+    return match(row)
+        .with({ type: 'elision' }, () => true)
+        .otherwise(() => false);
+}
+
 export interface GraphLayout {
     nodes: GraphNode[];
     edges: GraphEdge[];
+    terminations?: { x: number; y: number }[];
     width: number;
     height: number;
     rows: GraphRow[]; // The commits and spacer rows in display order

--- a/src/webview/layout-utils.ts
+++ b/src/webview/layout-utils.ts
@@ -14,20 +14,40 @@ import type { GraphLayout } from './graph-model';
  * completely at `x1` above its curve row, and completely at `x2` at/below its curve row.
  */
 export function computeCompactRowMaxX(layout: GraphLayout): number[] {
-    const rowMaxX = new Array(layout.rows.length).fill(0);
+    const rowMaxX = new Array(layout.height).fill(0);
 
+    // 1. Account for node positions
     for (const { x, y } of layout.nodes) {
-        if (y >= 0 && y < rowMaxX.length) {
-            rowMaxX[y] = Math.max(rowMaxX[y], x);
+        const rowIndex = Math.floor(y);
+        if (rowIndex >= 0 && rowIndex < rowMaxX.length) {
+            rowMaxX[rowIndex] = Math.max(rowMaxX[rowIndex], x);
         }
     }
 
+    // 2. Account for edges passing through rows.
+    // Instead of iterating over individual points (which might be missing for some rows),
+    // we analyze the continuous segments of each edge to determine which lanes are occupied
+    // at each integer row center.
     for (const e of layout.edges) {
-        const cY = e.curveY ?? e.y2;
-        for (let y = Math.max(0, e.y1); y <= e.y2 && y < rowMaxX.length; y++) {
-            // If the row center is above the curve, it is at x1.
-            // If the row center is at or below the curve, it has already curved to x2.
-            rowMaxX[y] = Math.max(rowMaxX[y], y < cY ? e.x1 : e.x2);
+        if (e.points.length < 2) {
+            continue;
+        }
+
+        const yCoords = e.points.map((p) => p.y);
+        const yMin = Math.floor(Math.min(...yCoords));
+        const yMax = Math.ceil(Math.max(...yCoords));
+
+        for (let y = Math.max(0, yMin); y <= yMax && y < rowMaxX.length; y++) {
+            for (let i = 0; i < e.points.length - 1; i++) {
+                const p1 = e.points[i];
+                const p2 = e.points[i + 1];
+                const segmentYMin = Math.min(p1.y, p2.y);
+                const segmentYMax = Math.max(p1.y, p2.y);
+
+                if (y >= segmentYMin && y <= segmentYMax) {
+                    rowMaxX[y] = Math.max(rowMaxX[y], p1.x, p2.x);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Refactors the commit graph layout engine to leverage `renderdag-ts`, replacing the custom, imperative routing logic with a more robust DAG renderer.

Since `jj` internally uses `renderdag` for its own CLI output, adopting this TypeScript port allows `jj-view` to generate a commit graph that exactly matches the layout and aesthetic of `jj log`.

This architectural shift addresses multiple long-standing layout issues.

Fixes #87, #233