### PR TITLE
feat: support restoring file changes on mutable ancestor commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -653,7 +653,7 @@
                 {
                     "command": "jj-view.restore",
                     "group": "inline@2",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/"
+                    "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/"
                 },
                 {
                     "command": "jj-view.squashInto",

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -13,9 +13,22 @@ export async function restoreCommand(scmProvider: JjScmProvider, jj: JjService, 
         return;
     }
 
-    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+    const statesByRevision = new Map<string, string[]>();
+    for (const state of resourceStates) {
+        const rev = state.revision || '@';
+        const list = statesByRevision.get(rev) || [];
+        list.push(state.resourceUri.fsPath);
+        statesByRevision.set(rev, list);
+    }
+
     try {
-        await withDelayedProgress('Restoring files...', jj.restore(paths));
+        for (const [rev, paths] of statesByRevision.entries()) {
+            if (rev === '@') {
+                await withDelayedProgress('Restoring files...', jj.restore(paths));
+            } else {
+                await withDelayedProgress(`Restoring files for ${rev}...`, jj.restore(paths, { changesIn: rev }));
+            }
+        }
         await scmProvider.refresh({ reason: 'after restore' });
     } catch (e: unknown) {
         await showJjError(e, 'Error restoring files', jj, scmProvider.outputChannel);

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -427,14 +427,21 @@ export class JjService {
         return output.trim().split('\n').filter(Boolean);
     }
 
-    async restore(paths: string[], from?: string): Promise<void> {
+    async restore(paths: string[], options: { from?: string; into?: string; changesIn?: string } = {}): Promise<void> {
         if (paths.length === 0) {
             return;
         }
         const relativePaths = paths.map((p) => this.toRelative(p));
         const cmdArgs = [...relativePaths];
-        if (from) {
-            cmdArgs.push('--from', from);
+        if (options.changesIn) {
+            cmdArgs.push('--changes-in', options.changesIn);
+        } else {
+            if (options.from) {
+                cmdArgs.push('--from', options.from);
+            }
+            if (options.into) {
+                cmdArgs.push('--into', options.into);
+            }
         }
         await this.run('restore', cmdArgs, { isMutation: true, label: 'restore' });
     }

--- a/src/test/commands/restore.test.ts
+++ b/src/test/commands/restore.test.ts
@@ -55,4 +55,67 @@ describe('restoreCommand', () => {
         const content = fs.readFileSync(path.join(repo.path, fileName), 'utf-8');
         expect(content).toBe('original');
     });
+
+    test('restores file content on mutable non-working copy commit', async () => {
+        const fileName = 'restore_non_wc.txt';
+        const ids = await buildGraph(repo, [
+            { label: 'parent', description: 'parent', files: { [fileName]: 'original' } },
+            {
+                label: 'ancestor',
+                parents: ['parent'],
+                description: 'ancestor',
+                files: { [fileName]: 'modified' },
+            },
+            {
+                label: 'child',
+                parents: ['ancestor'],
+                description: 'child',
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
+        const args = [{ resourceUri: fileUri, revision: ids.ancestor.changeId }];
+
+        await restoreCommand(scmProvider, jj, args);
+
+        const ancestorContent = repo.getFileContent(ids.ancestor.changeId, fileName);
+        expect(ancestorContent).toBe('original');
+    });
+
+    test('restores files across multiple revisions', async () => {
+        const file1 = 'file1.txt';
+        const file2 = 'file2.txt';
+        const ids = await buildGraph(repo, [
+            { label: 'parent', description: 'parent', files: { [file1]: 'original 1', [file2]: 'original 2' } },
+            {
+                label: 'ancestor',
+                parents: ['parent'],
+                description: 'ancestor',
+                files: { [file1]: 'modified 1' },
+            },
+            {
+                label: 'child',
+                parents: ['ancestor'],
+                description: 'child',
+                files: { [file2]: 'modified 2' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const file1Uri = vscode.Uri.file(path.join(repo.path, file1));
+        const file2Uri = vscode.Uri.file(path.join(repo.path, file2));
+        const args = [
+            { resourceUri: file1Uri, revision: ids.ancestor.changeId },
+            { resourceUri: file2Uri, revision: ids.child.changeId },
+        ];
+
+        await restoreCommand(scmProvider, jj, args);
+
+        const ancestorContent = repo.getFileContent(ids.ancestor.changeId, file1);
+        expect(ancestorContent).toBe('original 1');
+
+        const childContent = repo.getFileContent(ids.child.changeId, file2);
+        expect(childContent).toBe('original 2');
+    });
 });

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -612,4 +612,52 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('File-Level Actions: Discard Changes on Ancestor Commits', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const commits = await buildGraph(repo, [
+            {
+                label: 'initial',
+                description: 'initial',
+                files: { 'file_ancestor.txt': 'base' },
+            },
+            {
+                label: 'ancestor',
+                parents: ['initial'],
+                description: 'ancestor change',
+                files: { 'file_ancestor.txt': 'mod in ancestor' },
+            },
+            {
+                label: 'wc',
+                parents: ['ancestor'],
+                description: 'wc change',
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            const ancestorFileRow = page.getByRole('treeitem', { name: /file_ancestor\.txt.*modified/i });
+            await expect(ancestorFileRow).toBeVisible();
+
+            const discardIcon = ancestorFileRow
+                .locator('.action-item', { has: page.locator('.codicon-discard') })
+                .first();
+            await hoverAndClick(ancestorFileRow, discardIcon);
+
+            await expect(async () => {
+                expect(repo.getFileContent(commits.ancestor.changeId, 'file_ancestor.txt').trim()).toBe('base');
+            }).toPass({ timeout: 5000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });


### PR DESCRIPTION
Updates the `jj-view.restore` command to allow reverting modified files on non-working copy commits directly from the SCM pane.

Fixes #255