### PR TITLE
fix: discarding middle of file deletions in quick diff

### DIFF
--- a/src/commands/discard-change.ts
+++ b/src/commands/discard-change.ts
@@ -81,7 +81,7 @@ export async function discardChangeCommand(
 
             modifiedRange = new vscode.Range(startPos, endPos);
         } else {
-            const insertLine = change.modifiedStartLineNumber - 1;
+            const insertLine = Math.min(change.modifiedStartLineNumber, modifiedDoc.lineCount);
             modifiedRange = new vscode.Range(insertLine, 0, insertLine, 0);
         }
 

--- a/src/test/e2e/quick-diff.spec.ts
+++ b/src/test/e2e/quick-diff.spec.ts
@@ -4,11 +4,43 @@
  */
 
 import * as fs from 'node:fs';
-import { expect, test } from '@playwright/test';
+import * as path from 'node:path';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import { TestRepo } from '../test-repo';
 import { focusSCM, launchVSCode } from './e2e-helpers';
 
 test.describe('Quick Diff E2E', () => {
+    async function openFileInEditor(page: Page, fileName: string): Promise<Locator> {
+        await page.keyboard.press('Control+Shift+E');
+        const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
+        await expect(fileRowInExplorer).toBeVisible({ timeout: 10000 });
+        await fileRowInExplorer.click();
+
+        await expect(page.getByRole('tab', { name: fileName, selected: true })).toBeVisible({ timeout: 10000 });
+
+        const editor = page.locator('.editor-group-container.active .monaco-editor');
+        await expect(editor).toBeVisible({ timeout: 10000 });
+        return editor;
+    }
+
+    async function openGutterPeekView(page: Page, editor: Locator): Promise<{ peekView: Locator; gutter: Locator }> {
+        const gutter = editor.locator('[title="Added lines"], [title="Changed lines"], [title="Removed lines"]');
+        await expect(gutter.first()).toBeVisible({ timeout: 15000 });
+
+        const peekView = page.locator('.monaco-editor .zone-widget');
+        await expect(async () => {
+            await editor.click();
+            const target = gutter.first();
+            const box = await target.boundingBox();
+            if (box) {
+                await page.mouse.click(box.x + 1, box.y + box.height / 2, { delay: 100 });
+            }
+            await expect(peekView).toBeVisible({ timeout: 5000 });
+        }).toPass({ timeout: 20000 });
+
+        return { peekView, gutter };
+    }
+
     test('Gutter decorations and Diff Editor refresh after squash', async () => {
         const repo = new TestRepo();
         repo.init();
@@ -26,39 +58,10 @@ test.describe('Quick Diff E2E', () => {
 
         try {
             // 1. Open the file via the Explorer
-            await page.keyboard.press('Control+Shift+E');
-            const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
-            await expect(fileRowInExplorer).toBeVisible({ timeout: 10000 });
-            await fileRowInExplorer.click();
+            const editor = await openFileInEditor(page, fileName);
 
-            // Wait for the tab to be active
-            await expect(page.getByRole('tab', { name: fileName, selected: true })).toBeVisible({ timeout: 10000 });
-
-            // Wait for editor to be visible and focused
-            const editor = page.locator('.editor-group-container.active .monaco-editor');
-            await expect(editor).toBeVisible({ timeout: 10000 });
-
-            // 2. Verify Gutter Indicator
-            // VS Code uses specific titles for diff indicators in the gutter
-            const gutter = editor.locator('[title="Added lines"], [title="Changed lines"], [title="Deleted lines"]');
-            await expect(gutter.first()).toBeVisible({ timeout: 15000 });
-
-            // 3. Open Peek View
-            const peekView = page.locator('.monaco-editor .zone-widget');
-            await expect(async () => {
-                // Focus editor
-                await editor.click();
-
-                // Attempt edge-click (as user showed in screenshot, the visual bar is far-left)
-                const target = gutter.first();
-                const box = await target.boundingBox();
-                if (box) {
-                    await page.mouse.click(box.x + 1, box.y + box.height / 2, { delay: 100 });
-                }
-
-                // Wait for Peek View to appear
-                await expect(peekView).toBeVisible({ timeout: 5000 });
-            }).toPass({ timeout: 20000 });
+            // 2 & 3. Open Gutter Peek View
+            const { peekView, gutter } = await openGutterPeekView(page, editor);
 
             // The peek view contains a diff editor
             await expect(peekView.locator('.editor.original')).toContainText('line 2', { timeout: 5000 });
@@ -80,6 +83,51 @@ test.describe('Quick Diff E2E', () => {
             // Since it's squashed, it might still show up briefly or disappear.
             // Actually, after squash, the file matches the parent, so it should disappear from SCM.
             await expect(scmFileRow).not.toBeVisible({ timeout: 10000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Discard middle-of-file deletion via gutter peek view', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        const fileName = 'middle-deletion-e2e.txt';
+        const fileContentOriginal = 'a\nb\nc\nd\ne\n';
+        const fileContentModified = 'a\nb\nd\ne\n';
+
+        repo.writeFile(fileName, fileContentOriginal);
+        repo.describe('base');
+        repo.new();
+        repo.writeFile(fileName, fileContentModified);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            // 1. Open the file via the Explorer
+            const editor = await openFileInEditor(page, fileName);
+
+            // 2 & 3. Open Gutter Peek View
+            const { peekView } = await openGutterPeekView(page, editor);
+
+            // 4. Click Revert Change Button
+            const revertButton = peekView.locator('[aria-label="Discard Change"]');
+            await expect(revertButton).toBeVisible({ timeout: 5000 });
+            await revertButton.click();
+
+            // 5. Verify file content on disk
+            const filePath = path.join(repo.path, fileName);
+            await expect(async () => {
+                const content = fs.readFileSync(filePath, 'utf-8');
+                expect(content).toBe(fileContentOriginal);
+            }).toPass({ timeout: 10000 });
+
+            // Peek view should close
+            await expect(peekView).not.toBeVisible({ timeout: 5000 });
         } finally {
             await app.close();
             try {

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -46,13 +46,14 @@ suite('Quick Diff Commands Integration Test', () => {
         viewFileSystemProvider = new JjViewFileSystemProvider(jj);
         scmProvider = new JjScmProvider(context, jj, canonicalPath, outputChannel, viewFileSystemProvider);
 
-        // Register a test-specific content provider to handle 'jj-view-test' scheme
-        // This avoids conflict with the main extension's 'jj-view' provider
-        jjViewProviderDisposable = vscode.workspace.registerFileSystemProvider('jj-view-test', viewFileSystemProvider);
+        // Register a test-specific content provider to handle a unique scheme per test
+        // This avoids conflict with the main extension's 'jj-view' provider and parallel tests
+        const uniqueScheme = `jj-view-test-${Math.random().toString(36).substring(2, 11)}`;
+        jjViewProviderDisposable = vscode.workspace.registerFileSystemProvider(uniqueScheme, viewFileSystemProvider);
         context.subscriptions.push(jjViewProviderDisposable);
 
         scmProvider.provideOriginalResource = (uri: vscode.Uri) => {
-            return uri.with({ scheme: 'jj-view-test', query: 'base=@&side=left' });
+            return uri.with({ scheme: uniqueScheme, query: 'base=@&side=left' });
         };
 
         // Await the initial refresh to ensure state is ready before tests start
@@ -106,6 +107,51 @@ suite('Quick Diff Commands Integration Test', () => {
                 originalEndLineNumber: 1,
                 modifiedStartLineNumber: 1,
                 modifiedEndLineNumber: 1,
+            },
+        ];
+
+        // Execute Discard Command
+        await discardChangeCommand(scmProvider, fileUri, changes, 0);
+
+        // Verify final state on disk
+        const finalContent = fs.readFileSync(filePath, 'utf-8');
+        assert.strictEqual(finalContent, fileContentOriginal, 'File content should match original after discard');
+    });
+
+    test('Discard Change handles middle-of-file deletion', async () => {
+        const fileName = 'middle-deletion.txt';
+        const fileContentOriginal = 'a\nb\nc\nd\ne\n';
+        const fileContentModified = 'a\nb\nd\ne\n';
+
+        // Setup: Parent has 'a\nb\nc\nd\ne\n', WC has 'a\nb\nd\ne\n'
+        await buildGraph(repo, [
+            {
+                label: 'parent',
+                description: 'parent',
+                files: { [fileName]: fileContentOriginal },
+            },
+            {
+                parents: ['parent'],
+                files: { [fileName]: fileContentModified },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const filePath = path.join(canonicalPath, fileName);
+        const fileUri = vscode.Uri.file(filePath);
+
+        // Verify initial state
+        assert.strictEqual(fs.readFileSync(filePath, 'utf-8'), fileContentModified);
+
+        // Construct LineChange for deletion in the middle of the file
+        // original line 3 ("c") was deleted.
+        // VS Code reports modifiedStartLineNumber = 2 (the line before the deletion)
+        const changes = [
+            {
+                originalStartLineNumber: 3,
+                originalEndLineNumber: 3,
+                modifiedStartLineNumber: 2,
+                modifiedEndLineNumber: 0,
             },
         ];
 


### PR DESCRIPTION
Adjusts the range calculation in `discardChangeCommand` to correctly handle line numbers for deleted blocks, preventing out-of-bounds issues. Includes new integration and E2E tests verifying that middle-of-file deletions can be successfully reverted from the gutter peek view.

Fixes #248