### PR TITLE
feat: Add jj-view.openDiffOnClick config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,11 @@
                     "type": "string",
                     "default": ".workspaces",
                     "description": "Directory where new workspaces are created. Relative paths are resolved against the main repository root."
+                },
+                "jj-view.openDiffOnClick": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened."
                 }
             }
         },
@@ -251,6 +256,12 @@
                 "title": "Open File",
                 "category": "JJ View",
                 "icon": "$(go-to-file)"
+            },
+            {
+                "command": "jj-view.openChanges",
+                "title": "Open Changes",
+                "category": "JJ View",
+                "icon": "$(diff)"
             },
             {
                 "command": "jj-view.undo",
@@ -668,7 +679,12 @@
                 {
                     "command": "jj-view.openFile",
                     "group": "inline@1",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/ || scmResourceState == 'jj.resource.conflict'"
+                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && jj.openDiffOnClick || scmResourceState == 'jj.resource.conflict'"
+                },
+                {
+                    "command": "jj-view.openChanges",
+                    "group": "inline@1",
+                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && !jj.openDiffOnClick"
                 },
                 {
                     "command": "jj-view.restore",

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
+import type { JjResourceState } from '../jj-scm-provider';
 
 export async function openFileCommand(resourceState: vscode.SourceControlResourceState | undefined) {
     if (!resourceState) {
@@ -12,4 +13,12 @@ export async function openFileCommand(resourceState: vscode.SourceControlResourc
     // Strip query parameters to ensure we open the canonical file
     const uri = resourceState.resourceUri.with({ query: '' });
     await vscode.commands.executeCommand('vscode.open', uri);
+}
+
+export async function openChangesCommand(resourceState: JjResourceState | undefined) {
+    if (!resourceState?.diffCommand) {
+        return;
+    }
+    const { command, arguments: args } = resourceState.diffCommand;
+    await vscode.commands.executeCommand(command, ...(args ?? []));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,7 +23,7 @@ import { showMultiFileDiffCommand } from './commands/multi-diff';
 import { newCommand } from './commands/new';
 import { newAfterCommand } from './commands/new-after';
 import { newBeforeCommand } from './commands/new-before';
-import { openFileCommand } from './commands/open';
+import { openChangesCommand, openFileCommand } from './commands/open';
 import { type CommitMenuContext, rebaseOntoSelectedCommand } from './commands/rebase';
 import { redoCommand } from './commands/redo';
 import { refreshCommand } from './commands/refresh';
@@ -40,9 +40,10 @@ import { workspaceForgetCommand } from './commands/workspace-forget';
 import { GerritService } from './gerrit-service';
 import { checkGitColocation } from './git-colocation';
 import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provider';
+import { JjContextKey } from './jj-context-keys';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjLogWebviewProvider } from './jj-log-webview-provider';
-import { JjScmProvider } from './jj-scm-provider';
+import { type JjResourceState, JjScmProvider } from './jj-scm-provider';
 import { JjService } from './jj-service';
 import { TOGGLEABLE_COMMIT_ACTIONS } from './jj-types';
 import { JjViewFileSystemProvider } from './jj-view-fs-provider';
@@ -100,10 +101,20 @@ export function activate(context: vscode.ExtensionContext) {
 
     updateBinaryPath();
 
+    const setOpenDiffOnClickContext = () => {
+        const value = vscode.workspace.getConfiguration('jj-view').get<boolean>('openDiffOnClick', true);
+        vscode.commands.executeCommand('setContext', JjContextKey.OpenDiffOnClick, value);
+    };
+    setOpenDiffOnClickContext();
+
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration(async (e) => {
             if (e.affectsConfiguration('jj-view.binaryPath')) {
                 await updateBinaryPath();
+                scmProvider.refresh();
+            }
+            if (e.affectsConfiguration('jj-view.openDiffOnClick')) {
+                setOpenDiffOnClickContext();
                 scmProvider.refresh();
             }
         }),
@@ -228,6 +239,12 @@ export function activate(context: vscode.ExtensionContext) {
                 await openFileCommand(resourceState);
             },
         ),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.openChanges', async (resourceState: JjResourceState) => {
+            await openChangesCommand(resourceState);
+        }),
     );
 
     context.subscriptions.push(

--- a/src/jj-context-keys.ts
+++ b/src/jj-context-keys.ts
@@ -25,6 +25,9 @@ export enum JjContextKey {
 
     /** True when any number of commits are selected (create new commit before them) */
     SelectionAllowNewBefore = 'jj.selection.allowNewBefore',
+
+    /** Mirrors the jj-view.openDiffOnClick setting; controls inline button visibility */
+    OpenDiffOnClick = 'jj.openDiffOnClick',
 }
 
 /**

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -21,6 +21,8 @@ import { formatDisplayChangeId } from './utils/jj-utils';
 
 export interface JjResourceState extends vscode.SourceControlResourceState {
     revision: string;
+    /** The diff command for this resource, used by "Open Changes" when openDiffOnClick is off. */
+    diffCommand?: vscode.Command;
 }
 
 export class JjScmProvider implements vscode.Disposable {
@@ -167,6 +169,7 @@ export class JjScmProvider implements vscode.Disposable {
                 // 1. Fetch data in parallel for performance
                 const config = vscode.workspace.getConfiguration('jj-view');
                 const maxMutableAncestors = config.get<number>('maxMutableAncestors', 10);
+                const openDiffOnClick = config.get<boolean>('openDiffOnClick', true);
                 const limit = maxMutableAncestors + 1;
 
                 // Chain getLog directly off getLogIds so it runs concurrently with getChildren and getConflictedFiles
@@ -327,6 +330,7 @@ export class JjScmProvider implements vscode.Disposable {
                     const state = this.toResourceState(c, currentEntry?.change_id || '@', {
                         squashable: parentMutable,
                         multipleAncestors: ancestorsToDisplay.length > 1,
+                        openDiffOnClick,
                     });
                     decorationMap.set(state.resourceUri.toString(), c);
                     this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
@@ -336,7 +340,7 @@ export class JjScmProvider implements vscode.Disposable {
                 // 4. Update Conflict Group (conflictedPaths fetched above)
                 this._conflictGroup.resourceStates = conflictedPaths.map((path) => {
                     const entry: JjStatusEntry = { path, status: 'modified', conflicted: true };
-                    const state = this.toResourceState(entry, currentEntry?.change_id || '@');
+                    const state = this.toResourceState(entry, currentEntry?.change_id || '@', { openDiffOnClick });
                     decorationMap.set(state.resourceUri.toString(), entry);
                     return state;
                 });
@@ -389,6 +393,7 @@ export class JjScmProvider implements vscode.Disposable {
                             editable: isMutable,
                             squashable: canSquash,
                             multipleAncestors: remainingAncestors > 0,
+                            openDiffOnClick,
                         });
                         decorationMap.set(state.resourceUri.toString(), c);
                         return state;
@@ -550,6 +555,7 @@ export class JjScmProvider implements vscode.Disposable {
             workingCopyChangeId?: string;
             squashable?: boolean;
             multipleAncestors?: boolean;
+            openDiffOnClick?: boolean;
         } = {},
     ): JjResourceState {
         const root = this._sourceControl.rootUri?.fsPath || '';
@@ -559,21 +565,33 @@ export class JjScmProvider implements vscode.Disposable {
             workingCopyChangeId: this._currentEntry?.change_id,
         });
 
+        const openDiffOnClick = options.openDiffOnClick ?? true;
+        const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
+
+        const diffCommand: vscode.Command = {
+            command: 'vscode.diff',
+            title: 'Open Changes',
+            arguments: [leftUri, rightUri, `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`],
+        };
+
         const command: vscode.Command = entry.conflicted
             ? {
                   command: 'jj-view.openMergeEditor',
                   title: 'Open 3-Way Merge',
                   arguments: [{ resourceUri }],
               }
-            : {
-                  command: 'vscode.diff',
-                  title: 'Diff',
-                  arguments: [leftUri, rightUri, `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`],
-              };
+            : openDiffOnClick || isDeleted
+              ? diffCommand
+              : {
+                    command: 'vscode.open',
+                    title: 'Open File',
+                    arguments: [resourceUri.with({ query: '' })],
+                };
 
         return {
             resourceUri,
-            command: command,
+            command,
+            diffCommand: entry.conflicted ? undefined : diffCommand,
             decorations: {
                 tooltip: entry.conflicted ? 'Conflicted' : entry.status,
                 faded: false,

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -4,7 +4,8 @@
  */
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { openFileCommand } from '../../commands/open';
+import { openChangesCommand, openFileCommand } from '../../commands/open';
+import type { JjResourceState } from '../../jj-scm-provider';
 import { createMock } from '../test-utils';
 
 vi.mock('vscode', () => {
@@ -54,6 +55,50 @@ describe('openFileCommand', () => {
                 path: '/foo',
                 query: '',
             }),
+        );
+    });
+});
+
+describe('openChangesCommand', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('does nothing if no resource state', async () => {
+        await openChangesCommand(undefined);
+        expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    test('does nothing if resource state has no diffCommand', async () => {
+        const resourceState = createMock<JjResourceState>({
+            resourceUri: vscode.Uri.file('/foo'),
+            revision: '@',
+        });
+
+        await openChangesCommand(resourceState);
+        expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    test('executes the diffCommand with its arguments', async () => {
+        const leftUri = vscode.Uri.file('/left');
+        const rightUri = vscode.Uri.file('/right');
+        const resourceState = createMock<JjResourceState>({
+            resourceUri: vscode.Uri.file('/foo'),
+            revision: '@',
+            diffCommand: {
+                command: 'vscode.diff',
+                title: 'Open Changes',
+                arguments: [leftUri, rightUri, 'foo.txt (Working Copy)'],
+            },
+        });
+
+        await openChangesCommand(resourceState);
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.diff',
+            leftUri,
+            rightUri,
+            'foo.txt (Working Copy)',
         );
     });
 });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -11,7 +11,7 @@ import { compareAllFilesWithRevisionCommand } from '../commands/compare-all-file
 import { moveToChildCommand, moveToParentInDiffCommand } from '../commands/move';
 import { completeSquashCommand, squashCommand } from '../commands/squash';
 import { ScmContextValue } from '../jj-context-keys';
-import { JjScmProvider } from '../jj-scm-provider';
+import { type JjResourceState, JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { buildGraph, TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
@@ -122,6 +122,96 @@ suite('JJ SCM Provider Integration Test', () => {
             ].includes(wcState.contextValue as ScmContextValue),
         );
     });
+
+    test('When openDiffOnClick is false, opens modified files and diffs removed files', async () => {
+        const filePath = path.join(repo.path, 'test.txt');
+        const deletedFilePath = path.join(repo.path, 'deleted.txt');
+        await buildGraph(repo, [
+            {
+                label: 'initial',
+                description: 'initial',
+                files: { 'test.txt': 'initial', 'deleted.txt': 'will be deleted' },
+            },
+            {
+                parents: ['initial'],
+                files: { 'test.txt': 'modified' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+        await fsp.unlink(deletedFilePath);
+
+        const originalGetConfiguration = vscode.workspace.getConfiguration;
+        const configStub = {
+            get: (key: string, defaultValue: unknown) => {
+                if (key === 'openDiffOnClick') {
+                    return false;
+                }
+                return defaultValue;
+            },
+        };
+        (vscode.workspace as { getConfiguration: unknown }).getConfiguration = (section: string) => {
+            if (section === 'jj-view') {
+                return configStub;
+            }
+            return originalGetConfiguration(section);
+        };
+
+        try {
+            await scmProvider.refresh({ forceSnapshot: true });
+
+            const workingCopyGroup = accessPrivate(
+                scmProvider,
+                '_workingCopyGroup',
+            ) as vscode.SourceControlResourceGroup;
+            const resourceState = workingCopyGroup.resourceStates.find(
+                (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            );
+            assert.ok(resourceState, 'Should find resource state for modified file');
+
+            const command = resourceState.command;
+            assert.ok(command, 'Resource state should have a command');
+            assert.strictEqual(
+                command.command,
+                'vscode.open',
+                'Command should be vscode.open when openDiffOnClick is false',
+            );
+            assert.strictEqual(command.arguments?.length, 1, 'Open command should have 1 argument');
+            const openUri = command.arguments?.[0] as vscode.Uri;
+            assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
+            assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
+
+            const diffCommand = (resourceState as JjResourceState).diffCommand;
+            assert.ok(diffCommand, 'diffCommand should be set when openDiffOnClick is false');
+            assert.strictEqual(diffCommand.command, 'vscode.diff', 'diffCommand should be vscode.diff');
+            assert.strictEqual(diffCommand.arguments?.length, 3, 'diffCommand should have 3 arguments');
+
+            const [leftUri, rightUri] = diffCommand.arguments;
+            assert.strictEqual(
+                (leftUri as vscode.Uri).scheme,
+                'jj-view',
+                'diffCommand left URI scheme should be jj-view',
+            );
+            assert.strictEqual(
+                normalize((rightUri as vscode.Uri).fsPath),
+                normalize(filePath),
+                'diffCommand right URI should be the file path',
+            );
+
+            // Deleted files should still open the diff editor even when openDiffOnClick is false
+            const deletedState = workingCopyGroup.resourceStates.find(
+                (r) => normalize(r.resourceUri.fsPath) === normalize(deletedFilePath),
+            );
+            assert.ok(deletedState, 'Should find resource state for deleted file');
+            assert.strictEqual(
+                deletedState.command?.command,
+                'vscode.diff',
+                'Deleted file should use vscode.diff regardless of openDiffOnClick',
+            );
+        } finally {
+            (vscode.workspace as { getConfiguration: unknown }).getConfiguration = originalGetConfiguration;
+        }
+    });
+
     test('Shows parent commit changes in separate group', async () => {
         const filePath = path.join(repo.path, 'parent-file.txt');
         await buildGraph(repo, [


### PR DESCRIPTION
We replicate VS Code's `git:openDiffOnClick` option. By default the option is set to `true` and `jj-view`'s behaviour is as it is now.

When the option is set to `false`, clicking on a file in the "Changes" panel will open the current version of the file rather than a diff. This does not apply to conflicted and deleted files. For such files, the current behaviour is preserved.

For those files where clicking does open the file, we hide the existing "Open File" button and show a new "Open Changes" button instead. Clicking this button will open the same diff that is currently shown when clicking on the file.