### PR TITLE
chore: automate asset generation and improve contributor setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
     "[typescriptreact]": {
         "editor.rulers": [120]
     },
-    "jj-view.uploadCommand": "upload"
+    "jj-view.uploadCommand": "upload",
+    "npm.packageManager": "pnpm"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
         {
             "label": "watch",
-            "dependsOn": ["npm: watch:tsc", "npm: watch:esbuild"],
+            "dependsOn": ["npm: watch:tsc", "npm: watch:esbuild", "npm: watch:themes"],
             "presentation": {
                 "reveal": "never"
             },
@@ -56,6 +56,29 @@
             "presentation": {
                 "group": "watch",
                 "reveal": "never"
+            }
+        },
+        {
+            "type": "npm",
+            "script": "watch:themes",
+            "group": "build",
+            "isBackground": true,
+            "label": "npm: watch:themes",
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            },
+            "problemMatcher": {
+                "owner": "themes",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^(Watching for changes in|Detected change in).*themes\\.json.*$",
+                    "endsPattern": "^Generated .*themes\\.generated\\.(ts|css)$"
+                },
+                "pattern": {
+                    "regexp": "^Error generating themes: (.*)$",
+                    "message": 1
+                }
             }
         },
         {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,31 @@ Guidelines](https://opensource.google/conduct/).
 
 ## Contribution process
 
+### Development Setup
+
+1.  **Clone the repository**:
+    ```bash
+    jj git clone git@github.com:brychanrobot/jj-view.git
+    cd jj-view
+    ```
+2.  **Install dependencies**:
+    ```bash
+    pnpm install
+    ```
+    *Note: The `prepare` script will automatically generate necessary assets (themes and icons) after installation.*
+3.  **Configure Jujutsu**:
+    Run the setup script to link the repository-specific `jj` configuration:
+    ```bash
+    pnpm setup-jj
+    ```
+4.  **Build the project**:
+    If you need to manually regenerate assets or perform a full build:
+    ```bash
+    pnpm build
+    ```
+5.  **Run the extension**:
+    Open the project in VS Code and press `F5` to start the extension in a new Extension Development Host window.
+
 ### Code Reviews
 
 All submissions, including submissions by project members, require review. We

--- a/package.json
+++ b/package.json
@@ -755,8 +755,10 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "pnpm build:themes && pnpm check-types && pnpm lint && node esbuild.js --production",
-        "build": "pnpm build:themes && pnpm check-types && pnpm lint && node esbuild.js",
+        "setup-jj": "ts-node tooling/jj/setup.ts",
+        "prepare": "pnpm build:themes && pnpm build:icons",
+        "vscode:prepublish": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js --production",
+        "build": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js",
         "build:icons": "svgtofont -s media/custom-icons-src -o media/custom-icons",
         "watch": "npm-run-all -p watch:*",
         "watch:esbuild": "node esbuild.js --watch",


### PR DESCRIPTION
Automates the generation of themes and icons via a new `prepare` script in `package.json`, ensuring fresh clones are ready for type-checking. Includes a new `setup-jj` script for repository configuration and adds a detailed "Development Setup" section to the contributing guide. Also configures VS Code tasks to use pnpm and watch theme changes.

Fixes #268