### PR TITLE
Migrate tooling scripts to native Node.js TypeScript support

### DIFF
--- a/.agents/scripts/tsconfig.json
+++ b/.agents/scripts/tsconfig.json
@@ -1,11 +1,10 @@
 {
-    "extends": "../tsconfig.json",
+    "extends": "../../tsconfig.json",
     "compilerOptions": {
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
         "rootDir": ".",
-        "outDir": "../out/tooling"
+        "noEmit": true
     },
-    "include": ["**/*.ts"],
-    "exclude": []
+    "include": ["**/*.ts"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
               run: pnpm package --out jj-view.vsix
 
             - name: Verify VSIX Contents
-              run: pnpm exec ts-node tooling/verify-vsix.ts jj-view.vsix
+              run: node tooling/verify-vsix.ts jj-view.vsix
 
             - name: Upload Build Artifacts
               uses: actions/upload-artifact@v4

--- a/knip.json
+++ b/knip.json
@@ -10,5 +10,5 @@
     ],
     "project": ["src/**/*.{ts,tsx}"],
     "ignore": ["**/*.d.ts"],
-    "ignoreDependencies": ["ts-node", "@vscode/test-electron", "@types/mocha"]
+    "ignoreDependencies": ["@vscode/test-electron", "@types/mocha"]
 }

--- a/package.json
+++ b/package.json
@@ -776,7 +776,7 @@
         }
     },
     "scripts": {
-        "setup-jj": "ts-node tooling/jj/setup.ts",
+        "setup-jj": "node tooling/jj/setup.ts",
         "prepare": "pnpm build:themes && pnpm build:icons",
         "vscode:prepublish": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js --production",
         "build": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js",
@@ -784,12 +784,12 @@
         "watch": "npm-run-all -p watch:*",
         "watch:esbuild": "node esbuild.js --watch",
         "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-        "watch:themes": "ts-node tooling/generate-themes.ts --watch",
+        "watch:themes": "node tooling/generate-themes.ts --watch",
         "package": "pnpm vsce package --no-dependencies",
         "release": "pnpm ovsx publish --no-dependencies && pnpm vsce publish --no-dependencies",
         "clean:tests": "rimraf out",
         "build:tests": "tsc -p . --outDir out",
-        "build:themes": "ts-node tooling/generate-themes.ts",
+        "build:themes": "node tooling/generate-themes.ts",
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "pnpm build && pnpm build:tests && pnpm lint",
         "check-types": "tsc --noEmit",
@@ -806,7 +806,7 @@
         "test:screenshots": "playwright test",
         "test:e2e": "node esbuild.js && pnpm build:tests && playwright test -c playwright.e2e.config.ts",
         "test:unit": "vitest run",
-        "release:encode": "ts-node .agents/scripts/encode-release-notes.ts"
+        "release:encode": "node .agents/scripts/encode-release-notes.ts"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -831,7 +831,7 @@
         "rimraf": "^6.1.2",
         "sinon": "^21.0.1",
         "svgtofont": "^6.5.1",
-        "ts-node": "^10.9.2",
+
         "typescript": "^5.9.3",
         "vitest": "^4.0.16"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ importers:
       svgtofont:
         specifier: ^6.5.1
         version: 6.5.1(chokidar@3.6.0)
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.3)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -241,10 +238,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -461,9 +454,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@lit-labs/ssr-dom-shim@1.5.0':
     resolution: {integrity: sha512-HLomZXMmrCFHSRKESF5vklAKsDY7/fsT/ZhqCu3V0UoW/Qbv8wxmO4W9bx4KnCCF2Zak4yuk+AGraK/bPmI4kA==}
@@ -882,18 +872,6 @@ packages:
   '@textlint/types@15.5.0':
     resolution: {integrity: sha512-EjAPbuA+3NyQ9WyFP7iUlddi35F3mGrf4tb4cZM0nWywbtEJ3+XAYqL+5RsF0qFeSguxGir09NdZOWrG9wVOUQ==}
 
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1070,10 +1048,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -1120,9 +1094,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1369,9 +1340,6 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -1469,10 +1437,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
-    engines: {node: '>=0.3.1'}
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
@@ -2224,9 +2188,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
@@ -3096,20 +3057,6 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
@@ -3227,9 +3174,6 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -3439,10 +3383,6 @@ packages:
     resolution: {integrity: sha512-FemWD5/UqNm8ffj8oZIbjWXIF2KE0mZssggYpdaQkWDDgXBQ/35PNIxEuz6/YLn9o0kOxDBNJe8x8k9ljD7k/g==}
     engines: {node: '>=18.16.0'}
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -3582,10 +3522,6 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.12':
     optional: true
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.3)':
     dependencies:
@@ -3733,11 +3669,6 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4099,14 +4030,6 @@ snapshots:
     dependencies:
       '@textlint/ast-node-types': 15.5.0
 
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4327,10 +4250,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.4:
-    dependencies:
-      acorn: 8.15.0
-
   acorn@8.15.0: {}
 
   adm-zip@0.5.16: {}
@@ -4368,8 +4287,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -4654,8 +4571,6 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-require@1.1.1: {}
-
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -4758,8 +4673,6 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
-
-  diff@4.0.2: {}
 
   diff@7.0.0: {}
 
@@ -5599,8 +5512,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
-
-  make-error@1.3.6: {}
 
   make-fetch-happen@14.0.3:
     dependencies:
@@ -6631,24 +6542,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.3
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   ts-pattern@5.9.0: {}
 
   tslib@2.8.1: {}
@@ -6766,8 +6659,6 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
-
-  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -6977,7 +6868,5 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yerror@8.0.0: {}
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}

--- a/tooling/generate-themes.ts
+++ b/tooling/generate-themes.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as parcelWatcher from '@parcel/watcher';
-import * as Handlebars from 'handlebars';
+import Handlebars from 'handlebars';
 
 export interface ThemeJsonConfig {
     strategy: 'cycle' | 'clamp';
@@ -110,7 +110,7 @@ function writeIfChanged(filePath: string, content: string) {
 
 function runGeneration() {
     try {
-        const themesPath = path.join(__dirname, '../src/webview/themes.json');
+        const themesPath = path.join(import.meta.dirname, '../src/webview/themes.json');
         if (!fs.existsSync(themesPath)) {
             console.error(`Error: themes.json not found at ${themesPath}`);
             return;
@@ -120,8 +120,8 @@ function runGeneration() {
 
         const { ts, css } = generateThemes(themesData);
 
-        const tsOutputPath = path.join(__dirname, '../src/webview/themes.generated.ts');
-        const cssOutputPath = path.join(__dirname, '../media/themes.generated.css');
+        const tsOutputPath = path.join(import.meta.dirname, '../src/webview/themes.generated.ts');
+        const cssOutputPath = path.join(import.meta.dirname, '../media/themes.generated.css');
 
         writeIfChanged(tsOutputPath, ts);
         writeIfChanged(cssOutputPath, css);
@@ -131,7 +131,7 @@ function runGeneration() {
 }
 
 async function watchThemes() {
-    const themesPath = path.join(__dirname, '../src/webview/themes.json');
+    const themesPath = path.join(import.meta.dirname, '../src/webview/themes.json');
     const themesDir = path.dirname(themesPath);
     const themesFile = path.basename(themesPath);
 
@@ -165,6 +165,6 @@ function main() {
     }
 }
 
-if (require.main === module) {
+if (import.meta.main) {
     main();
 }

--- a/tooling/jj/repo-config.toml
+++ b/tooling/jj/repo-config.toml
@@ -1,6 +1,6 @@
 [aliases]
 sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s 'roots(mutable())' -d main --skip-emptied && jj log"]
-upload = ["util", "exec", "--", "pnpm", "exec", "ts-node", "tooling/jj/upload.ts"]
+upload = ["util", "exec", "--", "node", "tooling/jj/upload.ts"]
 
 [fix.tools.biome]
 command = ["$root/node_modules/.bin/biome", "format", "--stdin-file-path", "$path"]

--- a/tooling/jj/setup.ts
+++ b/tooling/jj/setup.ts
@@ -19,7 +19,7 @@ function question(query: string): Promise<string> {
 async function main() {
     try {
         const repoConfigPath = execFileSync('jj', ['config', 'path', '--repo'], { encoding: 'utf8' }).trim();
-        const sourceConfigPath = path.resolve(__dirname, 'repo-config.toml');
+        const sourceConfigPath = path.resolve(import.meta.dirname, 'repo-config.toml');
 
         console.log(`Target config location: ${repoConfigPath}`);
         console.log(`Source config location: ${sourceConfigPath}`);

--- a/tooling/package.json
+++ b/tooling/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/tooling/verify-vsix.ts
+++ b/tooling/verify-vsix.ts
@@ -8,7 +8,7 @@ import AdmZip from 'adm-zip';
 
 const vsixPath = process.argv[2];
 if (!vsixPath) {
-    console.error('Usage: ts-node scripts/verify-vsix.ts <vsix-path>');
+    console.error('Usage: node tooling/verify-vsix.ts <vsix-path>');
     process.exit(1);
 }
 


### PR DESCRIPTION
Replaces `ts-node` with native Node.js type-stripping for all development scripts. This modernization effort removes `ts-node` as a dependency and transitions the tooling scripts to pure ES Modules.

Key changes:

- Replaces legacy `__dirname` and `require.main` with `import.meta.dirname` and `import.meta.filename`.
- Updates `package.json` scripts and `jj` aliases to use the native `node` runner.
- Adds local `package.json` filee in `tooling/` to explicitly mark it as an ES Modules and silence Node.js warnings.
- Fixes `Handlebars` import for ESM compatibility.
- Removes `ts-node` and its associated dependencies from the lockfile.