### PR TITLE
Refactor SCM interaction to use raw URIs and expand E2E test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -689,7 +689,7 @@
                 {
                     "command": "jj-view.openChanges",
                     "group": "inline@1",
-                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && !jj.openDiffOnClick"
+                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && !jj.openDiffOnClick || scmResourceState == 'jj.resource.conflict'"
                 },
                 {
                     "command": "jj-view.restore",

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -5,20 +5,26 @@
 import * as vscode from 'vscode';
 import type { JjResourceState } from '../jj-scm-provider';
 
+// Opens the file on disk (usually the working copy version).
+// Strips the query parameter to ensure VS Code opens the local file path.
 export async function openFileCommand(resourceState: vscode.SourceControlResourceState | undefined) {
     if (!resourceState) {
         return;
     }
-    // Open the resourceUri (which is the file in the workspace)
-    // Strip query parameters to ensure we open the canonical file
     const uri = resourceState.resourceUri.with({ query: '' });
     await vscode.commands.executeCommand('vscode.open', uri);
 }
 
+// Opens the diff view for the given resource state.
+// Uses the pre-calculated left and right URIs stored on the JjResourceState.
 export async function openChangesCommand(resourceState: JjResourceState | undefined) {
-    if (!resourceState?.diffCommand) {
+    if (!resourceState?.leftUri || !resourceState?.rightUri) {
         return;
     }
-    const { command, arguments: args } = resourceState.diffCommand;
-    await vscode.commands.executeCommand(command, ...(args ?? []));
+    await vscode.commands.executeCommand(
+        'vscode.diff',
+        resourceState.leftUri,
+        resourceState.rightUri,
+        resourceState.diffTitle ?? 'Diff',
+    );
 }

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -21,8 +21,10 @@ import { formatDisplayChangeId } from './utils/jj-utils';
 
 export interface JjResourceState extends vscode.SourceControlResourceState {
     revision: string;
-    /** The diff command for this resource, used by "Open Changes" when openDiffOnClick is off. */
-    diffCommand?: vscode.Command;
+    /** The URIs used for generating diffs. */
+    leftUri?: vscode.Uri;
+    rightUri?: vscode.Uri;
+    diffTitle?: string;
 }
 
 export class JjScmProvider implements vscode.Disposable {
@@ -568,10 +570,12 @@ export class JjScmProvider implements vscode.Disposable {
         const openDiffOnClick = options.openDiffOnClick ?? true;
         const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
 
+        const diffTitle = `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`;
+
         const diffCommand: vscode.Command = {
             command: 'vscode.diff',
             title: 'Open Changes',
-            arguments: [leftUri, rightUri, `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`],
+            arguments: [leftUri, rightUri, diffTitle],
         };
 
         const command: vscode.Command = entry.conflicted
@@ -591,7 +595,9 @@ export class JjScmProvider implements vscode.Disposable {
         return {
             resourceUri,
             command,
-            diffCommand: entry.conflicted ? undefined : diffCommand,
+            leftUri,
+            rightUri,
+            diffTitle,
             decorations: {
                 tooltip: entry.conflicted ? 'Conflicted' : entry.status,
                 faded: false,

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -69,27 +69,26 @@ describe('openChangesCommand', () => {
         expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
     });
 
-    test('does nothing if resource state has no diffCommand', async () => {
+    test('does nothing if resource state has no leftUri or rightUri', async () => {
         const resourceState = createMock<JjResourceState>({
             resourceUri: vscode.Uri.file('/foo'),
             revision: '@',
+            // Missing leftUri and rightUri
         });
 
         await openChangesCommand(resourceState);
         expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
     });
 
-    test('executes the diffCommand with its arguments', async () => {
+    test('executes the diffCommand with its URIs and title', async () => {
         const leftUri = vscode.Uri.file('/left');
         const rightUri = vscode.Uri.file('/right');
         const resourceState = createMock<JjResourceState>({
             resourceUri: vscode.Uri.file('/foo'),
             revision: '@',
-            diffCommand: {
-                command: 'vscode.diff',
-                title: 'Open Changes',
-                arguments: [leftUri, rightUri, 'foo.txt (Working Copy)'],
-            },
+            leftUri,
+            rightUri,
+            diffTitle: 'foo.txt (Working Copy)',
         });
 
         await openChangesCommand(resourceState);

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -718,4 +718,137 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('File Click Behavior: openDiffOnClick = true (Default)', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            {
+                label: 'base',
+                files: { 'modified.txt': 'base', 'deleted.txt': 'base', 'conflict.txt': 'base' },
+            },
+            {
+                label: 'side1',
+                parents: ['base'],
+                files: { 'conflict.txt': 'side1' },
+            },
+            {
+                label: 'side2',
+                parents: ['base'],
+                files: { 'conflict.txt': 'side2' },
+            },
+            {
+                label: 'wc',
+                parents: ['side1', 'side2'], // Create conflict
+                description: 'wc change',
+                files: { 'modified.txt': 'mod' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+        fs.unlinkSync(path.join(repo.path, 'deleted.txt'));
+
+        const { app, page, userDataDir } = await launchVSCode(repo, {
+            'jj-view.openDiffOnClick': true,
+        });
+
+        try {
+            await focusSCM(page);
+
+            // 1. Click modified.txt -> should open diff editor
+            const modifiedRow = page.getByRole('treeitem', { name: /modified\.txt/i }).first();
+            await modifiedRow.click();
+            await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
+
+            // 2. Click deleted.txt -> should open diff editor
+            const deletedRow = page.getByRole('treeitem', { name: /deleted\.txt/i }).first();
+            await deletedRow.click();
+            await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
+
+            // 3. Click conflict.txt -> should open merge editor
+            const conflictRow = page.getByRole('treeitem', { name: /conflict\.txt/i }).first();
+            await conflictRow.click();
+            // Merge editor has specific class or attributes. Usually 'merge-editor' or similar.
+            // In VS Code, the merge editor has a 'merge-editor-container' or similar.
+            await expect(page.locator('.merge-editor')).toBeVisible({ timeout: 5000 });
+            // 4. Open File via inline button -> should open regular editor
+            await modifiedRow.hover();
+            const openFileIcon = modifiedRow.getByRole('button', { name: 'Open File', exact: true }).first();
+            await expect(openFileIcon).toBeVisible();
+            await openFileIcon.click();
+            await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
+            await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('File Click Behavior: openDiffOnClick = false', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        await buildGraph(repo, [
+            {
+                label: 'base',
+                files: { 'modified.txt': 'base', 'deleted.txt': 'base', 'conflict.txt': 'base' },
+            },
+            {
+                label: 'side1',
+                parents: ['base'],
+                files: { 'conflict.txt': 'side1' },
+            },
+            {
+                label: 'side2',
+                parents: ['base'],
+                files: { 'conflict.txt': 'side2' },
+            },
+            {
+                label: 'wc',
+                parents: ['side1', 'side2'],
+                description: 'wc change',
+                files: { 'modified.txt': 'mod' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+        fs.unlinkSync(path.join(repo.path, 'deleted.txt'));
+
+        const { app, page, userDataDir } = await launchVSCode(repo, {
+            'jj-view.openDiffOnClick': false,
+        });
+
+        try {
+            await focusSCM(page);
+
+            // 1. Click modified.txt -> should open regular editor
+            const modifiedRow = page.getByRole('treeitem', { name: /modified\.txt/i }).first();
+            await modifiedRow.click();
+            await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
+            await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
+
+            // 2. Click deleted.txt -> should still open diff editor
+            const deletedRow = page.getByRole('treeitem', { name: /deleted\.txt/i }).first();
+            await deletedRow.click();
+            await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
+
+            // 3. Click conflict.txt -> should open merge editor
+            const conflictRow = page.getByRole('treeitem', { name: /conflict\.txt/i }).first();
+            await conflictRow.click();
+            await expect(page.locator('.merge-editor')).toBeVisible({ timeout: 5000 });
+
+            // 4. Open Changes via inline button (for modified file) -> should open diff editor
+            await modifiedRow.hover();
+            const openChangesIcon = modifiedRow.getByRole('button', { name: 'Open Changes', exact: true }).first();
+            await expect(openChangesIcon).toBeVisible();
+            await openChangesIcon.click();
+            await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -180,22 +180,15 @@ suite('JJ SCM Provider Integration Test', () => {
             assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
             assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
 
-            const diffCommand = (resourceState as JjResourceState).diffCommand;
-            assert.ok(diffCommand, 'diffCommand should be set when openDiffOnClick is false');
-            assert.strictEqual(diffCommand.command, 'vscode.diff', 'diffCommand should be vscode.diff');
-            assert.strictEqual(diffCommand.arguments?.length, 3, 'diffCommand should have 3 arguments');
+            const diffTitle = (resourceState as JjResourceState).diffTitle;
+            assert.ok(diffTitle, 'diffTitle should be set');
 
-            const [leftUri, rightUri] = diffCommand.arguments;
-            assert.strictEqual(
-                (leftUri as vscode.Uri).scheme,
-                'jj-view',
-                'diffCommand left URI scheme should be jj-view',
-            );
-            assert.strictEqual(
-                normalize((rightUri as vscode.Uri).fsPath),
-                normalize(filePath),
-                'diffCommand right URI should be the file path',
-            );
+            const leftUri = (resourceState as JjResourceState).leftUri;
+            const rightUri = (resourceState as JjResourceState).rightUri;
+            assert.ok(leftUri && rightUri, 'leftUri and rightUri should be set');
+
+            assert.strictEqual(leftUri.scheme, 'jj-view', 'left URI scheme should be jj-view');
+            assert.strictEqual(normalize(rightUri.fsPath), normalize(filePath), 'right URI should be the file path');
 
             // Deleted files should still open the diff editor even when openDiffOnClick is false
             const deletedState = workingCopyGroup.resourceStates.find(


### PR DESCRIPTION
This change simplifies the architectural interaction between the SCM provider and command handlers by replacing the redundant `diffCommand` object in `JjResourceState` with raw `leftUri`, `rightUri`, and `diffTitle` fields. This reduces architectural coupling and memory overhead.

Additionally, the E2E test suite has been significantly expanded to verify the `jj-view.openDiffOnClick` setting across all resource types. New tests ensure that:

- Clicking modified files toggles between standard and diff editors based on the setting.
- Deleted and conflicted files consistently open the correct editor (Diff or Merge Editor) regardless of the setting.
- Inline hover buttons ("Open File" or "Open Changes") correctly bypass the default click behavior.