### PR TITLE
chore: Refactor E2E tests for improved stability

### DIFF
--- a/src/test/e2e/arbitrary-diff.spec.ts
+++ b/src/test/e2e/arbitrary-diff.spec.ts
@@ -4,10 +4,17 @@
  */
 
 import * as fs from 'node:fs';
-import { expect, type Locator, type Page, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import type { ElectronApplication } from 'playwright';
 import { buildGraph, type CommitId, TestRepo } from '../test-repo';
-import { expectModifiedFiles, focusJJLog, launchVSCode, openFileInEditor, waitForQuickInput } from './e2e-helpers';
+import {
+    expectModifiedFiles,
+    focusJJLog,
+    launchVSCode,
+    openFileInEditor,
+    waitForQuickInput,
+    waitForTab,
+} from './e2e-helpers';
 
 test.describe('Arbitrary Diff E2E', () => {
     let repo: TestRepo;
@@ -15,6 +22,27 @@ test.describe('Arbitrary Diff E2E', () => {
     let page: Page;
     let userDataDir: string;
     let nodes: Record<string, CommitId>;
+
+    async function compareWithRevision(
+        page: Page,
+        shortcut: string,
+        revision: string,
+        tabNamePattern: RegExp,
+    ): Promise<void> {
+        await expect(async () => {
+            await page.keyboard.press(shortcut);
+            const input = await waitForQuickInput(page, 2000);
+            await input.fill(revision);
+            await page.waitForTimeout(200); // Wait for VS Code to register the fill
+            await page.keyboard.press('Enter');
+
+            // 1. Ensure quick input is dismissed
+            await expect(page.locator('.quick-input-widget')).not.toBeVisible({ timeout: 3000 });
+
+            // 2. Ensure the tab appears
+            await waitForTab(page, tabNamePattern);
+        }, `Failed to compare with revision "${revision}" via shortcut "${shortcut}"`).toPass({ timeout: 20000 });
+    }
 
     test.beforeEach(async () => {
         repo = new TestRepo();
@@ -67,94 +95,46 @@ test.describe('Arbitrary Diff E2E', () => {
     });
 
     test('Compare All Files with Revision... (Ancestor)', async () => {
-        // Launch using keyboard shortcut with retry
-        let input!: Locator;
-        await expect(async () => {
-            await page.keyboard.press('Control+Alt+c');
-            input = await waitForQuickInput(page, 2000);
-        }).toPass({ timeout: 15000 });
-        await input.focus();
-
-        // Type prefix of commit1
         const commit1Id = nodes.commit1.changeId;
-        const prefix = commit1Id.substring(0, 4);
-        await input.fill(prefix);
-        await page.keyboard.press('Enter');
-
-        // Verification: A diff editor tab should open.
-        await expect(page.getByRole('tab', { name: new RegExp(`^Compare ${prefix}`) })).toBeVisible({
-            timeout: 10000,
-        });
-
+        await compareWithRevision(
+            page,
+            'Control+Alt+c',
+            commit1Id,
+            new RegExp(`^Compare ${commit1Id.substring(0, 4)}`),
+        );
         await expectModifiedFiles(page, ['f.txt']);
     });
 
     test('Compare All Files with Revision... (Arbitrary)', async () => {
-        // Launch using keyboard shortcut with retry
-        let input!: Locator;
-        await expect(async () => {
-            await page.keyboard.press('Control+Alt+c');
-            input = await waitForQuickInput(page, 2000);
-        }).toPass({ timeout: 15000 });
-        await input.focus();
-
-        // Type prefix of branchC1 (which is NOT an ancestor)
         const branchC1Id = nodes.branchC1.changeId;
-        const prefix = branchC1Id.substring(0, 4);
-        await input.fill(prefix);
-        await page.keyboard.press('Enter');
-
-        // Verification: A diff editor tab should open.
-        await expect(page.getByRole('tab', { name: new RegExp(`^Compare ${prefix}`) })).toBeVisible({
-            timeout: 10000,
-        });
-
+        await compareWithRevision(
+            page,
+            'Control+Alt+c',
+            branchC1Id,
+            new RegExp(`^Compare ${branchC1Id.substring(0, 4)}`),
+        );
         await expectModifiedFiles(page, ['f.txt', 'g.txt']);
     });
 
     test('Compare File with Revision... (Ancestor)', async () => {
         await openFileInEditor(page, 'f.txt');
-
-        // Launch using keyboard shortcut with retry
-        let input!: Locator;
-        await expect(async () => {
-            await page.keyboard.press('Control+Alt+f');
-            input = await waitForQuickInput(page, 2000);
-        }).toPass({ timeout: 15000 });
-        await input.focus();
-
-        // Type prefix of commit1
         const commit1Id = nodes.commit1.changeId;
-        const prefix = commit1Id.substring(0, 4);
-        await input.fill(prefix);
-        await page.keyboard.press('Enter');
-
-        // Verification: A diff editor tab should open.
-        await expect(page.getByRole('tab', { name: new RegExp(`f\\.txt \\(${prefix}`) })).toBeVisible({
-            timeout: 10000,
-        });
+        await compareWithRevision(
+            page,
+            'Control+Alt+f',
+            commit1Id,
+            new RegExp(`f\\.txt \\(${commit1Id.substring(0, 4)}`),
+        );
     });
 
     test('Compare File with Revision... (Arbitrary)', async () => {
         await openFileInEditor(page, 'f.txt');
-
-        // Launch using keyboard shortcut with retry
-        let input!: Locator;
-        await expect(async () => {
-            await page.keyboard.press('Control+Alt+f');
-            input = await waitForQuickInput(page, 2000);
-        }).toPass({ timeout: 15000 });
-        await input.focus();
-
-        // Type prefix of branchC1
         const branchC1Id = nodes.branchC1.changeId;
-        const prefix = branchC1Id.substring(0, 4);
-        await input.fill(prefix);
-        await page.keyboard.press('Enter');
-
-        // Verification: A diff editor tab should open.
-        await expect(page.getByRole('tab', { name: new RegExp(`f\\.txt \\(${prefix}`) })).toBeVisible({
-            timeout: 10000,
-        });
+        await compareWithRevision(
+            page,
+            'Control+Alt+f',
+            branchC1Id,
+            new RegExp(`f\\.txt \\(${branchC1Id.substring(0, 4)}`),
+        );
     });
 });

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -5,63 +5,20 @@
 
 import * as fs from 'node:fs';
 import { expect, type Page, test } from '@playwright/test';
-import type { ElectronApplication, Frame } from 'playwright';
+import type { ElectronApplication } from 'playwright';
 import { buildGraph, type CommitId, TestRepo } from '../test-repo';
 import {
     expectSettingsOpen,
     focusJJLog,
+    getDetailsWebview,
     getLogWebview,
     launchVSCode,
     redo,
     save,
     undo,
     waitForLogCommitRow,
+    waitForTab,
 } from './e2e-helpers';
-
-/**
- * Finds the webview frame containing the Commit Details panel.
- */
-async function getDetailsWebview(page: Page): Promise<Frame> {
-    const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
-        for (const f of frames) {
-            try {
-                // Return the first iframe that is actually visible (not hidden by VS Code's tab switching)
-                // We consider it the active webview if its textarea is visible, meaning it's the actively displayed tab
-                if (await f.locator('textarea').isVisible({ timeout: 50 })) {
-                    return f;
-                }
-
-                const nested = await findFrame(f.childFrames());
-                if (nested) {
-                    return nested;
-                }
-            } catch (_e) {}
-        }
-        return undefined;
-    };
-
-    let guestFrame: Frame | undefined;
-    await expect
-        .poll(
-            async () => {
-                guestFrame = await findFrame(page.frames());
-                return guestFrame;
-            },
-            {
-                timeout: 30000,
-                message: 'Could not find Commit Details webview frame',
-            },
-        )
-        .toBeDefined();
-
-    if (!guestFrame) {
-        throw new Error('Could not find Commit Details webview frame');
-    }
-
-    // Ensure the iframe is fully "ready" before returning
-    await expect(guestFrame.locator('textarea')).toBeVisible({ timeout: 10000 });
-    return guestFrame;
-}
 
 test.describe('Commit Details E2E', () => {
     let repo: TestRepo;
@@ -135,8 +92,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Opens with correct ID, description, and file list', async () => {
-            const webview = await getLogWebview(page);
-            const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+            const initialRow = await waitForLogCommitRow(page, 'initial setup');
 
             // Click the commit to open details panel
             await initialRow.click();
@@ -174,8 +130,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Save description via button', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -214,8 +169,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Save description via Ctrl+S', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -260,10 +214,9 @@ test.describe('Commit Details E2E', () => {
             // Refresh the webview by focusing it to pick up graph updates
             await focusJJLog(page);
 
-            const webview = await getLogWebview(page);
-
             // The new commit should be visible and have (no description)
-            const emptyRow = webview.locator('.commit-row', { hasText: '(no description)' }).first();
+            const emptyRow = await waitForLogCommitRow(page, { changeId: newCommitId });
+            await expect(emptyRow).toContainText('(no description)');
 
             // Click to open details
             await expect(emptyRow).toBeVisible({ timeout: 15000 });
@@ -302,8 +255,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Open file diff from file list', async () => {
-            const webview = await getLogWebview(page);
-            const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+            const initialRow = await waitForLogCommitRow(page, 'initial setup');
 
             // Click to open details
             await initialRow.click();
@@ -320,12 +272,11 @@ test.describe('Commit Details E2E', () => {
             await fileRow.click();
 
             // A diff tab should open with the filename
-            await expect(page.getByRole('tab', { name: /f\.txt/ })).toBeVisible({ timeout: 10000 });
+            await waitForTab(page, /f\.txt/);
         });
 
         test('Open Multi-File Diff from button', async () => {
-            const webview = await getLogWebview(page);
-            const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+            const initialRow = await waitForLogCommitRow(page, 'initial setup');
 
             // Click to open details
             await initialRow.click();
@@ -342,19 +293,15 @@ test.describe('Commit Details E2E', () => {
             await multiDiffButton.click();
 
             // A multi-file diff tab should open with the change ID prefix
-            await expect(page.getByRole('tab', { name: new RegExp(`^${shortId}`) })).toBeVisible({ timeout: 10000 });
+            await waitForTab(page, new RegExp(`^${shortId}`));
         });
 
         test('Panel updates when clicking different commit', async () => {
-            const webview = await getLogWebview(page);
-
             // Open details for 'initial'
-            const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+            const initialRow = await waitForLogCommitRow(page, 'initial setup');
             await initialRow.click();
             const shortId1 = nodes.initial.changeId.substring(0, 3);
-            await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId1}`) })).toBeVisible({
-                timeout: 15000,
-            });
+            await waitForTab(page, new RegExp(`^Commit: ${shortId1}`));
 
             const details = await getDetailsWebview(page);
             await expect(details.locator('textarea')).toHaveValue(/initial setup/);
@@ -367,9 +314,7 @@ test.describe('Commit Details E2E', () => {
             const featureRow = webview2.locator('.commit-row', { hasText: 'add feature' });
             await featureRow.click();
             const shortId2 = nodes.feature.changeId.substring(0, 3);
-            await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId2}`) })).toBeVisible({
-                timeout: 15000,
-            });
+            await waitForTab(page, new RegExp(`^Commit: ${shortId2}`));
 
             // The panel is reused — wait for the textarea content to update within the SAME frame
             await expect(async () => {
@@ -379,8 +324,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Panel auto-updates when commit description is changed externally', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -405,8 +349,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Panel auto-closes when commit is abandoned', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -426,8 +369,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Format Body button rewraps text while preserving title separation', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -455,8 +397,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Settings gear opens VS Code settings for jj-view.commit', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -517,8 +458,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Prompts to save when closing a dirty details panel', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
 
             // Click to open details
             await featureRow.click();
@@ -555,7 +495,7 @@ test.describe('Commit Details E2E', () => {
             }).toPass({ timeout: 10000 });
 
             // Verify the node is no longer selected in the graph
-            const updatedFeatureRow = webview.locator('.commit-row', { hasText: 'updated via test before close' });
+            const updatedFeatureRow = await waitForLogCommitRow(page, 'updated via test before close');
             await expect(updatedFeatureRow).toHaveAttribute('aria-selected', 'false', { timeout: 10000 });
         });
 
@@ -564,8 +504,7 @@ test.describe('Commit Details E2E', () => {
             repo.config('revset-aliases."immutable_heads()"', `commit_id("${nodes.initial.commitId}")`);
             await focusJJLog(page);
 
-            const webview = await getLogWebview(page);
-            const initialRow = webview.locator('.commit-row', { hasText: 'initial setup' });
+            const initialRow = await waitForLogCommitRow(page, 'initial setup');
 
             // Click to open details
             await initialRow.click();
@@ -589,8 +528,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Undo/Redo integration with VS Code', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
             await featureRow.click();
 
             const shortId = nodes.feature.changeId.substring(0, 3);
@@ -632,8 +570,7 @@ test.describe('Commit Details E2E', () => {
         });
 
         test('Stealth Save: Dirty state clears when manually returning to original state', async () => {
-            const webview = await getLogWebview(page);
-            const featureRow = webview.locator('.commit-row', { hasText: 'add feature' });
+            const featureRow = await waitForLogCommitRow(page, 'add feature');
             await featureRow.click();
 
             const shortId = nodes.feature.changeId.substring(0, 3);

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -18,6 +18,9 @@ import {
     rightClickAndSelect,
     selectCommits,
     triggerRefresh,
+    waitForLogCommitRow,
+    waitForLogPill,
+    waitForTab,
 } from './e2e-helpers';
 
 test.describe('JJ Log Context Menu E2E', () => {
@@ -71,16 +74,14 @@ test.describe('JJ Log Context Menu E2E', () => {
     });
 
     test('Abandon and Undo', async () => {
-        const webview = await getLogWebview(page);
-
-        await expect(webview.locator('.commit-row', { hasText: 'commit2' })).toBeVisible();
+        await waitForLogCommitRow(page, 'commit2');
 
         const commit2Id = nodes.commit2.changeId;
         const commit1Id = nodes.commit1.changeId;
         const initialId = nodes.initial.changeId;
 
         // Abandon commit 2
-        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
+        const commit2Row = await waitForLogCommitRow(page, 'commit2');
         await rightClickAndSelect(page, commit2Row, 'Abandon');
 
         await expectTree(repo, [
@@ -104,16 +105,14 @@ test.describe('JJ Log Context Menu E2E', () => {
     });
 
     test('New Before (Single)', async () => {
-        const webview = await getLogWebview(page);
-
-        await expect(webview.locator('.commit-row', { hasText: 'commit1' })).toBeVisible();
+        await waitForLogCommitRow(page, 'commit1');
 
         const commit2Id = nodes.commit2.changeId;
         const commit1Id = nodes.commit1.changeId;
         const initialId = nodes.initial.changeId;
 
         // New Before initial
-        const initialRow = webview.locator('.commit-row', { hasText: 'initial' });
+        const initialRow = await waitForLogCommitRow(page, 'initial');
         await rightClickAndSelect(page, initialRow, 'New Before');
 
         // After "New Before" initial:
@@ -130,12 +129,10 @@ test.describe('JJ Log Context Menu E2E', () => {
     });
 
     test('Multi-select Abandon', async () => {
-        const webview = await getLogWebview(page);
+        await waitForLogCommitRow(page, 'commit2');
 
-        await expect(webview.locator('.commit-row', { hasText: 'commit2' })).toBeVisible();
-
-        const commit2Row = webview.locator('.commit-row', { hasText: 'commit2' });
-        const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+        const commit2Row = await waitForLogCommitRow(page, 'commit2');
+        const commit1Row = await waitForLogCommitRow(page, 'commit1');
         const initialId = nodes.initial.changeId;
 
         // Select both
@@ -361,9 +358,7 @@ test.describe('JJ Log Context Menu E2E', () => {
             await page.keyboard.press('Enter');
 
             // Verification: bookmark pill should appear in the webview
-            await expect(commit1Row.locator('.bookmark-pill', { hasText: 'my-bookmark' })).toBeVisible({
-                timeout: 10000,
-            });
+            await waitForLogPill(page, 'my-bookmark', 'bookmark');
         }).toPass({ timeout: 30000 });
     });
 
@@ -397,33 +392,28 @@ test.describe('JJ Log Context Menu E2E', () => {
     });
 
     test('Show Multi-File Diff', async () => {
-        const webview = await getLogWebview(page);
         // Target 'initial' which has actual file changes (f.txt added)
-        const initialRow = webview.locator(`.commit-row[data-change-id="${nodes.initial.changeId}"]`);
+        const initialRow = await waitForLogCommitRow(page, { changeId: nodes.initial.changeId });
 
         // Show Multi-File Diff
         await rightClickAndSelect(page, initialRow, 'Show Multi-File Diff');
 
         // Verification: A diff editor should open.
         const shortId = nodes.initial.changeId.substring(0, 3);
-        await expect(page.getByRole('tab', { name: new RegExp(`^${shortId}`) })).toBeVisible({ timeout: 10000 });
+        await waitForTab(page, new RegExp(`^${shortId}`));
 
         await expectModifiedFiles(page, ['f.txt', 'f2.txt']);
     });
 
     test('Compare with Working Copy', async () => {
-        const webview = await getLogWebview(page);
-        const initialRow = webview.locator(`.commit-row[data-change-id="${nodes.initial.changeId}"]`);
-        await expect(initialRow).toBeVisible({ timeout: 10000 });
+        const initialRow = await waitForLogCommitRow(page, { changeId: nodes.initial.changeId });
 
         // Select Compare All Files with Revision...
         await rightClickAndSelect(page, initialRow, 'Compare All Files with Revision...');
 
         // Verification: A diff editor tab should open.
         const shortId = nodes.initial.changeId.substring(0, 3);
-        await expect(page.getByRole('tab', { name: new RegExp(`^Compare ${shortId}`) })).toBeVisible({
-            timeout: 10000,
-        });
+        await waitForTab(page, new RegExp(`^Compare ${shortId}`));
 
         await expectModifiedFiles(page, ['b.txt', 'b2.txt']);
     });

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -5,52 +5,17 @@
 
 import * as fs from 'node:fs';
 import { expect, type Page, test } from '@playwright/test';
-import type { ElectronApplication, Frame } from 'playwright';
+import type { ElectronApplication } from 'playwright';
 import { TestRepo } from '../test-repo';
-import { focusJJLog, getLogWebview, hoverAndClick, launchVSCode, triggerRefresh } from './e2e-helpers';
-
-/**
- * Finds the webview frame containing the Commit Details panel.
- * Reused from commit-details.spec.ts
- */
-async function getDetailsWebview(page: Page): Promise<Frame> {
-    const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
-        for (const f of frames) {
-            try {
-                if (await f.locator('textarea').isVisible({ timeout: 50 })) {
-                    return f;
-                }
-                const nested = await findFrame(f.childFrames());
-                if (nested) {
-                    return nested;
-                }
-            } catch (_e) {}
-        }
-        return undefined;
-    };
-
-    let guestFrame: Frame | undefined;
-    await expect
-        .poll(
-            async () => {
-                guestFrame = await findFrame(page.frames());
-                return guestFrame;
-            },
-            {
-                timeout: 30000,
-                message: 'Could not find Commit Details webview frame',
-            },
-        )
-        .toBeDefined();
-
-    if (!guestFrame) {
-        throw new Error('Could not find Commit Details webview frame');
-    }
-
-    // Ensure the iframe is fully "ready" before returning
-    await expect(guestFrame.locator('textarea')).toBeVisible({ timeout: 10000 });
-    return guestFrame;
-}
+import {
+    focusJJLog,
+    getDetailsWebview,
+    hoverAndClick,
+    launchVSCode,
+    triggerRefresh,
+    waitForLogCommitRow,
+    waitForTab,
+} from './e2e-helpers';
 
 test.describe('Divergent Commits E2E', () => {
     let repo: TestRepo;
@@ -96,15 +61,10 @@ test.describe('Divergent Commits E2E', () => {
     });
 
     test('Visualizes divergence and allows resolving it', async () => {
-        const webview = await getLogWebview(page);
-
         // 1. Verify graph visuals
         // Both A v1 (zombie) and A v2 (@) should be visible
-        const rowV1 = webview.locator('.commit-row', { hasText: 'commit A v1' });
-        const rowV2 = webview.locator('.commit-row', { hasText: 'commit A v2' });
-
-        await expect(rowV1).toBeVisible();
-        await expect(rowV2).toBeVisible();
+        const rowV1 = await waitForLogCommitRow(page, 'commit A v1');
+        const rowV2 = await waitForLogCommitRow(page, 'commit A v2');
 
         // Verify purple suffix in graph for both
         const suffix1 = rowV1.locator('.commit-id').locator('span', { hasText: /\/[012]/ });
@@ -135,9 +95,7 @@ test.describe('Divergent Commits E2E', () => {
 
         // Big Solidus is \u29F8
         const tabTitle = `Commit: ${shortId}\u29F8${offset}`;
-        await expect(page.getByRole('tab', { name: tabTitle })).toBeVisible({
-            timeout: 15000,
-        });
+        await waitForTab(page, tabTitle);
 
         // 3. Edit Description for A v2
         const details = await getDetailsWebview(page);
@@ -158,10 +116,8 @@ test.describe('Divergent Commits E2E', () => {
         await focusJJLog(page);
 
         // Re-get webview because focus might refresh it
-        const webview2 = await getLogWebview(page);
-        const rowToAbandon = webview2.locator('.commit-row', { hasText: 'commit A v1' });
+        const rowToAbandon = await waitForLogCommitRow(page, 'commit A v1');
 
-        await expect(rowToAbandon).toBeVisible();
         await hoverAndClick(rowToAbandon, rowToAbandon.locator('.icon-button[title="Abandon"]'));
 
         // 5. Verify divergence is resolved
@@ -169,9 +125,7 @@ test.describe('Divergent Commits E2E', () => {
             // Trigger refresh to ensure the backend update is picked up synchronously in the test
             await triggerRefresh(page);
 
-            const finalWebview = await getLogWebview(page);
-            const remainingRows = finalWebview.locator('.commit-row', { hasText: 'updated A v2 message' });
-            await expect(remainingRows).toHaveCount(1);
+            const remainingRows = await waitForLogCommitRow(page, 'updated A v2 message');
 
             // Should NO LONGER have a slash in the ID area
             const idArea = remainingRows.locator('.commit-id');

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -203,6 +203,15 @@ export async function focusJJLog(page: Page) {
 }
 
 /**
+ * Waits for a specific tab to become visible and selected.
+ */
+export async function waitForTab(page: Page, namePattern: RegExp | string): Promise<Locator> {
+    const tab = page.getByRole('tab', { name: namePattern });
+    await expect(tab).toBeVisible({ timeout: 10000 });
+    return tab;
+}
+
+/**
  * Finds the webview frame containing the JJ Log commit rows.
  */
 export async function getLogWebview(page: Page, timeout: number = 30000): Promise<Frame> {
@@ -431,21 +440,34 @@ export async function setScmDescription(page: Page, description: string) {
     await expect(async () => {
         // 1. Ensure the SCM input is visible and focused
         await scmInputRow.click();
-        const textbox = scmInputRow.getByRole('textbox');
-        await expect(textbox).toBeVisible({ timeout: 2000 });
+
+        // Wait for the native edit context or a textarea to be active
+        await page
+            .waitForFunction(
+                () => {
+                    const el = document.activeElement;
+                    return el?.getAttribute('role') === 'textbox' || el?.tagName === 'TEXTAREA';
+                },
+                { timeout: 2000 },
+            )
+            .catch((err) => {
+                console.error('Failed to wait for input to be active:', err);
+                throw err;
+            });
 
         // 2. Clear the input
         await page.keyboard.press('Control+A');
         await page.keyboard.press('Backspace');
 
         // 3. Set the description
+        // Use insertText for speed, but follow up with a validation
         await page.keyboard.insertText(description);
 
         // 4. Validate that all words appear in order inside the row (ignoring VS Code's weird whitespace concatenation).
         const words = description.trim().split(/\s+/).filter(Boolean);
         const regexPattern = words.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*');
-        await expect(scmInputRow).toHaveText(new RegExp(regexPattern), { timeout: 2000 });
-    }, `Failed to set SCM description to "${description}" reliably`).toPass({ timeout: 15000 });
+        await expect(scmInputRow).toHaveText(new RegExp(regexPattern), { timeout: 3000 });
+    }, `Failed to set SCM description to "${description}" reliably`).toPass({ timeout: 10000 });
 }
 
 /**
@@ -478,6 +500,35 @@ export async function waitForQuickInput(page: Page, timeout: number = 10000): Pr
     const input = quickInput.locator('input.input');
     await expect(input).toBeVisible({ timeout });
     return input;
+}
+
+export type LogPillKind = 'bookmark' | 'workspace' | 'tag' | 'remote-bookmark';
+
+/**
+ * Robustly waits for a bookmark or workspace pill to be visible in the JJ Log webview.
+ * Handles webview reloads by re-fetching the frame on each retry.
+ */
+export async function waitForLogPill(page: Page, label: string, kind?: LogPillKind): Promise<Locator> {
+    let pill: Locator | undefined;
+    await expect(
+        async () => {
+            const webview = await getLogWebview(page, 300);
+            let selector = '.bookmark-pill';
+            if (kind === 'bookmark') {
+                selector += ':has(.codicon-bookmark)';
+            } else if (kind === 'tag') {
+                selector += ':has(.codicon-tag)';
+            }
+            pill = webview.locator(selector, { hasText: label });
+            await expect(pill).toBeVisible({ timeout: 200 });
+        },
+        `Failed to find log ${kind || 'pill'} with text "${label}"`,
+    ).toPass({ timeout: 20000 });
+
+    if (!pill) {
+        throw new Error(`Failed to find log ${kind || 'pill'} with text "${label}"`);
+    }
+    return pill;
 }
 
 export type LogRowCriteria = string | RegExp | { changeId?: string; text?: string | RegExp };
@@ -567,14 +618,63 @@ export async function expectModifiedFiles(page: Page, expectedFiles: string[]) {
  * Robustly opens a file via the File Explorer tree view.
  */
 export async function openFileInEditor(page: Page, fileName: string): Promise<Locator> {
-    await page.keyboard.press('Control+Shift+E');
-    const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
-    await expect(fileRowInExplorer).toBeVisible({ timeout: 10000 });
-    await fileRowInExplorer.click();
+    await expect(async () => {
+        await page.keyboard.press('Control+Shift+E');
+        const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
+        await expect(fileRowInExplorer).toBeVisible({ timeout: 5000 });
+        await fileRowInExplorer.click();
 
-    await expect(page.getByRole('tab', { name: fileName, selected: true })).toBeVisible({ timeout: 10000 });
+        await expect(page.getByRole('tab', { name: fileName, selected: true })).toBeVisible({ timeout: 5000 });
 
-    const editor = page.locator('.editor-group-container.active .monaco-editor');
-    await expect(editor).toBeVisible({ timeout: 10000 });
-    return editor;
+        const editor = page.locator('.editor-group-container.active .monaco-editor').first();
+        await expect(editor).toBeVisible({ timeout: 5000 });
+    }, `Failed to open file "${fileName}" in editor`).toPass({ timeout: 20000 });
+
+    return page.locator('.editor-group-container.active .monaco-editor').first();
+}
+
+/**
+ * Finds the webview frame containing the Commit Details panel.
+ * Re-fetches frames on poll to handle detached frames.
+ */
+export async function getDetailsWebview(page: Page): Promise<Frame> {
+    const findFrame = async (frames: ReadonlyArray<Frame>): Promise<Frame | undefined> => {
+        for (const f of frames) {
+            try {
+                // Return the first iframe that is actually visible (not hidden by VS Code's tab switching)
+                // We consider it the active webview if its textarea is visible, meaning it's the actively displayed tab
+                if (await f.locator('textarea').isVisible({ timeout: 50 })) {
+                    return f;
+                }
+
+                const nested = await findFrame(f.childFrames());
+                if (nested) {
+                    return nested;
+                }
+            } catch (_e) {}
+        }
+        return undefined;
+    };
+
+    let guestFrame: Frame | undefined;
+    await expect
+        .poll(
+            async () => {
+                guestFrame = await findFrame(page.frames());
+                return guestFrame;
+            },
+            {
+                timeout: 30000,
+                message: 'Could not find Commit Details webview frame',
+            },
+        )
+        .toBeDefined();
+
+    if (!guestFrame) {
+        throw new Error('Could not find Commit Details webview frame');
+    }
+
+    // Ensure the iframe is fully "ready" before returning
+    await expect(guestFrame.locator('textarea')).toBeVisible({ timeout: 10000 });
+    return guestFrame;
 }

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -15,6 +15,7 @@ import {
     launchVSCode,
     ROOT_ID,
     waitForLogCommitRow,
+    waitForLogPill,
 } from './e2e-helpers';
 
 test.describe('JJ Log Pane E2E', () => {
@@ -55,8 +56,7 @@ test.describe('JJ Log Pane E2E', () => {
             await expect(wcDesc).toHaveCSS('font-weight', '700' /* bold */);
 
             // Assert Bookmark pill is present inside the working copy row
-            const bookmarkPill = webview.locator('.working-copy .bookmark-pill', { hasText: 'main' });
-            await expect(bookmarkPill).toBeVisible();
+            await waitForLogPill(page, 'main', 'bookmark');
         } finally {
             await app.close();
             try {

--- a/src/test/e2e/quick-diff.spec.ts
+++ b/src/test/e2e/quick-diff.spec.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, type Locator, type Page, test } from '@playwright/test';
 import { TestRepo } from '../test-repo';
-import { focusSCM, launchVSCode, openFileInEditor } from './e2e-helpers';
+import { focusSCM, hoverAndClick, launchVSCode, openFileInEditor } from './e2e-helpers';
 
 test.describe('Quick Diff E2E', () => {
     async function openGutterPeekView(page: Page, editor: Locator): Promise<{ peekView: Locator; gutter: Locator }> {
@@ -102,16 +102,24 @@ test.describe('Quick Diff E2E', () => {
             const { peekView } = await openGutterPeekView(page, editor);
 
             // 4. Click Revert Change Button
-            const revertButton = peekView.locator('[aria-label="Discard Change"]');
-            await expect(revertButton).toBeVisible({ timeout: 5000 });
-            await revertButton.click();
-
-            // 5. Verify file content on disk
-            const filePath = path.join(repo.path, fileName);
             await expect(async () => {
-                const content = fs.readFileSync(filePath, 'utf-8');
-                expect(content).toBe(fileContentOriginal);
-            }).toPass({ timeout: 10000 });
+                // Ensure editor has focus as the peek view actions can be focus-dependent
+                await editor.focus();
+
+                // Peek view might have multiple action items; be specific.
+                const discardIcon = peekView.locator('.codicon-discard');
+                await expect(discardIcon).toBeVisible({ timeout: 5000 });
+                await hoverAndClick(peekView, discardIcon);
+
+                // 5. Verify file content on disk
+                const filePath = path.join(repo.path, fileName);
+                await expect(async () => {
+                    const content = fs.readFileSync(filePath, 'utf-8');
+                    if (content !== fileContentOriginal) {
+                        throw new Error(`File content mismatch. Expected original content but got: ${content}`);
+                    }
+                }).toPass({ timeout: 20000 });
+            }).toPass({ timeout: 30000 });
 
             // Peek view should close
             await expect(peekView).not.toBeVisible({ timeout: 5000 });

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -7,7 +7,16 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { buildGraph, TestRepo } from '../test-repo';
-import { entry, expectTree, focusSCM, hoverAndClick, launchVSCode, ROOT_ID, setScmDescription } from './e2e-helpers';
+import {
+    entry,
+    expectTree,
+    focusSCM,
+    hoverAndClick,
+    launchVSCode,
+    ROOT_ID,
+    setScmDescription,
+    waitForTab,
+} from './e2e-helpers';
 
 test.describe('SCM Pane E2E', () => {
     test('Displays correct groups and populates SCM input', async () => {
@@ -180,16 +189,18 @@ test.describe('SCM Pane E2E', () => {
             const messageToFormat = `Title line\n\n${longBody}`;
 
             // 1. Test Set Description (Ctrl+S)
-            await setScmDescription(page, messageToFormat);
-            await page.keyboard.press('Control+S');
-
-            // Wait for description to be formatted and saved in repo
+            // Use a toPass block for the entire operation to handle synchronization delays
+            // between the renderer and extension host.
             await expect(async () => {
+                await setScmDescription(page, messageToFormat);
+                await page.keyboard.press('Control+S');
+
                 const desc = repo.getDescription('@');
-                const expectedDesc = `Title line\n\nThis is a very long body text that should be wrapped onto multiple lines\nwhen saved because it exceeds the limit of seventy-two characters.`;
+                const expectedDesc =
+                    'Title line\n\nThis is a very long body text that should be wrapped onto multiple lines\nwhen saved because it exceeds the limit of seventy-two characters.';
                 expect(desc).toBe(expectedDesc);
                 expect(desc.split('\n').length).toBeGreaterThan(2);
-            }).toPass({ timeout: 15000 });
+            }).toPass({ timeout: 20000 });
 
             // 2. Test Commit (Ctrl+Enter)
             const longBody2 =
@@ -467,7 +478,7 @@ test.describe('SCM Pane E2E', () => {
             // Use toPass to retry the entire Open Details sequence in case the icon/click was missed during SCM refresh.
             await expect(async () => {
                 await hoverAndClick(ancestorRow, detailsIcon);
-                await expect(page.getByRole('tab', { name: /^Commit: / })).toBeVisible({ timeout: 5000 });
+                await waitForTab(page, /^Commit: /);
             }).toPass({ timeout: 20000 });
 
             // Return focus to SCM View
@@ -532,8 +543,7 @@ test.describe('SCM Pane E2E', () => {
             await hoverAndClick(ancestorRowGroup, multiDiffIcon);
 
             // Wait for Multi-File Diff View to appear
-            const tabList = page.locator('.tabs-and-actions-container');
-            await expect(tabList).toContainText('ancestor change');
+            await waitForTab(page, /ancestor change/);
 
             // Wait for the diff editor inside the view
             await page.waitForSelector('.monaco-diff-editor');

--- a/src/test/e2e/workspace.spec.ts
+++ b/src/test/e2e/workspace.spec.ts
@@ -14,6 +14,7 @@ import {
     getLogWebview,
     launchVSCode,
     rightClickAndSelect,
+    waitForLogPill,
     waitForQuickInput,
 } from './e2e-helpers';
 
@@ -41,10 +42,10 @@ test.describe('Workspace Management E2E', () => {
             const webview = await getLogWebview(page);
 
             // The default workspace label is 'default@'
-            await expect(webview.locator('.bookmark-pill', { hasText: 'default@' })).toBeVisible();
+            await waitForLogPill(page, 'default@', 'workspace');
 
             // The secondary workspace label should match our workspace name
-            await expect(webview.locator('.bookmark-pill', { hasText: workspaceName })).toBeVisible();
+            await waitForLogPill(page, workspaceName, 'workspace');
 
             // 'default@' should be on the 'other' commit
             const otherRow = webview.locator(`[data-change-id="${otherId}"]`);
@@ -84,8 +85,7 @@ test.describe('Workspace Management E2E', () => {
             }, 'Failed to add workspace via title bar').toPass({ timeout: 20000 });
 
             // 3. Verify workspace pill appears in webview
-            const webview = await getLogWebview(page);
-            await expect(webview.locator('.bookmark-pill', { hasText: workspaceName })).toBeVisible({ timeout: 20000 });
+            await waitForLogPill(page, workspaceName, 'workspace');
 
             // 4. Click "Open Workspace" in the notification and verify a new window opens
             const nextWindowPromise = app.waitForEvent('window');
@@ -129,11 +129,9 @@ test.describe('Workspace Management E2E', () => {
 
         try {
             await focusJJLog(page);
-            const webview = await getLogWebview(page);
 
             // 1. Forget Workspace
-            const forgetPill = webview.locator('.bookmark-pill', { hasText: forgetWs });
-            await expect(forgetPill).toBeVisible();
+            const forgetPill = await waitForLogPill(page, forgetWs, 'workspace');
 
             await rightClickAndSelect(page, forgetPill, 'Forget Workspace');
 
@@ -142,14 +140,18 @@ test.describe('Workspace Management E2E', () => {
             await expect(forgetBtn, 'Forget confirmation button should be visible').toBeVisible({ timeout: 5000 });
             await forgetBtn.click();
 
-            await expect(forgetPill).not.toBeVisible({ timeout: 15000 });
+            await expect(async () => {
+                const webview = await getLogWebview(page, 300);
+                await expect(webview.locator('.bookmark-pill', { hasText: forgetWs })).not.toBeVisible({
+                    timeout: 500,
+                });
+            }).toPass({ timeout: 15000 });
 
             const stillExists = fs.existsSync(forgetWsPath);
             expect(stillExists, `Directory ${forgetWsPath} should still exist after forget`).toBe(true);
 
             // 2. Delete Workspace
-            const deletePill = webview.locator('.bookmark-pill', { hasText: deleteWs });
-            await expect(deletePill).toBeVisible();
+            const deletePill = await waitForLogPill(page, deleteWs, 'workspace');
 
             await rightClickAndSelect(page, deletePill, 'Delete Workspace Directory');
 
@@ -158,7 +160,12 @@ test.describe('Workspace Management E2E', () => {
             await expect(deleteBtn, 'Delete confirmation button should be visible').toBeVisible({ timeout: 5000 });
             await deleteBtn.click();
 
-            await expect(deletePill).not.toBeVisible({ timeout: 15000 });
+            await expect(async () => {
+                const webview = await getLogWebview(page, 300);
+                await expect(webview.locator('.bookmark-pill', { hasText: deleteWs })).not.toBeVisible({
+                    timeout: 500,
+                });
+            }).toPass({ timeout: 15000 });
 
             const gone = !fs.existsSync(deleteWsPath);
             expect(gone, `Directory ${deleteWsPath} should be removed after delete`).toBe(true);


### PR DESCRIPTION
Stabilizes the E2E test suite by centralizing common interactions into resilient, polling-based helpers in `e2e-helpers.ts`. This includes:

- Adding `waitForTab` and `waitForLogPill` helpers.
- Moving `getDetailsWebview` to shared helpers.
- Enhancing `openFileInEditor` and `setScmDescription` with robust retry logic.
- Standardizing `arbitrary-diff`, `commit-details`, `context-menu`, and `divergent` tests to use these centralized helpers.