### PR TITLE
fix: Support Gerrit Link trailers for CL identification

### DIFF
--- a/src/gerrit-service.ts
+++ b/src/gerrit-service.ts
@@ -41,6 +41,12 @@ export interface GerritChange {
 }
 
 export class GerritService implements vscode.Disposable {
+    private static readonly TRAILER_REGEXES = [
+        /^Change-Id: (I[0-9a-fA-F]{40})\s*$/m,
+        /^Link: .*\/\+\/(\d+)(?:\/\d+)?\/?\s*$/m,
+        /^Link: .*\/(\d+)\/?\s*$/m,
+    ];
+
     private poller: NodeJS.Timeout | undefined;
     private cache: Map<string, GerritClInfo> = new Map();
     private _gerritHost: string | undefined;
@@ -311,15 +317,17 @@ export class GerritService implements vscode.Disposable {
     }
 
     private resolveCacheKey(changeId?: string, description?: string): string | undefined {
-        // 1. Check description for Change-Id
+        // 1. Check description for trailers
         if (description) {
-            const match = description.match(/^Change-Id: (I[0-9a-fA-F]{40})/m);
-            if (match) {
-                return match[1];
+            for (const regex of GerritService.TRAILER_REGEXES) {
+                const match = description.match(regex);
+                if (match) {
+                    return match[1];
+                }
             }
         }
 
-        // 2. Use computed JJ Change-Id if no description ID found
+        // 2. Use computed JJ Change-Id if no description trailer found
         if (changeId) {
             try {
                 const hexId = convertJjChangeIdToHex(changeId);
@@ -495,10 +503,14 @@ export class GerritService implements vscode.Disposable {
         // Verify description matches
         if (info.remoteDescription && description) {
             const normalize = (desc: string) => {
-                // Gerrit appends the Change-Id footer to the description.
-                // Since our local description might not have this, we strip it out before comparing
+                // Gerrit appends trailers (Change-Id or Link) to the description.
+                // Since our local description might not have these, we strip them out before comparing
                 // to avoid false positive sync failures.
-                return desc.replace(/^Change-Id: I[0-9a-fA-F]{40}\s*$/gm, '').trim();
+                let normalized = desc;
+                for (const regex of GerritService.TRAILER_REGEXES) {
+                    normalized = normalized.replace(new RegExp(regex.source, 'gm'), '');
+                }
+                return normalized.trim();
             };
             if (normalize(description) !== normalize(info.remoteDescription)) {
                 return;

--- a/src/test/fake-gerrit-server.ts
+++ b/src/test/fake-gerrit-server.ts
@@ -44,8 +44,15 @@ export class FakeGerritServer {
             // Check for specific change query by change_id
             const match = urlStr.match(/q=change:([^&]+)/);
             if (match) {
-                const changeId = match[1];
-                const change = this.changes.get(changeId);
+                const searchKey = match[1];
+                let change = this.changes.get(searchKey);
+                if (!change) {
+                    // Try searching by change number (_number)
+                    const num = Number.parseInt(searchKey, 10);
+                    if (!Number.isNaN(num)) {
+                        change = Array.from(this.changes.values()).find((c) => c._number === num);
+                    }
+                }
                 const changes = change ? [change] : [];
                 return Promise.resolve(new Response(`)]}'\n${JSON.stringify(changes)}`, { status: 200 }));
             }

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -179,6 +179,77 @@ describe('GerritService Detection', () => {
         expect(result?.changeId).toBe('I1234567890abcdef1234567890abcdef12345678');
     });
 
+    test('fetchAndCacheStatus prioritizes Link trailer when Change-Id is missing', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        fakeGerritServer.addChange({
+            change_id: 'Iabcd',
+            _number: 7812281,
+            status: 'NEW',
+        });
+
+        const result = await service.fetchAndCacheStatus(
+            'commit-sha',
+            undefined,
+            'Description\n\nLink: https://chromium-review.googlesource.com/c/chromium/src/+/7812281\n',
+        );
+
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('change:7812281'));
+        expect(result?.changeNumber).toBe(7812281);
+    });
+
+    test('fetchAndCacheStatus extracts change number from different Link formats', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        fakeGerritServer.addChange({ _number: 111, status: 'NEW', change_id: 'I111' });
+        fakeGerritServer.addChange({ _number: 222, status: 'NEW', change_id: 'I222' });
+        fakeGerritServer.addChange({ _number: 333, status: 'NEW', change_id: 'I333' });
+        fakeGerritServer.addChange({ _number: 444, status: 'NEW', change_id: 'I444' });
+
+        // Format 1: /+/123
+        await service.fetchAndCacheStatus('c1', undefined, 'Desc\n\nLink: https://host.com/c/proj/+/111');
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('change:111'));
+
+        // Format 2: /123
+        await service.fetchAndCacheStatus('c2', undefined, 'Desc\n\nLink: https://host.com/222');
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('change:222'));
+
+        // Format 3: /123/ (trailing slash)
+        await service.fetchAndCacheStatus('c3', undefined, 'Desc\n\nLink: https://host.com/333/');
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('change:333'));
+
+        // Format 4: /+/123/4 (with patchset number — should extract 444, not 7)
+        await service.fetchAndCacheStatus('c4', undefined, 'Desc\n\nLink: https://host.com/c/proj/+/444/7');
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('change:444'));
+    });
+
+    test('fetchAndCacheStatus prioritizes Change-Id over Link trailer', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        const changeId = 'I1234567890abcdef1234567890abcdef12345678';
+        fakeGerritServer.addChange({
+            change_id: changeId,
+            _number: 123,
+            status: 'NEW',
+        });
+
+        await service.fetchAndCacheStatus(
+            'commit-sha',
+            undefined,
+            `Description\n\nChange-Id: ${changeId}\nLink: https://host.com/456\n`,
+        );
+
+        // Should use Change-Id, not Link
+        expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining(`change:${changeId}`));
+        expect(global.fetch).not.toHaveBeenCalledWith(expect.stringContaining('change:456'));
+    });
+
     test('fetchAndCacheStatus falls back to Computed Change-Id', async () => {
         mockConfig.get.mockReturnValue('https://host.com');
         service = new GerritService(repo.path, jjService);
@@ -603,6 +674,45 @@ describe('GerritService Detection', () => {
             commitId,
             jjId,
             'Local description has no Change-Id',
+        );
+        expect(resultSynced?.synced).toBeTruthy();
+    });
+
+    test('forceFetchAndCacheStatus ignores Link trailer footer differences during sync', async () => {
+        mockConfig.get.mockReturnValue('https://host.com');
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+
+        const changeNumber = 7812281;
+        const currentRev = 'commit-sha-on-gerrit';
+
+        repo.writeFile('file1.txt', 'content1');
+        await jjService.describe('Local description has no Link trailer');
+        const localHashes = await jjService.getGitBlobHashes(repo.getCommitId('@'), ['file1.txt']);
+
+        fakeGerritServer.addChange({
+            change_id: 'I000000000000ffffffffffffffffffffffffffff',
+            _number: changeNumber,
+            status: 'NEW',
+            current_revision: currentRev,
+            revisions: {
+                [currentRev]: {
+                    commit: {
+                        message: `Local description has no Link trailer\n\nLink: https://host.com/${changeNumber}`,
+                    },
+                    files: {
+                        'file1.txt': { status: 'A', new_sha: localHashes.get('file1.txt') },
+                    },
+                },
+            },
+        });
+
+        const commitId = repo.getCommitId('@').trim();
+
+        const resultSynced = await service.forceFetchAndCacheStatus(
+            commitId,
+            'zzzzzzzzzzzzkkkkkkkkkkkkkkkkkkkkkkkkkkkk', // Provide JJ Change-Id so it can find the Gerrit CL
+            'Local description has no Link trailer',
         );
         expect(resultSynced?.synced).toBeTruthy();
     });


### PR DESCRIPTION
Updates GerritService to recognize and extract change numbers from Link: trailers in commit descriptions. This enables the extension to identify and sync with Gerrit CLs even when the traditional Change-Id: trailer is absent. Includes updates to the fake Gerrit server for testing and comprehensive unit tests covering various URL formats and sync scenarios.

Fixes #278