### PR TITLE
feat: Implement ghost node visualization for hidden commits

### DIFF
--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -250,7 +250,10 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
 
                 // Default jj log (usually local heads/roots)
                 const logStart = performance.now();
-                commits = await this._jj.getLog({ omitChanges: true, includeNearestVisibleAncestors: true });
+                commits = await this._jj.getLog({
+                    omitChanges: true,
+                    includeNearestVisibleAncestors: true,
+                });
                 const logDuration = performance.now() - logStart;
                 this.outputChannel?.appendLine(
                     `[JjLogWebviewProvider] jj log took ${logDuration.toFixed(0)}ms, found ${commits.length} commits`,

--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -58,9 +58,9 @@ export function buildLogTemplate(schema: Record<string, JjTemplateField>): strin
     });
     return `"{" ++ ${parts.join(' ++ ", " ++ ')} ++ "}\\n"`;
 }
-export const CHANGE_ID_EXPR = 'if(divergent, change_id ++ "/" ++ change_offset, change_id)';
+export const CHANGE_ID_EXPR = 'if(divergent || hidden, change_id ++ "/" ++ change_offset, change_id)';
 export const CHANGE_ID_ITEM_EXPR =
-    'if(item.divergent(), item.change_id() ++ "/" ++ item.change_offset(), item.change_id())';
+    'if(item.divergent() || item.hidden(), item.change_id() ++ "/" ++ item.change_offset(), item.change_id())';
 
 // Schema for JjLogEntry - defines how to serialize each field
 export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
@@ -123,6 +123,7 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
         itemExpr: 'item.immutable()',
     },
     conflict: { type: 'raw', expr: 'conflict' },
+    is_hidden: { type: 'raw', expr: 'hidden' },
     changes: {
         type: 'array',
         expr: 'self.diff().files()',

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -49,6 +49,7 @@ export interface JjLogEntry {
     change_id_offset?: number;
     parents_immutable?: boolean[];
     conflict?: boolean;
+    is_hidden?: boolean;
     changes?: JjStatusEntry[];
     gerritCl?: GerritClInfo;
     gerritNeedsUpload?: boolean;

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -39,6 +39,7 @@ export async function launchVSCode(
         path.join(userSettingsDir, 'settings.json'),
         JSON.stringify(
             {
+                'workbench.colorTheme': 'Default Dark Modern',
                 'git.enabled': false,
                 'workbench.startupEditor': 'none',
                 'workbench.sideBar.location': 'left',

--- a/src/test/e2e/hidden-commits.spec.ts
+++ b/src/test/e2e/hidden-commits.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, test } from '@playwright/test';
+import { TestRepo } from '../test-repo';
+import { focusJJLog, getLogWebview, launchVSCode } from './e2e-helpers';
+
+test.describe('Hidden Commits', () => {
+    let repo: TestRepo;
+
+    test.beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+    });
+
+    test.afterEach(async () => {
+        repo.dispose();
+    });
+
+    test('renders a ghost shape for hidden commit nodes', async () => {
+        // 1. Create a commit that we will hide
+        repo.new([], 'ghost commit');
+        const ghostCommitId = repo.getCommitId('@');
+
+        // 2. Abandon it to make it hidden
+        repo.abandon('@');
+
+        // 3. Configure jj to show this hidden commit by including its ID in revsets.log
+        // We include it explicitly so it shows up in the graph.
+        const revset = `commit_id(${ghostCommitId.substring(0, 8)}) | present(@) | ancestors(immutable_heads().., 2) | trunk()`;
+        repo.config('revsets.log', revset);
+
+        const { page } = await launchVSCode(repo);
+
+        await focusJJLog(page);
+        const webview = await getLogWebview(page);
+
+        // 4. Verify the hidden commit is in the log text (to ensure it's loaded)
+        const ghostRow = webview.locator('.commit-row', { hasText: 'ghost commit' });
+        await expect(ghostRow).toBeVisible({ timeout: 10000 });
+
+        // 5. Verify the graph node is a ghost using our data attribute
+        const ghostPath = webview.locator('path[data-ghost="true"]');
+        await expect(ghostPath).toBeVisible();
+    });
+});

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -215,7 +215,15 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                     idPart.substring(0, idDisplayLength)
                                 )}
                                 {offsetPart && (
-                                    <span style={{ color: 'var(--vscode-charts-purple)' }}>/{offsetPart}</span>
+                                    <span
+                                        style={{
+                                            color: commit.is_hidden
+                                                ? 'var(--vscode-descriptionForeground)'
+                                                : 'var(--vscode-charts-purple)',
+                                        }}
+                                    >
+                                        /{offsetPart}
+                                    </span>
                                 )}
                             </>
                         );

--- a/src/webview/components/GraphRail.tsx
+++ b/src/webview/components/GraphRail.tsx
@@ -233,6 +233,25 @@ export const GraphRail: React.FC<GraphRailProps> = ({
                     </text>
                 </>
             );
+        } else if (node.isHidden) {
+            content = (
+                <g transform={`translate(${cx}, ${cy})`}>
+                    {/* Background to hide edges - circle provides better coverage for curving edges */}
+                    <circle cx="0" cy="0" r="8" fill="var(--vscode-sideBar-background)" />
+                    <path
+                        data-ghost="true"
+                        d="M -6,7 C -6,-2 -6,-6 0,-6 C 6,-6 6,-2 6,7 L 4,4 L 2,7 L 0,4 L -2,7 L -4,4 Z"
+                        fill="var(--vscode-descriptionForeground)"
+                        fillOpacity="0.4"
+                        stroke="var(--vscode-descriptionForeground)"
+                        strokeWidth="1.5"
+                        strokeOpacity="1"
+                        strokeLinejoin="round"
+                    />
+                    <circle cx="-2" cy="-1.5" r="1.5" fill="var(--vscode-sideBar-background)" />
+                    <circle cx="2" cy="-1.5" r="1.5" fill="var(--vscode-sideBar-background)" />
+                </g>
+            );
         } else if (node.conflict) {
             content = (
                 <>
@@ -291,7 +310,7 @@ export const GraphRail: React.FC<GraphRailProps> = ({
         }
 
         return (
-            <g key={node.commitId}>
+            <g key={node.commitId} data-commit-id={node.commitId}>
                 {isSelected && <Halo />}
                 {content}
             </g>

--- a/src/webview/graph-compute.ts
+++ b/src/webview/graph-compute.ts
@@ -136,6 +136,7 @@ export function computeGraphLayout(commits: JjLogEntry[], themeName: string = 'd
                 conflict: commit.conflict,
                 isEmpty: commit.is_empty,
                 isImmutable: commit.is_immutable,
+                isHidden: commit.is_hidden,
             });
         }
 

--- a/src/webview/graph-model.ts
+++ b/src/webview/graph-model.ts
@@ -16,6 +16,7 @@ export interface GraphNode {
     conflict?: boolean;
     isEmpty?: boolean;
     isImmutable?: boolean;
+    isHidden?: boolean;
 }
 
 export interface NodePoint {


### PR DESCRIPTION
Introduces a unique visual representation for hidden commits in the graph log. Hidden commits are now rendered as a "ghost" shape—a jagged-bottomed SVG with eye details—and their change ID offsets are styled with a neutral foreground color to distinguish them from active commits.

Key changes include:

- Extended the jj log template and TypeScript types to include the hidden status.
- Implemented the ghost node rendering in GraphRail.tsx using a custom SVG path and themed colors.
- Updated CommitNode.tsx to apply gray styling for hidden change IDs offsets.
- Added a new E2E test suite to verify the ghost node renders correctly when hidden commits are included in the revset.

Fixes #267