### PR TITLE
fix: ensure watch:themes task completes in VS Code

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -73,7 +73,7 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^(Watching for changes in|Detected change in).*themes\\.json.*$",
-                    "endsPattern": "^Generated .*themes\\.generated\\.(ts|css)$"
+                    "endsPattern": "^Theme generation complete\\.$"
                 },
                 "pattern": {
                     "regexp": "^Error generating themes: (.*)$",

--- a/tooling/generate-themes.ts
+++ b/tooling/generate-themes.ts
@@ -125,6 +125,7 @@ function runGeneration() {
 
         writeIfChanged(tsOutputPath, ts);
         writeIfChanged(cssOutputPath, css);
+        console.log('Theme generation complete.');
     } catch (e) {
         console.error(`Error generating themes: ${e instanceof Error ? e.message : e}`);
     }


### PR DESCRIPTION
Updates the theme generation script to always log a completion message, and updates the VS Code task configuration to recognize it. This prevents the task from hanging when theme files are already up-to-date.