### PR TITLE
fix: hide Edit action for current working copy

### DIFF
--- a/src/test/commit-utils.test.ts
+++ b/src/test/commit-utils.test.ts
@@ -33,6 +33,7 @@ describe('computeCommitActions', () => {
             { label: 'B', parents: ['A'] },
         ]);
         const commit = await getCommit(ids.B.changeId);
+        commit.is_current_working_copy = false;
 
         const hiddenActions = new Set<CommitAction>();
         const result = computeCommitActions(commit, hiddenActions, false, false, 0, false);
@@ -65,6 +66,7 @@ describe('computeCommitActions', () => {
             { label: 'B', parents: ['A'] },
         ]);
         const commit = await getCommit(ids.B.changeId);
+        commit.is_current_working_copy = false;
 
         const hiddenActions = new Set<CommitAction>(['newChild', 'squash']);
         const result = computeCommitActions(commit, hiddenActions, false, false, 0, false);
@@ -102,6 +104,7 @@ describe('computeCommitActions', () => {
     it('should handle selection states correctly', async () => {
         const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
         const commit = await getCommit(ids.A.changeId);
+        commit.is_current_working_copy = false;
 
         // Single selection
         const result1 = computeCommitActions(commit, new Set(), false, true, 1, false);
@@ -153,6 +156,7 @@ describe('computeCommitActions', () => {
             { label: 'B', parents: ['A'] },
         ]);
         const commit = await getCommit(ids.B.changeId);
+        commit.is_current_working_copy = false;
 
         // Selected in multi-selection
         const result1 = computeCommitActions(commit, new Set(), false, true, 2, false);
@@ -190,5 +194,17 @@ describe('computeCommitActions', () => {
         const result2 = computeCommitActions(commit, new Set(), false, true, 2, false);
         expect(result2.vscodeContext['jj.canNewChild']).toBe(false);
         expect(result2.vscodeContext['jj.canDuplicate']).toBe(false);
+    });
+
+    it('should hide Edit for current working copy', async () => {
+        const ids = await buildGraph(repo, [{ label: 'A', parents: ['root()'] }]);
+        const commit = await getCommit(ids.A.changeId);
+        // Simulate working copy
+        commit.is_current_working_copy = true;
+
+        const result = computeCommitActions(commit, new Set(), false, false, 0, false);
+
+        expect(result.visibleActions.edit).toBe(false);
+        expect(result.vscodeContext['jj.canEdit']).toBe(false);
     });
 });

--- a/src/webview/utils/commit-utils.ts
+++ b/src/webview/utils/commit-utils.ts
@@ -25,7 +25,7 @@ export function computeCommitActions(
 ): { visibleActions: CommitActionStates; vscodeContext: Record<string, unknown> } {
     const visibleActions: CommitActionStates = {
         newChild: !hiddenActions.has('newChild'),
-        edit: !isImmutable && !hiddenActions.has('edit'),
+        edit: !isImmutable && !commit.is_current_working_copy && !hiddenActions.has('edit'),
         squash: !hiddenActions.has('squash') && commit.parents?.length === 1 && !commit.parents[0].is_immutable,
         abandon: !isImmutable && !hiddenActions.has('abandon'),
     };
@@ -48,7 +48,7 @@ export function computeCommitActions(
         'jj.canUpload': !isImmutable && (!isSelected || !hasImmutableSelection),
 
         // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
-        'jj.canEdit': !isImmutable && (!isSelected || selectionCount <= 1),
+        'jj.canEdit': !isImmutable && !commit.is_current_working_copy && (!isSelected || selectionCount <= 1),
         'jj.canDuplicate': !isSelected || selectionCount <= 1,
         'jj.canNewChild': !isSelected || selectionCount <= 1,
 


### PR DESCRIPTION
Updates the commit action visibility logic in the log view to hide the "Edit" button and context menu item when the selected commit is the current working copy. This removes redundant UI actions since the working copy is already being edited. Added a unit test to verify the updated visibility rules.

Fixes #230