### PR TITLE
feat: Simplify squash completion workflow

### DIFF
--- a/src/commands/squash-revision.ts
+++ b/src/commands/squash-revision.ts
@@ -107,6 +107,15 @@ export async function squashRevisionIntoAncestorCommand(scmProvider: JjScmProvid
     }
 }
 
+const inProgressCompletions = new Set<string>();
+
+/**
+ * Checks if a squash operation is currently being completed for the given provider.
+ */
+export function isSquashInProgress(scmProvider: JjScmProvider): boolean {
+    return inProgressCompletions.has(scmProvider.getSquashStorageDir());
+}
+
 /**
  * Performs the squash operation, handling descriptions and potentially opening an editor.
  */
@@ -149,14 +158,14 @@ async function openSquashDescriptionEditor(
     parentDesc: string,
 ) {
     // 1. Combine descriptions
-    const combined = `${parentDesc}\n\n${sourceDesc}`.trim();
+    const combined = `${parentDesc.trim()}\n\n${sourceDesc.trim()}`;
 
     // 3. Write to temporary file
     const storageDir = scmProvider.getSquashStorageDir();
     const squashMsgPath = path.join(storageDir, 'SQUASH_MSG');
     await fs.mkdir(storageDir, { recursive: true });
 
-    const content = `${combined}\n\n# Please enter the commit message for your changes.\n# Lines starting with '#' will be ignored.\n# When finished, run the "Complete Squash" command or click the checkmark button in the editor title.`;
+    const content = `${combined}\n\nJJ: Please enter the commit message for your changes.\nJJ: Lines starting with "JJ:" will be ignored.\nJJ: When finished, save this file to complete the squash, or click the checkmark button in the editor title.`;
 
     await fs.writeFile(squashMsgPath, content);
 
@@ -172,10 +181,16 @@ async function openSquashDescriptionEditor(
     await fs.writeFile(path.join(storageDir, 'SQUASH_META.json'), JSON.stringify(meta));
 }
 
-export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, jj: JjService) {
+export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, jj: JjService, message: string) {
     const storageDir = scmProvider.getSquashStorageDir();
     const metaPath = path.join(storageDir, 'SQUASH_META.json');
     const msgPath = path.join(storageDir, 'SQUASH_MSG');
+
+    if (inProgressCompletions.has(storageDir)) {
+        return;
+    }
+
+    inProgressCompletions.add(storageDir);
 
     try {
         const metaContent = await fs.readFile(metaPath, 'utf-8');
@@ -185,37 +200,22 @@ export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, 
         }
         const { revision, parentRev } = metaRaw;
 
-        // Read message from editor (or file on disk)
-        const doc = vscode.workspace.textDocuments.find((d) => d.uri.fsPath === msgPath);
-        let message = '';
-        if (doc) {
-            if (doc.isDirty) {
-                await doc.save();
-            }
-            message = doc.getText();
-        } else {
-            message = await fs.readFile(msgPath, 'utf-8');
-        }
-
         // Strip comments
-        message = message
+        const finalMessage = message
             .split('\n')
-            .filter((line) => !line.startsWith('#'))
+            .filter((line) => !line.startsWith('JJ:'))
             .join('\n')
             .trim();
 
-        if (message.length === 0) {
+        if (finalMessage.length === 0) {
             vscode.window.showWarningMessage('Squash message is empty. Aborting.');
             return;
         }
 
         await withDelayedProgress(
             'Squashing revision...',
-            jj.squashRevision({ revision, intoRevision: parentRev, message }),
+            jj.squashRevision({ revision, intoRevision: parentRev, message: finalMessage }),
         );
-
-        await fs.unlink(metaPath).catch(() => {});
-        await fs.unlink(msgPath).catch(() => {});
 
         await scmProvider.refresh({ reason: 'after complete squash revision' });
         vscode.window.showInformationMessage('Squash completed.');
@@ -225,5 +225,16 @@ export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, 
         } else {
             await showJjError(e, 'Failed to complete squash revision', jj, scmProvider.outputChannel);
         }
+    } finally {
+        await fs.unlink(metaPath).catch(() => {});
+        await fs.unlink(msgPath).catch(() => {});
+
+        // Close the editor if it's still open
+        const tabs = vscode.window.tabGroups.all.flatMap((g) => g.tabs);
+        const tab = tabs.find((t) => t.input instanceof vscode.TabInputText && t.input.uri.fsPath === msgPath);
+        if (tab) {
+            await vscode.window.tabGroups.close(tab);
+        }
+        inProgressCompletions.delete(storageDir);
     }
 }

--- a/src/commands/squash-selection.ts
+++ b/src/commands/squash-selection.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getRevisionFromUri } from '../uri-utils';
 import { showJjError } from './command-utils';
 
 interface LineChange {
@@ -67,13 +68,7 @@ export async function squashHunkIntoParentCommand(
 
     const ranges = [{ startLine, endLine }];
     const relPath = path.relative(jj.workspaceRoot, uri.fsPath);
-
-    const originalUri = scmProvider.provideOriginalResource(uri);
-    let revision = '@';
-    if (originalUri && originalUri instanceof vscode.Uri && originalUri.query) {
-        const queryParams = new URLSearchParams(originalUri.query);
-        revision = queryParams.get('base') || '@';
-    }
+    const revision = getRevisionFromUri(uri) || '@';
 
     try {
         await jj.squashSelectionIntoParent(relPath, ranges, revision);
@@ -108,8 +103,8 @@ export async function squashSelectionIntoParentCommand(
     const fsPath = docUri.fsPath;
     const relPath = path.relative(jj.workspaceRoot, fsPath);
 
-    const query = new URLSearchParams(docUri.query);
-    const revision = query.get('jj-revision') || '@';
+    const revision = getRevisionFromUri(docUri) || '@';
+    scmProvider.outputChannel.appendLine(`Squashing selection from ${revision} into parent.`);
 
     const ranges = editor.selections.map((s) => ({ startLine: s.start.line, endLine: s.end.line }));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { abandonCommand } from './commands/abandon';
 import { absorbCommand } from './commands/absorb';
@@ -204,7 +205,15 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.completeSquashRevision', async () => {
-            await completeSquashRevisionCommand(scmProvider, jj);
+            const storageDir = scmProvider.getSquashStorageDir();
+            const msgPath = path.join(storageDir, 'SQUASH_MSG');
+            const doc = vscode.workspace.textDocuments.find((d) => d.uri.fsPath === msgPath);
+            if (doc) {
+                if (doc.isDirty) {
+                    await doc.save();
+                }
+                await completeSquashRevisionCommand(scmProvider, jj, doc.getText());
+            }
         }),
     );
 

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -9,7 +9,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ChangeDetectionManager } from './change-detection-manager';
 import { getErrorMessage } from './commands/command-utils';
-import { completeSquashRevisionCommand } from './commands/squash-revision';
+import { completeSquashRevisionCommand, isSquashInProgress } from './commands/squash-revision';
 import { JjContextKey, ScmContextValue } from './jj-context-keys';
 import { JjDecorationProvider } from './jj-decoration-provider';
 import type { JjEditFileSystemProvider } from './jj-edit-fs-provider';
@@ -89,7 +89,6 @@ export class JjScmProvider implements vscode.Disposable {
         this.disposables.push(
             vscode.workspace.onDidSaveTextDocument(async (doc) => {
                 if (doc.uri.scheme === 'jj-merge-output') {
-                    // ... (existing merge logic)
                     const query = new URLSearchParams(doc.uri.query);
                     const fsPath = query.get('path');
                     if (fsPath) {
@@ -103,34 +102,45 @@ export class JjScmProvider implements vscode.Disposable {
             }),
         );
 
+        // Finalize squash when the SQUASH_MSG tab is closed.
+        //
+        // RATIONALE: We use onDidChangeTabs rather than onDidCloseTextDocument because:
+        // 1. TextDocument disposal is often delayed by VS Code's internal cache, whereas
+        //    tab closure is an immediate UI signal that matches terminal "editor exit".
+        // 2. By accessing doc.getText() at the moment of closure, we avoid a race condition
+        //    where jj might read the file from disk before VS Code has finished an async save.
+        // 3. We check doc.isDirty to respect the user's "Don't Save" choice. If it's still
+        //    dirty on close, we revert to the original disk content.
         this.disposables.push(
-            vscode.workspace.onDidCloseTextDocument(async (doc) => {
-                const basename = path.basename(doc.uri.fsPath);
-                if (basename === 'SQUASH_MSG') {
-                    const storageDir = this.getSquashStorageDir();
-                    const metaPath = path.join(storageDir, 'SQUASH_META.json');
-                    const msgPath = path.join(storageDir, 'SQUASH_MSG');
+            vscode.window.tabGroups.onDidChangeTabs(async (e) => {
+                for (const tab of e.closed) {
+                    if (
+                        tab.input instanceof vscode.TabInputText &&
+                        path.basename(tab.input.uri.fsPath) === 'SQUASH_MSG'
+                    ) {
+                        const msgUri = tab.input.uri;
 
-                    // Check if pending squash exists
-                    try {
-                        await fs.access(metaPath);
-                        // Prompt user
-                        const choice = await vscode.window.showInformationMessage(
-                            'Pending squash description detected. Do you want to complete the squash?',
-                            { modal: true },
-                            'Complete Squash',
-                            'Abort',
-                        );
+                        const storageDir = this.getSquashStorageDir();
+                        const metaPath = path.join(storageDir, 'SQUASH_META.json');
 
-                        if (choice === 'Complete Squash') {
-                            await completeSquashRevisionCommand(this, this.jj);
-                        } else if (choice === 'Abort') {
-                            // Cleanup
-                            await fs.unlink(metaPath).catch(() => {});
-                            await fs.unlink(msgPath).catch(() => {});
+                        try {
+                            await fs.access(metaPath);
+                            if (isSquashInProgress(this)) {
+                                return;
+                            }
+
+                            // If the document is not dirty, it was either saved or never changed.
+                            // If it IS dirty, the user chose "Don't Save", so we read the original from disk.
+                            const doc = vscode.workspace.textDocuments.find(
+                                (d) => d.uri.toString() === msgUri.toString(),
+                            );
+                            const message =
+                                doc && !doc.isDirty ? doc.getText() : await fs.readFile(msgUri.fsPath, 'utf-8');
+
+                            await completeSquashRevisionCommand(this, this.jj, message);
+                        } catch {
+                            // No pending squash, ignore
                         }
-                    } catch {
-                        // No pending squash, ignore
                     }
                 }
             }),

--- a/src/test/commands/squash-revision.test.ts
+++ b/src/test/commands/squash-revision.test.ts
@@ -7,7 +7,11 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { pickAncestor } from '../../commands/command-utils';
-import { squashRevisionIntoAncestorCommand, squashRevisionIntoParentCommand } from '../../commands/squash-revision';
+import {
+    completeSquashRevisionCommand,
+    squashRevisionIntoAncestorCommand,
+    squashRevisionIntoParentCommand,
+} from '../../commands/squash-revision';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
@@ -20,10 +24,17 @@ vi.mock('vscode', async () => {
         window: {
             showQuickPick: vi.fn(),
             showTextDocument: vi.fn(),
+            tabGroups: {
+                all: [],
+                close: vi.fn(),
+            },
         },
         workspace: {
             openTextDocument: vi.fn(),
             textDocuments: [],
+        },
+        TabInputText: class MockTabInputText {
+            constructor(public uri: vscode.Uri) {}
         },
     });
 });
@@ -324,5 +335,142 @@ describe('squashRevisionIntoParentCommand', () => {
         await squashRevisionIntoParentCommand(scmProvider, jj, ['root()']);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith('Cannot squash a root revision.');
+    });
+
+    test('completeSquashRevisionCommand completes squash and closes editor', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'parent', description: 'Parent' },
+            { label: 'child', parents: ['parent'], description: 'Child', isCurrentWorkingCopy: true },
+        ]);
+
+        const storageDir = scmProvider.getSquashStorageDir();
+        fs.mkdirSync(storageDir, { recursive: true });
+        const metaPath = path.join(storageDir, 'SQUASH_META.json');
+        const msgPath = path.join(storageDir, 'SQUASH_MSG');
+
+        fs.writeFileSync(metaPath, JSON.stringify({ revision: '@', parentRev: ids.parent.commitId }));
+        fs.writeFileSync(msgPath, 'New combined description\n\n# Comment');
+
+        // Mock open editor
+        const msgUri = vscode.Uri.file(msgPath);
+        const mockDoc = createMock<vscode.TextDocument>({
+            uri: msgUri,
+            isDirty: false,
+            getText: vi.fn().mockReturnValue('New combined description\n\n# Comment'),
+        });
+        Object.defineProperty(vscode.workspace, 'textDocuments', {
+            value: [mockDoc],
+            configurable: true,
+        });
+
+        // Mock tab for closing
+        const mockTab = createMock<vscode.Tab>({
+            input: new vscode.TabInputText(msgUri),
+        });
+        Object.defineProperty(vscode.window.tabGroups, 'all', {
+            value: [
+                createMock<vscode.TabGroup>({
+                    tabs: [mockTab],
+                }),
+            ],
+            configurable: true,
+        });
+
+        await completeSquashRevisionCommand(scmProvider, jj, 'New combined description');
+
+        // Verify squash happened
+        expect(repo.getDescription('@-')).toBe('New combined description');
+
+        // Verify files cleaned up
+        expect(fs.existsSync(metaPath)).toBe(false);
+        expect(fs.existsSync(msgPath)).toBe(false);
+
+        // Verify editor closed
+        expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(mockTab);
+    });
+
+    test('completeSquashRevisionCommand prevents concurrent execution', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'parent', description: 'Parent' },
+            { label: 'child', parents: ['parent'], description: 'Child', isCurrentWorkingCopy: true },
+        ]);
+
+        const storageDir = scmProvider.getSquashStorageDir();
+        fs.mkdirSync(storageDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(storageDir, 'SQUASH_META.json'),
+            JSON.stringify({ revision: '@', parentRev: ids.parent.commitId }),
+        );
+        fs.writeFileSync(path.join(storageDir, 'SQUASH_MSG'), 'Desc');
+
+        // Slow down squash
+        const originalSquash = jj.squashRevision.bind(jj);
+        vi.spyOn(jj, 'squashRevision').mockImplementation(async (opts) => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            return originalSquash(opts);
+        });
+
+        // Trigger twice
+        const p1 = completeSquashRevisionCommand(scmProvider, jj, 'm1');
+        const p2 = completeSquashRevisionCommand(scmProvider, jj, 'm2');
+
+        await Promise.all([p1, p2]);
+
+        // Should only have called squashRevision once
+        expect(jj.squashRevision).toHaveBeenCalledTimes(1);
+    });
+
+    test('completeSquashRevisionCommand unlinks files and closes editor when message is empty', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'parent', description: 'Parent' },
+            { label: 'child', parents: ['parent'], description: 'Child', isCurrentWorkingCopy: true },
+        ]);
+
+        const storageDir = scmProvider.getSquashStorageDir();
+        fs.mkdirSync(storageDir, { recursive: true });
+        const metaPath = path.join(storageDir, 'SQUASH_META.json');
+        const msgPath = path.join(storageDir, 'SQUASH_MSG');
+
+        fs.writeFileSync(metaPath, JSON.stringify({ revision: '@', parentRev: ids.parent.commitId }));
+        fs.writeFileSync(msgPath, 'JJ: comment only');
+
+        // Mock open editor
+        const msgUri = vscode.Uri.file(msgPath);
+        const mockDoc = createMock<vscode.TextDocument>({
+            uri: msgUri,
+            isDirty: false,
+            getText: vi.fn().mockReturnValue('JJ: comment only'),
+        });
+        Object.defineProperty(vscode.workspace, 'textDocuments', {
+            value: [mockDoc],
+            configurable: true,
+        });
+
+        // Mock tab for closing
+        const mockTab = createMock<vscode.Tab>({
+            input: new vscode.TabInputText(msgUri),
+        });
+        Object.defineProperty(vscode.window.tabGroups, 'all', {
+            value: [
+                createMock<vscode.TabGroup>({
+                    tabs: [mockTab],
+                }),
+            ],
+            configurable: true,
+        });
+
+        // Call completeSquashRevisionCommand with empty message or comments only
+        await completeSquashRevisionCommand(scmProvider, jj, 'JJ: comment only');
+
+        // Verify squash did NOT happen (parent description remains unchanged)
+        expect(repo.getDescription('@-')).toBe('Parent');
+
+        // Verify files cleaned up
+        expect(fs.existsSync(metaPath)).toBe(false);
+        expect(fs.existsSync(msgPath)).toBe(false);
+
+        // Verify editor closed
+        expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(mockTab);
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('Squash message is empty. Aborting.');
     });
 });

--- a/src/test/commands/squash-selection.test.ts
+++ b/src/test/commands/squash-selection.test.ts
@@ -177,6 +177,80 @@ describe('squash-selection commands', () => {
 
             expect(scmProvider.refresh).toHaveBeenCalled();
         });
+
+        test('squashes selection from jj-edit editor', async () => {
+            const fileName = 'file.txt';
+            const ids = await buildGraph(repo, [
+                {
+                    label: 'root',
+                    files: { [fileName]: 'line1\nline2\nline3\n' },
+                },
+                {
+                    label: 'modified',
+                    parents: ['root'],
+                    files: {
+                        [fileName]: 'line1\nmodified2\nline3\n',
+                    },
+                },
+            ]);
+
+            // URI using 'revision' parameter (jj-edit style)
+            const uri = vscode.Uri.file(path.join(repo.path, fileName)).with({
+                scheme: 'jj-edit',
+                query: `revision=${ids.modified.changeId}`,
+            });
+
+            // Select the modification (line 2)
+            const mockEditor = createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({
+                    uri,
+                }),
+                selections: [new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 10))],
+            });
+
+            await squashSelectionIntoParentCommand(scmProvider, jj, mockEditor);
+
+            // Parent (root) should have the modification
+            const parentContent = repo.getFileContent(ids.root.changeId, fileName);
+            expect(parentContent).toBe('line1\nmodified2\nline3\n');
+        });
+
+        test('squashes selection from jj-view diff editor', async () => {
+            const fileName = 'file.txt';
+            const ids = await buildGraph(repo, [
+                {
+                    label: 'root',
+                    files: { [fileName]: 'line1\nline2\nline3\n' },
+                },
+                {
+                    label: 'modified',
+                    parents: ['root'],
+                    files: {
+                        [fileName]: 'line1\nmodified2\nline3\n',
+                    },
+                },
+            ]);
+
+            // URI using 'base' parameter (jj-view style)
+            const uri = vscode.Uri.file(path.join(repo.path, fileName)).with({
+                scheme: 'jj-view',
+                query: `base=${ids.modified.changeId}&side=right`,
+            });
+
+            // Select the modification (line 2)
+            const mockEditor = createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({
+                    uri,
+                }),
+                selections: [new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 10))],
+            });
+
+            await squashSelectionIntoParentCommand(scmProvider, jj, mockEditor);
+
+            // Parent (root) should have the modification
+            const parentContent = repo.getFileContent(ids.root.changeId, fileName);
+            expect(parentContent).toBe('line1\nmodified2\nline3\n');
+        });
     });
 });
 

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -405,6 +405,7 @@ export const SCM_ACTIONS = {
     ShowDetails: 'Show Details',
     Edit: 'Edit',
     MultiFileDiff: 'Multi-File Diff',
+    CompleteSquashRevision: 'Complete Squash Revision',
 } as const;
 
 /**
@@ -435,6 +436,7 @@ export async function clickScmAction(page: Page, rowName: string | RegExp, actio
                 [SCM_ACTIONS.ShowDetails]: '.codicon-list-selection',
                 [SCM_ACTIONS.Edit]: '.codicon-edit',
                 [SCM_ACTIONS.MultiFileDiff]: '.codicon-diff-multiple',
+                [SCM_ACTIONS.CompleteSquashRevision]: '.codicon-check',
             };
             const cls = iconMap[actionTitle];
             if (cls) {
@@ -906,4 +908,25 @@ export async function clickContextMenuItem(page: Page, label: string | RegExp) {
         // Wait for menu to disappear
         await expect(menu).not.toBeVisible({ timeout: 2000 });
     }, `Failed to click context menu item "${label}"`).toPass({ timeout: 5000 });
+}
+/**
+ * Saves the active editor using the platform-specific shortcut.
+ */
+export async function saveActiveEditor(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+s' : 'Control+s');
+}
+
+/**
+ * Clears all text in the active editor.
+ */
+export async function clearActiveEditor(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+a' : 'Control+a');
+    await page.keyboard.press('Backspace');
+}
+
+/**
+ * Closes the active editor using the platform-specific shortcut.
+ */
+export async function closeActiveEditor(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+w' : 'Control+w');
 }

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -977,4 +977,79 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('Squash selection into parent via non-working copy diff editor context menu', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        const fileName = 'squash-selection-non-wc-e2e.txt';
+        const fileContentOriginal = 'line 1\nline 2\nline 3\nline 4\nline 5\n';
+        const fileContentPartiallyModified = 'line 1\nline 2 modified\nline 3\nline 4\nline 5\n';
+        const fileContentFullyModified = 'line 1\nline 2 modified\nline 3\nline 4 modified\nline 5\n';
+
+        const ids = await buildGraph(repo, [
+            {
+                label: 'root',
+                files: { [fileName]: fileContentOriginal },
+            },
+            {
+                label: 'parent',
+                parents: ['root'],
+                description: 'parent commit',
+            },
+            {
+                label: 'child',
+                parents: ['parent'],
+                description: 'child commit',
+                files: { [fileName]: fileContentFullyModified },
+            },
+            {
+                label: 'wc',
+                parents: ['child'],
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            // 1. Open Diff Editor for the 'child' commit
+            // The group name in SCM for 'child' will be its description 'child commit'
+            await openScmDiff(page, fileName, /child commit/);
+
+            // 2. Select the FIRST modified line in the right side (line 2)
+            // In a non-WC diff, the right side is the 'child' commit
+            const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+            const line2 = await selectLine(page, rightEditor, 'line 2 modified');
+
+            // 3. Open Context Menu on the selected line and click "Squash Selection into Parent"
+            await line2.click({ button: 'right' });
+            await clickContextMenuItem(page, /Squash Selection into Parent/i);
+
+            // 4. Verify the change is moved to the parent in JJ
+            await expect(async () => {
+                const parentContent = repo.getFileContent(ids.parent.changeId, fileName);
+                const childContent = repo.getFileContent(ids.child.changeId, fileName);
+
+                // Parent should now have the squashed modification
+                expect(parentContent).toBe(fileContentPartiallyModified);
+
+                // Child should still have its original content (but only line 4 is now "new" relative to parent)
+                expect(childContent).toBe(fileContentFullyModified);
+
+                // Check diff of child to be sure
+                const childDiff = repo.getDiff(ids.child.changeId, { git: true });
+                expect(childDiff).toContain('+line 4 modified');
+                expect(childDiff).not.toContain('+line 2 modified');
+            }).toPass({ timeout: 15000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/e2e/squash.spec.ts
+++ b/src/test/e2e/squash.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import { expect, type Page, test } from '@playwright/test';
+import type { ElectronApplication } from 'playwright';
+import { buildGraph, type CommitId, TestRepo } from '../test-repo';
+import {
+    clearActiveEditor,
+    clickScmAction,
+    closeActiveEditor,
+    focusSCM,
+    launchVSCode,
+    SCM_ACTIONS,
+    waitForTab,
+} from './e2e-helpers';
+
+test.describe('Squash E2E', () => {
+    let repo: TestRepo;
+    let app: ElectronApplication;
+    let page: Page;
+    let userDataDir: string;
+    let ids: Record<string, CommitId>;
+
+    test.beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+        ids = await buildGraph(repo, [
+            { label: 'parent', description: 'parent description' },
+            { label: 'child', parents: ['parent'], description: 'child description', files: { 'f.txt': 'content' } },
+            { label: 'wc', parents: ['child'], isCurrentWorkingCopy: true },
+        ]);
+
+        const setup = await launchVSCode(repo);
+        app = setup.app;
+        page = setup.page;
+        userDataDir = setup.userDataDir;
+    });
+
+    test.afterEach(async () => {
+        if (app) {
+            await app.close();
+        }
+        if (userDataDir) {
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+        }
+        if (repo) {
+            repo.dispose();
+        }
+    });
+
+    test('Squash: Save and Close', async () => {
+        await focusSCM(page);
+
+        // Trigger squash. Since both have descriptions, it should open the editor.
+        await clickScmAction(page, /child description/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+        // Wait for SQUASH_MSG tab to open
+        await waitForTab(page, 'SQUASH_MSG');
+
+        // Find the editor and modify the text
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await editor.click();
+        await clearActiveEditor(page);
+        await page.keyboard.insertText('Combined Description');
+
+        // Close the tab to complete the squash
+        await closeActiveEditor(page);
+
+        // Handle VS Code's "Save changes?" dialog by clicking Save
+        const saveDialog = page.locator('.monaco-dialog-box').filter({ hasText: /Do you want to save the changes/ });
+        await expect(saveDialog).toBeVisible();
+        await saveDialog.getByRole('button', { name: 'Save', exact: true }).click();
+
+        // Verify the squash is completed in jj
+        await expect(async () => {
+            const log = repo.log();
+            const desc = repo.getDescription(ids.parent.changeId);
+            expect(log).not.toContain(ids.child.changeId.substring(0, 8));
+            expect(desc).toBe('Combined Description');
+        }).toPass({ timeout: 10000 });
+
+        // Verify the tab is closed automatically
+        const tab = page.getByRole('tab', { name: 'SQUASH_MSG' });
+        await expect(tab).not.toBeVisible({ timeout: 5000 });
+    });
+
+    test('Squash: Finalize via checkmark button', async () => {
+        await focusSCM(page);
+
+        // Trigger squash
+        await clickScmAction(page, /child description/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+        // Wait for SQUASH_MSG tab to open
+        await waitForTab(page, 'SQUASH_MSG');
+
+        // Find the editor and modify the text
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await editor.click();
+        await clearActiveEditor(page);
+        await page.keyboard.insertText('Description via Button');
+
+        // Click the checkmark button in the editor title bar
+        const completeButton = page.getByRole('button', { name: 'Complete Squash Revision' }).first();
+        await completeButton.click();
+
+        // Verify the squash is completed in jj
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).not.toContain(ids.child.changeId.substring(0, 8));
+            const desc = repo.getDescription(ids.parent.changeId);
+            expect(desc).toBe('Description via Button');
+        }).toPass({ timeout: 10000 });
+
+        // Verify the tab is closed automatically
+        const tab = page.getByRole('tab', { name: 'SQUASH_MSG' });
+        await expect(tab).not.toBeVisible({ timeout: 5000 });
+    });
+
+    test('Squash: Close without saving (unmodified)', async () => {
+        await focusSCM(page);
+
+        // Trigger squash
+        await clickScmAction(page, /child description/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+        // Wait for SQUASH_MSG tab to open
+        await waitForTab(page, 'SQUASH_MSG');
+
+        // Close the tab without modifying it. No VS Code save prompt should appear.
+        // This simulates the user just hitting Cmd+W to finish the squash immediately.
+        await closeActiveEditor(page);
+
+        // Verify the squash is completed with the original combined description
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).not.toContain(ids.child.changeId.substring(0, 8));
+            const desc = repo.getDescription(ids.parent.changeId);
+            expect(desc).toBe('parent description\n\nchild description');
+        }).toPass({ timeout: 10000 });
+
+        // Verify the tab is closed
+        const tab = page.getByRole('tab', { name: 'SQUASH_MSG' });
+        await expect(tab).not.toBeVisible();
+    });
+
+    test("Squash: Close without saving (modified, click Don't Save)", async () => {
+        await focusSCM(page);
+
+        // Trigger squash
+        await clickScmAction(page, /child description/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+        // Wait for SQUASH_MSG tab to open
+        await waitForTab(page, 'SQUASH_MSG');
+
+        // Find the editor and modify the text
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await editor.click();
+        await clearActiveEditor(page);
+        await page.keyboard.insertText('Description via Dialog');
+
+        // Close the tab without saving
+        await closeActiveEditor(page);
+
+        // Handle VS Code's "Save changes?" dialog
+        const saveDialog = page.locator('.monaco-dialog-box').filter({ hasText: /Do you want to save the changes/ });
+        await expect(saveDialog).toBeVisible();
+        await saveDialog.getByRole('button', { name: "Don't Save" }).click();
+
+        // Verify the squash is completed in jj, but since we didn't save, it uses the original disk contents
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).not.toContain(ids.child.changeId.substring(0, 8));
+            const desc = repo.getDescription(ids.parent.changeId);
+            expect(desc).toBe('parent description\n\nchild description');
+        }).toPass({ timeout: 10000 });
+
+        // Verify the tab is closed
+        const tab = page.getByRole('tab', { name: 'SQUASH_MSG' });
+        await expect(tab).not.toBeVisible();
+    });
+
+    test('Squash: Close without saving (modified, click Cancel)', async () => {
+        await focusSCM(page);
+
+        // Trigger squash
+        await clickScmAction(page, /child description/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+        // Wait for SQUASH_MSG tab to open
+        await waitForTab(page, 'SQUASH_MSG');
+
+        // Modify the text to make it dirty
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await editor.click();
+        await clearActiveEditor(page);
+        await page.keyboard.insertText('Some text');
+
+        // Close the tab without saving
+        await closeActiveEditor(page);
+
+        // Handle VS Code's "Save changes?" dialog
+        const saveDialog = page.locator('.monaco-dialog-box').filter({ hasText: /Do you want to save the changes/ });
+        await expect(saveDialog).toBeVisible();
+
+        // Click Cancel (or press Escape)
+        await page.keyboard.press('Escape');
+
+        // Verify the squash was NOT completed, since the tab is still open
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).toContain('child description');
+        }).toPass({ timeout: 5000 });
+
+        // Verify the tab is STILL open because we canceled the close
+        const tab = page.getByRole('tab', { name: 'SQUASH_MSG' });
+        await expect(tab).toBeVisible();
+    });
+});

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -612,7 +612,7 @@ suite('JJ SCM Provider Integration Test', () => {
         // Verify creation
         assert.ok(require('node:fs').existsSync(squashMsgPath), 'SQUASH_MSG should be created (Cond 1)');
 
-        await completeSquashRevisionCommand(scmProvider, jj);
+        await completeSquashRevisionCommand(scmProvider, jj, 'Parent Desc\n\nChild Desc');
         assert.ok(!require('node:fs').existsSync(squashMsgPath), 'Cleanup success');
 
         let parentDesc = repo.getDescription('@-');

--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
 import type { JjStatusEntry } from '../jj-types';
-import { createDiffUris } from '../uri-utils';
+import { createDiffUris, getRevisionFromUri } from '../uri-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {
@@ -165,5 +166,54 @@ describe('createDiffUris', () => {
         });
 
         expect(rightUri.scheme).toBe('file');
+    });
+});
+
+describe('getRevisionFromUri', () => {
+    it('returns undefined for URIs without revision parameters', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt');
+        expect(getRevisionFromUri(uri)).toBeUndefined();
+    });
+
+    it('extracts revision from jj-revision parameter', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: 'jj-revision=rev123',
+        });
+        expect(getRevisionFromUri(uri)).toBe('rev123');
+    });
+
+    it('extracts revision from revision parameter (jj-edit style)', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: 'revision=edit-rev',
+        });
+        expect(getRevisionFromUri(uri)).toBe('edit-rev');
+    });
+
+    it('extracts revision from base parameter (jj-view style)', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: 'base=view-rev&side=right',
+        });
+        expect(getRevisionFromUri(uri)).toBe('view-rev');
+    });
+
+    it('prioritizes jj-revision over others', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: 'jj-revision=primary&revision=secondary&base=tertiary',
+        });
+        expect(getRevisionFromUri(uri)).toBe('primary');
+    });
+
+    it('prioritizes revision over base', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: 'revision=secondary&base=tertiary',
+        });
+        expect(getRevisionFromUri(uri)).toBe('secondary');
+    });
+
+    it('returns undefined for empty query', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            query: '',
+        });
+        expect(getRevisionFromUri(uri)).toBeUndefined();
     });
 });

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -93,3 +93,12 @@ export function createDiffUris(
 
     return { leftUri, rightUri, resourceUri };
 }
+
+/**
+ * Extract a revision ID from a URI query.
+ * Handles jj-revision (SCM resource), revision (jj-edit), and base (jj-view diff).
+ */
+export function getRevisionFromUri(uri: vscode.Uri): string | undefined {
+    const query = new URLSearchParams(uri.query);
+    return query.get('jj-revision') || query.get('revision') || query.get('base') || undefined;
+}


### PR DESCRIPTION
Refactors the squash revision completion to utilize immediate VS Code tab change events instead of document close events. This prevents file-system race conditions and correctly respects the user's "Don't Save" choice.

We also removed the custom modal confirmation dialog and now rely entirely on VS Code's native file save and tab closure behavior, mirroring the native CLI jj experience where editor exit dictates completion status.

Key changes:

- Centralizes URI revision resolution via a new getRevisionFromUri utility.
- Implements concurrency guards to prevent concurrent squash executions.
- Adds thorough Playwright E2E and unit tests verifying all squash editor interactions (saving, discarding, checkmark finalization, and cancellation).

Partly addresses #141 and #144