### PR TITLE
feat: support searching revision QuickPick by description and detail

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -77,10 +77,26 @@ You MUST run individual test cases when writing a new test or debugging a broken
 
 - **Run a single test case (Required):** Use the `-g` flag for grep.
   You can also provide the filename to narrow it down further, but just using `-g` with a unique pattern is often more convenient.
+  
+  > [!IMPORTANT]
+  > **Playwright's `-g` / `--grep` uses Regular Expressions, not literal strings!**
+  > If a test name contains special regex characters like parentheses `()`, brackets `[]`, dots `.`, or asterisks `*`, a raw literal match will fail or behave unexpectedly (e.g. `(foo)` is interpreted as a regex capture group, not literal parentheses).
+  >
+  > To match these correctly:
+  > 1. Use the `.*` wildcard to bypass the special characters entirely.
+  > 2. Or, escape the special characters with backslashes (e.g. `\(` and `\)`).
+
   When debugging a flaky test, append `--repeat-each 5 --max-failures 1` to run it multiple times and fail fast.
     ```bash
-    pnpm test:e2e [-g "<test-name>"] [<filename>] [--repeat-each 5 --max-failures 1]
-    # Examples:
+    pnpm test:e2e [-g "<test-name-regex>"] [<filename>] [--repeat-each 5 --max-failures 1]
+    # Examples using wildcards (Recommended):
+    # pnpm test:e2e -g "Compare All Files with Revision.*Arbitrary"
+    # pnpm test:e2e -g "Compare File with Revision.*Ancestor"
+    #
+    # Examples with literal escaping:
+    # pnpm test:e2e -g "Compare File with Revision\.\.\. \(Arbitrary\)"
+    #
+    # Basic examples:
     # pnpm test:e2e -g "Additional Actions"
     # pnpm test:e2e scm.spec.ts -g "squash"
     ```

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -230,22 +230,8 @@ export async function promptForRevision(
             const quickPick = vscode.window.createQuickPick();
             quickPick.items = options;
             quickPick.placeholder = placeHolder;
-
-            // Enforce prefix matching on change_id or label
-            quickPick.onDidChangeValue((value) => {
-                const val = value.trim();
-                if (!val) {
-                    quickPick.items = options;
-                    return;
-                }
-                const filtered = options.filter((item) => {
-                    const detailMatch = item.detail?.toLowerCase().includes(val.toLowerCase());
-                    const labelMatch = item.label.toLowerCase().includes(val.toLowerCase());
-                    const descMatch = item.description?.toLowerCase().includes(val.toLowerCase());
-                    return detailMatch || labelMatch || descMatch;
-                });
-                quickPick.items = filtered;
-            });
+            quickPick.matchOnDescription = true;
+            quickPick.matchOnDetail = true;
 
             quickPick.onDidAccept(() => {
                 const selectedItem = quickPick.activeItems[0] || quickPick.selectedItems[0];

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -170,4 +170,40 @@ describe('promptForRevision', () => {
         expect(result).toBe('fallback-rev');
         expect(vscode.window.showInputBox).toHaveBeenCalledWith(expect.objectContaining({ prompt: 'Enter revision' }));
     });
+
+    it('configures quick pick to match on description and detail', async () => {
+        await buildGraph(repo, [{ label: 'v1', files: { 'file1.txt': 'v1\n' } }]);
+
+        const state = {
+            createdQuickPick: null as vscode.QuickPick<vscode.QuickPickItem> | null,
+        };
+        let acceptCallback: () => void = () => {};
+        const mockQuickPick = {
+            items: [],
+            selectedItems: [],
+            activeItems: [],
+            onDidChangeValue: vi.fn(),
+            value: 'custom-revision',
+            onDidAccept: vi.fn().mockImplementation((cb) => {
+                acceptCallback = cb;
+            }),
+            onDidHide: vi.fn(),
+            show: vi.fn().mockImplementation(() => {
+                acceptCallback();
+            }),
+            dispose: vi.fn(),
+            matchOnDescription: false,
+            matchOnDetail: false,
+        };
+        vi.mocked(vscode.window.createQuickPick).mockImplementation(() => {
+            state.createdQuickPick = createMock<vscode.QuickPick<vscode.QuickPickItem>>(mockQuickPick);
+            return state.createdQuickPick;
+        });
+
+        await promptForRevision(jj, '@');
+
+        expect(state.createdQuickPick).not.toBeNull();
+        expect(state.createdQuickPick?.matchOnDescription).toBe(true);
+        expect(state.createdQuickPick?.matchOnDetail).toBe(true);
+    });
 });

--- a/src/test/e2e/arbitrary-diff.spec.ts
+++ b/src/test/e2e/arbitrary-diff.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import * as fs from 'node:fs';
-import { expect, type Page, test } from '@playwright/test';
+import { type Page, test } from '@playwright/test';
 import type { ElectronApplication } from 'playwright';
 import { buildGraph, type CommitId, TestRepo } from '../test-repo';
 import {
@@ -12,7 +12,8 @@ import {
     focusJJLog,
     launchVSCode,
     openFileInEditor,
-    waitForQuickInput,
+    openQuickInputWithShortcut,
+    pickQuickPickItem,
     waitForTab,
 } from './e2e-helpers';
 
@@ -26,22 +27,13 @@ test.describe('Arbitrary Diff E2E', () => {
     async function compareWithRevision(
         page: Page,
         shortcut: string,
-        revision: string,
+        searchQuery: string,
         tabNamePattern: RegExp,
+        submitAsArbitraryText: boolean = false,
     ): Promise<void> {
-        await expect(async () => {
-            await page.keyboard.press(shortcut);
-            const input = await waitForQuickInput(page, 2000);
-            await input.fill(revision);
-            await page.waitForTimeout(200); // Wait for VS Code to register the fill
-            await page.keyboard.press('Enter');
-
-            // 1. Ensure quick input is dismissed
-            await expect(page.locator('.quick-input-widget')).not.toBeVisible({ timeout: 3000 });
-
-            // 2. Ensure the tab appears
-            await waitForTab(page, tabNamePattern);
-        }, `Failed to compare with revision "${revision}" via shortcut "${shortcut}"`).toPass({ timeout: 20000 });
+        await openQuickInputWithShortcut(page, shortcut);
+        await pickQuickPickItem(page, searchQuery, { submitAsArbitraryText });
+        await waitForTab(page, tabNamePattern);
     }
 
     test.beforeEach(async () => {
@@ -99,8 +91,8 @@ test.describe('Arbitrary Diff E2E', () => {
         await compareWithRevision(
             page,
             'Control+Alt+c',
-            commit1Id,
-            new RegExp(`^Compare ${commit1Id.substring(0, 4)}`),
+            'commit1',
+            new RegExp(`^Compare ${commit1Id.substring(0, 3)}`),
         );
         await expectModifiedFiles(page, ['f.txt']);
     });
@@ -111,7 +103,8 @@ test.describe('Arbitrary Diff E2E', () => {
             page,
             'Control+Alt+c',
             branchC1Id,
-            new RegExp(`^Compare ${branchC1Id.substring(0, 4)}`),
+            new RegExp(`^Compare ${branchC1Id.substring(0, 3)}`),
+            true,
         );
         await expectModifiedFiles(page, ['f.txt', 'g.txt']);
     });
@@ -122,8 +115,8 @@ test.describe('Arbitrary Diff E2E', () => {
         await compareWithRevision(
             page,
             'Control+Alt+f',
-            commit1Id,
-            new RegExp(`f\\.txt \\(${commit1Id.substring(0, 4)}`),
+            'commit1',
+            new RegExp(`f\\.txt \\(${commit1Id.substring(0, 3)}`),
         );
     });
 
@@ -134,7 +127,8 @@ test.describe('Arbitrary Diff E2E', () => {
             page,
             'Control+Alt+f',
             branchC1Id,
-            new RegExp(`f\\.txt \\(${branchC1Id.substring(0, 4)}`),
+            new RegExp(`f\\.txt \\(${branchC1Id.substring(0, 3)}`),
+            true,
         );
     });
 });

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -348,7 +348,7 @@ test.describe('JJ Log Context Menu E2E', () => {
             await rightClickAndSelect(page, commit1Row, 'Set Bookmark');
 
             // Wait for QuickPick/InputBox to appear. The InputBox has an input.input element.
-            const quickInput = page.locator('.quick-input-widget');
+            const quickInput = page.locator('.quick-input-widget').filter({ visible: true });
             const input = quickInput.locator('input.input');
             await expect(input).toBeVisible({ timeout: 5000 });
 

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -561,9 +561,28 @@ export async function clickNotificationButton(page: Page, actionLabel: string) {
  * Waits for the VS Code QuickInput widget to be visible and returns the input locator.
  */
 export async function waitForQuickInput(page: Page, timeout: number = 10000): Promise<Locator> {
-    const quickInput = page.locator('.quick-input-widget');
+    const quickInput = page.locator('.quick-input-widget').filter({ visible: true });
     const input = quickInput.locator('input.input');
     await expect(input).toBeVisible({ timeout });
+    return input;
+}
+
+/**
+ * Robustly presses a shortcut key to open the QuickInput widget, retrying if VS Code ignores the keypress.
+ */
+export async function openQuickInputWithShortcut(page: Page, shortcut: string): Promise<Locator> {
+    const quickInput = page.locator('.quick-input-widget');
+    const input = quickInput.locator('input.input');
+
+    // Ensure any leftover quick input is closed first
+    await expect(quickInput).not.toBeVisible({ timeout: 5000 });
+
+    await expect(async () => {
+        if (!(await input.isVisible())) {
+            await page.keyboard.press(shortcut);
+        }
+        await waitForQuickInput(page, 200);
+    }, `Failed to open quick input via shortcut "${shortcut}"`).toPass({ timeout: 20000 });
     return input;
 }
 
@@ -693,17 +712,32 @@ export async function expectModifiedFiles(page: Page, expectedFiles: string[]) {
  * Robustly opens a file via the File Explorer tree view.
  */
 export async function openFileInEditor(page: Page, fileName: string): Promise<Locator> {
-    await expect(async () => {
-        await page.keyboard.press('Control+Shift+E');
-        const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
-        await expect(fileRowInExplorer).toBeVisible({ timeout: 5000 });
-        await fileRowInExplorer.click();
+    const explorerPane = page.locator('#workbench\\.view\\.explorer');
+    const fileRowInExplorer = page.getByRole('treeitem', { name: fileName }).first();
+    const tab = page.getByRole('tab', { name: fileName, selected: true });
 
-        await expect(page.getByRole('tab', { name: fileName, selected: true })).toBeVisible({ timeout: 5000 });
+    await expect(async () => {
+        // Ensure Explorer sidebar is open
+        if (!(await explorerPane.isVisible())) {
+            await page.keyboard.press('Control+Shift+E');
+            await expect(explorerPane).toBeVisible({ timeout: 200 });
+        }
+
+        // If the file tab is already open and selected, we don't need to click anything
+        if (await tab.isVisible()) {
+            const editor = page.locator('.editor-group-container.active .monaco-editor').first();
+            if (await editor.isVisible()) {
+                return;
+            }
+        }
+
+        await expect(fileRowInExplorer).toBeVisible({ timeout: 200 });
+        await fileRowInExplorer.click();
+        await expect(tab).toBeVisible({ timeout: 200 });
 
         const editor = page.locator('.editor-group-container.active .monaco-editor').first();
-        await expect(editor).toBeVisible({ timeout: 5000 });
-    }, `Failed to open file "${fileName}" in editor`).toPass({ timeout: 20000 });
+        await expect(editor).toBeVisible({ timeout: 200 });
+    }, `Failed to open file "${fileName}" in editor`).toPass({ timeout: 7000 });
 
     return page.locator('.editor-group-container.active .monaco-editor').first();
 }
@@ -862,15 +896,34 @@ export async function getDetailsWebview(page: Page): Promise<Frame> {
     return guestFrame;
 }
 
-export async function pickQuickPickItem(page: Page, label: string | RegExp) {
+export async function pickQuickPickItem(
+    page: Page,
+    label: string | RegExp,
+    options?: { submitAsArbitraryText?: boolean },
+) {
     await expect(async () => {
-        await waitForQuickInput(page);
-        const quickPick = page.locator('.quick-input-widget');
+        const input = await waitForQuickInput(page);
 
-        // Find the item by text within the quickpick list
-        const item = quickPick.locator('.monaco-list-row').filter({ hasText: label }).first();
-        await expect(item).toBeVisible({ timeout: 2000 });
-        await item.click();
+        // If it's a string, type/fill it to filter the quick pick list
+        if (typeof label === 'string') {
+            await input.focus();
+            await input.fill(label);
+            await expect(input).toHaveValue(label);
+        }
+
+        const quickPick = page.locator('.quick-input-widget').filter({ visible: true });
+
+        if (options?.submitAsArbitraryText) {
+            // Give VS Code a moment to register the input value change in the extension host
+            await page.waitForTimeout(200);
+            await input.press('Enter');
+        } else {
+            // Find the item by text within the quickpick list
+            const item = quickPick.locator('.monaco-list-row').filter({ hasText: label }).first();
+            await expect(item).toBeVisible({ timeout: 2000 });
+            await item.click();
+        }
+
         await expect(quickPick).not.toBeVisible({ timeout: 5000 });
     }, `Failed to pick QuickPick item "${label}"`).toPass({ timeout: 15000 });
 }


### PR DESCRIPTION
- Enable `matchOnDescription` and `matchOnDetail` in the `promptForRevision` QuickPick to allow native VS Code filtering to match against descriptions and long change IDs.
- Add unit tests verifying that `promptForRevision` correctly configures these QuickPick options.
- Update Playwright E2E tests to search by friendly description for ancestor comparisons, and submit via Enter using `submitAsArbitraryText: true` with the actual hexadecimal change ID for non-ancestor (arbitrary) comparisons.