### PR TITLE
test: fix extension host crash in missing binary e2e test

### DIFF
--- a/src/test/e2e/binary-config.spec.ts
+++ b/src/test/e2e/binary-config.spec.ts
@@ -52,11 +52,20 @@ test.describe('JJ Binary Configuration E2E', () => {
         const repo = new TestRepo();
         repo.init();
 
-        // Launch with empty PATH and empty HOME to avoid discovery
+        // Filter PATH to exclude directories containing 'jj' so we don't crash the extension host
+        // by passing an empty PATH.
+        const isWin = process.platform === 'win32';
+        const jjBinaryName = isWin ? 'jj.exe' : 'jj';
+        const filteredPath = (process.env.PATH || '')
+            .split(path.delimiter)
+            .filter((p) => !fs.existsSync(path.join(p, jjBinaryName)))
+            .join(path.delimiter);
+
+        // Launch with filtered PATH and empty HOME to avoid discovery
         const { app, page, userDataDir } = await launchVSCode(
             repo,
             { 'jj-view.binaryPath': '' }, // Ensure not set
-            { PATH: '', HOME: path.join(os.tmpdir(), 'jj-empty-home') },
+            { PATH: filteredPath, HOME: path.join(os.tmpdir(), 'jj-empty-home') },
         );
 
         try {


### PR DESCRIPTION
Previously, the e2e test simulating a missing `jj` binary would set `PATH` to an empty string. This caused the VS Code extension host to crash due to missing standard shell utilities, leading to test flakiness and incorrect toast behavior.

This replaces the empty `PATH` with a filtered `PATH` that specifically excludes the directory containing the `jj` binary, ensuring the extension host stays alive while still simulating the missing binary.