### PR TITLE
refactor: use space-separated capability flags for SCM context values

### DIFF
--- a/package.json
+++ b/package.json
@@ -738,74 +738,69 @@
                 {
                     "command": "jj-view.absorb",
                     "group": "inline",
-                    "when": "scmResourceGroup == 'jj.group.workingCopy' && jj.parentMutable"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowAbsorb\\b/"
                 },
                 {
                     "command": "jj-view.showMultiFileDiff",
                     "group": "inline@1",
-                    "when": "scmResourceGroupState =~ /^jj\\.group\\.ancestor/ || scmResourceGroup == 'jj.group.workingCopy'"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowShowMultiFileDiff\\b/"
                 },
                 {
                     "command": "jj-view.abandon",
                     "group": "inline@2",
-                    "when": "scmResourceGroup == 'jj.group.workingCopy'"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowAbandon\\b/"
                 },
                 {
                     "command": "jj-view.squashRevisionIntoParent",
                     "group": "inline@3",
-                    "when": "scmResourceGroup == 'jj.group.workingCopy' && jj.parentMutable || scmResourceGroupState == 'jj.group.ancestor:squashable'"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
                 },
                 {
                     "command": "jj-view.squashRevisionIntoAncestor",
                     "group": "inline@4",
-                    "when": "scmResourceGroup == 'jj.group.workingCopy' && jj.parentMutable || scmResourceGroupState == 'jj.group.ancestor:squashable'"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
                 },
                 {
                     "command": "jj-view.showDetails",
                     "group": "inline@5",
-                    "when": "scmResourceGroupState =~ /^jj\\.group\\.ancestor/"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowShowDetails\\b/"
                 },
                 {
                     "command": "jj-view.edit",
                     "group": "inline@6",
-                    "when": "scmResourceGroupState =~ /^jj\\.group\\.ancestor:(mutable|squashable)/"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowEdit\\b/"
                 }
             ],
             "scm/resourceState/context": [
                 {
                     "command": "jj-view.openFile",
                     "group": "inline@1",
-                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && jj.openDiffOnClick || scmResourceState == 'jj.resource.conflict'"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowOpen\\b/ && jj.openDiffOnClick || scmResourceState =~ /\\bjj\\.resource\\.allowOpenMergeEditor\\b/"
                 },
                 {
                     "command": "jj-view.openChanges",
                     "group": "inline@1",
-                    "when": "(scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/) && !jj.openDiffOnClick || scmResourceState == 'jj.resource.conflict'"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowOpen\\b/ && !jj.openDiffOnClick || scmResourceState =~ /\\bjj\\.resource\\.allowOpenMergeEditor\\b/"
                 },
                 {
                     "command": "jj-view.restore",
                     "group": "inline@2",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/ || scmResourceState =~ /^jj\\.resource\\.ancestor/"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowRestore\\b/"
                 },
                 {
                     "command": "jj-view.squashFilesIntoAncestor",
                     "group": "inline@3",
-                    "when": "scmResourceState =~ /jj\\.resource.*:squashable:multi/"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowSquashIntoAncestor\\b/"
                 },
                 {
                     "command": "jj-view.squashFilesIntoParent",
                     "group": "inline@4",
-                    "when": "scmResourceState =~ /jj\\.resource.*:squashable/"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowSquashIntoParent\\b/"
                 },
                 {
                     "command": "jj-view.squashFilesIntoChild",
                     "group": "inline@5",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.ancestor/"
-                },
-                {
-                    "command": "jj-view.squashFilesIntoChild",
-                    "group": "inline@6",
-                    "when": "scmResourceState =~ /^jj\\.resource\\.workingCopy/ && jj.hasChild"
+                    "when": "scmResourceState =~ /\\bjj\\.resource\\.allowSquashIntoChild\\b/"
                 }
             ],
             "scm/change/title": [

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -6,8 +6,9 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { ScmContextValue } from '../jj-context-keys';
-import type { JjResourceState, JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
+import type { JjResourceState } from '../scm-resource-state';
 import { formatCommitDescription } from '../utils/format-utils';
 
 // Internal type guards to keep the messy VS Code argument matching encapsulated

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
-import type { JjResourceState } from '../jj-scm-provider';
+import type { JjResourceState } from '../scm-resource-state';
 
 // Opens the file on disk (usually the working copy version).
 // Strips the query parameter to ensure VS Code opens the local file path.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,10 +51,11 @@ import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provid
 import { JjContextKey } from './jj-context-keys';
 import { JjEditFileSystemProvider } from './jj-edit-fs-provider';
 import { JjLogWebviewProvider } from './jj-log-webview-provider';
-import { type JjResourceState, JjScmProvider } from './jj-scm-provider';
+import { JjScmProvider } from './jj-scm-provider';
 import { JjService } from './jj-service';
 import { TOGGLEABLE_COMMIT_ACTIONS } from './jj-types';
 import { JjViewFileSystemProvider } from './jj-view-fs-provider';
+import type { JjResourceState } from './scm-resource-state';
 import { resolveJjBinary } from './utils/binary-utils';
 
 export interface Api {

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -2,11 +2,9 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from './jj-service';
-import { createDiffUris } from './uri-utils';
-import { shortenChangeId } from './utils/jj-utils';
+import { createJjResourceState } from './scm-resource-state';
 
 export class JjCommitDocument implements vscode.CustomDocument {
     public readonly uri: vscode.Uri;
@@ -312,16 +310,17 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                         const changeId = message.payload.changeId;
                         const isImmutable = message.payload.isImmutable;
 
-                        const { leftUri, rightUri } = createDiffUris(file, changeId, this._jj.workspaceRoot, {
+                        const state = createJjResourceState(file, changeId, this._jj.workspaceRoot, {
                             editable: !isImmutable,
+                            openDiffOnClick: true,
                         });
 
-                        await vscode.commands.executeCommand(
-                            'vscode.diff',
-                            leftUri,
-                            rightUri,
-                            `${path.basename(file.path)} (${shortenChangeId(changeId, minChangeIdLength)})${!isImmutable ? ' (Editable)' : ''}`,
-                        );
+                        if (state.command) {
+                            await vscode.commands.executeCommand(
+                                state.command.command,
+                                ...(state.command.arguments ?? []),
+                            );
+                        }
                         break;
                     }
                     case 'openMultiDiff':

--- a/src/jj-context-keys.ts
+++ b/src/jj-context-keys.ts
@@ -31,22 +31,31 @@ export enum JjContextKey {
 }
 
 /**
- * Context values assigned to SCM Resource Groups and States.
- * Evaluated against `scmResourceGroupState` and `scmResourceState` in `package.json`.
+ * Context values used as `SourceControlResourceGroup.contextValue` (ScmContextValue.Group*)
+ * or `SourceControlResourceState.contextValue` (ScmContextValue.Resource*).
+ *
+ * For SCM Resource States, the contextValue contains a space-separated list of capability keys
+ * (e.g. "jj.resource.allowRestore jj.resource.allowOpen"), and package.json matches them via regex
+ * like `scmResourceState =~ /\bjj\.resource\.allowRestore\b/`.
  */
 export enum ScmContextValue {
-    // Group States
+    // SCM Resource Group IDs
     WorkingCopyGroup = 'jj.group.workingCopy',
     ConflictGroup = 'jj.group.conflict',
-    AncestorGroupMutable = 'jj.group.ancestor:mutable',
-    AncestorGroupSquashable = 'jj.group.ancestor:squashable',
 
-    // Item States
-    WorkingCopy = 'jj.resource.workingCopy',
-    WorkingCopySquashable = 'jj.resource.workingCopy:squashable',
-    WorkingCopySquashableMulti = 'jj.resource.workingCopy:squashable:multi',
-    Conflict = 'jj.resource.conflict',
-    AncestorMutable = 'jj.resource.ancestor:mutable',
-    AncestorSquashable = 'jj.resource.ancestor:squashable',
-    AncestorSquashableMulti = 'jj.resource.ancestor:squashable:multi',
+    // SCM Resource Group Capabilities
+    GroupAllowShowMultiFileDiff = 'jj.group.allowShowMultiFileDiff',
+    GroupAllowShowDetails = 'jj.group.allowShowDetails',
+    GroupAllowEdit = 'jj.group.allowEdit',
+    GroupAllowSquash = 'jj.group.allowSquash',
+    GroupAllowAbsorb = 'jj.group.allowAbsorb',
+    GroupAllowAbandon = 'jj.group.allowAbandon',
+
+    // SCM Resource Item Capabilities
+    ResourceAllowRestore = 'jj.resource.allowRestore',
+    ResourceAllowSquashIntoParent = 'jj.resource.allowSquashIntoParent',
+    ResourceAllowSquashIntoAncestor = 'jj.resource.allowSquashIntoAncestor',
+    ResourceAllowSquashIntoChild = 'jj.resource.allowSquashIntoChild',
+    ResourceAllowOpen = 'jj.resource.allowOpen',
+    ResourceAllowOpenMergeEditor = 'jj.resource.allowOpenMergeEditor',
 }

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -9,7 +9,7 @@ import { JjCommitDetailsEditorProvider } from './jj-commit-details-editor-provid
 import { JjContextKey } from './jj-context-keys';
 import type { JjService } from './jj-service';
 import { type JjLogEntry, TOGGLEABLE_COMMIT_ACTIONS, type ToggleableCommitAction } from './jj-types';
-import { formatCommitTitle } from './utils/jj-utils';
+import { canAbsorbCommit, formatCommitTitle } from './utils/jj-utils';
 
 export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'jj-view.logView';
@@ -218,11 +218,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                         const selectedCommit = this._cachedCommits.find(
                             (c) => c.change_id === data.payload.commitIds[0],
                         );
-                        if (selectedCommit?.parents) {
-                            // If any parent is NOT immutable (i.e. is mutable), then we can absorb
-                            parentMutable = selectedCommit.parents.some((parent) => !parent.is_immutable);
-                        } else if (selectedCommit) {
-                            parentMutable = false;
+                        if (selectedCommit) {
+                            parentMutable = canAbsorbCommit(selectedCommit);
                         }
                     }
 

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -18,16 +18,9 @@ import { JjService } from './jj-service';
 import type { JjLogEntry, JjStatusEntry } from './jj-types';
 import type { JjViewFileSystemProvider } from './jj-view-fs-provider';
 import { RefreshScheduler } from './refresh-scheduler';
-import { createDiffUris } from './uri-utils';
-import { formatDisplayChangeId } from './utils/jj-utils';
+import { createJjResourceState, type JjResourceState } from './scm-resource-state';
 
-export interface JjResourceState extends vscode.SourceControlResourceState {
-    revision: string;
-    /** The URIs used for generating diffs. */
-    leftUri?: vscode.Uri;
-    rightUri?: vscode.Uri;
-    diffTitle?: string;
-}
+import { canAbsorbCommit, canSquashCommit, formatDisplayChangeId, isMutableCommit } from './utils/jj-utils';
 
 export class JjScmProvider implements vscode.Disposable {
     private _disposed = false;
@@ -334,12 +327,24 @@ export class JjScmProvider implements vscode.Disposable {
                     this._workingCopyGroup.label = 'Working Copy';
                 }
 
+                const wcFlags = [ScmContextValue.GroupAllowShowMultiFileDiff, ScmContextValue.GroupAllowAbandon];
+                if (currentEntry) {
+                    if (canAbsorbCommit(currentEntry)) {
+                        wcFlags.push(ScmContextValue.GroupAllowAbsorb);
+                    }
+                    if (canSquashCommit(currentEntry)) {
+                        wcFlags.push(ScmContextValue.GroupAllowSquash);
+                    }
+                }
+                this._workingCopyGroup.contextValue = wcFlags.join(' ');
+
                 // Working copy items are squashable if the parent is mutable
                 this._workingCopyGroup.resourceStates = changes.map((c) => {
                     const state = this.toResourceState(c, currentEntry?.change_id || '@', {
                         squashable: parentMutable,
                         multipleAncestors: ancestorsToDisplay.length > 1,
                         openDiffOnClick,
+                        hasChild,
                     });
                     decorationMap.set(state.resourceUri.toString(), c);
                     this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
@@ -378,9 +383,17 @@ export class JjScmProvider implements vscode.Disposable {
 
                     // Reuse existing group or create new one
                     let group: vscode.SourceControlResourceGroup;
-                    const contextValue = canSquash
-                        ? ScmContextValue.AncestorGroupSquashable
-                        : ScmContextValue.AncestorGroupMutable;
+                    const groupFlags = [
+                        ScmContextValue.GroupAllowShowMultiFileDiff,
+                        ScmContextValue.GroupAllowShowDetails,
+                    ];
+                    if (isMutableCommit(ancestorEntry)) {
+                        groupFlags.push(ScmContextValue.GroupAllowEdit);
+                    }
+                    if (canSquashCommit(ancestorEntry)) {
+                        groupFlags.push(ScmContextValue.GroupAllowSquash);
+                    }
+                    const contextValue = groupFlags.join(' ');
 
                     if (i < this._parentGroups.length) {
                         group = this._parentGroups[i];
@@ -559,72 +572,12 @@ export class JjScmProvider implements vscode.Disposable {
     private toResourceState(
         entry: JjStatusEntry,
         revision: string = '@',
-        options: {
-            editable?: boolean;
-            workingCopyChangeId?: string;
-            squashable?: boolean;
-            multipleAncestors?: boolean;
-            openDiffOnClick?: boolean;
-        } = {},
+        options: Parameters<typeof createJjResourceState>[3] = {},
     ): JjResourceState {
-        const root = this._sourceControl.rootUri?.fsPath || '';
-        const isCurrentWorkingCopy = revision === '@' || revision === this._currentEntry?.change_id;
-        const { leftUri, rightUri, resourceUri } = createDiffUris(entry, revision, root, {
+        return createJjResourceState(entry, revision, this._sourceControl.rootUri?.fsPath || '', {
             ...options,
             workingCopyChangeId: this._currentEntry?.change_id,
         });
-
-        const openDiffOnClick = options.openDiffOnClick ?? true;
-        const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
-
-        const diffTitle = `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`;
-
-        const diffCommand: vscode.Command = {
-            command: 'vscode.diff',
-            title: 'Open Changes',
-            arguments: [leftUri, rightUri, diffTitle],
-        };
-
-        const command: vscode.Command = entry.conflicted
-            ? {
-                  command: 'jj-view.openMergeEditor',
-                  title: 'Open 3-Way Merge',
-                  arguments: [{ resourceUri }],
-              }
-            : openDiffOnClick || isDeleted
-              ? diffCommand
-              : {
-                    command: 'vscode.open',
-                    title: 'Open File',
-                    arguments: [resourceUri.with({ query: '' })],
-                };
-
-        return {
-            resourceUri,
-            command,
-            leftUri,
-            rightUri,
-            diffTitle,
-            decorations: {
-                tooltip: entry.conflicted ? 'Conflicted' : entry.status,
-                faded: false,
-                strikeThrough: entry.status === 'removed',
-            },
-            contextValue: entry.conflicted
-                ? ScmContextValue.Conflict
-                : isCurrentWorkingCopy
-                  ? options.squashable
-                      ? options.multipleAncestors
-                          ? ScmContextValue.WorkingCopySquashableMulti
-                          : ScmContextValue.WorkingCopySquashable
-                      : ScmContextValue.WorkingCopy
-                  : options.squashable
-                    ? options.multipleAncestors
-                        ? ScmContextValue.AncestorSquashableMulti
-                        : ScmContextValue.AncestorSquashable
-                    : ScmContextValue.AncestorMutable,
-            revision: revision,
-        };
     }
 
     provideOriginalResource(uri: vscode.Uri): vscode.ProviderResult<vscode.Uri> {

--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type * as vscode from 'vscode';
+import { ScmContextValue } from './jj-context-keys';
+import type { JjStatusEntry } from './jj-types';
+import { createDiffUris } from './uri-utils';
+
+export interface JjResourceState extends vscode.SourceControlResourceState {
+    leftUri?: vscode.Uri;
+    rightUri?: vscode.Uri;
+    diffTitle?: string;
+    revision: string;
+}
+
+export function createJjResourceState(
+    entry: JjStatusEntry,
+    revision: string,
+    root: string,
+    options: {
+        editable?: boolean;
+        workingCopyChangeId?: string;
+        squashable?: boolean;
+        multipleAncestors?: boolean;
+        openDiffOnClick?: boolean;
+        hasChild?: boolean;
+    } = {},
+): JjResourceState {
+    const isCurrentWorkingCopy = revision === '@' || revision === options.workingCopyChangeId;
+    const { leftUri, rightUri, resourceUri } = createDiffUris(entry, revision, root, options);
+
+    const openDiffOnClick = options.openDiffOnClick ?? true;
+    const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
+
+    const diffTitle = `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`;
+
+    const diffCommand: vscode.Command = {
+        command: 'vscode.diff',
+        title: 'Open Changes',
+        arguments: [leftUri, rightUri, diffTitle],
+    };
+
+    const command: vscode.Command = entry.conflicted
+        ? {
+              command: 'jj-view.openMergeEditor',
+              title: 'Open 3-Way Merge',
+              arguments: [{ resourceUri }],
+          }
+        : openDiffOnClick || isDeleted
+          ? diffCommand
+          : {
+                command: 'vscode.open',
+                title: 'Open File',
+                arguments: [resourceUri.with({ query: '' })],
+            };
+
+    const flags: string[] = [];
+
+    flags.push(ScmContextValue.ResourceAllowRestore);
+
+    if (entry.conflicted) {
+        flags.push(ScmContextValue.ResourceAllowOpenMergeEditor);
+    } else {
+        flags.push(ScmContextValue.ResourceAllowOpen);
+        if (options.squashable) {
+            flags.push(ScmContextValue.ResourceAllowSquashIntoParent);
+            if (options.multipleAncestors) {
+                flags.push(ScmContextValue.ResourceAllowSquashIntoAncestor);
+            }
+        }
+        if (!isCurrentWorkingCopy || options.hasChild) {
+            flags.push(ScmContextValue.ResourceAllowSquashIntoChild);
+        }
+    }
+
+    const contextValue = flags.join(' ');
+
+    return {
+        resourceUri,
+        command,
+        leftUri,
+        rightUri,
+        diffTitle,
+        decorations: {
+            tooltip: entry.conflicted ? 'Conflicted' : entry.status,
+            faded: false,
+            strikeThrough: entry.status === 'removed',
+        },
+        contextValue,
+        revision,
+    };
+}

--- a/src/test/commands/details.test.ts
+++ b/src/test/commands/details.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type * as vscode from 'vscode';
 import { showDetailsCommand } from '../../commands/details';
 import type { JjLogWebviewProvider } from '../../jj-log-webview-provider';
-import type { JjResourceState } from '../../jj-scm-provider';
+import type { JjResourceState } from '../../scm-resource-state';
 import { createMock } from '../test-utils';
 
 vi.mock('vscode', async () => {

--- a/src/test/commands/edit.test.ts
+++ b/src/test/commands/edit.test.ts
@@ -5,8 +5,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type * as vscode from 'vscode';
 import { editCommand } from '../../commands/edit';
-import type { JjResourceState, JjScmProvider } from '../../jj-scm-provider';
+import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
+import type { JjResourceState } from '../../scm-resource-state';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
 

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -5,7 +5,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { openChangesCommand, openFileCommand } from '../../commands/open';
-import type { JjResourceState } from '../../jj-scm-provider';
+import type { JjResourceState } from '../../scm-resource-state';
 import { createMock } from '../test-utils';
 
 vi.mock('vscode', () => {

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -12,8 +12,9 @@ import { squashFilesIntoParentCommand } from '../commands/squash-files';
 import { completeSquashRevisionCommand, squashRevisionIntoParentCommand } from '../commands/squash-revision';
 import { squashSelectionIntoParentCommand } from '../commands/squash-selection';
 import { ScmContextValue } from '../jj-context-keys';
-import { type JjResourceState, JjScmProvider } from '../jj-scm-provider';
+import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
+import type { JjResourceState } from '../scm-resource-state';
 import { buildGraph, TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
 
@@ -74,7 +75,7 @@ suite('JJ SCM Provider Integration Test', () => {
 
         const resourceState = workingCopyGroup.resourceStates[0];
         assert.strictEqual(normalize(resourceState.resourceUri.fsPath), normalize(filePath));
-        assert.strictEqual(resourceState.contextValue, ScmContextValue.WorkingCopy);
+        assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
     });
 
     test('Detects modified file', async () => {
@@ -116,13 +117,8 @@ suite('JJ SCM Provider Integration Test', () => {
         );
 
         const wcState = workingCopyGroup.resourceStates[0];
-        assert.ok(
-            [
-                ScmContextValue.WorkingCopy,
-                ScmContextValue.WorkingCopySquashable,
-                ScmContextValue.WorkingCopySquashableMulti,
-            ].includes(wcState.contextValue as ScmContextValue),
-        );
+        assert.ok((wcState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
+        assert.ok((wcState.contextValue as string).includes(ScmContextValue.ResourceAllowOpen));
     });
 
     test('When openDiffOnClick is false, opens modified files and diffs removed files', async () => {
@@ -232,15 +228,7 @@ suite('JJ SCM Provider Integration Test', () => {
             (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
         );
         assert.ok(resourceState, 'Parent resource should be visible');
-        const expectedContext = [
-            ScmContextValue.AncestorMutable,
-            ScmContextValue.AncestorSquashable,
-            ScmContextValue.AncestorSquashableMulti,
-        ];
-        assert.ok(
-            expectedContext.includes(resourceState.contextValue as ScmContextValue),
-            `Expected ${resourceState.contextValue} to be in ${expectedContext}`,
-        );
+        assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
         assert.ok(parentGroup.label.startsWith('@-1'), `Label '${parentGroup.label}' should start with '@-1'`);
 
         const command = resourceState.command;
@@ -261,14 +249,8 @@ suite('JJ SCM Provider Integration Test', () => {
             assert.strictEqual(rightParams.get('side'), 'right', 'Right query should have side=right');
         }
 
-        const expectedContext2 = [
-            ScmContextValue.AncestorMutable,
-            ScmContextValue.AncestorSquashable,
-            ScmContextValue.AncestorSquashableMulti,
-        ];
         assert.ok(
-            expectedContext2.includes(parentGroup.resourceStates[0].contextValue as ScmContextValue),
-            `Expected ${parentGroup.resourceStates[0].contextValue} to be in ${expectedContext2}`,
+            (parentGroup.resourceStates[0].contextValue as string).includes(ScmContextValue.ResourceAllowRestore),
         );
 
         repo.new([], 'child commit');
@@ -324,8 +306,12 @@ suite('JJ SCM Provider Integration Test', () => {
 
             // Parent group (@-1) - This parent has a mutable parent (grandparent), so it should be squashable
             assert.ok(parentGroups[0].label.startsWith('@-1'), `First group label should start with '@-1'`);
-            assert.strictEqual(parentGroups[0].contextValue, ScmContextValue.AncestorGroupSquashable);
-            assert.strictEqual(parentGroups[0].resourceStates[0].contextValue, ScmContextValue.AncestorSquashableMulti);
+            assert.ok((parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowSquash));
+            assert.ok(
+                (parentGroups[0].resourceStates[0].contextValue as string).includes(
+                    ScmContextValue.ResourceAllowSquashIntoAncestor,
+                ),
+            );
 
             // Grandparent group (@-2) - Its parent might be the implicit root/initial commit, so we don't strictly assert its squashability here
             assert.ok(parentGroups[1].label.startsWith('@-2'), `Second group label should start with '@-2'`);
@@ -853,10 +839,9 @@ suite('JJ SCM Provider Integration Test', () => {
             assert.strictEqual(parentGroups.length, 1, 'Should show 1 ancestor group (direct parent)');
 
             // This is the key assertion: Did the group get the correct context value?
-            assert.strictEqual(
-                parentGroups[0].contextValue,
-                ScmContextValue.AncestorGroupMutable,
-                'Parent (C1) should be mutable',
+            assert.ok(
+                (parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowEdit),
+                'Parent (C1) should allow edit',
             );
             assert.ok(parentGroups[0].label.includes('C1'), 'Group should be C1');
         } finally {
@@ -910,11 +895,7 @@ suite('JJ SCM Provider Integration Test', () => {
         // Squashable expects a single mutable parent. Merge commit has 2, so our squash command prevents it anyway.
         // But in `jj-scm-provider.ts` it blindly assigns `:squashable` if the first parent is mutable!
         assert.ok(
-            [
-                ScmContextValue.WorkingCopy,
-                ScmContextValue.WorkingCopySquashable,
-                ScmContextValue.WorkingCopySquashableMulti,
-            ].includes(wcState.contextValue as ScmContextValue),
+            (wcState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore),
             `Unexpected wc context value: ${wcState.contextValue}`,
         );
 
@@ -924,16 +905,17 @@ suite('JJ SCM Provider Integration Test', () => {
         // 4. Assert Conflict Resource State
         const conflictState = conflictGroup.resourceStates.find((s) => s.resourceUri.fsPath.endsWith('conflict.txt'));
         assert.ok(conflictState, 'Conflict resource missing');
-        assert.strictEqual(conflictState.contextValue, ScmContextValue.Conflict, 'Conflict Resource State mismatch');
+        assert.ok(
+            (conflictState.contextValue as string).includes(ScmContextValue.ResourceAllowOpenMergeEditor),
+            'Conflict Resource State mismatch',
+        );
 
         // 5. Assert Parent Resource Group
         assert.ok(parentGroups.length > 0, 'Should have parent group');
         // The first parent group is the merge commit itself (for some reason, oh wait! The parents are the parents of @!)
         // Since @ is a merge, its parents are 'left commit' and 'right commit'.
         assert.ok(
-            [ScmContextValue.AncestorGroupMutable, ScmContextValue.AncestorGroupSquashable].includes(
-                parentGroups[0].contextValue as ScmContextValue,
-            ),
+            (parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowEdit),
             `Unexpected parent context value: ${parentGroups[0].contextValue}`,
         );
     });

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -55,7 +55,7 @@ suite('JJ SCM Visibility Integration Test', () => {
         assert.strictEqual(workingCopyGroup.resourceStates.length, 1);
 
         const resourceState = workingCopyGroup.resourceStates[0];
-        assert.strictEqual(resourceState.contextValue, ScmContextValue.WorkingCopy);
+        assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
 
         // 2. Ensure parent mutability
         // Create new commit "first commit" and work on top of it ("working on this")

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { JjStatusEntry } from '../jj-types';
+import { createJjResourceState } from '../scm-resource-state';
+
+// Mock vscode
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    return await createVscodeMock({});
+});
+
+describe('createJjResourceState', () => {
+    const root = '/root';
+
+    describe('Basic Fields and URI construction', () => {
+        it('creates resource state with correct basic fields', () => {
+            const entry: JjStatusEntry = {
+                path: 'file.txt',
+                status: 'modified',
+            };
+            const state = createJjResourceState(entry, 'rev123', root);
+
+            expect(state.resourceUri.path).toBe('/root/file.txt');
+            expect(state.revision).toBe('rev123');
+            expect(state.leftUri?.path).toBe('/root/file.txt');
+            expect(state.rightUri?.path).toBe('/root/file.txt');
+        });
+
+        it('uses oldPath as leftPath for renamed entries', () => {
+            const entry: JjStatusEntry = {
+                path: 'new-file.txt',
+                status: 'renamed',
+                oldPath: 'old-file.txt',
+            };
+            const state = createJjResourceState(entry, 'rev123', root);
+
+            expect(state.leftUri?.path).toBe('/root/old-file.txt');
+            expect(state.rightUri?.path).toBe('/root/new-file.txt');
+        });
+
+        it('uses oldPath as leftPath for copied entries', () => {
+            const entry: JjStatusEntry = {
+                path: 'new-file.txt',
+                status: 'copied',
+                oldPath: 'old-file.txt',
+            };
+            const state = createJjResourceState(entry, 'rev123', root);
+
+            expect(state.leftUri?.path).toBe('/root/old-file.txt');
+            expect(state.rightUri?.path).toBe('/root/new-file.txt');
+        });
+
+        it('uses jj-edit scheme for editable non-working-copy rightUri', () => {
+            const entry: JjStatusEntry = {
+                path: 'file.txt',
+                status: 'modified',
+            };
+            const state = createJjResourceState(entry, 'rev123', root, {
+                editable: true,
+            });
+
+            expect(state.rightUri?.scheme).toBe('jj-edit');
+            expect(state.rightUri?.query).toBe('revision=rev123');
+        });
+
+        it('uses jj-view scheme for non-editable non-working-copy rightUri', () => {
+            const entry: JjStatusEntry = {
+                path: 'file.txt',
+                status: 'modified',
+            };
+            const state = createJjResourceState(entry, 'rev123', root, {
+                editable: false,
+            });
+
+            expect(state.rightUri?.scheme).toBe('jj-view');
+            expect(state.rightUri?.query).toContain('side=right');
+        });
+    });
+
+    describe('Working Copy Detection & Diff Title', () => {
+        const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
+
+        it('detects working copy when revision is @', () => {
+            const state = createJjResourceState(entry, '@', root);
+            expect(state.diffTitle).toBe('file.txt (Working Copy)');
+        });
+
+        it('detects working copy when revision matches workingCopyChangeId', () => {
+            const state = createJjResourceState(entry, 'commit-123', root, {
+                workingCopyChangeId: 'commit-123',
+            });
+            expect(state.diffTitle).toBe('file.txt (Working Copy)');
+        });
+
+        it('does not detect working copy when revision differs from workingCopyChangeId', () => {
+            const state = createJjResourceState(entry, 'commit-456', root, {
+                workingCopyChangeId: 'commit-123',
+            });
+            expect(state.diffTitle).toBe('file.txt (commit-456)');
+        });
+    });
+
+    describe('Command Routing', () => {
+        const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
+
+        it('routes to merge editor if conflicted, ignoring openDiffOnClick settings', () => {
+            const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
+            const state = createJjResourceState(conflictedEntry, 'rev123', root, {
+                openDiffOnClick: false,
+            });
+
+            expect(state.command?.command).toBe('jj-view.openMergeEditor');
+            expect(state.command?.arguments?.[0]).toEqual({
+                resourceUri: state.resourceUri,
+            });
+        });
+
+        it('routes to diff command if openDiffOnClick is true', () => {
+            const state = createJjResourceState(entry, 'rev123', root, {
+                openDiffOnClick: true,
+            });
+
+            expect(state.command?.command).toBe('vscode.diff');
+            expect(state.command?.arguments).toEqual([state.leftUri, state.rightUri, 'file.txt (rev123)']);
+        });
+
+        it('routes to diff command if status is deleted/removed, even if openDiffOnClick is false', () => {
+            const deletedEntry: JjStatusEntry = { path: 'file.txt', status: 'removed' };
+            const state = createJjResourceState(deletedEntry, 'rev123', root, {
+                openDiffOnClick: false,
+            });
+
+            expect(state.command?.command).toBe('vscode.diff');
+        });
+
+        it('routes to vscode.open with query stripped if openDiffOnClick is false and not deleted', () => {
+            const state = createJjResourceState(entry, 'rev123', root, {
+                openDiffOnClick: false,
+            });
+
+            expect(state.command?.command).toBe('vscode.open');
+            expect(state.command?.arguments?.[0].path).toBe('/root/file.txt');
+            expect(state.command?.arguments?.[0].query).toBe('');
+        });
+    });
+
+    describe('Decorations', () => {
+        it('sets Conflicted tooltip for conflicted entries', () => {
+            const entry: JjStatusEntry = { path: 'file.txt', status: 'modified', conflicted: true };
+            const state = createJjResourceState(entry, 'rev123', root);
+            expect(state.decorations?.tooltip).toBe('Conflicted');
+        });
+
+        it('sets status as tooltip for non-conflicted entries', () => {
+            const entry: JjStatusEntry = { path: 'file.txt', status: 'added' };
+            const state = createJjResourceState(entry, 'rev123', root);
+            expect(state.decorations?.tooltip).toBe('added');
+        });
+
+        it('sets strikeThrough for removed entries', () => {
+            const entry: JjStatusEntry = { path: 'file.txt', status: 'removed' };
+            const state = createJjResourceState(entry, 'rev123', root);
+            expect(state.decorations?.strikeThrough).toBe(true);
+        });
+
+        it('does not set strikeThrough for modified entries', () => {
+            const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
+            const state = createJjResourceState(entry, 'rev123', root);
+            expect(state.decorations?.strikeThrough).toBe(false);
+        });
+    });
+
+    describe('Context Capabilities (ContextValue)', () => {
+        const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
+
+        it('gives conflicted entries restore and openMergeEditor flags, but no open or squash flags', () => {
+            const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
+            const state = createJjResourceState(conflictedEntry, 'rev123', root, {
+                squashable: true,
+                multipleAncestors: true,
+                hasChild: true,
+            });
+
+            const flags = state.contextValue?.split(' ') || [];
+            expect(flags).toContain('jj.resource.allowRestore');
+            expect(flags).toContain('jj.resource.allowOpenMergeEditor');
+            expect(flags).not.toContain('jj.resource.allowOpen');
+            expect(flags).not.toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).not.toContain('jj.resource.allowSquashIntoAncestor');
+            expect(flags).not.toContain('jj.resource.allowSquashIntoChild');
+        });
+
+        it('gives basic non-conflicted entries restore and open flags', () => {
+            const state = createJjResourceState(entry, 'rev123', root);
+            const flags = state.contextValue?.split(' ') || [];
+
+            expect(flags).toContain('jj.resource.allowRestore');
+            expect(flags).toContain('jj.resource.allowOpen');
+            expect(flags).not.toContain('jj.resource.allowOpenMergeEditor');
+        });
+
+        it('sets squash-into-parent only when squashable is true', () => {
+            const state = createJjResourceState(entry, 'rev123', root, {
+                squashable: true,
+            });
+            const flags = state.contextValue?.split(' ') || [];
+
+            expect(flags).toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).not.toContain('jj.resource.allowSquashIntoAncestor');
+        });
+
+        it('sets squash-into-ancestor only when both squashable and multipleAncestors are true', () => {
+            const state = createJjResourceState(entry, 'rev123', root, {
+                squashable: true,
+                multipleAncestors: true,
+            });
+            const flags = state.contextValue?.split(' ') || [];
+
+            expect(flags).toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).toContain('jj.resource.allowSquashIntoAncestor');
+        });
+
+        it('does not set squash-into-ancestor if multipleAncestors is true but squashable is false', () => {
+            const state = createJjResourceState(entry, 'rev123', root, {
+                squashable: false,
+                multipleAncestors: true,
+            });
+            const flags = state.contextValue?.split(' ') || [];
+
+            expect(flags).not.toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).not.toContain('jj.resource.allowSquashIntoAncestor');
+        });
+
+        describe('Squash Into Child capability', () => {
+            it('sets squash-into-child for working copy (@) ONLY when hasChild is true', () => {
+                const stateWithChild = createJjResourceState(entry, '@', root, { hasChild: true });
+                const flagsWithChild = stateWithChild.contextValue?.split(' ') || [];
+                expect(flagsWithChild).toContain('jj.resource.allowSquashIntoChild');
+
+                const stateNoChild = createJjResourceState(entry, '@', root, { hasChild: false });
+                const flagsNoChild = stateNoChild.contextValue?.split(' ') || [];
+                expect(flagsNoChild).not.toContain('jj.resource.allowSquashIntoChild');
+            });
+
+            it('sets squash-into-child for matched workingCopyChangeId ONLY when hasChild is true', () => {
+                const stateWithChild = createJjResourceState(entry, 'rev-wc', root, {
+                    workingCopyChangeId: 'rev-wc',
+                    hasChild: true,
+                });
+                const flagsWithChild = stateWithChild.contextValue?.split(' ') || [];
+                expect(flagsWithChild).toContain('jj.resource.allowSquashIntoChild');
+
+                const stateNoChild = createJjResourceState(entry, 'rev-wc', root, {
+                    workingCopyChangeId: 'rev-wc',
+                    hasChild: false,
+                });
+                const flagsNoChild = stateNoChild.contextValue?.split(' ') || [];
+                expect(flagsNoChild).not.toContain('jj.resource.allowSquashIntoChild');
+            });
+
+            it('sets squash-into-child unconditionally for non-working copy revisions regardless of hasChild', () => {
+                const state = createJjResourceState(entry, 'rev123', root, { hasChild: false });
+                const flags = state.contextValue?.split(' ') || [];
+                expect(flags).toContain('jj.resource.allowSquashIntoChild');
+            });
+        });
+    });
+});

--- a/src/utils/jj-utils.ts
+++ b/src/utils/jj-utils.ts
@@ -62,3 +62,24 @@ export function formatCommitTitle(
     const offsetSuffix = commit.is_divergent ? `⧸${commit.change_id_offset}` : '';
     return `Commit: ${shortId}${offsetSuffix}`;
 }
+
+/**
+ * Checks if a commit can be squashed (i.e. is mutable, has exactly one parent, and that parent is mutable).
+ */
+export function canSquashCommit(commit: { is_immutable?: boolean; parents?: { is_immutable: boolean }[] }): boolean {
+    return !commit.is_immutable && !!commit.parents && commit.parents.length === 1 && !commit.parents[0].is_immutable;
+}
+
+/**
+ * Checks if a commit is mutable (not immutable).
+ */
+export function isMutableCommit(commit: { is_immutable?: boolean }): boolean {
+    return !commit.is_immutable;
+}
+
+/**
+ * Checks if a commit has any mutable parent (allowing absorb).
+ */
+export function canAbsorbCommit(commit: { parents?: { is_immutable: boolean }[] }): boolean {
+    return !!commit.parents && commit.parents.some((p) => !p.is_immutable);
+}

--- a/src/webview/utils/commit-utils.ts
+++ b/src/webview/utils/commit-utils.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { CommitAction, JjLogEntry } from '../../jj-types';
+import { canAbsorbCommit, canSquashCommit, isMutableCommit } from '../../utils/jj-utils';
 
 export interface CommitActionStates {
     newChild: boolean;
@@ -18,21 +19,22 @@ export interface CommitActionStates {
 export function computeCommitActions(
     commit: JjLogEntry,
     hiddenActions: Set<CommitAction>,
-    isImmutable: boolean,
+    _isImmutable: boolean,
     isSelected: boolean,
     selectionCount: number,
     hasImmutableSelection: boolean,
 ): { visibleActions: CommitActionStates; vscodeContext: Record<string, unknown> } {
     const visibleActions: CommitActionStates = {
         newChild: !hiddenActions.has('newChild'),
-        edit: !isImmutable && !commit.is_current_working_copy && !hiddenActions.has('edit'),
-        squash: !hiddenActions.has('squash') && commit.parents?.length === 1 && !commit.parents[0].is_immutable,
-        abandon: !isImmutable && !hiddenActions.has('abandon'),
+        edit: isMutableCommit(commit) && !commit.is_current_working_copy && !hiddenActions.has('edit'),
+        squash: !hiddenActions.has('squash') && canSquashCommit(commit),
+        abandon: isMutableCommit(commit) && !hiddenActions.has('abandon'),
     };
 
     const vscodeContext = {
         webviewSection: 'commit',
         'jj.isCurrentWorkingCopy': commit.is_current_working_copy,
+
         'jj.newChildVisible': visibleActions.newChild,
         'jj.editVisible': visibleActions.edit,
         'jj.squashVisible': visibleActions.squash,
@@ -42,24 +44,25 @@ export function computeCommitActions(
         changeId: commit.change_id,
 
         // Abandon, New Before, and New After supported on multi-selection, but also on unselected items
-        'jj.canAbandon': !isImmutable && (!isSelected || !hasImmutableSelection),
-        'jj.canNewBefore': !isImmutable && (!isSelected || !hasImmutableSelection),
+        'jj.canAbandon': isMutableCommit(commit) && (!isSelected || !hasImmutableSelection),
+        'jj.canNewBefore': isMutableCommit(commit) && (!isSelected || !hasImmutableSelection),
         'jj.canNewAfter': !isSelected || !hasImmutableSelection,
-        'jj.canUpload': !isImmutable && (!isSelected || !hasImmutableSelection),
+        'jj.canUpload': isMutableCommit(commit) && (!isSelected || !hasImmutableSelection),
 
         // Edit, Duplicate, and Absorb restricted to single-item context (or unselected item)
-        'jj.canEdit': !isImmutable && !commit.is_current_working_copy && (!isSelected || selectionCount <= 1),
+        'jj.canEdit':
+            isMutableCommit(commit) && !commit.is_current_working_copy && (!isSelected || selectionCount <= 1),
         'jj.canDuplicate': !isSelected || selectionCount <= 1,
         'jj.canNewChild': !isSelected || selectionCount <= 1,
 
         // Rebase source must be mutable, and we rebase ONTO the current selection
-        'jj.canRebaseOnto': !isImmutable && !isSelected && selectionCount > 0,
+        'jj.canRebaseOnto': isMutableCommit(commit) && !isSelected && selectionCount > 0,
 
         // Merge requires multiple items selected
         'jj.canMerge': isSelected && selectionCount > 1,
 
         // Absorb requires at least one mutable parent and single-item context
-        'jj.canAbsorb': commit.parents?.some((ref) => !ref.is_immutable) && (!isSelected || selectionCount <= 1),
+        'jj.canAbsorb': canAbsorbCommit(commit) && (!isSelected || selectionCount <= 1),
 
         preventDefaultContextMenuItems: true,
     };


### PR DESCRIPTION
Unifies the computation of SCM resource group and state context values by using space-separated capability flags (such as 'jj.resource.allowRestore') rather than monolithic state strings. Introduces a shared 'createJjResourceState' utility to construct these states, and updates SCM command 'when' clauses in package.json to match specific capabilities via regex pattern matching. Also cleans up and deduplicates commit status checks (absorb, squash, edit) across the SCM provider and log webview.

Also adds retore to conflicted files.

Fixes #290