### PR TITLE
fix: swap ordering of squash ancestor and squash parent group actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -751,12 +751,12 @@
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowAbandon\\b/"
                 },
                 {
-                    "command": "jj-view.squashRevisionIntoParent",
+                    "command": "jj-view.squashRevisionIntoAncestor",
                     "group": "inline@3",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
                 },
                 {
-                    "command": "jj-view.squashRevisionIntoAncestor",
+                    "command": "jj-view.squashRevisionIntoParent",
                     "group": "inline@4",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
                 },


### PR DESCRIPTION
Swaps the ordering of "Squash Revision into Ancestor" and "Squash Revision into Parent" inline SCM resource group commands in package.json. "Squash Revision into Ancestor" is now mapped to `inline@3`, while "Squash Revision into Parent" is mapped to `inline@4`.