### PR TITLE
feat(gerrit): auto-recover from failed host detection

### DIFF
--- a/src/gerrit-service.ts
+++ b/src/gerrit-service.ts
@@ -59,18 +59,20 @@ export class GerritService implements vscode.Disposable {
     private _initPromise: Promise<void>;
 
     private lastRefreshTime: number = 0;
+    private lastDetectionTime = 0;
+    private detectPromise: Promise<void> | undefined;
 
     constructor(
         private workspaceRoot: string,
         private jjService: JjService,
         private outputChannel?: vscode.OutputChannel, // Optional for easier testing
     ) {
-        this._initPromise = this.detectGerritHost();
+        this._initPromise = this.detectGerritHost(true);
 
         // Listen for config changes
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration('jj-view.gerrit')) {
-                this.detectGerritHost();
+                this.detectGerritHost(true);
             }
         });
 
@@ -153,126 +155,151 @@ export class GerritService implements vscode.Disposable {
         }
     }
 
-    private async detectGerritHost() {
+    public async detectGerritHost(force = false): Promise<void> {
+        if (!force && this._gerritHost) {
+            return;
+        }
+
+        const now = Date.now();
+        if (!force && now - this.lastDetectionTime < 30000) {
+            return;
+        }
+
+        if (this.detectPromise) {
+            return this.detectPromise;
+        }
+
+        this.detectPromise = (async () => {
+            this.lastDetectionTime = now;
+            await this._doDetectGerritHost();
+        })();
+
+        try {
+            await this.detectPromise;
+        } finally {
+            this.detectPromise = undefined;
+        }
+    }
+
+    private async _doDetectGerritHost() {
+        const oldHost = this._gerritHost;
+        let detectedHost: string | undefined;
+
         // 1. Check extension setting
         const config = vscode.workspace.getConfiguration('jj-view');
         const settingHost = config.get<string>('gerrit.host');
 
         if (settingHost) {
-            this._gerritHost = settingHost.replace(/\/$/, ''); // Remove trailing slash
-            return;
-        }
-
-        // 2. Check .gitreview file
-        try {
-            const gitreviewPath = path.join(this.workspaceRoot, '.gitreview');
-            if (fs.existsSync(gitreviewPath)) {
-                const content = await fs.promises.readFile(gitreviewPath, 'utf8');
-                const match = content.match(/host=(.+)/);
-                if (match?.[1]) {
-                    let host = match[1].trim();
-                    if (!host.startsWith('http')) {
-                        host = `https://${host}`;
-                    }
-                    this._gerritHost = host.replace(/\/$/, '');
-                    return;
-                }
-            }
-        } catch (e) {
-            console.error('Failed to parse .gitreview:', e);
-        }
-
-        // 3. Check git remotes via jj
-        try {
-            const remotes = await this.jjService.getGitRemotes();
-
-            // Prioritize 'origin', then 'gerrit', then others
-            // Find specific remotes if they exist
-            const origin = remotes.find((r) => r.name === 'origin');
-            const gerrit = remotes.find((r) => r.name === 'gerrit');
-
-            // Create a sorted list based on priority
-            const sortedRemotes = [];
-            if (origin) {
-                sortedRemotes.push(origin);
-            }
-            if (gerrit) {
-                sortedRemotes.push(gerrit);
-            }
-            // Add remaining
-            remotes.forEach((r) => {
-                if (r.name !== 'origin' && r.name !== 'gerrit') {
-                    sortedRemotes.push(r);
-                }
-            });
-
-            for (const { name, url } of sortedRemotes) {
-                this.outputChannel?.appendLine(`[GerritService] Checking remote '${name}' URL: '${url}'`);
-
-                let host: string | undefined;
-
-                if (url.includes('googlesource.com') || url.includes('/gerrit/')) {
-                    host = url;
-                } else if (url.startsWith('sso://')) {
-                    // Handle sso://chromium/chromium/src.git -> https://chromium.googlesource.com/chromium/src.git
-                    // Format: sso://<host-part>/<path>
-                    // We'll treat the first segment as the subdomain for googlesource.com
-                    const match = url.match(/sso:\/\/([^/]+)\/(.+)/);
-                    if (match) {
-                        host = `https://${match[1]}.googlesource.com/${match[2]}`;
-                    }
-                }
-
-                if (host) {
-                    // Handle SSH: ssh://user@host:port/path -> https://host
-                    if (host.startsWith('ssh://')) {
-                        const match = host.match(/ssh:\/\/([^@]+@)?([^:/]+)(:\d+)?\/(.+)/);
-                        if (match) {
-                            host = `https://${match[2]}`;
+            detectedHost = settingHost.replace(/\/$/, ''); // Remove trailing slash
+        } else {
+            // 2. Check .gitreview file
+            try {
+                const gitreviewPath = path.join(this.workspaceRoot, '.gitreview');
+                if (fs.existsSync(gitreviewPath)) {
+                    const content = await fs.promises.readFile(gitreviewPath, 'utf8');
+                    const match = content.match(/host=(.+)/);
+                    if (match?.[1]) {
+                        let host = match[1].trim();
+                        if (!host.startsWith('http')) {
+                            host = `https://${host}`;
                         }
+                        detectedHost = host.replace(/\/$/, '');
                     }
+                }
+            } catch (e) {
+                console.error('Failed to parse .gitreview:', e);
+            }
 
-                    if (host.endsWith('.git')) {
-                        host = host.slice(0, -4);
+            // 3. Check git remotes via jj
+            if (!detectedHost) {
+                try {
+                    const remotes = await this.jjService.getGitRemotes();
+
+                    // Prioritize 'origin', then 'gerrit', then others
+                    const origin = remotes.find((r) => r.name === 'origin');
+                    const gerrit = remotes.find((r) => r.name === 'gerrit');
+
+                    const sortedRemotes = [];
+                    if (origin) {
+                        sortedRemotes.push(origin);
                     }
+                    if (gerrit) {
+                        sortedRemotes.push(gerrit);
+                    }
+                    remotes.forEach((r) => {
+                        if (r.name !== 'origin' && r.name !== 'gerrit') {
+                            sortedRemotes.push(r);
+                        }
+                    });
 
-                    // For googlesource.com, extract origin or convert to https
-                    if (host.includes('googlesource.com')) {
-                        try {
-                            const urlObj = new URL(host);
-                            host = urlObj.origin;
-                        } catch {
-                            if (!host.startsWith('http')) {
-                                const match = host.match(/([a-zA-Z0-9-]+\.googlesource\.com)/);
+                    for (const { name, url } of sortedRemotes) {
+                        this.outputChannel?.appendLine(`[GerritService] Checking remote '${name}' URL: '${url}'`);
+
+                        let host: string | undefined;
+
+                        if (url.includes('googlesource.com') || url.includes('/gerrit/')) {
+                            host = url;
+                        } else if (url.startsWith('sso://')) {
+                            const match = url.match(/sso:\/\/([^/]+)\/(.+)/);
+                            if (match) {
+                                host = `https://${match[1]}.googlesource.com/${match[2]}`;
+                            }
+                        }
+
+                        if (host) {
+                            if (host.startsWith('ssh://')) {
+                                const match = host.match(/ssh:\/\/([^@]+@)?([^:/]+)(:\d+)?\/(.+)/);
                                 if (match) {
-                                    host = `https://${match[1]}`;
+                                    host = `https://${match[2]}`;
                                 }
+                            }
+
+                            if (host.endsWith('.git')) {
+                                host = host.slice(0, -4);
+                            }
+
+                            if (host.includes('googlesource.com')) {
+                                try {
+                                    const urlObj = new URL(host);
+                                    host = urlObj.origin;
+                                } catch {
+                                    if (!host.startsWith('http')) {
+                                        const match = host.match(/([a-zA-Z0-9-]+\.googlesource\.com)/);
+                                        if (match) {
+                                            host = `https://${match[1]}`;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (host.includes('googlesource.com') && !host.includes('-review')) {
+                                host = host.replace('.googlesource.com', '-review.googlesource.com');
+                            }
+
+                            if (await this.probeGerritHost(host)) {
+                                detectedHost = host;
+                                break;
+                            } else {
+                                this.outputChannel?.appendLine(`[GerritService] Probe failed for host: ${host}`);
                             }
                         }
                     }
-
-                    // Append -review if on googlesource
-                    if (host.includes('googlesource.com') && !host.includes('-review')) {
-                        host = host.replace('.googlesource.com', '-review.googlesource.com');
-                    }
-
-                    // Verify if it is a Gerrit host
-                    if (await this.probeGerritHost(host)) {
-                        this._gerritHost = host;
-                        this.outputChannel?.appendLine(`[GerritService] Detected host: ${this._gerritHost}`);
-                        this._onDidUpdate.fire(); // Notify listeners that we are now enabled
-                        return;
-                    } else {
-                        this.outputChannel?.appendLine(`[GerritService] Probe failed for host: ${host}`);
-                    }
+                } catch (e) {
+                    this.outputChannel?.appendLine(`[GerritService] Failed to detect git remotes: ${e}`);
                 }
             }
-        } catch (e) {
-            this.outputChannel?.appendLine(`[GerritService] Failed to detect git remotes: ${e}`);
         }
 
-        this._gerritHost = undefined;
-        this.outputChannel?.appendLine('[GerritService] No Gerrit host detected.');
+        this._gerritHost = detectedHost;
+        if (this._gerritHost) {
+            this.outputChannel?.appendLine(`[GerritService] Detected host: ${this._gerritHost}`);
+        } else {
+            this.outputChannel?.appendLine('[GerritService] No Gerrit host detected.');
+        }
+
+        if (this._gerritHost !== oldHost) {
+            this._onDidUpdate.fire();
+        }
     }
 
     private async probeGerritHost(host: string): Promise<boolean> {
@@ -300,6 +327,9 @@ export class GerritService implements vscode.Disposable {
     }
 
     public async isGerrit(): Promise<boolean> {
+        if (!this._gerritHost) {
+            await this.detectGerritHost();
+        }
         return !!this._gerritHost;
     }
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -282,6 +282,10 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             return;
         }
         if (!this._gerrit.isEnabled) {
+            await this._gerrit.detectGerritHost();
+            // Since detectGerritHost() fires onDidUpdate if a host is detected,
+            // that event listener has already triggered a concurrent refreshGerrit().
+            // We return early here to avoid duplicate parallel fetches.
             return;
         }
 

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -11,6 +11,7 @@ import { GerritService } from '../gerrit-service';
 import { JjService } from '../jj-service';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
 import { TestRepo } from './test-repo';
+import { accessPrivate, asMock, exposePrivate } from './test-utils';
 
 // Mock VS Code
 const mockConfig = {
@@ -58,13 +59,13 @@ describe('GerritService Detection', () => {
         repo.init();
         mockConfig.get.mockReset();
 
-        mockOnDidChangeWindowState = vscode.window.onDidChangeWindowState as unknown as ReturnType<typeof vi.fn>;
+        mockOnDidChangeWindowState = asMock(vscode.window.onDidChangeWindowState);
         mockOnDidChangeWindowState.mockReset();
         mockOnDidChangeWindowState.mockReturnValue({ dispose: vi.fn() });
 
         // Default: allow host probing to succeed in tests
         vi.spyOn(
-            GerritService.prototype as unknown as { probeGerritHost(h: string): Promise<boolean> },
+            exposePrivate<{ probeGerritHost(h: string): Promise<boolean> }>(GerritService.prototype),
             'probeGerritHost',
         ).mockResolvedValue(true);
 
@@ -86,7 +87,7 @@ describe('GerritService Detection', () => {
 
     // Helper to access private property without using 'any'
     function getGerritHost(srv: GerritService): string | undefined {
-        return (srv as unknown as { _gerritHost: string | undefined })._gerritHost;
+        return accessPrivate<string | undefined>(srv, '_gerritHost');
     }
 
     test('Detects from extension setting (highest priority)', async () => {
@@ -774,6 +775,133 @@ describe('GerritService Detection', () => {
         expect(updateCount).toBe(2);
 
         disposable.dispose();
+
+        vi.useRealTimers();
+    });
+
+    test('detectGerritHost is rate-limited and coalesced', async () => {
+        vi.useFakeTimers();
+
+        // Start with no config so detection fails
+        mockConfig.get.mockReturnValue(undefined);
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+        expect(service.isEnabled).toBe(false);
+
+        // Spy on public jjService.getGitRemotes
+        const getGitRemotesSpy = vi.spyOn(jjService, 'getGitRemotes');
+
+        // Advance timers by 31 seconds to bypass rate limit from constructor detection
+        await vi.advanceTimersByTimeAsync(31000);
+
+        // Call detectGerritHost - should attempt detection because rate limit has passed
+        await service.detectGerritHost();
+        expect(getGitRemotesSpy).toHaveBeenCalledTimes(1);
+
+        // Call detectGerritHost again immediately - should NOT run due to 30s limit
+        await service.detectGerritHost();
+        expect(getGitRemotesSpy).toHaveBeenCalledTimes(1);
+
+        // Call with force = true - should run regardless of time limit
+        await service.detectGerritHost(true);
+        expect(getGitRemotesSpy).toHaveBeenCalledTimes(2);
+
+        // Advance timers by 31 seconds - should now run again
+        await vi.advanceTimersByTimeAsync(31000);
+        await service.detectGerritHost();
+        expect(getGitRemotesSpy).toHaveBeenCalledTimes(3);
+
+        // Test coalescing: call multiple times in parallel.
+        // We mock getGitRemotes to return a promise that resolves slowly.
+        let resolveRemotes: (value: { name: string; url: string }[]) => void = () => {};
+        const slowRemotesPromise = new Promise<{ name: string; url: string }[]>((resolve) => {
+            resolveRemotes = resolve;
+        });
+        getGitRemotesSpy.mockImplementation(() => slowRemotesPromise);
+
+        // Advance timers past rate limit first
+        await vi.advanceTimersByTimeAsync(31000);
+
+        const p1 = service.detectGerritHost();
+        const p2 = service.detectGerritHost();
+        const p3 = service.detectGerritHost(true); // force doesn't bypass active coalesced promise if already running
+
+        resolveRemotes([]);
+        await Promise.all([p1, p2, p3]);
+
+        // getGitRemotes should only be called once for these parallel invocations
+        expect(getGitRemotesSpy).toHaveBeenCalledTimes(4);
+
+        vi.useRealTimers();
+    });
+
+    test('detectGerritHost fires onDidUpdate only when host status changes', async () => {
+        // Start disabled
+        mockConfig.get.mockReturnValue(undefined);
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+        expect(service.isEnabled).toBe(false);
+
+        let updateCount = 0;
+        const disposable = service.onDidUpdate(() => {
+            updateCount++;
+        });
+
+        // Try detecting, still fails, should not fire
+        await service.detectGerritHost(true);
+        expect(updateCount).toBe(0);
+
+        // Set config so it succeeds
+        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        await service.detectGerritHost(true);
+        expect(service.isEnabled).toBe(true);
+        expect(updateCount).toBe(1);
+
+        // Detect again with same host, should not fire
+        await service.detectGerritHost(true);
+        expect(updateCount).toBe(1);
+
+        // Change config back to undefined, should fire when disabled
+        mockConfig.get.mockReturnValue(undefined);
+        await service.detectGerritHost(true);
+        expect(service.isEnabled).toBe(false);
+        expect(updateCount).toBe(2);
+
+        disposable.dispose();
+    });
+
+    test('isGerrit triggers detectGerritHost when host is not set', async () => {
+        vi.useFakeTimers();
+
+        // Start disabled
+        mockConfig.get.mockReturnValue(undefined);
+        service = new GerritService(repo.path, jjService);
+        await service.awaitReady();
+        expect(service.isEnabled).toBe(false);
+
+        const detectSpy = vi.spyOn(service, 'detectGerritHost');
+
+        // isGerrit should trigger detection
+        const result = await service.isGerrit();
+        expect(result).toBe(false);
+        expect(detectSpy).toHaveBeenCalledTimes(1);
+
+        // Now set gerrit url
+        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+
+        // Calling isGerrit should trigger detect again because _gerritHost is undefined and rate-limiting is not hit
+        // Since isGerrit() does not pass force=true, rate-limiting is active.
+        // Advance timers by 31 seconds to bypass rate limit naturally
+        await vi.advanceTimersByTimeAsync(31000);
+
+        const result2 = await service.isGerrit();
+        expect(result2).toBe(true);
+        expect(detectSpy).toHaveBeenCalledTimes(2);
+
+        // When it is enabled, calling isGerrit should be instant and not call detectGerritHost
+        const result3 = await service.isGerrit();
+        expect(result3).toBe(true);
+        expect(detectSpy).toHaveBeenCalledTimes(2); // Still 2
 
         vi.useRealTimers();
     });

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -8,7 +8,7 @@ import { JjService } from '../jj-service';
 import type { GerritClInfo, JjLogEntry } from '../jj-types';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
 import { TestRepo } from './test-repo';
-import { createMock } from './test-utils';
+import { createMock, exposePrivate } from './test-utils';
 
 // Mock VS Code configuration
 const mockConfig = {
@@ -49,7 +49,7 @@ describe('Gerrit Sync Verification', () => {
 
         // Allow host probing to succeed
         vi.spyOn(
-            GerritService.prototype as unknown as { probeGerritHost: (h: string) => Promise<boolean> },
+            exposePrivate<{ probeGerritHost(h: string): Promise<boolean> }>(GerritService.prototype),
             'probeGerritHost',
         ).mockResolvedValue(true);
 
@@ -447,10 +447,10 @@ describe('Gerrit Sync Verification', () => {
             });
 
             // Access private cache to populate it for structural check
-            const servicePriv = service as unknown as {
+            const servicePriv = exposePrivate<{
                 resolveCacheKey: (id: string) => string;
                 cache: Map<string, GerritClInfo>;
-            };
+            }>(service);
             vi.spyOn(servicePriv, 'resolveCacheKey').mockImplementation((id) => id);
             servicePriv.cache.set('IA', aCl);
             servicePriv.cache.set('IB', bCl);

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -28,3 +28,7 @@ export function accessPrivate<T = unknown>(obj: object, key: string): T {
 export function setPrivate(obj: object, key: string, value: unknown): void {
     (obj as Record<string, unknown>)[key] = value;
 }
+
+export function exposePrivate<T>(obj: object): T {
+    return obj as unknown as T;
+}

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -92,6 +92,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
                 return { dispose: () => {} };
             },
             isEnabled: false,
+            detectGerritHost: () => Promise.resolve(),
             startPolling: () => {},
             stopPolling: () => {},
             dispose: () => {},

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -57,6 +57,7 @@ suite('Webview Initialization Integration Test', () => {
         const gerritService = createMock<GerritService>({
             onDidUpdate: () => ({ dispose: () => {} }),
             isEnabled: false,
+            detectGerritHost: () => Promise.resolve(),
             startPolling: () => {},
             stopPolling: () => {},
             dispose: () => {},

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -57,6 +57,7 @@ suite('Webview Selection Integration Test', () => {
                 return { dispose: () => {} };
             },
             isEnabled: false,
+            detectGerritHost: () => Promise.resolve(),
             startPolling: () => {},
             stopPolling: () => {},
             dispose: () => {},

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -68,6 +68,7 @@ suite('Webview Visibility Integration Test', () => {
         const gerritService = createMock<GerritService>({
             onDidUpdate: () => ({ dispose: () => {} }),
             isEnabled: false,
+            detectGerritHost: () => Promise.resolve(),
             startPolling: () => {},
             stopPolling: () => {},
             dispose: () => {},


### PR DESCRIPTION
If Gerrit detection fails on startup (e.g. because of network issues), the extension now automatically tries to detect the host again when you manually refresh the webview or when checking Gerrit status. To keep this efficient and avoid spamming network requests, host detection is now rate-limited to once every 30 seconds and parallel detection calls are coalesced.

Includes unit tests for the new rate-limiting and coalescing logic, and updates integration mocks to match.

Fixes #301