### PR TITLE
feat: centralize authentication management for code forge providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,30 @@ The extension automatically refreshes the view when:
 - `jj` operations are performed via the CLI (external changes are polled).
 - You switch focus back to the VS Code window.
 
+## 🌐 Code Forge Integrations
+
+**JJ View** integrates with popular code forge providers to bring your pull request/change reviews directly into the VS Code interface:
+
 ### 🤖 Gerrit Integration
+- Displays the current **Gerrit Status** (e.g., Active, Merged) and provides a click-to-open link to the CL.
+- Configuration: Set `jj-view.gerrit.host` and `jj-view.gerrit.project` if they aren't automatically detected from your remotes or `.gitreview`.
 
-If you use Gerrit, **JJ View** provides enhanced integration:
+### 🐱 GitHub Integration
+- Displays the **PR status** (e.g., Open, Merged, Draft), checks for mergeability, and shows the count of unresolved comments.
+- Supports uploading changes directly via SCM actions.
+- Automatically detected from your Git remote URL.
 
-- Shows the current **Gerrit Status** (e.g., Active, Merged) and provides a link to the CL.
-- Configuration: Set `jj-view.gerrit.host` and `jj-view.gerrit.project` if they aren't automatically detected.
+### 🦊 GitLab Integration
+- Displays the **Merge Request status** (e.g., Open, Merged, Draft), checks for mergeability, and shows the count of unresolved comments.
+- Supports uploading changes directly via SCM actions.
+- Auto-detected from Git remote URLs (including self-hosted instances). Set `jj-view.gitlab.host` if you use a custom self-hosted instance.
+
+### 🔑 Authentication
+
+Configuring credentials (such as OAuth tokens or Personal Access Tokens) for GitHub and GitLab is seamless:
+- Integrates with VS Code's built-in OAuth flows or allows you to securely store a Personal Access Token (PAT).
+- Automatically prompts you when authentication is required to fetch status for private repositories.
+- Provides a **Manage Code Forge Authentication** option in the Source Control title bar to easily update tokens, disable/enable auth prompts, or reset preferences.
 
 ## Extension Settings
 

--- a/package.json
+++ b/package.json
@@ -460,6 +460,17 @@
                 "command": "jj-view.toggleCommitAction.abandon.off",
                 "title": "○ Abandon",
                 "category": "JJ View"
+            },
+            {
+                "command": "jj-view.manageAuth",
+                "title": "Manage Code Forge Authentication",
+                "category": "JJ View",
+                "icon": "$(key)"
+            },
+            {
+                "command": "jj-view.gitlab.enterPat",
+                "title": "Enter GitLab Personal Access Token (PAT)",
+                "category": "JJ View"
             }
         ],
         "keybindings": [
@@ -736,6 +747,11 @@
                 {
                     "command": "jj-view.refresh",
                     "group": "navigation@10"
+                },
+                {
+                    "command": "jj-view.manageAuth",
+                    "group": "navigation@0",
+                    "when": "jj.codeForgeAuthManageable"
                 }
             ],
             "scm/resourceGroup/context": [

--- a/src/code-forge-auth.ts
+++ b/src/code-forge-auth.ts
@@ -1,0 +1,509 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import type { AuthManageItem } from './code-forge-provider';
+
+export type AuthToken = string;
+
+export interface ExtensionInstaller {
+    extensionId: string;
+    extensionName: string;
+    providerName: string;
+}
+
+export type AuthResult =
+    | { status: 'success'; token: AuthToken }
+    | { status: 'cancelled' }
+    | { status: 'failure'; error: unknown };
+
+export interface AlternativeChoice {
+    label: string;
+    /**
+     * Executes the alternative choice action.
+     * Should return an AuthResult indicating success, cancellation, or failure.
+     */
+    execute: () => Promise<AuthResult>;
+}
+
+export class CodeForgeAuthManager {
+    private promptedThisSession = new Set<string>();
+    private unavailableProviders = new Set<string>();
+    private registeredProviderIds = new Set<string>();
+
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly outputChannel?: vscode.OutputChannel,
+    ) {}
+
+    public registerProvider(providerId: string): void {
+        this.registeredProviderIds.add(providerId);
+    }
+
+    public get secrets(): vscode.SecretStorage {
+        return this.context.secrets;
+    }
+
+    public isAuthSkipped(providerId: string): boolean {
+        this.registerProvider(providerId);
+        return this.context.globalState.get<boolean>(`jj-view.auth.skipped.${providerId}`, false);
+    }
+
+    public async setAuthSkipped(providerId: string, skipped: boolean): Promise<void> {
+        this.registerProvider(providerId);
+        await this.context.globalState.update(`jj-view.auth.skipped.${providerId}`, skipped);
+        if (!skipped) {
+            this.promptedThisSession.delete(providerId);
+        }
+        this.outputChannel?.appendLine(
+            `[CodeForgeAuthManager] Auth skipped state for '${providerId}' set to: ${skipped}`,
+        );
+    }
+
+    public hasPromptedThisSession(providerId: string): boolean {
+        this.registerProvider(providerId);
+        return this.promptedThisSession.has(providerId);
+    }
+
+    public markPromptedThisSession(providerId: string): void {
+        this.registerProvider(providerId);
+        this.promptedThisSession.add(providerId);
+    }
+
+    public isProviderUnavailable(providerId: string): boolean {
+        this.registerProvider(providerId);
+        return this.unavailableProviders.has(providerId);
+    }
+
+    public setProviderUnavailable(providerId: string, unavailable: boolean): void {
+        this.registerProvider(providerId);
+        if (unavailable) {
+            this.unavailableProviders.add(providerId);
+        } else {
+            this.unavailableProviders.delete(providerId);
+        }
+    }
+
+    public async resetAllChoices(): Promise<void> {
+        this.promptedThisSession.clear();
+        this.unavailableProviders.clear();
+        const promises = Array.from(this.registeredProviderIds).map((id) => this.setAuthSkipped(id, false));
+        await Promise.all(promises);
+        this.outputChannel?.appendLine(`[CodeForgeAuthManager] Reset all authentication choices.`);
+    }
+
+    /**
+     * Checks whether an active OAuth session exists for the given provider.
+     * Uses a short timeout (500ms) so callers stay responsive (e.g., UI menus).
+     * Also updates the `isProviderUnavailable` cache so subsequent calls are instant.
+     */
+    public async hasOAuthSession(providerId: string, scopes: string[]): Promise<boolean> {
+        if (this.isProviderUnavailable(providerId)) {
+            return false;
+        }
+        try {
+            const session = await this.withTimeout(
+                Promise.resolve(vscode.authentication.getSession(providerId, scopes, { silent: true })),
+                500,
+                `${providerId} session check timed out`,
+            );
+            if (session) {
+                // Only clear the unavailable flag when we actually get a session back.
+                // If getSession returns undefined it could mean "provider registered but
+                // not signed in" OR "provider not registered" — we can't distinguish.
+                this.setProviderUnavailable(providerId, false);
+                return true;
+            }
+            return false;
+        } catch (e) {
+            const errorStr = String(e);
+            // Treat both "not registered" errors AND timeouts as "provider unavailable".
+            // A timeout means the provider extension is likely missing or not yet activated.
+            const isUnregistered =
+                errorStr.includes('not registered') ||
+                errorStr.includes('No authentication provider') ||
+                errorStr.includes('session check timed out');
+            if (isUnregistered) {
+                this.setProviderUnavailable(providerId, true);
+            }
+            return false;
+        }
+    }
+
+    private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, rejectReason: string): Promise<T> {
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(rejectReason)), timeoutMs);
+        });
+        // Attach a no-op catch handler to prevent unhandled promise rejections if
+        // the timeout triggers first and the caller's promise rejects in the background.
+        promise.catch(() => {});
+        try {
+            return await Promise.race([promise, timeoutPromise]);
+        } finally {
+            if (timer) {
+                clearTimeout(timer);
+            }
+        }
+    }
+
+    public async getSessionToken(
+        providerId: string,
+        options: {
+            scopes: string[];
+            envTokenKey: string;
+            secretTokenKey?: string;
+            promptMessage: string;
+            signInLabel?: string;
+            prompt?: boolean;
+            alternativeChoice?: AlternativeChoice;
+            shouldSkipPrompt?: () => boolean;
+            extensionInstaller?: ExtensionInstaller;
+        },
+    ): Promise<AuthToken | undefined> {
+        this.registerProvider(providerId);
+
+        // 1. Check environment variables
+        if (process.env[options.envTokenKey]) {
+            return process.env[options.envTokenKey];
+        }
+
+        // 2. Check stored token in secrets
+        if (options.secretTokenKey) {
+            try {
+                const storedToken = await this.secrets.get(options.secretTokenKey);
+                if (storedToken) {
+                    return storedToken;
+                }
+            } catch (err) {
+                this.outputChannel?.appendLine(
+                    `[CodeForgeAuthManager] Failed to read token from secrets for '${providerId}': ${err}`,
+                );
+            }
+        }
+
+        // 3. Check if auth is skipped
+        if (this.isAuthSkipped(providerId)) {
+            return undefined;
+        }
+
+        const prompt = options.prompt ?? true;
+
+        // Always try silently first to see if an active session exists
+        try {
+            const silentPromise = Promise.resolve(
+                vscode.authentication.getSession(providerId, options.scopes, { silent: true }),
+            );
+            const session = await this.withTimeout(
+                silentPromise,
+                1000,
+                `${providerId} authentication silent check timed out`,
+            );
+            this.setProviderUnavailable(providerId, false);
+            if (session) {
+                return session.accessToken;
+            }
+        } catch (e) {
+            const errorStr = String(e);
+            const isUnregistered =
+                errorStr.includes('not registered') || errorStr.includes('No authentication provider');
+
+            if (isUnregistered) {
+                this.setProviderUnavailable(providerId, true);
+                this.outputChannel?.appendLine(
+                    `[CodeForgeAuthManager] ${providerId} authentication provider is not available in VS Code. Using unauthenticated requests only.`,
+                );
+                return undefined;
+            } else {
+                this.outputChannel?.appendLine(
+                    `[CodeForgeAuthManager] Failed to get OAuth token silently for ${providerId}: ${errorStr}`,
+                );
+            }
+        }
+
+        if (!prompt) {
+            return undefined;
+        }
+
+        // Check if provider-specific checks indicate we should skip the prompt
+        if (options.shouldSkipPrompt?.()) {
+            return undefined;
+        }
+
+        // Prompting flow
+        if (this.hasPromptedThisSession(providerId)) {
+            return undefined;
+        }
+        this.markPromptedThisSession(providerId);
+
+        const signInLabel = options.signInLabel ?? 'Sign In';
+        const skipLabel = "Don't Sign In (Skip)";
+        const choices = [signInLabel];
+        if (options.alternativeChoice) {
+            choices.push(options.alternativeChoice.label);
+        }
+        choices.push(skipLabel);
+
+        try {
+            const choice = await vscode.window.showWarningMessage(options.promptMessage, ...choices);
+            if (choice === signInLabel) {
+                const session = await vscode.authentication.getSession(providerId, options.scopes, {
+                    createIfNone: true,
+                });
+                return session?.accessToken;
+            } else if (options.alternativeChoice && choice === options.alternativeChoice.label) {
+                const result = await options.alternativeChoice.execute();
+                return result.status === 'success' ? result.token : undefined;
+            } else if (choice === skipLabel) {
+                await this.setAuthSkipped(providerId, true);
+            }
+        } catch (e) {
+            this.outputChannel?.appendLine(
+                `[CodeForgeAuthManager] Failed to prompt or sign in for ${providerId}: ${e}`,
+            );
+            return (await this.handleAuthError(providerId, e, {
+                extensionInstaller: options.extensionInstaller,
+                alternativeChoice: options.alternativeChoice,
+            })) as string | undefined;
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Helper to perform an OAuth sign in flow.
+     * Checks if the required extension is installed (if extensionInstaller is provided).
+     * Attempts to acquire the OAuth session.
+     * On success, invokes the success callback (e.g. to clear cache).
+     * On error, delegates to handleAuthError.
+     */
+    public async performOAuthSignIn(
+        providerId: string,
+        scopes: string[],
+        options: {
+            hasOAuth: boolean;
+            clearCache: () => void;
+            extensionInstaller?: ExtensionInstaller;
+            alternativeChoice?: AlternativeChoice;
+        },
+    ): Promise<void> {
+        if (options.extensionInstaller) {
+            const hasExtension = !!vscode.extensions.getExtension(options.extensionInstaller.extensionId);
+            if (!hasExtension) {
+                await this.handleAuthError(providerId, new Error('No authentication provider found'), {
+                    extensionInstaller: options.extensionInstaller,
+                    alternativeChoice: options.alternativeChoice,
+                });
+                return;
+            }
+        }
+        try {
+            const session = await vscode.authentication.getSession(providerId, scopes, {
+                createIfNone: true,
+                forceNewSession: options.hasOAuth ? true : undefined,
+            });
+            if (session) {
+                const providerName =
+                    options.extensionInstaller?.providerName ||
+                    providerId.charAt(0).toUpperCase() + providerId.slice(1);
+                vscode.window.showInformationMessage(`Successfully authenticated with ${providerName}.`);
+                options.clearCache();
+            }
+        } catch (e) {
+            await this.handleAuthError(providerId, e, {
+                extensionInstaller: options.extensionInstaller,
+                alternativeChoice: options.alternativeChoice,
+            });
+        }
+    }
+
+    public async handleAuthError(
+        providerId: string,
+        error: unknown,
+        options?: {
+            extensionInstaller?: ExtensionInstaller;
+            alternativeChoice?: AlternativeChoice;
+        },
+    ): Promise<AuthToken | undefined> {
+        const errorStr = String(error);
+        const isCancelled = errorStr.toLowerCase().includes('cancelled') || errorStr.toLowerCase().includes('canceled');
+        if (isCancelled) {
+            return undefined;
+        }
+
+        const isUnregistered =
+            errorStr.includes('not registered') ||
+            errorStr.includes('timed out waiting') ||
+            errorStr.includes('No authentication provider');
+
+        if (isUnregistered && options?.extensionInstaller) {
+            const { providerName, extensionName, extensionId } = options.extensionInstaller;
+            const installAction = `Install ${providerName} Extension`;
+            const patAction = options.alternativeChoice ? options.alternativeChoice.label : 'Enter PAT';
+            const choices = [installAction];
+            if (options.alternativeChoice) {
+                choices.push(patAction);
+            }
+
+            const choice = await vscode.window.showErrorMessage(
+                `${providerName} authentication provider is not available. Please install the official '${extensionName}' extension or configure a Personal Access Token (PAT).`,
+                ...choices,
+            );
+            if (choice === installAction) {
+                vscode.commands.executeCommand('workbench.extensions.search', extensionId);
+            } else if (options.alternativeChoice && choice === patAction) {
+                const result = await options.alternativeChoice.execute();
+                return result.status === 'success' ? result.token : undefined;
+            }
+        } else {
+            vscode.window.showErrorMessage(`Authentication failed for ${providerId}: ${error}`);
+        }
+        return undefined;
+    }
+
+    /**
+     * Generates custom authentication management items for a provider.
+     * Consolidates condition checking, item mapping, and action executions for OAuth,
+     * entering/updating PATs, and clearing PATs.
+     */
+    public async getAuthManageItems(
+        providerId: string,
+        options: {
+            displayName: string;
+            scopes: string[];
+            envTokenKey: string;
+            secretTokenKey: string;
+            hasAuth: () => Promise<boolean>;
+            clearCache: () => void;
+            promptForPat: () => Promise<AuthResult>;
+            extensionInstaller?: ExtensionInstaller;
+        },
+    ): Promise<AuthManageItem[]> {
+        let hasPat = false;
+        try {
+            hasPat = !!(await this.secrets.get(options.secretTokenKey));
+        } catch {}
+        const hasEnv = !!process.env[options.envTokenKey];
+        const hasOAuth = !hasPat && !hasEnv && (await options.hasAuth());
+        const items: AuthManageItem[] = [];
+
+        items.push({
+            label: hasOAuth ? '$(sign-in) Sign In Again (OAuth)' : '$(sign-in) Sign In (OAuth)',
+            description: hasOAuth
+                ? `Authenticate again or switch ${options.displayName} accounts`
+                : `Authenticate with ${options.displayName} using OAuth`,
+            execute: async () => {
+                await this.performOAuthSignIn(providerId, options.scopes, {
+                    hasOAuth,
+                    clearCache: options.clearCache,
+                    extensionInstaller: options.extensionInstaller,
+                    alternativeChoice: {
+                        label: 'Enter PAT',
+                        execute: options.promptForPat,
+                    },
+                });
+            },
+        });
+
+        items.push({
+            label: hasPat ? '$(key) Update Personal Access Token (PAT)' : '$(key) Enter Personal Access Token (PAT)',
+            description: hasPat
+                ? 'Update configured Personal Access Token'
+                : `Configure a personal access token for ${options.displayName}`,
+            execute: async () => {
+                await options.promptForPat();
+            },
+        });
+
+        if (hasPat) {
+            items.push({
+                label: '$(trash) Clear Personal Access Token (PAT)',
+                description: 'Delete the configured Personal Access Token',
+                execute: async () => {
+                    try {
+                        await this.secrets.delete(options.secretTokenKey);
+                        vscode.window.showInformationMessage(
+                            `Successfully cleared stored ${options.displayName} Personal Access Token.`,
+                        );
+                        options.clearCache();
+                    } catch (e) {
+                        vscode.window.showErrorMessage(
+                            `Failed to clear ${options.displayName} Personal Access Token: ${e}`,
+                        );
+                    }
+                },
+            });
+        }
+
+        return items;
+    }
+
+    /**
+     * Clears a stored PAT from SecretStorage when a 401 Unauthorized response is received,
+     * provided the token in use matches the stored one. This prevents the extension from
+     * repeatedly retrying with a known-invalid token. Tokens supplied via environment
+     * variables are never deleted (the env var would take precedence on the next request).
+     */
+    public async clearInvalidToken(options: {
+        providerId: string;
+        secretTokenKey: string;
+        currentToken: string;
+        envTokenKey: string;
+    }): Promise<void> {
+        if (process.env[options.envTokenKey]) {
+            // The token came from an env var — don't touch SecretStorage.
+            return;
+        }
+        try {
+            const storedToken = await this.secrets.get(options.secretTokenKey);
+            if (storedToken === options.currentToken) {
+                this.outputChannel?.appendLine(
+                    `[CodeForgeAuthManager] Clearing invalid stored PAT for '${options.providerId}'...`,
+                );
+                await this.secrets.delete(options.secretTokenKey);
+            }
+        } catch (err) {
+            this.outputChannel?.appendLine(
+                `[CodeForgeAuthManager] Failed to delete token for '${options.providerId}': ${err}`,
+            );
+        }
+    }
+
+    /**
+     * Prompts the user to enter a Personal Access Token (PAT), stores it in secrets storage,
+     * logs success/failure, clears the provider's cache, and returns the result.
+     */
+    public async promptForPat(options: {
+        providerId: string;
+        displayName: string;
+        secretTokenKey: string;
+        prompt: string;
+        placeHolder: string;
+        clearCache: () => void;
+    }): Promise<AuthResult> {
+        const token = await vscode.window.showInputBox({
+            prompt: options.prompt,
+            placeHolder: options.placeHolder,
+            password: true,
+            ignoreFocusOut: true,
+        });
+
+        if (token === undefined || token.trim() === '') {
+            return { status: 'cancelled' };
+        }
+
+        try {
+            await this.secrets.store(options.secretTokenKey, token.trim());
+            this.outputChannel?.appendLine(`[${options.displayName}Provider] Personal Access Token saved successfully`);
+            options.clearCache();
+            return { status: 'success', token: token.trim() };
+        } catch (err) {
+            this.outputChannel?.appendLine(
+                `[${options.displayName}Provider] Secrets storage is not available to save PAT: ${err}`,
+            );
+            return { status: 'failure', error: err };
+        }
+    }
+}

--- a/src/code-forge-provider.ts
+++ b/src/code-forge-provider.ts
@@ -49,4 +49,14 @@ export interface CodeForgeProvider {
     deactivate(): void;
     /** Hook to clear provider's cached data */
     clearCache(): void;
+    /** Check if authentication is currently configured/available for this provider */
+    hasAuth?(): Promise<boolean>;
+    /** True if this provider supports managing authentication preferences/tokens */
+    readonly isAuthManageable?: boolean;
+    /** Returns custom authentication management items for this provider */
+    getAuthManageItems?(): Promise<AuthManageItem[]>;
+}
+
+export interface AuthManageItem extends vscode.QuickPickItem {
+    execute(): Promise<void>;
 }

--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -50,6 +50,7 @@ export class CodeForgeService implements vscode.Disposable {
             vscode.workspace.onDidChangeConfiguration((e) => {
                 if (
                     e.affectsConfiguration('jj-view.gerrit') ||
+                    e.affectsConfiguration('jj-view.github') ||
                     e.affectsConfiguration('jj-view.gitlab') ||
                     e.affectsConfiguration('jj-view.codeForge')
                 ) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@
  */
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { CodeForgeAuthManager } from './code-forge-auth';
 import type { CodeForgeProvider } from './code-forge-provider';
 import { CodeForgeRegistry } from './code-forge-registry';
 import { CodeForgeService } from './code-forge-service';
@@ -137,9 +138,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     const codeForgeRegistry = new CodeForgeRegistry();
     context.subscriptions.push(codeForgeRegistry);
+    const authManager = new CodeForgeAuthManager(context, outputChannel);
     const gerritProvider = new GerritProvider(jj, outputChannel);
-    const githubProvider = new GitHubProvider(outputChannel);
-    const gitlabProvider = new GitLabProvider(outputChannel, context.secrets);
+    const githubProvider = new GitHubProvider(authManager, outputChannel);
+    const gitlabProvider = new GitLabProvider(authManager, outputChannel);
 
     context.subscriptions.push(codeForgeRegistry.register(gerritProvider));
     context.subscriptions.push(codeForgeRegistry.register(githubProvider));
@@ -151,6 +153,9 @@ export function activate(context: vscode.ExtensionContext) {
     // Track active provider changes to update context keys
     const updateContextKeys = (provider: CodeForgeProvider | undefined) => {
         vscode.commands.executeCommand('setContext', 'jj.codeForgeActive', !!provider);
+        vscode.commands.executeCommand('setContext', 'jj.codeForgeProvider', provider?.id);
+        const manageable = !!provider?.isAuthManageable;
+        vscode.commands.executeCommand('setContext', 'jj.codeForgeAuthManageable', manageable);
         vscode.commands.executeCommand(
             'setContext',
             'jj.codeForgeTerm',
@@ -159,6 +164,77 @@ export function activate(context: vscode.ExtensionContext) {
     };
     updateContextKeys(codeForgeRegistry.getActive());
     context.subscriptions.push(codeForgeRegistry.onDidActiveProviderChange(updateContextKeys));
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.manageAuth', async () => {
+            const activeProvider = codeForgeRegistry.getActive();
+            if (!activeProvider) {
+                vscode.window.showErrorMessage('No active code forge provider detected.');
+                return;
+            }
+            if (!activeProvider.isAuthManageable) {
+                vscode.window.showInformationMessage(
+                    `Authentication management is not supported for ${activeProvider.displayName}.`,
+                );
+                return;
+            }
+
+            const providerId = activeProvider.id;
+            const isSkipped = authManager.isAuthSkipped(providerId);
+            const items: (vscode.QuickPickItem & { execute(): Promise<void> })[] = [];
+
+            if (!(await activeProvider.hasAuth?.())) {
+                items.push({
+                    label: isSkipped
+                        ? '$(pass) Enable Authentication Prompts'
+                        : '$(circle-slash) Disable Authentication Prompts',
+                    description: `Currently ${isSkipped ? 'disabled (skipped)' : 'enabled'} for ${activeProvider.displayName}`,
+                    execute: async () => {
+                        await authManager.setAuthSkipped(providerId, !isSkipped);
+                        vscode.window.showInformationMessage(
+                            `Authentication prompts for ${activeProvider.displayName} have been ${!isSkipped ? 'disabled' : 'enabled'}.`,
+                        );
+                        codeForgeService.forceRefresh();
+                    },
+                });
+            }
+
+            for (const item of (await activeProvider.getAuthManageItems?.()) ?? []) {
+                items.push({
+                    label: item.label,
+                    description: item.description,
+                    detail: item.detail,
+                    execute: () => item.execute(),
+                });
+            }
+
+            items.push({
+                label: '$(refresh) Reset All Preferences',
+                description: 'Reset auth preferences for all code forge providers',
+                execute: async () => {
+                    await authManager.resetAllChoices();
+                    vscode.window.showInformationMessage('Authentication preferences have been reset.');
+                    codeForgeService.forceRefresh();
+                },
+            });
+
+            const choice = await vscode.window.showQuickPick(items, {
+                placeHolder: `Manage Authentication for ${activeProvider.displayName}`,
+            });
+
+            if (!choice) {
+                return;
+            }
+
+            await choice.execute();
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand('jj-view.gitlab.enterPat', async () => {
+            await gitlabProvider.promptForPat();
+        }),
+    );
 
     const viewFileSystemProvider = new JjViewFileSystemProvider(jj);
     const editProvider = new JjEditFileSystemProvider(jj);

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
-import type { ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
+import type { AuthResult, CodeForgeAuthManager } from './code-forge-auth';
+import type { AuthManageItem, ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
@@ -54,16 +55,21 @@ export class GitHubProvider implements CodeForgeProvider {
     public readonly id = 'github';
     public readonly displayName = 'GitHub';
     public readonly changeTerm = 'PR' as const;
+    public readonly isAuthManageable = true;
 
     private cache = new Map<string, CodeForgeChangeInfo>();
     private owner: string | undefined;
     private repo: string | undefined;
-    private tokenRequested = false;
 
     private _onDidUpdate = new vscode.EventEmitter<void>();
     public readonly onDidUpdate = this._onDidUpdate.event;
 
-    constructor(private outputChannel?: vscode.OutputChannel) {}
+    constructor(
+        private readonly authManager: CodeForgeAuthManager,
+        private outputChannel?: vscode.OutputChannel,
+    ) {
+        this.authManager.registerProvider(this.id);
+    }
 
     public async detect(_workspaceRoot: string, remotes: GitRemote[]): Promise<boolean> {
         const remotePriority = (name: string): number => {
@@ -116,28 +122,6 @@ export class GitHubProvider implements CodeForgeProvider {
                 owner: match[1],
                 repo: match[2],
             };
-        }
-        return undefined;
-    }
-
-    private async getSessionToken(): Promise<string | undefined> {
-        if (process.env.JJ_VIEW_GITHUB_TOKEN) {
-            return process.env.JJ_VIEW_GITHUB_TOKEN;
-        }
-        try {
-            // Try silently first
-            let session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
-            if (session) {
-                return session.accessToken;
-            }
-            // If silent failed, prompt once
-            if (!this.tokenRequested) {
-                this.tokenRequested = true;
-                session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
-                return session?.accessToken;
-            }
-        } catch (e) {
-            this.outputChannel?.appendLine(`[GitHubProvider] Failed to get OAuth token: ${e}`);
         }
         return undefined;
     }
@@ -220,7 +204,7 @@ export class GitHubProvider implements CodeForgeProvider {
         const results = new Map<string, CodeForgeChangeInfo>();
         const token = await this.getSessionToken();
         if (!token) {
-            throw new Error('No GitHub session token available');
+            return results;
         }
         if (!this.owner || !this.repo) {
             return results;
@@ -289,6 +273,18 @@ export class GitHubProvider implements CodeForgeProvider {
                 },
             }),
         });
+
+        if (response.status === 401 && token) {
+            this.outputChannel?.appendLine(
+                `[GitHubProvider] Request failed with 401 Unauthorized using token. Stored token may be invalid or expired.`,
+            );
+            await this.authManager.clearInvalidToken({
+                providerId: 'github',
+                secretTokenKey: 'github_token',
+                currentToken: token,
+                envTokenKey: 'JJ_VIEW_GITHUB_TOKEN',
+            });
+        }
 
         if (!response.ok) {
             throw new Error(`GraphQL request failed with status: ${response.statusText}`);
@@ -369,16 +365,65 @@ export class GitHubProvider implements CodeForgeProvider {
 
     public clearCache(): void {
         this.cache.clear();
-        this.tokenRequested = false;
         this._onDidUpdate.fire();
     }
 
     public activate(): void {
-        this.tokenRequested = false;
         this.outputChannel?.appendLine('[GitHubProvider] Activated');
     }
 
     public deactivate(): void {
         this.outputChannel?.appendLine('[GitHubProvider] Deactivated');
+    }
+
+    private async getSessionToken(): Promise<string | undefined> {
+        return this.authManager.getSessionToken(this.id, {
+            scopes: ['repo'],
+            envTokenKey: 'JJ_VIEW_GITHUB_TOKEN',
+            secretTokenKey: 'github_token',
+            promptMessage: 'GitHub authentication is required to fetch PR status.',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            alternativeChoice: {
+                label: 'Enter PAT',
+                execute: () => this.promptForPat(),
+            },
+        });
+    }
+
+    public async promptForPat(): Promise<AuthResult> {
+        return this.authManager.promptForPat({
+            providerId: this.id,
+            displayName: this.displayName,
+            secretTokenKey: 'github_token',
+            prompt: "Enter your GitHub Personal Access Token (PAT). Requires 'repo' scope.",
+            placeHolder: 'ghp_...',
+            clearCache: () => this.clearCache(),
+        });
+    }
+
+    public async hasAuth(): Promise<boolean> {
+        if (process.env.JJ_VIEW_GITHUB_TOKEN) {
+            return true;
+        }
+        try {
+            const storedToken = await this.authManager.secrets.get('github_token');
+            if (storedToken) {
+                return true;
+            }
+        } catch {}
+        return this.authManager.hasOAuthSession(this.id, ['repo']);
+    }
+
+    public async getAuthManageItems(): Promise<AuthManageItem[]> {
+        return this.authManager.getAuthManageItems(this.id, {
+            displayName: this.displayName,
+            scopes: ['repo'],
+            envTokenKey: 'JJ_VIEW_GITHUB_TOKEN',
+            secretTokenKey: 'github_token',
+            hasAuth: () => this.hasAuth(),
+            clearCache: () => this.clearCache(),
+            promptForPat: () => this.promptForPat(),
+        });
     }
 }

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
-import type { ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
+import type { AuthResult, CodeForgeAuthManager } from './code-forge-auth';
+import type { AuthManageItem, ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
@@ -27,21 +28,24 @@ export class GitLabProvider implements CodeForgeProvider {
     public readonly id = 'gitlab';
     public readonly displayName = 'GitLab';
     public readonly changeTerm = 'PR' as const;
+    public readonly isAuthManageable = true;
 
     private cache = new Map<string, CodeForgeChangeInfo>();
     private gitlabHost: string | undefined;
     private projectPath: string | undefined;
-    private tokenRequested = false;
-    private gitlabAuthUnavailable = false;
     private extensionPromptShown = false;
 
     private _onDidUpdate = new vscode.EventEmitter<void>();
     public readonly onDidUpdate = this._onDidUpdate.event;
 
+    private hasWarned403 = false;
+
     constructor(
+        private readonly authManager: CodeForgeAuthManager,
         private outputChannel?: vscode.OutputChannel,
-        private secrets?: vscode.SecretStorage,
-    ) {}
+    ) {
+        this.authManager.registerProvider(this.id);
+    }
 
     public async detect(_workspaceRoot: string, remotes: GitRemote[]): Promise<boolean> {
         const preferredHost = vscode.workspace.getConfiguration('jj-view').get<string>('gitlab.host')?.trim();
@@ -73,7 +77,7 @@ export class GitLabProvider implements CodeForgeProvider {
         if (host && projectPath) {
             if (this.gitlabHost !== host || this.projectPath !== projectPath) {
                 this.clearCache();
-                this.gitlabAuthUnavailable = false;
+                this.authManager.setProviderUnavailable(this.id, false);
                 this.extensionPromptShown = false;
             }
             this.gitlabHost = host;
@@ -151,82 +155,6 @@ export class GitLabProvider implements CodeForgeProvider {
         return undefined;
     }
 
-    private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, rejectReason: string): Promise<T> {
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            timer = setTimeout(() => reject(new Error(rejectReason)), timeoutMs);
-        });
-        try {
-            return await Promise.race([promise, timeoutPromise]);
-        } finally {
-            if (timer) {
-                clearTimeout(timer);
-            }
-        }
-    }
-
-    private async getSessionToken(prompt = false): Promise<string | undefined> {
-        if (process.env.JJ_VIEW_GITLAB_TOKEN) {
-            return process.env.JJ_VIEW_GITLAB_TOKEN;
-        }
-
-        if (this.secrets) {
-            try {
-                const storedToken = await this.secrets.get('gitlab_token');
-                if (storedToken) {
-                    return storedToken;
-                }
-            } catch (err) {
-                this.outputChannel?.appendLine(`[GitLabProvider] Failed to read token from secrets: ${err}`);
-            }
-        }
-
-        // Check if GitLab extension is installed or if we already verified provider is available
-        const hasGitLabExtension = !!vscode.extensions.getExtension('GitLab.gitlab-workflow');
-        if (this.gitlabAuthUnavailable && !hasGitLabExtension) {
-            return undefined;
-        }
-
-        try {
-            if (prompt) {
-                if (this.tokenRequested) {
-                    return undefined;
-                }
-                this.tokenRequested = true;
-                const session = await vscode.authentication.getSession('gitlab', ['read_api'], { createIfNone: true });
-                return session?.accessToken;
-            } else {
-                // Try silently first with a short timeout to check if provider exists
-                const silentPromise = Promise.resolve(
-                    vscode.authentication.getSession('gitlab', ['read_api'], { silent: true }),
-                );
-                const session = await this.withTimeout(
-                    silentPromise,
-                    1000,
-                    'GitLab authentication provider not registered or timed out',
-                );
-                this.gitlabAuthUnavailable = false;
-                return session?.accessToken;
-            }
-        } catch (e) {
-            const errorStr = String(e);
-            const isUnregistered =
-                errorStr.includes('not registered') ||
-                errorStr.includes('Timed out waiting') ||
-                errorStr.includes('No authentication provider');
-
-            if (isUnregistered) {
-                this.gitlabAuthUnavailable = true;
-                this.outputChannel?.appendLine(
-                    `[GitLabProvider] GitLab authentication provider is not available in VS Code. Using unauthenticated requests only.`,
-                );
-            } else {
-                this.outputChannel?.appendLine(`[GitLabProvider] Failed to get OAuth token: ${errorStr}`);
-            }
-        }
-        return undefined;
-    }
-
     private async promptInstallGitLabExtension(): Promise<void> {
         const installAction = 'Install Extension';
         const patAction = 'Enter Personal Access Token (PAT)';
@@ -240,25 +168,6 @@ export class GitLabProvider implements CodeForgeProvider {
             vscode.commands.executeCommand('workbench.extensions.search', 'GitLab.gitlab-workflow');
         } else if (choice === patAction) {
             await this.promptForPat();
-        }
-    }
-
-    private async promptForPat(): Promise<void> {
-        const token = await vscode.window.showInputBox({
-            prompt: 'Enter your GitLab Personal Access Token (PAT)',
-            placeHolder: 'glpat-...',
-            password: true,
-            ignoreFocusOut: true,
-        });
-
-        if (token?.trim()) {
-            if (this.secrets) {
-                await this.secrets.store('gitlab_token', token.trim());
-                this.outputChannel?.appendLine('[GitLabProvider] Personal Access Token saved successfully');
-                this.clearCache();
-            } else {
-                this.outputChannel?.appendLine('[GitLabProvider] Secrets storage is not available to save PAT');
-            }
         }
     }
 
@@ -381,7 +290,7 @@ export class GitLabProvider implements CodeForgeProvider {
                 let response = await fetchWithTimeout(urlStr, 15000, { headers: getHeaders(sharedToken) });
 
                 if ((response.status === 401 || response.status === 404) && !sharedToken) {
-                    if (this.gitlabAuthUnavailable) {
+                    if (this.authManager.isProviderUnavailable(this.id)) {
                         if (!this.extensionPromptShown) {
                             this.extensionPromptShown = true;
                             this.promptInstallGitLabExtension();
@@ -402,27 +311,24 @@ export class GitLabProvider implements CodeForgeProvider {
                     this.outputChannel?.appendLine(
                         `[GitLabProvider] Request failed with 401 Unauthorized using token. Stored token may be invalid or expired.`,
                     );
+                    // Reset the in-memory token cache so the next request re-fetches credentials.
                     if (sharedToken === currentToken) {
                         sharedToken = undefined;
                         tokenPromise = null;
                     }
-                    if (this.secrets && !process.env.JJ_VIEW_GITLAB_TOKEN) {
-                        try {
-                            const storedToken = await this.secrets.get('gitlab_token');
-                            if (storedToken === currentToken) {
-                                this.outputChannel?.appendLine(`[GitLabProvider] Clearing invalid stored PAT...`);
-                                await this.secrets.delete('gitlab_token');
-                            }
-                        } catch (err) {
-                            this.outputChannel?.appendLine(`[GitLabProvider] Failed to delete token: ${err}`);
-                        }
-                    }
+                    await this.authManager.clearInvalidToken({
+                        providerId: 'gitlab',
+                        secretTokenKey: 'gitlab_token',
+                        currentToken,
+                        envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+                    });
                 }
 
                 if (!response.ok) {
                     this.outputChannel?.appendLine(
                         `[GitLabProvider] Request failed with status ${response.status}: ${response.statusText}`,
                     );
+                    this.handle403Warning(response);
                     return;
                 }
 
@@ -443,6 +349,7 @@ export class GitLabProvider implements CodeForgeProvider {
                             this.outputChannel?.appendLine(
                                 `[GitLabProvider] Failed to fetch single MR detail with status ${singleResponse.status}, falling back to list MR data`,
                             );
+                            this.handle403Warning(singleResponse);
                         }
                     } catch (singleErr) {
                         this.outputChannel?.appendLine(
@@ -521,20 +428,105 @@ export class GitLabProvider implements CodeForgeProvider {
         return { subcommand: 'git', args };
     }
 
+    private handle403Warning(response: Response) {
+        if (response.status === 403 && !this.hasWarned403) {
+            this.hasWarned403 = true;
+            const oauthScopes = response.headers.get('x-oauth-scopes');
+            if (oauthScopes) {
+                const scopes = oauthScopes.split(',').map((s) => s.trim().toLowerCase());
+                const hasRequired = scopes.some((s) => s === 'api' || s === 'read_api' || s.includes('merge_request'));
+                if (!hasRequired) {
+                    vscode.window.showWarningMessage(
+                        `GitLab request failed (403 Forbidden). The provided token has scopes [${oauthScopes}] but requires 'Merge Request' read/write permissions or 'api' scope.`,
+                    );
+                }
+            } else {
+                vscode.window.showWarningMessage(
+                    `GitLab request failed (403 Forbidden). Please check that your token has 'Merge Request' read/write permissions or 'api' scope.`,
+                );
+            }
+        }
+    }
+
     public clearCache(): void {
         this.cache.clear();
-        this.tokenRequested = false;
+        this.hasWarned403 = false;
         this._onDidUpdate.fire();
     }
 
     public activate(): void {
-        this.tokenRequested = false;
-        this.gitlabAuthUnavailable = false;
+        this.authManager.setProviderUnavailable(this.id, false);
         this.extensionPromptShown = false;
+        this.hasWarned403 = false;
         this.outputChannel?.appendLine('[GitLabProvider] Activated');
     }
 
     public deactivate(): void {
         this.outputChannel?.appendLine('[GitLabProvider] Deactivated');
+    }
+
+    private async getSessionToken(prompt = false): Promise<string | undefined> {
+        return this.authManager.getSessionToken(this.id, {
+            scopes: ['api'],
+            envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+            secretTokenKey: 'gitlab_token',
+            promptMessage: `GitLab authentication is required to fetch MR status for '${this.projectPath}'.`,
+            signInLabel: 'Sign In (OAuth)',
+            prompt,
+            alternativeChoice: {
+                label: 'Enter PAT',
+                execute: () => this.promptForPat(),
+            },
+            shouldSkipPrompt: () => {
+                const hasGitLabExtension = !!vscode.extensions.getExtension('GitLab.gitlab-workflow');
+                return this.authManager.isProviderUnavailable(this.id) && !hasGitLabExtension;
+            },
+            extensionInstaller: {
+                extensionId: 'GitLab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+        });
+    }
+
+    public async promptForPat(): Promise<AuthResult> {
+        return this.authManager.promptForPat({
+            providerId: this.id,
+            displayName: this.displayName,
+            secretTokenKey: 'gitlab_token',
+            prompt: "Enter your GitLab Personal Access Token (PAT). Requires 'Merge Request' read/write permissions or 'api' scope.",
+            placeHolder: 'glpat-...',
+            clearCache: () => this.clearCache(),
+        });
+    }
+
+    public async hasAuth(): Promise<boolean> {
+        if (process.env.JJ_VIEW_GITLAB_TOKEN) {
+            return true;
+        }
+        try {
+            const storedToken = await this.authManager.secrets.get('gitlab_token');
+            if (storedToken) {
+                return true;
+            }
+        } catch {}
+        return this.authManager.hasOAuthSession(this.id, ['api']);
+    }
+
+    public async getAuthManageItems(): Promise<AuthManageItem[]> {
+        return this.authManager.getAuthManageItems(this.id, {
+            displayName: this.displayName,
+            scopes: ['api'],
+            envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+            secretTokenKey: 'gitlab_token',
+            hasAuth: () => this.hasAuth(),
+            clearCache: () => this.clearCache(),
+            promptForPat: () => this.promptForPat(),
+            extensionInstaller: {
+                extensionId: 'GitLab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+        });
     }
 }

--- a/src/test/code-forge-auth.test.ts
+++ b/src/test/code-forge-auth.test.ts
@@ -1,0 +1,608 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { type AuthResult, CodeForgeAuthManager } from '../code-forge-auth';
+import { createMock } from './test-utils';
+
+// Mock VS Code
+vi.mock('vscode', () => ({
+    workspace: {
+        getConfiguration: () => ({
+            get: vi.fn(),
+        }),
+    },
+    window: {
+        showWarningMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showInputBox: vi.fn(),
+    },
+    authentication: {
+        getSession: vi.fn(),
+    },
+    extensions: {
+        getExtension: vi.fn(),
+    },
+    commands: {
+        executeCommand: vi.fn(),
+    },
+    Disposable: class {
+        static from = vi.fn();
+        dispose() {}
+    },
+}));
+
+describe('CodeForgeAuthManager', () => {
+    let context: vscode.ExtensionContext;
+    let outputChannel: vscode.OutputChannel;
+    let authManager: CodeForgeAuthManager;
+    let globalStateMap: Map<string, unknown>;
+
+    beforeEach(() => {
+        globalStateMap = new Map<string, unknown>();
+        context = createMock<vscode.ExtensionContext>({
+            globalState: createMock<vscode.Memento & { setKeysForSync(keys: readonly string[]): void }>({
+                get: vi.fn().mockImplementation((key: string, defaultValue: unknown) => {
+                    return globalStateMap.has(key) ? globalStateMap.get(key) : defaultValue;
+                }),
+                update: vi.fn().mockImplementation(async (key: string, value: unknown) => {
+                    globalStateMap.set(key, value);
+                }),
+                setKeysForSync: vi.fn(),
+            }),
+            secrets: createMock<vscode.SecretStorage>({
+                get: vi.fn(),
+                store: vi.fn(),
+                delete: vi.fn(),
+            }),
+        });
+
+        outputChannel = createMock<vscode.OutputChannel>({
+            appendLine: vi.fn(),
+        });
+
+        authManager = new CodeForgeAuthManager(context, outputChannel);
+        vi.mocked(vscode.window.showWarningMessage).mockReset();
+        vi.mocked(vscode.authentication.getSession).mockReset();
+        vi.mocked(vscode.extensions.getExtension).mockReset();
+    });
+
+    test('isAuthSkipped and setAuthSkipped persistent states', async () => {
+        expect(authManager.isAuthSkipped('github')).toBe(false);
+        await authManager.setAuthSkipped('github', true);
+        expect(authManager.isAuthSkipped('github')).toBe(true);
+
+        expect(authManager.isAuthSkipped('gitlab')).toBe(false);
+        await authManager.setAuthSkipped('gitlab', true);
+        expect(authManager.isAuthSkipped('gitlab')).toBe(true);
+    });
+
+    test('prompt session tracking and resetAllChoices', async () => {
+        expect(authManager.hasPromptedThisSession('github')).toBe(false);
+        authManager.markPromptedThisSession('github');
+        expect(authManager.hasPromptedThisSession('github')).toBe(true);
+
+        authManager.setProviderUnavailable('github', true);
+        expect(authManager.isProviderUnavailable('github')).toBe(true);
+
+        await authManager.resetAllChoices();
+        expect(authManager.hasPromptedThisSession('github')).toBe(false);
+        expect(authManager.isProviderUnavailable('github')).toBe(false);
+        expect(authManager.isAuthSkipped('github')).toBe(false);
+    });
+
+    test('getSessionToken checks environment variables first', async () => {
+        process.env.TEST_GITHUB_ENV_KEY = 'env-token-123';
+        try {
+            const token = await authManager.getSessionToken('github', {
+                scopes: ['repo'],
+                envTokenKey: 'TEST_GITHUB_ENV_KEY',
+                promptMessage: 'test',
+                prompt: false,
+            });
+            expect(token).toBe('env-token-123');
+        } finally {
+            delete process.env.TEST_GITHUB_ENV_KEY;
+        }
+    });
+
+    test('getSessionToken checks stored token in secrets', async () => {
+        vi.mocked(context.secrets.get).mockResolvedValue('stored-secret-pat');
+        const token = await authManager.getSessionToken('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            secretTokenKey: 'gitlab_token',
+            promptMessage: 'test',
+            prompt: false,
+        });
+        expect(token).toBe('stored-secret-pat');
+        expect(context.secrets.get).toHaveBeenCalledWith('gitlab_token');
+    });
+
+    test('getSessionToken returns undefined if auth is skipped', async () => {
+        await authManager.setAuthSkipped('github', true);
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'test',
+            prompt: true,
+        });
+        expect(token).toBeUndefined();
+        expect(vscode.authentication.getSession).not.toHaveBeenCalled();
+    });
+
+    test('getSessionToken silent mode success', async () => {
+        vi.mocked(vscode.authentication.getSession).mockResolvedValue({ accessToken: 'silent-oauth-token' } as never);
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'test',
+            prompt: false,
+        });
+        expect(token).toBe('silent-oauth-token');
+        expect(vscode.authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { silent: true });
+        expect(authManager.isProviderUnavailable('github')).toBe(false);
+    });
+
+    test('getSessionToken silent mode handles unregistered provider error and sets state', async () => {
+        vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('No authentication provider found'));
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'test',
+            prompt: false,
+        });
+        expect(token).toBeUndefined();
+        expect(authManager.isProviderUnavailable('github')).toBe(true);
+    });
+
+    test('getSessionToken prompt mode warning flow choosing OAuth Sign In', async () => {
+        vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Sign In' as never);
+        vi.mocked(vscode.authentication.getSession)
+            .mockResolvedValueOnce(undefined)
+            .mockResolvedValueOnce({ accessToken: 'oauth-token' } as never);
+
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitHub authentication required',
+            signInLabel: 'Sign In',
+            prompt: true,
+        });
+
+        expect(token).toBe('oauth-token');
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            'GitHub authentication required',
+            'Sign In',
+            "Don't Sign In (Skip)",
+        );
+        expect(vscode.authentication.getSession).toHaveBeenNthCalledWith(1, 'github', ['repo'], { silent: true });
+        expect(vscode.authentication.getSession).toHaveBeenNthCalledWith(2, 'github', ['repo'], { createIfNone: true });
+    });
+
+    test('getSessionToken prompt mode warning flow choosing alternative choice', async () => {
+        vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Enter PAT' as never);
+        const alternativeExecute = vi.fn().mockResolvedValue({ status: 'success', token: 'custom-pat-token' });
+
+        const token = await authManager.getSessionToken('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitLab authentication required',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            alternativeChoice: {
+                label: 'Enter PAT',
+                execute: alternativeExecute,
+            },
+        });
+
+        expect(token).toBe('custom-pat-token');
+        expect(alternativeExecute).toHaveBeenCalled();
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            'GitLab authentication required',
+            'Sign In (OAuth)',
+            'Enter PAT',
+            "Don't Sign In (Skip)",
+        );
+    });
+
+    test('getSessionToken prompt mode warning flow choosing Skip', async () => {
+        vi.mocked(vscode.window.showWarningMessage).mockResolvedValue("Don't Sign In (Skip)" as never);
+
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitHub authentication required',
+            signInLabel: 'Sign In',
+            prompt: true,
+        });
+
+        expect(token).toBeUndefined();
+        expect(authManager.isAuthSkipped('github')).toBe(true);
+    });
+
+    test('getSessionToken skip prompt check', async () => {
+        vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('No authentication provider found'));
+        authManager.setProviderUnavailable('gitlab', true);
+        vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined); // GitLab workflow extension not installed
+
+        const token = await authManager.getSessionToken('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitLab authentication required',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            shouldSkipPrompt: () => {
+                const hasGitLabExtension = !!vscode.extensions.getExtension('GitLab.gitlab-workflow');
+                return authManager.isProviderUnavailable('gitlab') && !hasGitLabExtension;
+            },
+        });
+
+        expect(token).toBeUndefined();
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    test('handleAuthError cancelled sign-in silently returns undefined', async () => {
+        const result = await authManager.handleAuthError('github', new Error('User cancelled the sign-in flow'));
+        expect(result).toBeUndefined();
+        expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    test('handleAuthError unregistered provider shows error message and installs extension', async () => {
+        vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Install GitLab Extension' as never);
+        const result = await authManager.handleAuthError('gitlab', new Error('No authentication provider found'), {
+            extensionInstaller: {
+                extensionId: 'GitLab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+        });
+        expect(result).toBeUndefined();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension or configure a Personal Access Token (PAT).",
+            'Install GitLab Extension',
+        );
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'workbench.extensions.search',
+            'GitLab.gitlab-workflow',
+        );
+    });
+
+    test('handleAuthError unregistered provider with alternativeChoice execute option', async () => {
+        vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enter PAT' as never);
+        const alternativeExecute = vi.fn().mockResolvedValue({ status: 'success', token: 'test-pat' });
+        const result = await authManager.handleAuthError('gitlab', new Error('No authentication provider found'), {
+            extensionInstaller: {
+                extensionId: 'GitLab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+            alternativeChoice: {
+                label: 'Enter PAT',
+                execute: alternativeExecute,
+            },
+        });
+        expect(result).toBe('test-pat');
+        expect(alternativeExecute).toHaveBeenCalled();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension or configure a Personal Access Token (PAT).",
+            'Install GitLab Extension',
+            'Enter PAT',
+        );
+    });
+
+    test('handleAuthError fallback generic error display', async () => {
+        const result = await authManager.handleAuthError('github', new Error('Some API error'));
+        expect(result).toBeUndefined();
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            'Authentication failed for github: Error: Some API error',
+        );
+    });
+
+    describe('performOAuthSignIn', () => {
+        test('successful sign-in calls clearCache and shows information message', async () => {
+            vi.mocked(vscode.extensions.getExtension).mockReturnValue({} as never);
+            vi.mocked(vscode.authentication.getSession).mockResolvedValue({ accessToken: 'valid-token' } as never);
+            vi.mocked(vscode.window.showInformationMessage);
+            const clearCache = vi.fn();
+
+            await authManager.performOAuthSignIn('gitlab', ['api'], {
+                hasOAuth: false,
+                clearCache,
+                extensionInstaller: {
+                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionName: 'GitLab Workflow',
+                    providerName: 'GitLab',
+                },
+            });
+
+            expect(vscode.authentication.getSession).toHaveBeenCalledWith('gitlab', ['api'], {
+                createIfNone: true,
+                forceNewSession: undefined,
+            });
+            expect(clearCache).toHaveBeenCalled();
+            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+                'Successfully authenticated with GitLab.',
+            );
+        });
+
+        test('aborts and calls handleAuthError when required extension is missing', async () => {
+            vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined);
+            const clearCache = vi.fn();
+            const handleAuthErrorSpy = vi.spyOn(authManager, 'handleAuthError').mockResolvedValue(undefined);
+
+            await authManager.performOAuthSignIn('gitlab', ['api'], {
+                hasOAuth: false,
+                clearCache,
+                extensionInstaller: {
+                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionName: 'GitLab Workflow',
+                    providerName: 'GitLab',
+                },
+            });
+
+            expect(vscode.extensions.getExtension).toHaveBeenCalledWith('GitLab.gitlab-workflow');
+            expect(vscode.authentication.getSession).not.toHaveBeenCalled();
+            expect(clearCache).not.toHaveBeenCalled();
+            expect(handleAuthErrorSpy).toHaveBeenCalledWith(
+                'gitlab',
+                expect.any(Error),
+                expect.objectContaining({
+                    extensionInstaller: expect.any(Object),
+                }),
+            );
+        });
+
+        test('delegates to handleAuthError when getSession throws an error', async () => {
+            vi.mocked(vscode.extensions.getExtension).mockReturnValue({} as never);
+            vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('Auth failed'));
+            const clearCache = vi.fn();
+            const handleAuthErrorSpy = vi.spyOn(authManager, 'handleAuthError').mockResolvedValue(undefined);
+
+            await authManager.performOAuthSignIn('gitlab', ['api'], {
+                hasOAuth: false,
+                clearCache,
+                extensionInstaller: {
+                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionName: 'GitLab Workflow',
+                    providerName: 'GitLab',
+                },
+            });
+
+            expect(vscode.authentication.getSession).toHaveBeenCalled();
+            expect(clearCache).not.toHaveBeenCalled();
+            expect(handleAuthErrorSpy).toHaveBeenCalledWith(
+                'gitlab',
+                expect.any(Error),
+                expect.objectContaining({
+                    extensionInstaller: expect.any(Object),
+                }),
+            );
+        });
+    });
+
+    describe('getAuthManageItems', () => {
+        let hasAuthMock: Mock<() => Promise<boolean>>;
+        let clearCacheMock: Mock<() => void>;
+        let promptForPatMock: Mock<() => Promise<AuthResult>>;
+
+        beforeEach(() => {
+            hasAuthMock = vi.fn().mockResolvedValue(false);
+            clearCacheMock = vi.fn();
+            promptForPatMock = vi.fn().mockResolvedValue({ status: 'success', token: 'pat-token' });
+            vi.mocked(context.secrets.get).mockResolvedValue(undefined);
+            delete process.env.JJ_VIEW_TEST_TOKEN;
+        });
+
+        test('returns items for unauthenticated user (no PAT, no Env, no OAuth)', async () => {
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            expect(items.length).toBe(2);
+            expect(items[0].label).toBe('$(sign-in) Sign In (OAuth)');
+            expect(items[0].description).toBe('Authenticate with TestProvider using OAuth');
+            expect(items[1].label).toBe('$(key) Enter Personal Access Token (PAT)');
+            expect(items[1].description).toBe('Configure a personal access token for TestProvider');
+        });
+
+        test('returns items for OAuth authenticated user', async () => {
+            hasAuthMock.mockResolvedValue(true);
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            expect(items.length).toBe(2);
+            expect(items[0].label).toBe('$(sign-in) Sign In Again (OAuth)');
+            expect(items[0].description).toBe('Authenticate again or switch TestProvider accounts');
+        });
+
+        test('returns items when PAT is configured', async () => {
+            vi.mocked(context.secrets.get).mockResolvedValue('existing-pat');
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            expect(items.length).toBe(3);
+            expect(items[0].label).toBe('$(sign-in) Sign In (OAuth)');
+            expect(items[1].label).toBe('$(key) Update Personal Access Token (PAT)');
+            expect(items[2].label).toBe('$(trash) Clear Personal Access Token (PAT)');
+        });
+
+        test('OAuth item execution triggers performOAuthSignIn', async () => {
+            const performOAuthSignInSpy = vi.spyOn(authManager, 'performOAuthSignIn').mockResolvedValue(undefined);
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            await items[0].execute();
+            expect(performOAuthSignInSpy).toHaveBeenCalledWith(
+                'test-provider',
+                ['test-scope'],
+                expect.objectContaining({
+                    hasOAuth: false,
+                    clearCache: clearCacheMock,
+                    alternativeChoice: expect.objectContaining({
+                        label: 'Enter PAT',
+                    }),
+                }),
+            );
+        });
+
+        test('PAT item execution triggers promptForPat', async () => {
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            await items[1].execute();
+            expect(promptForPatMock).toHaveBeenCalled();
+        });
+
+        test('Clear PAT item execution deletes secret, shows info message and clears cache', async () => {
+            vi.mocked(context.secrets.get).mockResolvedValue('existing-pat');
+            const items = await authManager.getAuthManageItems('test-provider', {
+                displayName: 'TestProvider',
+                scopes: ['test-scope'],
+                envTokenKey: 'JJ_VIEW_TEST_TOKEN',
+                secretTokenKey: 'test_token',
+                hasAuth: hasAuthMock,
+                clearCache: clearCacheMock,
+                promptForPat: promptForPatMock,
+            });
+
+            await items[2].execute();
+            expect(context.secrets.delete).toHaveBeenCalledWith('test_token');
+            expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+                'Successfully cleared stored TestProvider Personal Access Token.',
+            );
+            expect(clearCacheMock).toHaveBeenCalled();
+        });
+    });
+
+    describe('promptForPat', () => {
+        let clearCacheMock: Mock<() => void>;
+
+        beforeEach(() => {
+            clearCacheMock = vi.fn();
+            vi.mocked(vscode.window.showInputBox).mockReset();
+            vi.mocked(context.secrets.store).mockReset();
+        });
+
+        test('returns success and stores token when valid token is entered', async () => {
+            vi.mocked(vscode.window.showInputBox).mockResolvedValue('my-new-token');
+            vi.mocked(context.secrets.store).mockResolvedValue(undefined);
+
+            const result = await authManager.promptForPat({
+                providerId: 'test-provider',
+                displayName: 'TestProvider',
+                secretTokenKey: 'test_token',
+                prompt: 'Enter token',
+                placeHolder: 'token...',
+                clearCache: clearCacheMock,
+            });
+
+            expect(result).toEqual({ status: 'success', token: 'my-new-token' });
+            expect(vscode.window.showInputBox).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    prompt: 'Enter token',
+                    placeHolder: 'token...',
+                    password: true,
+                    ignoreFocusOut: true,
+                }),
+            );
+            expect(context.secrets.store).toHaveBeenCalledWith('test_token', 'my-new-token');
+            expect(clearCacheMock).toHaveBeenCalled();
+            expect(outputChannel.appendLine).toHaveBeenCalledWith(
+                '[TestProviderProvider] Personal Access Token saved successfully',
+            );
+        });
+
+        test('returns cancelled and does not store if input is cancelled (undefined)', async () => {
+            vi.mocked(vscode.window.showInputBox).mockResolvedValue(undefined);
+
+            const result = await authManager.promptForPat({
+                providerId: 'test-provider',
+                displayName: 'TestProvider',
+                secretTokenKey: 'test_token',
+                prompt: 'Enter token',
+                placeHolder: 'token...',
+                clearCache: clearCacheMock,
+            });
+
+            expect(result).toEqual({ status: 'cancelled' });
+            expect(context.secrets.store).not.toHaveBeenCalled();
+            expect(clearCacheMock).not.toHaveBeenCalled();
+        });
+
+        test('returns cancelled and does not store if input is empty string', async () => {
+            vi.mocked(vscode.window.showInputBox).mockResolvedValue('   ');
+
+            const result = await authManager.promptForPat({
+                providerId: 'test-provider',
+                displayName: 'TestProvider',
+                secretTokenKey: 'test_token',
+                prompt: 'Enter token',
+                placeHolder: 'token...',
+                clearCache: clearCacheMock,
+            });
+
+            expect(result).toEqual({ status: 'cancelled' });
+            expect(context.secrets.store).not.toHaveBeenCalled();
+            expect(clearCacheMock).not.toHaveBeenCalled();
+        });
+
+        test('returns failure if secrets storage fails', async () => {
+            vi.mocked(vscode.window.showInputBox).mockResolvedValue('my-new-token');
+            const error = new Error('Secret storage write error');
+            vi.mocked(context.secrets.store).mockRejectedValue(error);
+
+            const result = await authManager.promptForPat({
+                providerId: 'test-provider',
+                displayName: 'TestProvider',
+                secretTokenKey: 'test_token',
+                prompt: 'Enter token',
+                placeHolder: 'token...',
+                clearCache: clearCacheMock,
+            });
+
+            expect(result).toEqual({ status: 'failure', error });
+            expect(clearCacheMock).not.toHaveBeenCalled();
+            expect(outputChannel.appendLine).toHaveBeenCalledWith(
+                '[TestProviderProvider] Secrets storage is not available to save PAT: Error: Secret storage write error',
+            );
+        });
+    });
+});

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -4,6 +4,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
+import type { CodeForgeAuthManager } from '../../code-forge-auth';
 import type { CodeForgeService } from '../../code-forge-service';
 import { uploadCommand } from '../../commands/upload';
 import { GitHubProvider } from '../../github-provider';
@@ -264,7 +265,10 @@ describe('uploadCommand', () => {
         try {
             mockConfig.get.mockReturnValue(undefined);
 
-            const githubProvider = new GitHubProvider(mockOutputChannel);
+            const mockAuthManager = createMock<CodeForgeAuthManager>({
+                registerProvider: vi.fn(),
+            });
+            const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
             const githubCodeForgeService = createMock<CodeForgeService>({
                 isEnabled: true,
                 requestRefreshWithBackoffs: vi.fn(),
@@ -309,7 +313,10 @@ describe('uploadCommand', () => {
 
             mockConfig.get.mockReturnValue(undefined);
 
-            const githubProvider = new GitHubProvider(mockOutputChannel);
+            const mockAuthManager = createMock<CodeForgeAuthManager>({
+                registerProvider: vi.fn(),
+            });
+            const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
             const githubCodeForgeService = createMock<CodeForgeService>({
                 isEnabled: true,
                 requestRefreshWithBackoffs: vi.fn(),

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -6,7 +6,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { expect, type Locator } from '@playwright/test';
+import { expect, type Locator, test } from '@playwright/test';
 import { downloadAndUnzipVSCode, SilentReporter } from '@vscode/test-electron';
 import { type ElectronApplication, _electron as electron, type Frame, type Page } from 'playwright';
 import type { TestRepo } from '../test-repo';
@@ -110,7 +110,8 @@ export async function launchVSCode(
         '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-updates',
-        // --- THESE PREVENT WINDOW FOCUS ---
+        '--password-store=basic',
+        // --- THESE PREVENT WINDOW FOCUS AND WINDOW VISIBILITY ---
         '--headless=new',
         '--no-startup-window',
     ];
@@ -632,10 +633,32 @@ export async function clickNotificationButton(page: Page, actionLabel: string) {
 }
 
 /**
+ * Waits for a notification toast containing the expected text to be visible.
+ */
+export async function expectNotificationToast(page: Page, text: string | RegExp, timeout = 10000) {
+    const toast = page.locator('.notifications-toasts .notification-toast');
+    await expect(toast.filter({ hasText: text }).first()).toBeVisible({ timeout });
+}
+
+/**
+ * Returns the locator for the active QuickInput widget.
+ */
+export function locateQuickInputWidget(page: Page): Locator {
+    return page.locator('.quick-input-widget');
+}
+
+/**
+ * Returns the locator for a specific item in the active QuickInput widget.
+ */
+export function locateQuickInputItem(page: Page, label: string | RegExp): Locator {
+    return locateQuickInputWidget(page).locator('.monaco-list-row').filter({ hasText: label });
+}
+
+/**
  * Waits for the VS Code QuickInput widget to be visible and returns the input locator.
  */
 export async function waitForQuickInput(page: Page, timeout: number = 10000): Promise<Locator> {
-    const quickInput = page.locator('.quick-input-widget').filter({ visible: true });
+    const quickInput = locateQuickInputWidget(page).filter({ visible: true });
     const input = quickInput.locator('input.input');
     await expect(input).toBeVisible({ timeout });
     return input;
@@ -645,7 +668,7 @@ export async function waitForQuickInput(page: Page, timeout: number = 10000): Pr
  * Robustly presses a shortcut key to open the QuickInput widget, retrying if VS Code ignores the keypress.
  */
 export async function openQuickInputWithShortcut(page: Page, shortcut: string): Promise<Locator> {
-    const quickInput = page.locator('.quick-input-widget');
+    const quickInput = locateQuickInputWidget(page);
     const input = quickInput.locator('input.input');
 
     // Ensure any leftover quick input is closed first
@@ -949,21 +972,37 @@ export async function pickQuickPickItem(
             await expect(input).toHaveValue(label);
         }
 
-        const quickPick = page.locator('.quick-input-widget').filter({ visible: true });
+        const quickPick = locateQuickInputWidget(page).filter({ visible: true });
 
         if (options?.submitAsArbitraryText) {
             // Wait for the list to filter down (no items should match the arbitrary text)
             const listRow = quickPick.locator('.monaco-list-row');
             await expect(listRow).toHaveCount(0, { timeout: 2000 });
             await input.press('Enter');
+
+            // Wait for the quick pick to close or transition (input value changes/clears)
+            await expect(async () => {
+                const isInputVisible = await input.isVisible();
+                if (!isInputVisible) {
+                    return; // Closed successfully
+                }
+                if (typeof label === 'string') {
+                    const value = await input.inputValue().catch(() => '');
+                    expect(value).not.toBe(label);
+                } else {
+                    const listRows = quickPick.locator('.monaco-list-row');
+                    await expect(listRows).toHaveCount(0);
+                }
+            }).toPass({ timeout: 5000 });
         } else {
             // Find the item by text within the quickpick list
-            const item = quickPick.locator('.monaco-list-row').filter({ hasText: label }).first();
+            const item = locateQuickInputItem(page, label).first();
             await expect(item).toBeVisible({ timeout: 2000 });
             await item.click();
-        }
 
-        await expect(quickPick).not.toBeVisible({ timeout: 5000 });
+            // Wait for the clicked item to disappear (either closed or transitioned)
+            await expect(item).not.toBeVisible({ timeout: 5000 });
+        }
     }, `Failed to pick QuickPick item "${label}"`).toPass({ timeout: 15000 });
 }
 
@@ -1032,4 +1071,40 @@ export async function expectBadgeLink(row: Locator, hasText: string, expectedUrl
         timeout: 20000,
     });
     await expect(badgeLink).toHaveAttribute('href', expectedUrl);
+}
+
+/**
+ * Prints the extension's logs from the VS Code user data directory if the test failed.
+ */
+export function maybePrintExtensionLogs(userDataDir: string) {
+    try {
+        const testInfo = test.info();
+        if (testInfo.status !== 'passed' && testInfo.status !== 'skipped') {
+            const findJjViewLog = (dir: string): string | undefined => {
+                const entries = fs.readdirSync(dir, { withFileTypes: true });
+                for (const entry of entries) {
+                    const fullPath = path.join(dir, entry.name);
+                    if (entry.isDirectory()) {
+                        const found = findJjViewLog(fullPath);
+                        if (found) {
+                            return found;
+                        }
+                    } else if (entry.name.includes('JJ View') && entry.name.endsWith('.log')) {
+                        return fullPath;
+                    }
+                }
+                return undefined;
+            };
+            const logFile = findJjViewLog(userDataDir);
+            if (logFile) {
+                console.log('--- JJ VIEW OUTPUT CHANNEL LOG ---');
+                console.log(fs.readFileSync(logFile, 'utf8'));
+                console.log('----------------------------------');
+            } else {
+                console.log('Could not find JJ View log file in', userDataDir);
+            }
+        }
+    } catch (err) {
+        console.error('Failed to read logs:', err);
+    }
 }

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -7,7 +7,18 @@ import * as fs from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { FakeGitHubServer } from '../helpers/fake-github-server';
 import { buildGraph, type CommitDefinition, TestRepo } from '../test-repo';
-import { expectBadgeLink, focusJJLog, launchVSCode, waitForLogCommitRow } from './e2e-helpers';
+import {
+    expectBadgeLink,
+    expectNotificationToast,
+    focusJJLog,
+    focusSCM,
+    launchVSCode,
+    locateQuickInputItem,
+    locateQuickInputWidget,
+    pickQuickPickItem,
+    waitForLogCommitRow,
+    waitForQuickInput,
+} from './e2e-helpers';
 
 test.describe('GitHub Integration E2E', () => {
     let github: FakeGitHubServer;
@@ -222,6 +233,132 @@ test.describe('GitHub Integration E2E', () => {
             } catch {}
             repo.dispose();
             remoteRepo.dispose();
+        }
+    });
+
+    test('Manages GitHub auth choices via Quick Pick', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://github.com/test-owner/test-repo.git');
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'github',
+            },
+            {
+                JJ_VIEW_GITHUB_API_URL: github.url,
+            },
+        );
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+
+            // Click the Manage Auth button in the Source Control title bar
+            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+            await manageAuthButton.click();
+
+            // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
+            await pickQuickPickItem(page, /Disable Authentication Prompts/);
+
+            // Verify confirmation message or state by checking that the quick pick closed
+            const quickPick = locateQuickInputWidget(page);
+            await expect(quickPick).not.toBeVisible();
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Manages GitHub PAT flow via Quick Pick', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://github.com/test-owner/test-repo.git');
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'github',
+            },
+            {
+                JJ_VIEW_GITHUB_API_URL: github.url,
+            },
+            true, // showNotifications = true
+        );
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+
+            // Click the Manage Auth button in the Source Control title bar
+            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+            await manageAuthButton.click();
+
+            // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
+            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
+
+            // Click "Enter Personal Access Token (PAT)"
+            await pickQuickPickItem(page, 'Enter Personal Access Token');
+
+            // Wait for the showInputBox input to appear
+            const input = await waitForQuickInput(page);
+            await input.focus();
+            await input.fill('ghp_test-mock-token');
+            await input.press('Enter');
+
+            // Wait for input box to close
+            await expect(quickPick).not.toBeVisible();
+
+            // Re-open the Manage Auth menu
+            await focusSCM(page);
+            await scmInputRow.click();
+            await manageAuthButton.click();
+            await expect(quickPick).toBeVisible();
+
+            // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
+            await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
+            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
+
+            // Click "Clear Personal Access Token (PAT)"
+            await pickQuickPickItem(page, 'Clear Personal Access Token');
+
+            // Wait for menu to close
+            await expect(quickPick).not.toBeVisible();
+
+            // Wait for the success toast to appear, indicating the deletion is complete
+            await expectNotificationToast(page, 'Successfully cleared stored GitHub Personal Access Token');
+
+            // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
+            await expect(async () => {
+                const isVisible = await quickPick.isVisible();
+                if (isVisible) {
+                    await page.keyboard.press('Escape');
+                    await expect(quickPick).not.toBeVisible();
+                }
+                await focusSCM(page);
+                await scmInputRow.click();
+                await manageAuthButton.click();
+                await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
+                    timeout: 2000,
+                });
+            }).toPass({ timeout: 15000 });
+
+            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
         }
     });
 });

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -7,7 +7,19 @@ import * as fs from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { FakeGitLabServer } from '../helpers/fake-gitlab-server';
 import { buildGraph, type CommitDefinition, TestRepo } from '../test-repo';
-import { expectBadgeLink, focusJJLog, launchVSCode, waitForLogCommitRow } from './e2e-helpers';
+import {
+    expectBadgeLink,
+    expectNotificationToast,
+    focusJJLog,
+    focusSCM,
+    launchVSCode,
+    locateQuickInputItem,
+    locateQuickInputWidget,
+    maybePrintExtensionLogs,
+    pickQuickPickItem,
+    waitForLogCommitRow,
+    waitForQuickInput,
+} from './e2e-helpers';
 
 test.describe('GitLab Integration E2E', () => {
     let gitlab: FakeGitLabServer;
@@ -79,6 +91,7 @@ test.describe('GitLab Integration E2E', () => {
             const uploadButton = row.getByRole('button', { name: 'Upload changes to GitLab' });
             await expect(uploadButton).not.toBeVisible();
         } finally {
+            maybePrintExtensionLogs(userDataDir);
             await app.close();
             try {
                 fs.rmSync(userDataDir, { recursive: true, force: true });
@@ -153,6 +166,209 @@ test.describe('GitLab Integration E2E', () => {
                 expect(desc).toContain('uploaded_successfully');
             }).toPass({ timeout: 15000 });
         } finally {
+            maybePrintExtensionLogs(userDataDir);
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Manages GitLab auth choices via Quick Pick', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://gitlab.com/test-owner/test-repo.git');
+
+        const graph: CommitDefinition[] = [
+            { label: 'base', description: 'base' },
+            { label: 'mr-commit', parents: ['base'], description: 'MR Commit', bookmarks: ['my-feature-branch'] },
+        ];
+        const commits = await buildGraph(repo, graph);
+
+        gitlab.registerMR('my-feature-branch', {
+            id: 123456,
+            iid: 42,
+            state: 'opened',
+            title: 'MR Commit',
+            description: 'Mock MR Commit Description',
+            web_url: 'https://gitlab.com/test-owner/test-repo/-/merge_requests/42',
+            draft: false,
+            merge_status: 'can_be_merged',
+            detailed_merge_status: 'mergeable',
+            blocking_discussions_resolved: false,
+            sha: commits['mr-commit'].commitId,
+        });
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'gitlab',
+                'jj-view.gitlab.host': gitlab.url,
+            },
+            {
+                JJ_VIEW_GITLAB_API_URL: gitlab.url,
+            },
+        );
+
+        try {
+            await focusJJLog(page);
+            await waitForLogCommitRow(page, 'MR Commit');
+
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+
+            // Click the Manage Auth button in the Source Control title bar
+            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+            await manageAuthButton.click();
+
+            // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
+            await pickQuickPickItem(page, /Disable Authentication Prompts/);
+
+            // Verify confirmation message or state by checking that the quick pick closed
+            const quickPick = locateQuickInputWidget(page);
+            await expect(quickPick).not.toBeVisible();
+        } finally {
+            maybePrintExtensionLogs(userDataDir);
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Manages GitLab PAT flow via Quick Pick', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://gitlab.com/test-owner/test-repo.git');
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'gitlab',
+                'jj-view.gitlab.host': gitlab.url,
+            },
+            {
+                JJ_VIEW_GITLAB_API_URL: gitlab.url,
+            },
+            true, // showNotifications = true
+        );
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+
+            // Click the Manage Auth button in the Source Control title bar
+            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+            await manageAuthButton.click();
+
+            // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
+            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
+
+            // Click "Enter Personal Access Token (PAT)"
+            await pickQuickPickItem(page, 'Enter Personal Access Token');
+
+            // Wait for the showInputBox input to appear
+            const input = await waitForQuickInput(page);
+            await input.focus();
+            await input.fill('glpat-test-mock-token');
+            await input.press('Enter');
+
+            // Wait for input box to close
+            await expect(quickPick).not.toBeVisible();
+
+            // Re-open the Manage Auth menu
+            await focusSCM(page);
+            await scmInputRow.click();
+            await manageAuthButton.click();
+            await expect(quickPick).toBeVisible();
+
+            // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
+            await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
+            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
+
+            // Click "Clear Personal Access Token (PAT)"
+            await pickQuickPickItem(page, 'Clear Personal Access Token');
+
+            // Wait for menu to close
+            await expect(quickPick).not.toBeVisible();
+
+            // Wait for the success toast to appear, indicating the deletion is complete
+            await expectNotificationToast(page, 'Successfully cleared stored GitLab Personal Access Token');
+
+            // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
+            await expect(async () => {
+                const isVisible = await quickPick.isVisible();
+                if (isVisible) {
+                    await page.keyboard.press('Escape');
+                    await expect(quickPick).not.toBeVisible();
+                }
+                await focusSCM(page);
+                await scmInputRow.click();
+                await manageAuthButton.click();
+                await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
+                    timeout: 2000,
+                });
+            }).toPass({ timeout: 15000 });
+
+            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
+        } finally {
+            maybePrintExtensionLogs(userDataDir);
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Shows warning notification toast on 403 Forbidden scope errors', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://gitlab.com/test-owner/test-repo.git');
+
+        const graph: CommitDefinition[] = [
+            { label: 'base', description: 'base' },
+            { label: 'mr-commit', parents: ['base'], description: 'MR Commit', bookmarks: ['my-feature-branch'] },
+        ];
+        await buildGraph(repo, graph);
+
+        // Override status on fake GitLab server to return 403 with specific scopes
+        gitlab.statusOverride = {
+            status: 403,
+            headers: {
+                'x-oauth-scopes': 'read_user, read_repository',
+            },
+            body: 'Forbidden',
+        };
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'gitlab',
+                'jj-view.gitlab.host': gitlab.url,
+            },
+            {
+                JJ_VIEW_GITLAB_TOKEN: 'test-token',
+                JJ_VIEW_GITLAB_API_URL: gitlab.url,
+            },
+            true, // showNotifications = true
+        );
+
+        try {
+            await focusJJLog(page);
+
+            // Wait for the warning notification toast to appear
+            await expectNotificationToast(page, "requires 'Merge Request' read/write permissions or 'api' scope");
+        } finally {
+            gitlab.statusOverride = undefined;
+            maybePrintExtensionLogs(userDataDir);
             await app.close();
             try {
                 fs.rmSync(userDataDir, { recursive: true, force: true });

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
-import type { ChangeStatusRequest } from '../code-forge-provider';
+import * as vscode from 'vscode';
+import type { CodeForgeAuthManager } from '../code-forge-auth';
+import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
 import { GitHubProvider } from '../github-provider';
 import { accessPrivate, createMock, exposePrivate, setPrivate } from './test-utils';
 
@@ -15,6 +16,15 @@ vi.mock('vscode', () => ({
             get: vi.fn(),
         }),
         onDidChangeConfiguration: vi.fn(),
+    },
+    window: {
+        showWarningMessage: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+    },
+    authentication: {
+        getSession: vi.fn(),
     },
     Disposable: class {
         static from = vi.fn();
@@ -30,10 +40,29 @@ vi.mock('vscode', () => ({
 describe('GitHubProvider', () => {
     let provider: GitHubProvider;
     let mockOutputChannel: vscode.OutputChannel;
+    let mockAuthManager: CodeForgeAuthManager;
 
     beforeEach(() => {
         mockOutputChannel = createMock<vscode.OutputChannel>({ appendLine: vi.fn() });
-        provider = new GitHubProvider(mockOutputChannel);
+        mockAuthManager = createMock<CodeForgeAuthManager>({
+            isAuthSkipped: vi.fn().mockReturnValue(false),
+            hasPromptedThisSession: vi.fn().mockReturnValue(false),
+            markPromptedThisSession: vi.fn(),
+            setAuthSkipped: vi.fn(),
+            registerProvider: vi.fn(),
+            getSessionToken: vi.fn().mockResolvedValue('test-token'),
+            hasOAuthSession: vi.fn().mockResolvedValue(false),
+            performOAuthSignIn: vi.fn(),
+            getAuthManageItems: vi.fn(),
+            promptForPat: vi.fn(),
+            secrets: createMock<vscode.SecretStorage>({
+                get: vi.fn(),
+                store: vi.fn(),
+                delete: vi.fn(),
+            }),
+        });
+        provider = new GitHubProvider(mockAuthManager, mockOutputChannel);
+        vi.mocked(vscode.window.showWarningMessage).mockReset();
     });
 
     test('parseGitHubUrl correctly parses standard and dotted repo URLs', () => {
@@ -71,12 +100,6 @@ describe('GitHubProvider', () => {
         expect(result2).toBe(false);
         expect(accessPrivate(provider, 'owner')).toBeUndefined();
         expect(accessPrivate(provider, 'repo')).toBeUndefined();
-    });
-
-    test('clearCache resets tokenRequested state', () => {
-        setPrivate(provider, 'tokenRequested', true);
-        provider.clearCache();
-        expect(accessPrivate(provider, 'tokenRequested')).toBe(false);
     });
 
     test('detect clears cache on owner/repo change, but preserves it if unchanged', async () => {
@@ -323,5 +346,95 @@ describe('GitHubProvider', () => {
         expect(cache.get('bm-1')).toBeDefined();
         const cachedEntry = cache.get('bm-1') as { status: string } | undefined;
         expect(cachedEntry?.status).toBe('NEW');
+    });
+
+    test('getSessionToken delegates to authManager.getSessionToken', async () => {
+        vi.mocked(mockAuthManager.getSessionToken).mockResolvedValue('delegated-token');
+        const getSession = exposePrivate<{ getSessionToken(): Promise<string | undefined> }>(
+            provider,
+        ).getSessionToken.bind(provider);
+        const token = await getSession();
+        expect(token).toBe('delegated-token');
+        expect(mockAuthManager.getSessionToken).toHaveBeenCalledWith('github', {
+            scopes: ['repo'],
+            envTokenKey: 'JJ_VIEW_GITHUB_TOKEN',
+            secretTokenKey: 'github_token',
+            promptMessage: 'GitHub authentication is required to fetch PR status.',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            alternativeChoice: expect.any(Object),
+        });
+    });
+
+    test('hasAuth returns true if environment variable JJ_VIEW_GITHUB_TOKEN is set', async () => {
+        const originalEnv = process.env.JJ_VIEW_GITHUB_TOKEN;
+        try {
+            process.env.JJ_VIEW_GITHUB_TOKEN = 'test-token';
+            const hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+        } finally {
+            process.env.JJ_VIEW_GITHUB_TOKEN = originalEnv;
+        }
+    });
+
+    test('hasAuth returns true if stored token is found, false otherwise', async () => {
+        const originalEnv = process.env.JJ_VIEW_GITHUB_TOKEN;
+        delete process.env.JJ_VIEW_GITHUB_TOKEN;
+        try {
+            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
+            let hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+            expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('github_token');
+
+            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
+            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
+            hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+            expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('github', ['repo']);
+
+            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
+            hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(false);
+        } finally {
+            process.env.JJ_VIEW_GITHUB_TOKEN = originalEnv;
+        }
+    });
+
+    test('getAuthManageItems delegates to authManager.getAuthManageItems', async () => {
+        const expectedItems = [{ label: 'test-item', execute: vi.fn() }] as AuthManageItem[];
+        vi.mocked(mockAuthManager.getAuthManageItems).mockResolvedValue(expectedItems);
+
+        const items = await provider.getAuthManageItems();
+        expect(items).toBe(expectedItems);
+        expect(mockAuthManager.getAuthManageItems).toHaveBeenCalledWith(
+            'github',
+            expect.objectContaining({
+                displayName: 'GitHub',
+                scopes: ['repo'],
+                envTokenKey: 'JJ_VIEW_GITHUB_TOKEN',
+                secretTokenKey: 'github_token',
+                hasAuth: expect.any(Function),
+                clearCache: expect.any(Function),
+                promptForPat: expect.any(Function),
+            }),
+        );
+    });
+
+    test('promptForPat delegates to authManager.promptForPat', async () => {
+        const expectedResult = { status: 'success', token: 'mock-token' } as const;
+        vi.mocked(mockAuthManager.promptForPat).mockResolvedValue(expectedResult);
+
+        const result = await provider.promptForPat();
+        expect(result).toBe(expectedResult);
+        expect(mockAuthManager.promptForPat).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providerId: 'github',
+                displayName: 'GitHub',
+                secretTokenKey: 'github_token',
+                prompt: "Enter your GitHub Personal Access Token (PAT). Requires 'repo' scope.",
+                placeHolder: 'ghp_...',
+                clearCache: expect.any(Function),
+            }),
+        );
     });
 });

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
-import type { ChangeStatusRequest } from '../code-forge-provider';
+import * as vscode from 'vscode';
+import type { CodeForgeAuthManager } from '../code-forge-auth';
+import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
 import { GitLabProvider } from '../gitlab-provider';
 import { accessPrivate, createMock, exposePrivate, setPrivate } from './test-utils';
 
@@ -14,6 +15,18 @@ vi.mock('vscode', () => ({
             get: vi.fn(),
         }),
         onDidChangeConfiguration: vi.fn(),
+    },
+    window: {
+        showWarningMessage: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+    },
+    authentication: {
+        getSession: vi.fn(),
+    },
+    extensions: {
+        getExtension: vi.fn(),
     },
     Disposable: class {
         static from = vi.fn();
@@ -29,10 +42,31 @@ vi.mock('vscode', () => ({
 describe('GitLabProvider', () => {
     let provider: GitLabProvider;
     let mockOutputChannel: vscode.OutputChannel;
+    let mockAuthManager: CodeForgeAuthManager;
 
     beforeEach(() => {
         mockOutputChannel = createMock<vscode.OutputChannel>({ appendLine: vi.fn() });
-        provider = new GitLabProvider(mockOutputChannel);
+        mockAuthManager = createMock<CodeForgeAuthManager>({
+            isAuthSkipped: vi.fn().mockReturnValue(false),
+            hasPromptedThisSession: vi.fn().mockReturnValue(false),
+            markPromptedThisSession: vi.fn(),
+            setAuthSkipped: vi.fn(),
+            isProviderUnavailable: vi.fn().mockReturnValue(false),
+            setProviderUnavailable: vi.fn(),
+            registerProvider: vi.fn(),
+            getSessionToken: vi.fn().mockResolvedValue('test-token'),
+            hasOAuthSession: vi.fn().mockResolvedValue(false),
+            performOAuthSignIn: vi.fn(),
+            getAuthManageItems: vi.fn(),
+            promptForPat: vi.fn(),
+            secrets: createMock<vscode.SecretStorage>({
+                get: vi.fn(),
+                store: vi.fn(),
+                delete: vi.fn(),
+            }),
+        });
+        provider = new GitLabProvider(mockAuthManager, mockOutputChannel);
+        vi.mocked(vscode.window.showWarningMessage).mockReset();
     });
 
     test('parseGitLabUrl correctly parses standard, subgroup, and configured host URLs', () => {
@@ -108,12 +142,6 @@ describe('GitLabProvider', () => {
         expect(result2).toBe(false);
         expect(accessPrivate(provider, 'gitlabHost')).toBeUndefined();
         expect(accessPrivate(provider, 'projectPath')).toBeUndefined();
-    });
-
-    test('clearCache resets tokenRequested state', () => {
-        setPrivate(provider, 'tokenRequested', true);
-        provider.clearCache();
-        expect(accessPrivate(provider, 'tokenRequested')).toBe(false);
     });
 
     test('parseGitLabMr calculates submittable correctly based on draft, merge_status, and blocking_discussions_resolved', () => {
@@ -274,5 +302,156 @@ describe('GitLabProvider', () => {
         expect(fetchBatchSpy.mock.calls[0][0].length).toBe(10);
         expect(fetchBatchSpy.mock.calls[1][0].length).toBe(10);
         expect(fetchBatchSpy.mock.calls[2][0].length).toBe(5);
+    });
+
+    test('getSessionToken delegates to authManager.getSessionToken', async () => {
+        vi.mocked(mockAuthManager.getSessionToken).mockResolvedValue('delegated-gitlab-token');
+        const getSession = exposePrivate<{ getSessionToken(prompt?: boolean): Promise<string | undefined> }>(
+            provider,
+        ).getSessionToken.bind(provider);
+
+        // Test default call (silent)
+        const tokenDefault = await getSession();
+        expect(tokenDefault).toBe('delegated-gitlab-token');
+        expect(mockAuthManager.getSessionToken).toHaveBeenLastCalledWith('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+            secretTokenKey: 'gitlab_token',
+            promptMessage: expect.any(String),
+            signInLabel: 'Sign In (OAuth)',
+            prompt: false,
+            alternativeChoice: expect.any(Object),
+            shouldSkipPrompt: expect.any(Function),
+            extensionInstaller: expect.any(Object),
+        });
+
+        // Test with prompting
+        const tokenPrompt = await getSession(true);
+        expect(tokenPrompt).toBe('delegated-gitlab-token');
+        expect(mockAuthManager.getSessionToken).toHaveBeenLastCalledWith('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+            secretTokenKey: 'gitlab_token',
+            promptMessage: expect.any(String),
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            alternativeChoice: expect.any(Object),
+            shouldSkipPrompt: expect.any(Function),
+            extensionInstaller: expect.any(Object),
+        });
+    });
+
+    test('handle403Warning triggers warning on 403 Forbidden', () => {
+        const response = createMock<Response>({
+            status: 403,
+            headers: createMock<Headers>({
+                get: vi.fn().mockReturnValue(null),
+            }),
+        });
+
+        exposePrivate<{ handle403Warning(r: Response): void }>(provider).handle403Warning(response);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            expect.stringContaining('GitLab request failed (403 Forbidden)'),
+        );
+    });
+
+    test('handle403Warning triggers warning with scopes if x-oauth-scopes present', () => {
+        const response = createMock<Response>({
+            status: 403,
+            headers: createMock<Headers>({
+                get: vi.fn().mockImplementation((name: string) => {
+                    if (name === 'x-oauth-scopes') {
+                        return 'read_user, read_repository';
+                    }
+                    return null;
+                }),
+            }),
+        });
+
+        exposePrivate<{ handle403Warning(r: Response): void }>(provider).handle403Warning(response);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "The provided token has scopes [read_user, read_repository] but requires 'Merge Request' read/write permissions or 'api' scope",
+            ),
+        );
+    });
+
+    test('hasAuth returns true if environment variable JJ_VIEW_GITLAB_TOKEN is set', async () => {
+        const originalEnv = process.env.JJ_VIEW_GITLAB_TOKEN;
+        try {
+            process.env.JJ_VIEW_GITLAB_TOKEN = 'test-token';
+            const hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+        } finally {
+            process.env.JJ_VIEW_GITLAB_TOKEN = originalEnv;
+        }
+    });
+
+    test('hasAuth returns true if stored token is found, false otherwise', async () => {
+        const originalEnv = process.env.JJ_VIEW_GITLAB_TOKEN;
+        delete process.env.JJ_VIEW_GITLAB_TOKEN;
+        try {
+            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
+            let hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+            expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('gitlab_token');
+
+            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
+            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
+            hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(true);
+            expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('gitlab', ['api']);
+
+            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
+            hasAuth = await provider.hasAuth();
+            expect(hasAuth).toBe(false);
+        } finally {
+            process.env.JJ_VIEW_GITLAB_TOKEN = originalEnv;
+        }
+    });
+
+    test('getAuthManageItems delegates to authManager.getAuthManageItems', async () => {
+        const expectedItems = [{ label: 'test-item', execute: vi.fn() }] as AuthManageItem[];
+        vi.mocked(mockAuthManager.getAuthManageItems).mockResolvedValue(expectedItems);
+
+        const items = await provider.getAuthManageItems();
+        expect(items).toBe(expectedItems);
+        expect(mockAuthManager.getAuthManageItems).toHaveBeenCalledWith(
+            'gitlab',
+            expect.objectContaining({
+                displayName: 'GitLab',
+                scopes: ['api'],
+                envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+                secretTokenKey: 'gitlab_token',
+                hasAuth: expect.any(Function),
+                clearCache: expect.any(Function),
+                promptForPat: expect.any(Function),
+                extensionInstaller: expect.objectContaining({
+                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionName: 'GitLab Workflow',
+                    providerName: 'GitLab',
+                }),
+            }),
+        );
+    });
+
+    test('promptForPat delegates to authManager.promptForPat', async () => {
+        const expectedResult = { status: 'success', token: 'mock-token' } as const;
+        vi.mocked(mockAuthManager.promptForPat).mockResolvedValue(expectedResult);
+
+        const result = await provider.promptForPat();
+        expect(result).toBe(expectedResult);
+        expect(mockAuthManager.promptForPat).toHaveBeenCalledWith(
+            expect.objectContaining({
+                providerId: 'gitlab',
+                displayName: 'GitLab',
+                secretTokenKey: 'gitlab_token',
+                prompt: "Enter your GitLab Personal Access Token (PAT). Requires 'Merge Request' read/write permissions or 'api' scope.",
+                placeHolder: 'glpat-...',
+                clearCache: expect.any(Function),
+            }),
+        );
     });
 });

--- a/src/test/helpers/fake-gitlab-server.ts
+++ b/src/test/helpers/fake-gitlab-server.ts
@@ -25,6 +25,7 @@ export class FakeGitLabServer {
     private server: http.Server | undefined;
     public url = '';
     public requests: { url: string; method: string }[] = [];
+    public statusOverride: { status: number; headers?: Record<string, string>; body?: string } | undefined;
 
     public registerMR(bookmark: string, mr: FakeMrInfo) {
         this.mrs.set(bookmark, mr);
@@ -38,6 +39,16 @@ export class FakeGitLabServer {
         this.server = http.createServer((req, res) => {
             const urlStr = req.url || '';
             this.requests.push({ url: urlStr, method: req.method || 'GET' });
+
+            if (this.statusOverride) {
+                const headers = {
+                    'Content-Type': 'application/json',
+                    ...this.statusOverride.headers,
+                };
+                res.writeHead(this.statusOverride.status, headers);
+                res.end(this.statusOverride.body || '');
+                return;
+            }
 
             const urlObj = new URL(urlStr, `http://${req.headers.host || 'localhost'}`);
             const pathname = urlObj.pathname;


### PR DESCRIPTION
Introduces a centralized auth manager to coordinate OAuth sign-ins, personal access tokens (PATs), and prompt preferences across multiple code forge integrations.

Key changes:

- Centralized Auth: Implements `CodeForgeAuthManager` to resolve and cache credential states.
- Settings & Actions: Exposes a Quick Pick menu via `jj-view.manageAuth` command to let users enable/disable prompts, configure tokens, or reset settings.
- Scope Warnings: Adds 403 Forbidden handling in GitLab provider to warn users of insufficient scopes.
- Tests & Validation: Adds unit test coverage for auth states and integrates them into provider and end-to-end (E2E) specs.