### PR TITLE
fix: detect missing GitLab extension and prompt to install

### DIFF
--- a/src/code-forge-auth.ts
+++ b/src/code-forge-auth.ts
@@ -249,6 +249,12 @@ export class CodeForgeAuthManager {
         try {
             const choice = await vscode.window.showWarningMessage(options.promptMessage, ...choices);
             if (choice === signInLabel) {
+                if (
+                    options.extensionInstaller &&
+                    !vscode.extensions.getExtension(options.extensionInstaller.extensionId)
+                ) {
+                    return this.promptInstallOrPat(options.extensionInstaller, options.alternativeChoice);
+                }
                 const session = await vscode.authentication.getSession(providerId, options.scopes, {
                     createIfNone: true,
                 });
@@ -289,15 +295,9 @@ export class CodeForgeAuthManager {
             alternativeChoice?: AlternativeChoice;
         },
     ): Promise<void> {
-        if (options.extensionInstaller) {
-            const hasExtension = !!vscode.extensions.getExtension(options.extensionInstaller.extensionId);
-            if (!hasExtension) {
-                await this.handleAuthError(providerId, new Error('No authentication provider found'), {
-                    extensionInstaller: options.extensionInstaller,
-                    alternativeChoice: options.alternativeChoice,
-                });
-                return;
-            }
+        if (options.extensionInstaller && !vscode.extensions.getExtension(options.extensionInstaller.extensionId)) {
+            await this.promptInstallOrPat(options.extensionInstaller, options.alternativeChoice);
+            return;
         }
         try {
             const session = await vscode.authentication.getSession(providerId, scopes, {
@@ -317,6 +317,35 @@ export class CodeForgeAuthManager {
                 alternativeChoice: options.alternativeChoice,
             });
         }
+    }
+
+    /**
+     * Prompts the user to install the missing authentication provider extension or configure a PAT.
+     */
+    private async promptInstallOrPat(
+        extensionInstaller: ExtensionInstaller,
+        alternativeChoice?: AlternativeChoice,
+    ): Promise<AuthToken | undefined> {
+        const { providerName, extensionName, extensionId } = extensionInstaller;
+        const installAction = `Install ${providerName} Extension`;
+        const patAction = alternativeChoice ? alternativeChoice.label : 'Enter PAT';
+        const choices = [installAction];
+        if (alternativeChoice) {
+            choices.push(patAction);
+        }
+
+        const message = alternativeChoice
+            ? `${providerName} authentication provider is not available. Please install the official '${extensionName}' extension or configure a Personal Access Token (PAT).`
+            : `${providerName} authentication provider is not available. Please install the official '${extensionName}' extension.`;
+
+        const choice = await vscode.window.showErrorMessage(message, ...choices);
+        if (choice === installAction) {
+            vscode.commands.executeCommand('workbench.extensions.search', extensionId);
+        } else if (alternativeChoice && choice === patAction) {
+            const result = await alternativeChoice.execute();
+            return result.status === 'success' ? result.token : undefined;
+        }
+        return undefined;
     }
 
     public async handleAuthError(
@@ -339,24 +368,7 @@ export class CodeForgeAuthManager {
             errorStr.includes('No authentication provider');
 
         if (isUnregistered && options?.extensionInstaller) {
-            const { providerName, extensionName, extensionId } = options.extensionInstaller;
-            const installAction = `Install ${providerName} Extension`;
-            const patAction = options.alternativeChoice ? options.alternativeChoice.label : 'Enter PAT';
-            const choices = [installAction];
-            if (options.alternativeChoice) {
-                choices.push(patAction);
-            }
-
-            const choice = await vscode.window.showErrorMessage(
-                `${providerName} authentication provider is not available. Please install the official '${extensionName}' extension or configure a Personal Access Token (PAT).`,
-                ...choices,
-            );
-            if (choice === installAction) {
-                vscode.commands.executeCommand('workbench.extensions.search', extensionId);
-            } else if (options.alternativeChoice && choice === patAction) {
-                const result = await options.alternativeChoice.execute();
-                return result.status === 'success' ? result.token : undefined;
-            }
+            return this.promptInstallOrPat(options.extensionInstaller, options.alternativeChoice);
         } else {
             vscode.window.showErrorMessage(`Authentication failed for ${providerId}: ${error}`);
         }

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -9,6 +9,8 @@ import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
 
+const GITLAB_EXTENSION_ID = 'gitlab.gitlab-workflow';
+
 interface GitLabMergeRequest {
     id: number;
     iid: number;
@@ -165,7 +167,7 @@ export class GitLabProvider implements CodeForgeProvider {
         );
 
         if (choice === installAction) {
-            vscode.commands.executeCommand('workbench.extensions.search', 'GitLab.gitlab-workflow');
+            vscode.commands.executeCommand('workbench.extensions.search', GITLAB_EXTENSION_ID);
         } else if (choice === patAction) {
             await this.promptForPat();
         }
@@ -478,11 +480,11 @@ export class GitLabProvider implements CodeForgeProvider {
                 execute: () => this.promptForPat(),
             },
             shouldSkipPrompt: () => {
-                const hasGitLabExtension = !!vscode.extensions.getExtension('GitLab.gitlab-workflow');
+                const hasGitLabExtension = !!vscode.extensions.getExtension(GITLAB_EXTENSION_ID);
                 return this.authManager.isProviderUnavailable(this.id) && !hasGitLabExtension;
             },
             extensionInstaller: {
-                extensionId: 'GitLab.gitlab-workflow',
+                extensionId: GITLAB_EXTENSION_ID,
                 extensionName: 'GitLab Workflow',
                 providerName: 'GitLab',
             },
@@ -523,7 +525,7 @@ export class GitLabProvider implements CodeForgeProvider {
             clearCache: () => this.clearCache(),
             promptForPat: () => this.promptForPat(),
             extensionInstaller: {
-                extensionId: 'GitLab.gitlab-workflow',
+                extensionId: GITLAB_EXTENSION_ID,
                 extensionName: 'GitLab Workflow',
                 providerName: 'GitLab',
             },

--- a/src/test/code-forge-auth.test.ts
+++ b/src/test/code-forge-auth.test.ts
@@ -66,8 +66,12 @@ describe('CodeForgeAuthManager', () => {
 
         authManager = new CodeForgeAuthManager(context, outputChannel);
         vi.mocked(vscode.window.showWarningMessage).mockReset();
+        vi.mocked(vscode.window.showErrorMessage).mockReset();
+        vi.mocked(vscode.window.showInformationMessage).mockReset();
+        vi.mocked(vscode.window.showInputBox).mockReset();
         vi.mocked(vscode.authentication.getSession).mockReset();
         vi.mocked(vscode.extensions.getExtension).mockReset();
+        vi.mocked(vscode.commands.executeCommand).mockReset();
     });
 
     test('isAuthSkipped and setAuthSkipped persistent states', async () => {
@@ -224,6 +228,37 @@ describe('CodeForgeAuthManager', () => {
         expect(authManager.isAuthSkipped('github')).toBe(true);
     });
 
+    test('getSessionToken prompt mode warning flow choosing OAuth Sign In with missing extension installer prompts to install extension', async () => {
+        vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Sign In (OAuth)' as never);
+        vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined); // extension not installed
+        vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Install GitLab Extension' as never);
+
+        const token = await authManager.getSessionToken('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitLab authentication required',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            extensionInstaller: {
+                extensionId: 'gitlab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+        });
+
+        expect(token).toBeUndefined();
+        expect(vscode.extensions.getExtension).toHaveBeenCalledWith('gitlab.gitlab-workflow');
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+            "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension.",
+            'Install GitLab Extension',
+        );
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'workbench.extensions.search',
+            'gitlab.gitlab-workflow',
+        );
+        expect(vscode.authentication.getSession).not.toHaveBeenCalledWith('gitlab', ['api'], { createIfNone: true });
+    });
+
     test('getSessionToken skip prompt check', async () => {
         vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('No authentication provider found'));
         authManager.setProviderUnavailable('gitlab', true);
@@ -236,7 +271,7 @@ describe('CodeForgeAuthManager', () => {
             signInLabel: 'Sign In (OAuth)',
             prompt: true,
             shouldSkipPrompt: () => {
-                const hasGitLabExtension = !!vscode.extensions.getExtension('GitLab.gitlab-workflow');
+                const hasGitLabExtension = !!vscode.extensions.getExtension('gitlab.gitlab-workflow');
                 return authManager.isProviderUnavailable('gitlab') && !hasGitLabExtension;
             },
         });
@@ -255,19 +290,19 @@ describe('CodeForgeAuthManager', () => {
         vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Install GitLab Extension' as never);
         const result = await authManager.handleAuthError('gitlab', new Error('No authentication provider found'), {
             extensionInstaller: {
-                extensionId: 'GitLab.gitlab-workflow',
+                extensionId: 'gitlab.gitlab-workflow',
                 extensionName: 'GitLab Workflow',
                 providerName: 'GitLab',
             },
         });
         expect(result).toBeUndefined();
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-            "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension or configure a Personal Access Token (PAT).",
+            "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension.",
             'Install GitLab Extension',
         );
         expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
             'workbench.extensions.search',
-            'GitLab.gitlab-workflow',
+            'gitlab.gitlab-workflow',
         );
     });
 
@@ -276,7 +311,7 @@ describe('CodeForgeAuthManager', () => {
         const alternativeExecute = vi.fn().mockResolvedValue({ status: 'success', token: 'test-pat' });
         const result = await authManager.handleAuthError('gitlab', new Error('No authentication provider found'), {
             extensionInstaller: {
-                extensionId: 'GitLab.gitlab-workflow',
+                extensionId: 'gitlab.gitlab-workflow',
                 extensionName: 'GitLab Workflow',
                 providerName: 'GitLab',
             },
@@ -313,7 +348,7 @@ describe('CodeForgeAuthManager', () => {
                 hasOAuth: false,
                 clearCache,
                 extensionInstaller: {
-                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionId: 'gitlab.gitlab-workflow',
                     extensionName: 'GitLab Workflow',
                     providerName: 'GitLab',
                 },
@@ -329,30 +364,31 @@ describe('CodeForgeAuthManager', () => {
             );
         });
 
-        test('aborts and calls handleAuthError when required extension is missing', async () => {
+        test('aborts and prompts to install when required extension is missing', async () => {
             vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined);
+            vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Install GitLab Extension' as never);
             const clearCache = vi.fn();
-            const handleAuthErrorSpy = vi.spyOn(authManager, 'handleAuthError').mockResolvedValue(undefined);
 
             await authManager.performOAuthSignIn('gitlab', ['api'], {
                 hasOAuth: false,
                 clearCache,
                 extensionInstaller: {
-                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionId: 'gitlab.gitlab-workflow',
                     extensionName: 'GitLab Workflow',
                     providerName: 'GitLab',
                 },
             });
 
-            expect(vscode.extensions.getExtension).toHaveBeenCalledWith('GitLab.gitlab-workflow');
+            expect(vscode.extensions.getExtension).toHaveBeenCalledWith('gitlab.gitlab-workflow');
             expect(vscode.authentication.getSession).not.toHaveBeenCalled();
             expect(clearCache).not.toHaveBeenCalled();
-            expect(handleAuthErrorSpy).toHaveBeenCalledWith(
-                'gitlab',
-                expect.any(Error),
-                expect.objectContaining({
-                    extensionInstaller: expect.any(Object),
-                }),
+            expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+                "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension.",
+                'Install GitLab Extension',
+            );
+            expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+                'workbench.extensions.search',
+                'gitlab.gitlab-workflow',
             );
         });
 
@@ -366,7 +402,7 @@ describe('CodeForgeAuthManager', () => {
                 hasOAuth: false,
                 clearCache,
                 extensionInstaller: {
-                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionId: 'gitlab.gitlab-workflow',
                     extensionName: 'GitLab Workflow',
                     providerName: 'GitLab',
                 },

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -328,6 +328,69 @@ test.describe('GitLab Integration E2E', () => {
         }
     });
 
+    test('Shows extension-not-found interstitial when signing in via OAuth without GitLab extension', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://gitlab.com/test-owner/test-repo.git');
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'gitlab',
+                'jj-view.gitlab.host': gitlab.url,
+            },
+            {
+                JJ_VIEW_GITLAB_API_URL: gitlab.url,
+                // No JJ_VIEW_GITLAB_TOKEN: forces the auth prompt
+            },
+            true, // showNotifications = true
+        );
+
+        try {
+            await focusSCM(page);
+            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            await scmInputRow.click();
+
+            // Click the Manage Auth button in the Source Control title bar
+            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+            await manageAuthButton.click();
+
+            // The Quick Pick should be visible. Select "Sign In (OAuth)"
+            await pickQuickPickItem(page, /Sign In.*OAuth/);
+
+            // Since the GitLab Workflow extension is not installed in the E2E environment
+            // (VS Code runs with --disable-extensions), we expect an error notification
+            // explaining the extension is missing, with options to install or use a PAT.
+            const notificationToast = page.locator('.notifications-toasts .notification-toast', {
+                hasText: 'authentication provider is not available',
+            });
+            await expect(notificationToast).toBeVisible({ timeout: 10000 });
+
+            // The toast should offer "Enter PAT" as an alternative
+            const enterPatButton = notificationToast.getByRole('button', { name: 'Enter PAT' });
+            await expect(enterPatButton).toBeVisible();
+            await enterPatButton.click();
+
+            // Wait for the showInputBox input to appear for PAT entry
+            const input = await waitForQuickInput(page);
+            await input.focus();
+            await input.fill('glpat-extension-not-found-test');
+            await input.press('Enter');
+
+            // Verify the quick input is gone — PAT was accepted
+            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+            await expect(quickPick).not.toBeVisible();
+        } finally {
+            maybePrintExtensionLogs(userDataDir);
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
     test('Shows warning notification toast on 403 Forbidden scope errors', async () => {
         const repo = new TestRepo();
         repo.init();

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -429,7 +429,7 @@ describe('GitLabProvider', () => {
                 clearCache: expect.any(Function),
                 promptForPat: expect.any(Function),
                 extensionInstaller: expect.objectContaining({
-                    extensionId: 'GitLab.gitlab-workflow',
+                    extensionId: 'gitlab.gitlab-workflow',
                     extensionName: 'GitLab Workflow',
                     providerName: 'GitLab',
                 }),


### PR DESCRIPTION
When OAuth sign-in is selected but the GitLab Workflow extension is absent, the auth flow now intercepts before attempting getSession and shows an error message offering to install the extension or fall back to a Personal Access Token. This replaces the previous approach of letting the call fail and routing through handleAuthError. The interstitial logic is extracted into a shared promptInstallOrPat helper used by both getSessionToken and performOAuthSignIn. Also adds a GITLAB_EXTENSION_ID constant to eliminate hardcoded strings, improves test hygiene with explicit mock resets per test, and covers the new flow with a unit test and an E2E test.