### PR TITLE
feat(scm): support tracking pull/merge requests from forks to mainline

### DIFF
--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -16,6 +16,11 @@ interface GitHubPrNode {
     mergeable: string;
     reviewDecision?: string | null;
     url: string;
+    headRepository?: {
+        owner: {
+            login: string;
+        };
+    } | null;
     reviewThreads?: {
         nodes?: {
             isResolved: boolean;
@@ -42,11 +47,26 @@ interface GitHubPrNode {
 interface GitHubGqlResponse {
     errors?: unknown[];
     data?: {
-        repository?: Record<
+        repository?: {
+            parent?: Record<
+                string,
+                {
+                    nodes?: GitHubPrNode[];
+                }
+            > | null;
+        } & Record<
             string,
-            {
-                nodes?: GitHubPrNode[];
-            }
+            | {
+                  nodes?: GitHubPrNode[];
+              }
+            | Record<
+                  string,
+                  {
+                      nodes?: GitHubPrNode[];
+                  }
+              >
+            | null
+            | undefined
         >;
     };
 }
@@ -60,6 +80,7 @@ export class GitHubProvider implements CodeForgeProvider {
     private cache = new Map<string, CodeForgeChangeInfo>();
     private owner: string | undefined;
     private repo: string | undefined;
+    private allowedOwners = new Set<string>();
 
     private _onDidUpdate = new vscode.EventEmitter<void>();
     public readonly onDidUpdate = this._onDidUpdate.event;
@@ -74,15 +95,23 @@ export class GitHubProvider implements CodeForgeProvider {
     public async detect(_workspaceRoot: string, remotes: GitRemote[]): Promise<boolean> {
         const remotePriority = (name: string): number => {
             const lower = name.toLowerCase();
-            if (lower === 'origin') {
+            if (lower === 'upstream') {
                 return 0;
             }
-            if (lower === 'upstream') {
+            if (lower === 'origin') {
                 return 1;
             }
             return 2;
         };
         const prioritized = [...remotes].sort((a, b) => remotePriority(a.name) - remotePriority(b.name));
+
+        this.allowedOwners.clear();
+        for (const remote of remotes) {
+            const parsed = this.parseGitHubUrl(remote.url);
+            if (parsed) {
+                this.allowedOwners.add(parsed.owner.toLowerCase());
+            }
+        }
 
         let owner: string | undefined;
         let repo: string | undefined;
@@ -148,10 +177,12 @@ export class GitHubProvider implements CodeForgeProvider {
         }
 
         const bookmarkNames = new Set<string>();
+        const bookmarkToCommitId = new Map<string, string>();
         for (const change of changes) {
             if (change.bookmarks) {
                 for (const bookmark of change.bookmarks) {
                     bookmarkNames.add(bookmark);
+                    bookmarkToCommitId.set(bookmark, change.commitId);
                 }
             }
         }
@@ -168,7 +199,7 @@ export class GitHubProvider implements CodeForgeProvider {
 
         const processBatch = async (batch: string[]): Promise<void> => {
             try {
-                const fetchedInfoMap = await this.fetchBatchFromNetwork(batch);
+                const fetchedInfoMap = await this.fetchBatchFromNetwork(batch, bookmarkToCommitId);
                 for (const bookmark of batch) {
                     const info = fetchedInfoMap.get(bookmark);
                     const oldInfo = this.cache.get(bookmark);
@@ -177,8 +208,10 @@ export class GitHubProvider implements CodeForgeProvider {
                         const matchingChange = changes.find((c) => c.bookmarks?.includes(bookmark));
                         if (matchingChange) {
                             info.contentSynced = info.currentRevision === matchingChange.commitId;
+                            this.cache.set(bookmark, info);
+                        } else {
+                            this.cache.delete(bookmark);
                         }
-                        this.cache.set(bookmark, info);
                     } else {
                         this.cache.delete(bookmark);
                     }
@@ -200,7 +233,10 @@ export class GitHubProvider implements CodeForgeProvider {
         return changed;
     }
 
-    private async fetchBatchFromNetwork(bookmarkNames: string[]): Promise<Map<string, CodeForgeChangeInfo>> {
+    private async fetchBatchFromNetwork(
+        bookmarkNames: string[],
+        bookmarkToCommitId: Map<string, string>,
+    ): Promise<Map<string, CodeForgeChangeInfo>> {
         const results = new Map<string, CodeForgeChangeInfo>();
         const token = await this.getSessionToken();
         if (!token) {
@@ -222,6 +258,11 @@ export class GitHubProvider implements CodeForgeProvider {
                     mergeable
                     reviewDecision
                     headRefName
+                    headRepository {
+                        owner {
+                            login
+                        }
+                    }
                     # commits(last: 1) fetches the last commit in chronological order,
                     # which is the HEAD (latest) commit of the PR.
                     commits(last: 1) {
@@ -252,6 +293,9 @@ export class GitHubProvider implements CodeForgeProvider {
         const query = `
         query($owner: String!, $name: String!) {
             repository(owner: $owner, name: $name) {
+                parent {
+                    ${aliasQueries.join('\n')}
+                }
                 ${aliasQueries.join('\n')}
             }
         }
@@ -297,11 +341,32 @@ export class GitHubProvider implements CodeForgeProvider {
 
         const repoData = json.data?.repository;
         if (repoData) {
+            const filterPrNodes = (nodes?: GitHubPrNode[], localCommitId?: string) => {
+                return (nodes || []).filter((pr) => {
+                    const headOwner = pr.headRepository?.owner?.login;
+                    if (headOwner) {
+                        return this.allowedOwners.size === 0 || this.allowedOwners.has(headOwner.toLowerCase());
+                    }
+                    if (localCommitId && pr.commits?.nodes?.[0]?.commit?.oid) {
+                        return pr.commits.nodes[0].commit.oid === localCommitId;
+                    }
+                    return false;
+                });
+            };
+
             for (let i = 0; i < bookmarkNames.length; i++) {
                 const alias = `pr_${i}`;
-                const prNodes = repoData[alias]?.nodes;
-                if (Array.isArray(prNodes) && prNodes.length > 0) {
-                    const pr = prNodes[0];
+                const parentPrNodes = repoData.parent?.[alias]?.nodes;
+                const prData = repoData[alias] as { nodes?: GitHubPrNode[] } | undefined;
+                const prNodes = prData?.nodes;
+
+                const localCommitId = bookmarkToCommitId.get(bookmarkNames[i]);
+                const filteredParentNodes = filterPrNodes(parentPrNodes, localCommitId);
+                const filteredChildNodes = filterPrNodes(prNodes, localCommitId);
+                const chosenPrNodes = filteredParentNodes.length > 0 ? filteredParentNodes : filteredChildNodes;
+
+                if (chosenPrNodes.length > 0) {
+                    const pr = chosenPrNodes[0];
                     const info = this.parseGitHubPr(pr);
                     if (info) {
                         results.set(bookmarkNames[i], info);

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -24,6 +24,14 @@ interface GitLabMergeRequest {
     user_notes_count?: number;
     web_url: string;
     sha: string;
+    source_project_id?: number;
+}
+
+interface GitLabRequestContext {
+    apiBaseUrl: string;
+    sharedToken?: string;
+    tokenPromise: Promise<string | undefined> | null;
+    bookmarkToCommitId: Map<string, string>;
 }
 
 export class GitLabProvider implements CodeForgeProvider {
@@ -35,6 +43,11 @@ export class GitLabProvider implements CodeForgeProvider {
     private cache = new Map<string, CodeForgeChangeInfo>();
     private gitlabHost: string | undefined;
     private projectPath: string | undefined;
+    private resolvedProjectPath: string | undefined;
+    private allowedProjectIds = new Set<number>();
+    private remoteProjectPaths = new Set<string>();
+    private forkResolutionPromise: Promise<string> | null = null;
+    private forkResolutionPromiseHasToken = false;
     private extensionPromptShown = false;
 
     private _onDidUpdate = new vscode.EventEmitter<void>();
@@ -54,10 +67,10 @@ export class GitLabProvider implements CodeForgeProvider {
 
         const remotePriority = (name: string): number => {
             const lower = name.toLowerCase();
-            if (lower === 'origin') {
+            if (lower === 'upstream') {
                 return 0;
             }
-            if (lower === 'upstream') {
+            if (lower === 'origin') {
                 return 1;
             }
             return 2;
@@ -77,6 +90,13 @@ export class GitLabProvider implements CodeForgeProvider {
         }
 
         if (host && projectPath) {
+            const projectPaths = new Set<string>();
+            for (const remote of remotes) {
+                const parsed = this.parseGitLabUrl(remote.url, preferredHost);
+                if (parsed) {
+                    projectPaths.add(parsed.projectPath);
+                }
+            }
             if (this.gitlabHost !== host || this.projectPath !== projectPath) {
                 this.clearCache();
                 this.authManager.setProviderUnavailable(this.id, false);
@@ -84,6 +104,7 @@ export class GitLabProvider implements CodeForgeProvider {
             }
             this.gitlabHost = host;
             this.projectPath = projectPath;
+            this.remoteProjectPaths = projectPaths;
             this.outputChannel?.appendLine(
                 `[GitLabProvider] Detected GitLab repo: host=${this.gitlabHost}, projectPath=${this.projectPath}`,
             );
@@ -195,10 +216,12 @@ export class GitLabProvider implements CodeForgeProvider {
         }
 
         const bookmarkNames = new Set<string>();
+        const bookmarkToCommitId = new Map<string, string>();
         for (const change of changes) {
             if (change.bookmarks) {
                 for (const bookmark of change.bookmarks) {
                     bookmarkNames.add(bookmark);
+                    bookmarkToCommitId.set(bookmark, change.commitId);
                 }
             }
         }
@@ -215,7 +238,7 @@ export class GitLabProvider implements CodeForgeProvider {
 
         const processBatch = async (batch: string[]): Promise<void> => {
             try {
-                const fetchedInfoMap = await this.fetchBatchFromNetwork(batch);
+                const fetchedInfoMap = await this.fetchBatchFromNetwork(batch, bookmarkToCommitId);
                 for (const bookmark of batch) {
                     const info = fetchedInfoMap.get(bookmark);
                     const oldInfo = this.cache.get(bookmark);
@@ -224,8 +247,10 @@ export class GitLabProvider implements CodeForgeProvider {
                         const matchingChange = changes.find((c) => c.bookmarks?.includes(bookmark));
                         if (matchingChange) {
                             info.contentSynced = info.currentRevision === matchingChange.commitId;
+                            this.cache.set(bookmark, info);
+                        } else {
+                            this.cache.delete(bookmark);
                         }
-                        this.cache.set(bookmark, info);
                     } else {
                         this.cache.delete(bookmark);
                     }
@@ -247,132 +272,309 @@ export class GitLabProvider implements CodeForgeProvider {
         return changed;
     }
 
-    private async fetchBatchFromNetwork(bookmarkNames: string[]): Promise<Map<string, CodeForgeChangeInfo>> {
+    private async fetchBatchFromNetwork(
+        bookmarkNames: string[],
+        bookmarkToCommitId: Map<string, string>,
+    ): Promise<Map<string, CodeForgeChangeInfo>> {
         const results = new Map<string, CodeForgeChangeInfo>();
         const projectPath = this.projectPath;
         if (!this.gitlabHost || !projectPath || bookmarkNames.length === 0) {
             return results;
         }
 
-        let sharedToken = await this.getSessionToken(false);
-        let tokenPromise: Promise<string | undefined> | null = null;
+        const sharedToken = await this.getSessionToken(false);
+        const apiBaseUrl = process.env.JJ_VIEW_GITLAB_API_URL || `${this.gitlabHost}/api/v4`;
+
+        // Resolve upstream project path once if fork
+        if (!this.resolvedProjectPath) {
+            await this.resolveForkPath(apiBaseUrl, sharedToken);
+        }
+
+        const context: GitLabRequestContext = {
+            apiBaseUrl,
+            sharedToken,
+            tokenPromise: null,
+            bookmarkToCommitId,
+        };
+
+        const fetchBookmarkWrapper = async (bookmark: string): Promise<void> => {
+            const info = await this.fetchBookmark(bookmark, context);
+            if (info) {
+                results.set(bookmark, info);
+            }
+        };
+
+        await Promise.all(bookmarkNames.map((bookmark) => fetchBookmarkWrapper(bookmark)));
+        return results;
+    }
+
+    private async fetchBookmark(
+        bookmark: string,
+        context: GitLabRequestContext,
+    ): Promise<CodeForgeChangeInfo | undefined> {
+        const projectPath = this.projectPath;
+        if (!projectPath) {
+            return undefined;
+        }
 
         const acquireToken = async (): Promise<string | undefined> => {
-            if (sharedToken) {
-                return sharedToken;
+            if (context.sharedToken) {
+                return context.sharedToken;
             }
-            if (!tokenPromise) {
-                tokenPromise = (async () => {
+            if (!context.tokenPromise) {
+                context.tokenPromise = (async () => {
                     const promptToken = await this.getSessionToken(true);
                     if (promptToken) {
-                        sharedToken = promptToken;
+                        context.sharedToken = promptToken;
                     }
                     return promptToken;
                 })();
             }
-            return tokenPromise;
+            return context.tokenPromise;
         };
 
-        const getHeaders = (t: string | undefined): Record<string, string> => {
-            const h: Record<string, string> = {
-                'User-Agent': 'jj-view-vscode-extension',
-            };
-            if (t) {
-                h.Authorization = `Bearer ${t}`;
-            }
-            return h;
-        };
+        const getUrl = (path: string) =>
+            `${context.apiBaseUrl}/projects/${encodeURIComponent(path)}/merge_requests?source_branch=${encodeURIComponent(bookmark)}&with_merge_status_recheck=true`;
 
-        const apiBaseUrl = process.env.JJ_VIEW_GITLAB_API_URL || `${this.gitlabHost}/api/v4`;
+        try {
+            let currentPath = this.resolvedProjectPath || projectPath;
+            let response = await fetchWithTimeout(getUrl(currentPath), 15000, {
+                headers: this.getHeaders(context.sharedToken),
+            });
 
-        const fetchBookmark = async (bookmark: string): Promise<void> => {
-            const urlStr = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests?source_branch=${encodeURIComponent(bookmark)}&with_merge_status_recheck=true`;
+            const retryResult = await this.tryUnauthenticatedRetry(
+                response,
+                currentPath,
+                getUrl,
+                context,
+                acquireToken,
+            );
+            response = retryResult.response;
+            currentPath = retryResult.currentPath;
 
-            try {
-                let response = await fetchWithTimeout(urlStr, 15000, { headers: getHeaders(sharedToken) });
+            await this.handleInvalidTokenIfNeeded(response.status, context);
 
-                if ((response.status === 401 || response.status === 404) && !sharedToken) {
-                    if (this.authManager.isProviderUnavailable(this.id)) {
-                        if (!this.extensionPromptShown) {
-                            this.extensionPromptShown = true;
-                            this.promptInstallGitLabExtension();
-                        }
-                    } else {
-                        this.outputChannel?.appendLine(
-                            `[GitLabProvider] Unauthenticated request failed with status ${response.status}. Prompting for GitLab OAuth...`,
-                        );
-                        const promptToken = await acquireToken();
-                        if (promptToken) {
-                            response = await fetchWithTimeout(urlStr, 15000, { headers: getHeaders(promptToken) });
-                        }
-                    }
-                }
-
-                const currentToken = sharedToken;
-                if (response.status === 401 && currentToken) {
-                    this.outputChannel?.appendLine(
-                        `[GitLabProvider] Request failed with 401 Unauthorized using token. Stored token may be invalid or expired.`,
-                    );
-                    // Reset the in-memory token cache so the next request re-fetches credentials.
-                    if (sharedToken === currentToken) {
-                        sharedToken = undefined;
-                        tokenPromise = null;
-                    }
-                    await this.authManager.clearInvalidToken({
-                        providerId: 'gitlab',
-                        secretTokenKey: 'gitlab_token',
-                        currentToken,
-                        envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
-                    });
-                }
-
-                if (!response.ok) {
-                    this.outputChannel?.appendLine(
-                        `[GitLabProvider] Request failed with status ${response.status}: ${response.statusText}`,
-                    );
-                    this.handle403Warning(response);
-                    return;
-                }
-
-                const mrs = (await response.json()) as GitLabMergeRequest[];
-                if (Array.isArray(mrs) && mrs.length > 0) {
-                    const openMr = mrs.find((mr) => mr.state === 'opened');
-                    const selectedMr = openMr || mrs[0];
-
-                    let detailedMr = selectedMr;
-                    const singleMrUrl = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${selectedMr.iid}`;
-                    try {
-                        const singleResponse = await fetchWithTimeout(singleMrUrl, 15000, {
-                            headers: getHeaders(sharedToken),
-                        });
-                        if (singleResponse.ok) {
-                            detailedMr = (await singleResponse.json()) as GitLabMergeRequest;
-                        } else {
-                            this.outputChannel?.appendLine(
-                                `[GitLabProvider] Failed to fetch single MR detail with status ${singleResponse.status}, falling back to list MR data`,
-                            );
-                            this.handle403Warning(singleResponse);
-                        }
-                    } catch (singleErr) {
-                        this.outputChannel?.appendLine(
-                            `[GitLabProvider] Error fetching single MR detail: ${singleErr}, falling back to list MR data`,
-                        );
-                    }
-
-                    const info = this.parseGitLabMr(detailedMr);
-                    if (info) {
-                        results.set(bookmark, info);
-                    }
-                }
-            } catch (error) {
+            if (!response.ok) {
                 this.outputChannel?.appendLine(
-                    `[GitLabProvider] Failed to fetch MR for bookmark ${bookmark}: ${error}`,
+                    `[GitLabProvider] Request failed with status ${response.status}: ${response.statusText}`,
                 );
+                this.handle403Warning(response);
+                return undefined;
             }
-        };
 
-        await Promise.all(bookmarkNames.map((bookmark) => fetchBookmark(bookmark)));
-        return results;
+            const mrs = (await response.json()) as GitLabMergeRequest[];
+            if (Array.isArray(mrs) && mrs.length > 0) {
+                const filteredMrs = this.filterGitLabMrs(mrs, bookmark, context.bookmarkToCommitId);
+                if (filteredMrs.length > 0) {
+                    const openMr = filteredMrs.find((mr) => mr.state === 'opened');
+                    const selectedMr = openMr || filteredMrs[0];
+
+                    const detailedMr = await this.fetchSingleMrDetails(
+                        context.apiBaseUrl,
+                        currentPath,
+                        selectedMr,
+                        context.sharedToken,
+                    );
+
+                    return this.parseGitLabMr(detailedMr);
+                }
+            }
+        } catch (error) {
+            this.outputChannel?.appendLine(`[GitLabProvider] Failed to fetch MR for bookmark ${bookmark}: ${error}`);
+        }
+        return undefined;
+    }
+
+    private async tryUnauthenticatedRetry(
+        response: Response,
+        currentPath: string,
+        getUrl: (path: string) => string,
+        context: GitLabRequestContext,
+        acquireToken: () => Promise<string | undefined>,
+    ): Promise<{ response: Response; currentPath: string }> {
+        if ((response.status === 401 || response.status === 404) && !context.sharedToken) {
+            if (this.authManager.isProviderUnavailable(this.id)) {
+                if (!this.extensionPromptShown) {
+                    this.extensionPromptShown = true;
+                    this.promptInstallGitLabExtension();
+                }
+            } else {
+                this.outputChannel?.appendLine(
+                    `[GitLabProvider] Unauthenticated request failed with status ${response.status}. Prompting for GitLab OAuth...`,
+                );
+                const promptToken = await acquireToken();
+                if (promptToken) {
+                    const resolvedPath = await this.resolveForkPath(context.apiBaseUrl, promptToken);
+                    const retriedResponse = await fetchWithTimeout(getUrl(resolvedPath), 15000, {
+                        headers: this.getHeaders(promptToken),
+                    });
+                    return { response: retriedResponse, currentPath: resolvedPath };
+                }
+            }
+        }
+        return { response, currentPath };
+    }
+
+    private async handleInvalidTokenIfNeeded(status: number, context: GitLabRequestContext): Promise<void> {
+        const currentToken = context.sharedToken;
+        if (status === 401 && currentToken) {
+            this.outputChannel?.appendLine(
+                `[GitLabProvider] Request failed with 401 Unauthorized using token. Stored token may be invalid or expired.`,
+            );
+            // Reset the in-memory token cache so the next request re-fetches credentials.
+            if (context.sharedToken === currentToken) {
+                context.sharedToken = undefined;
+                context.tokenPromise = null;
+            }
+            await this.authManager.clearInvalidToken({
+                providerId: 'gitlab',
+                secretTokenKey: 'gitlab_token',
+                currentToken,
+                envTokenKey: 'JJ_VIEW_GITLAB_TOKEN',
+            });
+        }
+    }
+
+    private filterGitLabMrs(
+        mrs: GitLabMergeRequest[],
+        bookmark: string,
+        bookmarkToCommitId: Map<string, string>,
+    ): GitLabMergeRequest[] {
+        return mrs.filter((mr) => {
+            const sourceId = mr.source_project_id;
+            if (sourceId) {
+                return this.allowedProjectIds.size === 0 || this.allowedProjectIds.has(sourceId);
+            }
+            const localCommitId = bookmarkToCommitId.get(bookmark);
+            if (localCommitId && mr.sha) {
+                return mr.sha === localCommitId;
+            }
+            return false;
+        });
+    }
+
+    private async fetchSingleMrDetails(
+        apiBaseUrl: string,
+        projectPath: string,
+        selectedMr: GitLabMergeRequest,
+        token: string | undefined,
+    ): Promise<GitLabMergeRequest> {
+        const singleMrUrl = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${selectedMr.iid}`;
+        try {
+            const response = await fetchWithTimeout(singleMrUrl, 15000, {
+                headers: this.getHeaders(token),
+            });
+            if (response.ok) {
+                return (await response.json()) as GitLabMergeRequest;
+            }
+            this.outputChannel?.appendLine(
+                `[GitLabProvider] Failed to fetch single MR detail with status ${response.status}, falling back to list MR data`,
+            );
+            this.handle403Warning(response);
+        } catch (err) {
+            this.outputChannel?.appendLine(
+                `[GitLabProvider] Error fetching single MR detail: ${err}, falling back to list MR data`,
+            );
+        }
+        return selectedMr;
+    }
+
+    private getHeaders(token: string | undefined): Record<string, string> {
+        const headers: Record<string, string> = {
+            'User-Agent': 'jj-view-vscode-extension',
+        };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+        return headers;
+    }
+
+    private async resolveForkPath(apiBaseUrl: string, token: string | undefined): Promise<string> {
+        const projectPath = this.projectPath;
+        if (!projectPath) {
+            return '';
+        }
+        if (this.resolvedProjectPath) {
+            return this.resolvedProjectPath;
+        }
+        if (this.forkResolutionPromise && (this.forkResolutionPromiseHasToken || !token)) {
+            return this.forkResolutionPromise;
+        }
+        this.forkResolutionPromiseHasToken = !!token;
+        this.forkResolutionPromise = (async () => {
+            // First resolve project IDs for all configured remote project paths
+            for (const path of this.remoteProjectPaths) {
+                if (path === projectPath) {
+                    continue;
+                }
+                const projectInfo = await this.fetchProjectInfo(apiBaseUrl, path, token);
+                if (projectInfo) {
+                    if (projectInfo.id) {
+                        this.allowedProjectIds.add(projectInfo.id);
+                    }
+                    if (projectInfo.forked_from_project?.id) {
+                        this.allowedProjectIds.add(projectInfo.forked_from_project.id);
+                    }
+                }
+            }
+
+            const projectInfo = await this.fetchProjectInfo(apiBaseUrl, projectPath, token);
+            if (projectInfo) {
+                if (projectInfo.id) {
+                    this.allowedProjectIds.add(projectInfo.id);
+                }
+                if (projectInfo.forked_from_project?.id) {
+                    this.allowedProjectIds.add(projectInfo.forked_from_project.id);
+                }
+                if (projectInfo.forked_from_project?.path_with_namespace) {
+                    this.resolvedProjectPath = projectInfo.forked_from_project.path_with_namespace;
+                    this.outputChannel?.appendLine(
+                        `[GitLabProvider] Detected parent project for fork: ${this.resolvedProjectPath}`,
+                    );
+                } else {
+                    // Mark as resolved (none) so we don't query again
+                    this.resolvedProjectPath = projectPath;
+                }
+            }
+            this.forkResolutionPromise = null;
+            this.forkResolutionPromiseHasToken = false;
+            return this.resolvedProjectPath || projectPath;
+        })();
+        return this.forkResolutionPromise;
+    }
+
+    private async fetchProjectInfo(
+        apiBaseUrl: string,
+        path: string,
+        token: string | undefined,
+    ): Promise<
+        | {
+              id?: number;
+              forked_from_project?: {
+                  id?: number;
+                  path_with_namespace?: string;
+              };
+          }
+        | undefined
+    > {
+        try {
+            const projectUrl = `${apiBaseUrl}/projects/${encodeURIComponent(path)}`;
+            const response = await fetchWithTimeout(projectUrl, 10000, {
+                headers: this.getHeaders(token),
+            });
+            if (response.ok) {
+                return (await response.json()) as {
+                    id?: number;
+                    forked_from_project?: {
+                        id?: number;
+                        path_with_namespace?: string;
+                    };
+                };
+            }
+        } catch (e) {
+            this.outputChannel?.appendLine(`[GitLabProvider] Failed to fetch project details for ${path}: ${e}`);
+        }
+        return undefined;
     }
 
     private parseGitLabMr(mr: GitLabMergeRequest): CodeForgeChangeInfo | undefined {
@@ -452,6 +654,11 @@ export class GitLabProvider implements CodeForgeProvider {
 
     public clearCache(): void {
         this.cache.clear();
+        this.resolvedProjectPath = undefined;
+        this.allowedProjectIds.clear();
+        this.remoteProjectPaths.clear();
+        this.forkResolutionPromise = null;
+        this.forkResolutionPromiseHasToken = false;
         this.hasWarned403 = false;
         this._onDidUpdate.fire();
     }

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -361,4 +361,54 @@ test.describe('GitHub Integration E2E', () => {
             repo.dispose();
         }
     });
+
+    test('Detects PR from fork targeting mainline repo', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://github.com/mainline-owner/mainline-repo.git');
+        repo.addRemote('fork', 'https://github.com/fork-owner/fork-repo.git');
+
+        const graph: CommitDefinition[] = [
+            { label: 'base', description: 'base' },
+            { label: 'fork-commit', parents: ['base'], description: 'Fork Commit', bookmarks: ['my-fork-branch'] },
+        ];
+
+        const commits = await buildGraph(repo, graph);
+
+        github.registerPR('my-fork-branch', {
+            id: 'pr_node_id_fork',
+            number: 99,
+            state: 'OPEN',
+            mergeable: 'MERGEABLE',
+            url: 'https://github.com/mainline-owner/mainline-repo/pull/99',
+            currentRevision: commits['fork-commit'].commitId,
+            headOwner: 'fork-owner',
+        });
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'github',
+            },
+            {
+                JJ_VIEW_GITHUB_API_URL: github.url,
+                JJ_VIEW_GITHUB_TOKEN: 'test-token',
+            },
+        );
+
+        try {
+            await focusJJLog(page);
+
+            const row = await waitForLogCommitRow(page, 'Fork Commit');
+
+            // Verify PR badge is shown with correct number and URL (even though the headOwner is 'fork-owner')
+            await expectBadgeLink(row, 'PR #99', 'https://github.com/mainline-owner/mainline-repo/pull/99');
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -439,4 +439,60 @@ test.describe('GitLab Integration E2E', () => {
             repo.dispose();
         }
     });
+
+    test('Detects MR from fork targeting mainline repo', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://gitlab.com/mainline-owner/mainline-repo.git');
+        repo.addRemote('fork', 'https://gitlab.com/fork-owner/fork-repo.git');
+
+        const graph: CommitDefinition[] = [
+            { label: 'base', description: 'base' },
+            { label: 'fork-commit', parents: ['base'], description: 'Fork Commit', bookmarks: ['my-fork-branch'] },
+        ];
+
+        const commits = await buildGraph(repo, graph);
+
+        gitlab.registerMR('my-fork-branch', {
+            id: 99,
+            iid: 99,
+            state: 'opened',
+            title: 'MR Title',
+            description: 'MR Desc',
+            web_url: 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/99',
+            draft: false,
+            merge_status: 'can_be_merged',
+            detailed_merge_status: 'mergeable',
+            sha: commits['fork-commit'].commitId,
+            source_project_id: 200, // Allowed fork source project ID
+        });
+
+        const { app, page, userDataDir } = await launchVSCode(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'gitlab',
+                'jj-view.gitlab.host': gitlab.url,
+            },
+            {
+                JJ_VIEW_GITLAB_API_URL: gitlab.url,
+                JJ_VIEW_GITLAB_TOKEN: 'test-token',
+            },
+        );
+
+        try {
+            await focusJJLog(page);
+
+            const row = await waitForLogCommitRow(page, 'Fork Commit');
+
+            // Verify MR badge is shown with correct ID (even though it's submitted from project ID 200, which is the fork)
+            await expectBadgeLink(row, 'MR !99', 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/99');
+        } finally {
+            maybePrintExtensionLogs(userDataDir);
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import type { CodeForgeAuthManager } from '../code-forge-auth';
 import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
 import { GitHubProvider } from '../github-provider';
+import type { CodeForgeChangeInfo } from '../jj-types';
 import { accessPrivate, createMock, exposePrivate, setPrivate } from './test-utils';
 
 // Mock VS Code
@@ -100,6 +101,18 @@ describe('GitHubProvider', () => {
         expect(result2).toBe(false);
         expect(accessPrivate(provider, 'owner')).toBeUndefined();
         expect(accessPrivate(provider, 'repo')).toBeUndefined();
+    });
+
+    test('detect prioritizes upstream remote over origin', async () => {
+        const remotes = [
+            { name: 'origin', url: 'https://github.com/fork-owner/fork-repo.git' },
+            { name: 'upstream', url: 'https://github.com/mainline-owner/mainline-repo.git' },
+        ];
+        const result = await provider.detect('/root', remotes);
+
+        expect(result).toBe(true);
+        expect(accessPrivate(provider, 'owner')).toBe('mainline-owner');
+        expect(accessPrivate(provider, 'repo')).toBe('mainline-repo');
     });
 
     test('detect clears cache on owner/repo change, but preserves it if unchanged', async () => {
@@ -436,5 +449,117 @@ describe('GitHubProvider', () => {
                 clearCache: expect.any(Function),
             }),
         );
+    });
+
+    test('fetchBatchFromNetwork handles parent repository for forks', async () => {
+        setPrivate(provider, 'owner', 'fork-owner');
+        setPrivate(provider, 'repo', 'fork-repo');
+
+        const originalFetch = global.fetch;
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                data: {
+                    repository: {
+                        parent: {
+                            pr_0: {
+                                nodes: [
+                                    {
+                                        id: 'parent-pr-id',
+                                        number: 42,
+                                        state: 'OPEN',
+                                        mergeable: 'MERGEABLE',
+                                        url: 'https://github.com/parent-owner/parent-repo/pull/42',
+                                        commits: {
+                                            nodes: [
+                                                {
+                                                    commit: {
+                                                        oid: 'sha-parent',
+                                                        message: 'msg',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                        pr_0: {
+                            nodes: [],
+                        },
+                    },
+                },
+            }),
+        });
+        global.fetch = fetchMock;
+
+        try {
+            const fetchBatch = exposePrivate<{
+                fetchBatchFromNetwork(
+                    bookmarkNames: string[],
+                    bookmarkToCommitId: Map<string, string>,
+                ): Promise<Map<string, CodeForgeChangeInfo>>;
+            }>(provider).fetchBatchFromNetwork.bind(provider);
+
+            const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
+            expect(results.size).toBe(1);
+            const pr = results.get('my-feature-branch');
+            expect(pr).toBeDefined();
+            expect(pr?.id).toBe('parent-pr-id');
+            expect(pr?.number).toBe(42);
+            expect(pr?.url).toBe('https://github.com/parent-owner/parent-repo/pull/42');
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            const requestBody = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+            expect(requestBody.query).toContain('parent {');
+        } finally {
+            global.fetch = originalFetch;
+        }
+    });
+
+    test('fetchStatuses matches closed/merged PRs even if local commit ID differs', async () => {
+        setPrivate(provider, 'owner', 'my-owner');
+        setPrivate(provider, 'repo', 'my-repo');
+        const allowedOwners = accessPrivate<Set<string>>(provider, 'allowedOwners');
+        allowedOwners.clear();
+        allowedOwners.add('my-owner');
+
+        vi.spyOn(
+            exposePrivate<{
+                fetchBatchFromNetwork(
+                    bookmarkNames: string[],
+                    bookmarkToCommitId: Map<string, string>,
+                ): Promise<Map<string, CodeForgeChangeInfo>>;
+            }>(provider),
+            'fetchBatchFromNetwork',
+        ).mockResolvedValue(
+            new Map([
+                [
+                    'my-feature-merged',
+                    {
+                        id: 'pr-1',
+                        number: 1,
+                        displayLabel: 'PR #1',
+                        providerName: 'GitHub',
+                        status: 'MERGED',
+                        submittable: true,
+                        url: 'url-1',
+                        unresolvedComments: 0,
+                        currentRevision: 'sha-merged',
+                    },
+                ],
+            ]),
+        );
+
+        const cache = accessPrivate<Map<string, CodeForgeChangeInfo>>(provider, 'cache');
+
+        const changes: ChangeStatusRequest[] = [{ commitId: 'sha-local-differs', bookmarks: ['my-feature-merged'] }];
+
+        await provider.fetchStatuses(changes);
+
+        // my-feature-merged SHOULD be cached even though local commit ID doesn't match
+        expect(cache.get('my-feature-merged')).toBeDefined();
+        expect(cache.get('my-feature-merged')?.contentSynced).toBe(false);
     });
 });

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import type { CodeForgeAuthManager } from '../code-forge-auth';
 import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
 import { GitLabProvider } from '../gitlab-provider';
+import type { CodeForgeChangeInfo } from '../jj-types';
 import { accessPrivate, createMock, exposePrivate, setPrivate } from './test-utils';
 
 vi.mock('vscode', () => ({
@@ -144,6 +145,18 @@ describe('GitLabProvider', () => {
         expect(accessPrivate(provider, 'projectPath')).toBeUndefined();
     });
 
+    test('detect prioritizes upstream remote over origin', async () => {
+        const remotes = [
+            { name: 'origin', url: 'https://gitlab.com/fork-owner/fork-repo.git' },
+            { name: 'upstream', url: 'https://gitlab.com/mainline-owner/mainline-repo.git' },
+        ];
+        const result = await provider.detect('/root', remotes);
+
+        expect(result).toBe(true);
+        expect(accessPrivate(provider, 'gitlabHost')).toBe('https://gitlab.com');
+        expect(accessPrivate(provider, 'projectPath')).toBe('mainline-owner/mainline-repo');
+    });
+
     test('parseGitLabMr calculates submittable correctly based on draft, merge_status, and blocking_discussions_resolved', () => {
         interface MockGitLabMr {
             id: number;
@@ -266,11 +279,14 @@ describe('GitLabProvider', () => {
         const fetchBatchSpy = vi
             .spyOn(
                 exposePrivate<{
-                    fetchBatchFromNetwork(bookmarkNames: string[]): Promise<Map<string, unknown>>;
+                    fetchBatchFromNetwork(
+                        bookmarkNames: string[],
+                        bookmarkToCommitId: Map<string, string>,
+                    ): Promise<Map<string, unknown>>;
                 }>(provider),
                 'fetchBatchFromNetwork',
             )
-            .mockImplementation(async (bookmarkNames: string[]) => {
+            .mockImplementation(async (bookmarkNames: string[], _bookmarkToCommitId: Map<string, string>) => {
                 const results = new Map<string, unknown>();
                 for (const name of bookmarkNames) {
                     results.set(name, {
@@ -453,5 +469,91 @@ describe('GitLabProvider', () => {
                 clearCache: expect.any(Function),
             }),
         );
+    });
+
+    test('fetchBatchFromNetwork handles fork parent resolution', async () => {
+        setPrivate(provider, 'gitlabHost', 'https://gitlab.com');
+        setPrivate(provider, 'projectPath', 'fork-owner/fork-repo');
+
+        const originalFetch = global.fetch;
+        const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+            if (url.includes('/projects/fork-owner%2Ffork-repo')) {
+                return createMock<Response>({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        id: 200,
+                        forked_from_project: {
+                            id: 100,
+                            path_with_namespace: 'mainline-owner/mainline-repo',
+                        },
+                    }),
+                });
+            }
+            if (url.includes('/projects/mainline-owner%2Fmainline-repo/merge_requests/42')) {
+                return createMock<Response>({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({
+                        id: 101,
+                        iid: 42,
+                        state: 'opened',
+                        web_url: 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/42',
+                        sha: 'sha-parent',
+                        merge_status: 'can_be_merged',
+                        source_project_id: 200,
+                    }),
+                });
+            }
+            if (url.includes('/projects/mainline-owner%2Fmainline-repo/merge_requests')) {
+                return createMock<Response>({
+                    ok: true,
+                    status: 200,
+                    json: async () => [
+                        {
+                            id: 102,
+                            iid: 43,
+                            state: 'opened',
+                            web_url: 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/43',
+                            sha: 'sha-other',
+                            merge_status: 'can_be_merged',
+                            source_project_id: 999, // Mismatched fork (ignored)
+                        },
+                        {
+                            id: 101,
+                            iid: 42,
+                            state: 'opened',
+                            web_url: 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/42',
+                            sha: 'sha-parent',
+                            merge_status: 'can_be_merged',
+                            source_project_id: 200, // Allowed fork (chosen)
+                        },
+                    ],
+                });
+            }
+            return createMock<Response>({ ok: false, status: 404 });
+        });
+        global.fetch = fetchMock;
+
+        try {
+            const fetchBatch = exposePrivate<{
+                fetchBatchFromNetwork(
+                    bookmarkNames: string[],
+                    bookmarkToCommitId: Map<string, string>,
+                ): Promise<Map<string, CodeForgeChangeInfo>>;
+            }>(provider).fetchBatchFromNetwork.bind(provider);
+
+            const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
+            expect(results.size).toBe(1);
+            const mr = results.get('my-feature-branch');
+            expect(mr).toBeDefined();
+            expect(mr?.id).toBe('101');
+            expect(mr?.number).toBe(42);
+            expect(mr?.url).toBe('https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/42');
+
+            expect(accessPrivate(provider, 'resolvedProjectPath')).toBe('mainline-owner/mainline-repo');
+        } finally {
+            global.fetch = originalFetch;
+        }
     });
 });

--- a/src/test/helpers/fake-github-server.ts
+++ b/src/test/helpers/fake-github-server.ts
@@ -14,6 +14,7 @@ export interface FakePrInfo {
     currentRevision?: string;
     remoteParents?: string[];
     unresolvedComments?: number;
+    headOwner?: string;
 }
 
 interface GqlPrNode {
@@ -22,6 +23,11 @@ interface GqlPrNode {
     state: string;
     mergeable: string;
     url: string;
+    headRepository?: {
+        owner?: {
+            login?: string;
+        };
+    };
     reviewThreads?: {
         nodes?: {
             isResolved: boolean;
@@ -90,6 +96,11 @@ export class FakeGitHubServer {
                                     state: pr.state,
                                     mergeable: pr.mergeable,
                                     url: pr.url,
+                                    headRepository: {
+                                        owner: {
+                                            login: pr.headOwner || 'test-owner',
+                                        },
+                                    },
                                 };
 
                                 if (pr.unresolvedComments !== undefined) {

--- a/src/test/helpers/fake-gitlab-server.ts
+++ b/src/test/helpers/fake-gitlab-server.ts
@@ -18,6 +18,7 @@ export interface FakeMrInfo {
     blocking_discussions_resolved?: boolean;
     sha: string;
     user_notes_count?: number;
+    source_project_id?: number;
 }
 
 export class FakeGitLabServer {
@@ -28,6 +29,9 @@ export class FakeGitLabServer {
     public statusOverride: { status: number; headers?: Record<string, string>; body?: string } | undefined;
 
     public registerMR(bookmark: string, mr: FakeMrInfo) {
+        if (mr.source_project_id === undefined) {
+            mr.source_project_id = 100;
+        }
         this.mrs.set(bookmark, mr);
     }
 
@@ -87,6 +91,35 @@ export class FakeGitLabServer {
                 res.writeHead(200, { 'Content-Type': 'application/json' });
                 res.end(JSON.stringify(results));
                 return;
+            }
+
+            if (pathname.includes('/projects/')) {
+                if (!pathname.endsWith('/merge_requests') && !pathname.includes('/merge_requests/')) {
+                    const projectPath = decodeURIComponent(
+                        pathname.substring(pathname.indexOf('/projects/') + '/projects/'.length),
+                    );
+                    if (projectPath === 'fork-owner/fork-repo') {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(
+                            JSON.stringify({
+                                id: 200,
+                                forked_from_project: {
+                                    id: 100,
+                                    path_with_namespace: 'mainline-owner/mainline-repo',
+                                },
+                            }),
+                        );
+                        return;
+                    } else if (projectPath === 'mainline-owner/mainline-repo') {
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(
+                            JSON.stringify({
+                                id: 100,
+                            }),
+                        );
+                        return;
+                    }
+                }
             }
 
             res.writeHead(404);


### PR DESCRIPTION
Implements detection and tracking of fork PRs/MRs targeting the mainline repository. The providers resolve the upstream/parent repository or project and filter incoming PRs to match only those from allowed remote owners or project IDs.

Includes a fallback validation to verify that commit IDs match when the head repository has been deleted (i.e. is null/missing) to prevent incorrect matching of common branch names like 'main'.