### PR TITLE
fix: show only the subject line of ancestor commit descriptions

### DIFF
--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -379,7 +379,8 @@ export class JjScmProvider implements vscode.Disposable {
                         minChangeIdLength,
                     );
                     const desc = ancestorEntry.description?.trim() || '(no description)';
-                    const label = `${prefix}: ${shortId} - ${desc}`;
+                    const subject = desc.split('\n', 1 /* limit */)[0].trim();
+                    const label = `${prefix}: ${shortId} - ${subject}`;
 
                     // Reuse existing group or create new one
                     let group: vscode.SourceControlResourceGroup;

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -259,6 +259,34 @@ suite('JJ SCM Provider Integration Test', () => {
         await scmProvider.refresh({ forceSnapshot: true });
     });
 
+    test('Shows parent commit changes with only the first line of a multiline description', async () => {
+        await buildGraph(repo, [
+            {
+                label: 'parent',
+                description: 'First line of description\nSecond line of description',
+                files: { 'parent-file.txt': 'content' },
+            },
+            {
+                parents: ['parent'],
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        await scmProvider.refresh({ forceSnapshot: true });
+
+        const parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
+        assert.ok(parentGroups && parentGroups.length > 0, 'Should have at least one parent group');
+        const parentGroup = parentGroups[0];
+        assert.ok(
+            parentGroup.label.includes('First line of description'),
+            `Label should contain first line. Got: ${parentGroup.label}`,
+        );
+        assert.ok(
+            !parentGroup.label.includes('Second line of description'),
+            `Label should NOT contain second line. Got: ${parentGroup.label}`,
+        );
+    });
+
     test('Fetches multiple mutable ancestors based on config', async () => {
         await buildGraph(repo, [
             {


### PR DESCRIPTION
SCM parent group label now displays only the first line (subject) of ancestor commit descriptions, preventing long, multiline messages from cluttering the Source Control view headers. Also includes an integration test validating this format.

Fixes #317