### PR TITLE
feat: add focus SCM description input command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 - `JJ View: Refresh`: Refresh the current status and log.
 - `JJ View: Show Current Change`: Focus the graph on the current working copy change.
 - `JJ View: Show Details`: Open a dedicated panel with full details of the selected commit.
+- `JJ View: Focus SCM Description Input`: Focus the description input field in the Source Control view.
 - `JJ View: Undo`: Undo the last `jj` operation.
 - `JJ View: Redo`: Redo the last undone `jj` operation.
 
@@ -107,6 +108,7 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 
 - **Commit**: `Ctrl+Enter` (or `Cmd+Enter` on macOS) in the SCM input box to commit changes.
 - **Set Description**: `Ctrl+S` (or `Cmd+S` on macOS) in the SCM input box or Commit Details panel to save the description without finishing the commit.
+- **Focus SCM Description Input**: `Ctrl+Shift+G` (or `Cmd+Shift+G` on macOS) to open Source Control and focus the description input field (overrides VS Code's default SCM view binding when `scmProvider == 'jj'`).
 
 ### 🔄 Automatic Refresh
 

--- a/package.json
+++ b/package.json
@@ -209,6 +209,11 @@
                 "icon": "$(save)"
             },
             {
+                "command": "jj-view.focusDescriptionInput",
+                "title": "Focus SCM Description Input",
+                "category": "JJ View"
+            },
+            {
                 "command": "jj-view.commit",
                 "title": "Commit",
                 "category": "JJ View",
@@ -485,6 +490,12 @@
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
                 "when": "scmProvider == 'jj' && editorLangId == 'scminput'"
+            },
+            {
+                "command": "jj-view.focusDescriptionInput",
+                "key": "ctrl+shift+g",
+                "mac": "cmd+shift+g",
+                "when": "scmProvider == 'jj'"
             }
         ],
         "menus": {

--- a/src/commands/focus-description-input.ts
+++ b/src/commands/focus-description-input.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+
+export async function focusDescriptionInputCommand() {
+    await vscode.commands.executeCommand('workbench.view.scm');
+    await vscode.commands.executeCommand('list.focusFirst');
+    await vscode.commands.executeCommand('list.select');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { showDetailsCommand } from './commands/details';
 import { discardChangeCommand } from './commands/discard-change';
 import { duplicateCommand } from './commands/duplicate';
 import { editCommand } from './commands/edit';
+import { focusDescriptionInputCommand } from './commands/focus-description-input';
 import { type MergeCommandArg, newMergeChangeCommand } from './commands/merge';
 import { openMergeEditorCommand } from './commands/merge-editor';
 import { showMultiFileDiffCommand } from './commands/multi-diff';
@@ -287,6 +288,10 @@ export function activate(context: vscode.ExtensionContext) {
         await describePromptCommand(scmProvider, jj);
     });
 
+    const focusDescriptionInputCmd = vscode.commands.registerCommand('jj-view.focusDescriptionInput', async () => {
+        await focusDescriptionInputCommand();
+    });
+
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.abandon', async (arg: unknown) => {
             await abandonCommand(scmProvider, jj, [arg]);
@@ -518,6 +523,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(commitCmd);
     context.subscriptions.push(commitPromptCmd);
     context.subscriptions.push(describePromptCmd);
+    context.subscriptions.push(focusDescriptionInputCmd);
     context.subscriptions.push(scmProvider);
 
     context.subscriptions.push(

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -181,18 +181,28 @@ export async function launchVSCode(
 }
 
 /**
- * Ensures the SCM view is open.
+ * Presses the keyboard shortcut to focus the SCM view / SCM description input.
+ */
+export async function pressScmShortcut(page: Page) {
+    await page.keyboard.press(isMac ? 'Meta+Shift+G' : 'Control+Shift+G');
+}
+
+/**
+ * Ensures the SCM view is open and focused.
  */
 export async function focusSCM(page: Page) {
     await expect(async () => {
-        // Control+Shift+G is the standard VS Code shortcut to show/focus Source Control
-        await page.keyboard.press('Control+Shift+G');
+        // Use standard shortcut to show/focus Source Control
+        await pressScmShortcut(page);
 
         // Wait for either the input row or the side bar title to be visible
         const scmTitle = page.locator('.pane-header', { hasText: 'Source Control' }).first();
         const scmInput = page.getByRole('treeitem', { name: 'Source Control Input' });
 
         await expect(scmTitle.or(scmInput)).toBeVisible({ timeout: 2000 });
+
+        // Click the SCM input row to ensure the provider context is active
+        await scmInput.click();
     }).toPass({ timeout: 20000 });
 }
 
@@ -500,15 +510,17 @@ export async function expectSettingsOpen(page: Page, settingName: string | RegEx
 
 /**
  * Robustly sets the description in the SCM input field.
- * Uses Playwright's .fill() most of the time, but includes
- * explicit validation to prevent partial/mangled entries.
+ * Focuses the input using the focusDescriptionInput shortcut,
+ * inserts the description text, and validates the input value.
+ *
+ * @returns The locator targeting the Source Control Input treeitem.
  */
-export async function setScmDescription(page: Page, description: string) {
+export async function setScmDescription(page: Page, description: string): Promise<Locator> {
     const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
 
     await expect(async () => {
         // 1. Ensure the SCM input is visible and focused
-        await scmInputRow.click();
+        await pressScmShortcut(page);
 
         // Wait for the native edit context or a textarea to be active
         await page
@@ -537,6 +549,8 @@ export async function setScmDescription(page: Page, description: string) {
         const regexPattern = words.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*');
         await expect(scmInputRow).toHaveText(new RegExp(regexPattern), { timeout: 3000 });
     }, `Failed to set SCM description to "${description}" reliably`).toPass({ timeout: 10000 });
+
+    return scmInputRow;
 }
 
 /**

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -253,8 +253,6 @@ test.describe('GitHub Integration E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click();
 
             // Click the Manage Auth button in the Source Control title bar
             const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
@@ -294,8 +292,6 @@ test.describe('GitHub Integration E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click();
 
             // Click the Manage Auth button in the Source Control title bar
             const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
@@ -320,7 +316,6 @@ test.describe('GitHub Integration E2E', () => {
 
             // Re-open the Manage Auth menu
             await focusSCM(page);
-            await scmInputRow.click();
             await manageAuthButton.click();
             await expect(quickPick).toBeVisible();
 
@@ -345,7 +340,6 @@ test.describe('GitHub Integration E2E', () => {
                     await expect(quickPick).not.toBeVisible();
                 }
                 await focusSCM(page);
-                await scmInputRow.click();
                 await manageAuthButton.click();
                 await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
                     timeout: 2000,

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -216,8 +216,6 @@ test.describe('GitLab Integration E2E', () => {
             await waitForLogCommitRow(page, 'MR Commit');
 
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click();
 
             // Click the Manage Auth button in the Source Control title bar
             const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
@@ -259,8 +257,6 @@ test.describe('GitLab Integration E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click();
 
             // Click the Manage Auth button in the Source Control title bar
             const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
@@ -285,7 +281,6 @@ test.describe('GitLab Integration E2E', () => {
 
             // Re-open the Manage Auth menu
             await focusSCM(page);
-            await scmInputRow.click();
             await manageAuthButton.click();
             await expect(quickPick).toBeVisible();
 
@@ -310,7 +305,6 @@ test.describe('GitLab Integration E2E', () => {
                     await expect(quickPick).not.toBeVisible();
                 }
                 await focusSCM(page);
-                await scmInputRow.click();
                 await manageAuthButton.click();
                 await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
                     timeout: 2000,
@@ -348,8 +342,6 @@ test.describe('GitLab Integration E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click();
 
             // Click the Manage Auth button in the Source Control title bar
             const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, test } from '@playwright/test';
 import { buildGraph, TestRepo } from '../test-repo';
 import {
     clickContextMenuItem,
@@ -91,11 +91,9 @@ test.describe('SCM Pane E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
-            await scmInputRow.click(); // Focus the editor
 
             // Set Description and Commit with robust helper
-            await setScmDescription(page, 'Updated description explicitly');
+            const scmInput = await setScmDescription(page, 'Updated description explicitly');
 
             // Commit using button inside the Source Control view title bar
             const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
@@ -107,7 +105,7 @@ test.describe('SCM Pane E2E', () => {
             }).toPass({ timeout: 5000 });
 
             // Ensure wait for SCM refresh before next action
-            await expect(scmInputRow).not.toContainText('Updated description explicitly', { timeout: 10000 });
+            await expect(scmInput).not.toContainText('Updated description explicitly', { timeout: 10000 });
 
             const prevWcId = repo.getWorkingCopyId();
 
@@ -144,11 +142,11 @@ test.describe('SCM Pane E2E', () => {
 
         try {
             await focusSCM(page);
-            const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' });
+            let scmInput: Locator | undefined;
 
             // Set Description and Save with Control+S
             await expect(async () => {
-                await setScmDescription(page, 'Using keyboard shortcuts');
+                scmInput = await setScmDescription(page, 'Using keyboard shortcuts');
                 await page.keyboard.press('Control+S');
 
                 // Wait for input to be stable (picked up by the backend)
@@ -157,7 +155,7 @@ test.describe('SCM Pane E2E', () => {
 
             // Set Description and Commit with Control+Enter
             await expect(async () => {
-                await setScmDescription(page, 'Commit via keyboard');
+                scmInput = await setScmDescription(page, 'Commit via keyboard');
                 await page.keyboard.press('Control+Enter');
 
                 // Wait for it to be committed and appear in log
@@ -165,10 +163,10 @@ test.describe('SCM Pane E2E', () => {
                 expect(log).toContain('Commit via keyboard');
             }).toPass({ timeout: 15000 });
 
-            // Wait for input to clear in UI
-
-            // Wait for input to clear in UI
-            await expect(scmInputRow).not.toContainText('Commit via keyboard', { timeout: 10000 });
+            if (!scmInput) {
+                throw new Error('scmInput not initialized');
+            }
+            await expect(scmInput).not.toContainText('Commit via keyboard', { timeout: 10000 });
         } finally {
             await app.close();
             try {
@@ -219,8 +217,9 @@ test.describe('SCM Pane E2E', () => {
                 'Another very long body text that should be wrapped onto multiple lines when committed from the SCM input box.';
             const messageToFormat2 = `Commit Title\n\n${longBody2}`;
 
-            await setScmDescription(page, messageToFormat2);
+            const scmInput2 = await setScmDescription(page, messageToFormat2);
             await page.keyboard.press('Control+Enter');
+            await expect(scmInput2).not.toContainText('Commit Title', { timeout: 10000 });
 
             // Wait for it to be committed, formatted, and appear in log
             await expect(async () => {
@@ -450,8 +449,9 @@ test.describe('SCM Pane E2E', () => {
 
             // Create a chain (initial -> wc_commit -> new_wc) to verify squash into a non-immediate ancestor
             await focusSCM(page);
-            await setScmDescription(page, 'commit wc');
+            const scmInputSquash = await setScmDescription(page, 'commit wc');
             await page.keyboard.press('Control+Enter');
+            await expect(scmInputSquash).not.toContainText('commit wc', { timeout: 10000 });
 
             await expect(async () => {
                 expect(repo.getParents('@').length).toBe(1);

--- a/src/test/extension.integration.test.ts
+++ b/src/test/extension.integration.test.ts
@@ -47,4 +47,9 @@ suite('Extension Test Suite', () => {
         // Verify scmProvider has viewFileSystemProvider (essential for cache invalidation fix)
         assert.ok(api.scmProvider.viewFileSystemProvider, 'viewFileSystemProvider not assigned to scmProvider');
     });
+
+    test('Command jj-view.focusDescriptionInput should be registered', async () => {
+        const commands = await vscode.commands.getCommands(true);
+        assert.ok(commands.includes('jj-view.focusDescriptionInput'), 'jj-view.focusDescriptionInput not registered');
+    });
 });

--- a/src/test/screenshots/generate.spec.ts
+++ b/src/test/screenshots/generate.spec.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import { test } from '@playwright/test';
 import { downloadAndUnzipVSCode, SilentReporter } from '@vscode/test-electron';
 import { _electron as electron } from 'playwright';
+import { focusSCM } from '../e2e/e2e-helpers';
 import { buildGraph, TestRepo } from '../test-repo';
 
 /**
@@ -225,7 +226,7 @@ if __name__ == "__main__":
     }
 
     // 4. Switch to SCM View
-    await page.keyboard.press('Control+Shift+G');
+    await focusSCM(page);
     await page.waitForTimeout(2000);
 
     // 5. Layout Adjustment: Maximize JJ Log View


### PR DESCRIPTION
Adds the jj-view.focusDescriptionInput command to programmatically focus the SCM description input, mapping it to ctrl+shift+g / cmd+shift+g.

Fixes #315