### PR TITLE
🧪 Add tests for canSquashCommit logic

### DIFF
--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+    canSquashCommit,
     convertJjChangeIdToHex,
     formatCommitTitle,
     formatDisplayChangeId,
@@ -83,6 +84,47 @@ describe('JJ Utils', () => {
 
         it('should handle short full ID', () => {
             expect(formatDisplayChangeId('abc', 'abc', 8)).toBe('abc');
+        });
+    });
+
+    describe('canSquashCommit', () => {
+        it('should return true for a mutable commit with exactly one mutable parent', () => {
+            const commit = {
+                is_immutable: false,
+                parents: [{ is_immutable: false }],
+            };
+            expect(canSquashCommit(commit)).toBe(true);
+        });
+
+        it('should return false if the commit is immutable', () => {
+            const commit = {
+                is_immutable: true,
+                parents: [{ is_immutable: false }],
+            };
+            expect(canSquashCommit(commit)).toBe(false);
+        });
+
+        it('should return false if the commit has no parents', () => {
+            const commit1 = { is_immutable: false };
+            const commit2 = { is_immutable: false, parents: [] };
+            expect(canSquashCommit(commit1)).toBe(false);
+            expect(canSquashCommit(commit2)).toBe(false);
+        });
+
+        it('should return false if the commit has multiple parents', () => {
+            const commit = {
+                is_immutable: false,
+                parents: [{ is_immutable: false }, { is_immutable: false }],
+            };
+            expect(canSquashCommit(commit)).toBe(false);
+        });
+
+        it('should return false if the single parent is immutable', () => {
+            const commit = {
+                is_immutable: false,
+                parents: [{ is_immutable: true }],
+            };
+            expect(canSquashCommit(commit)).toBe(false);
         });
     });
 


### PR DESCRIPTION
🎯 **What:** Adds unit tests for the `canSquashCommit` function in `src/utils/jj-utils.ts` to address a testing gap.
📊 **Coverage:** The tests cover the happy path (mutable commit with a single mutable parent) as well as scenarios where the commit is immutable, has zero parents, has multiple parents, or has an immutable parent.
✨ **Result:** Increased unit test coverage for commit squashing logic, enhancing reliability of the `canSquashCommit` checks.

---
*PR created automatically by Jules for task [729150565358762825](https://jules.google.com/task/729150565358762825) started by @brychanrobot*