### PR TITLE
test: add unit tests for canAbsorbCommit

### DIFF
--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import {
+    canAbsorbCommit,
     canSquashCommit,
     convertJjChangeIdToHex,
     formatCommitTitle,
@@ -169,6 +170,54 @@ describe('JJ Utils', () => {
                 is_divergent: false,
             };
             expect(formatCommitTitle(commit, 8)).toBe('Commit: abcdef');
+        });
+    });
+
+    describe('canAbsorbCommit', () => {
+        describe('when there are no parents', () => {
+            it('should return false if parents array is missing', () => {
+                expect(canAbsorbCommit({})).toBe(false);
+            });
+
+            it('should return false if parents array is empty', () => {
+                expect(canAbsorbCommit({ parents: [] })).toBe(false);
+            });
+        });
+
+        describe('when there are parents', () => {
+            it('should correctly determine if the commit can be absorbed based on parents mutability', () => {
+                const cases = [
+                    {
+                        parents: [{ is_immutable: true }],
+                        expected: false,
+                        description: 'single immutable parent',
+                    },
+                    {
+                        parents: [{ is_immutable: true }, { is_immutable: true }],
+                        expected: false,
+                        description: 'all multiple parents are immutable',
+                    },
+                    {
+                        parents: [{}],
+                        expected: true,
+                        description: 'parent lacks explicit is_immutable flag (defaults to mutable)',
+                    },
+                    {
+                        parents: [{ is_immutable: false }],
+                        expected: true,
+                        description: 'single mutable parent',
+                    },
+                    {
+                        parents: [{ is_immutable: true }, { is_immutable: false }],
+                        expected: true,
+                        description: 'one of multiple parents is mutable',
+                    },
+                ];
+
+                for (const { parents, expected, description } of cases) {
+                    expect(canAbsorbCommit({ parents }), description).toBe(expected);
+                }
+            });
         });
     });
 

--- a/src/utils/jj-utils.ts
+++ b/src/utils/jj-utils.ts
@@ -66,7 +66,7 @@ export function formatCommitTitle(
 /**
  * Checks if a commit can be squashed (i.e. is mutable, has exactly one parent, and that parent is mutable).
  */
-export function canSquashCommit(commit: { is_immutable?: boolean; parents?: { is_immutable: boolean }[] }): boolean {
+export function canSquashCommit(commit: { is_immutable?: boolean; parents?: { is_immutable?: boolean }[] }): boolean {
     return !commit.is_immutable && !!commit.parents && commit.parents.length === 1 && !commit.parents[0].is_immutable;
 }
 
@@ -80,6 +80,6 @@ export function isMutableCommit(commit: { is_immutable?: boolean }): boolean {
 /**
  * Checks if a commit has any mutable parent (allowing absorb).
  */
-export function canAbsorbCommit(commit: { parents?: { is_immutable: boolean }[] }): boolean {
+export function canAbsorbCommit(commit: { parents?: { is_immutable?: boolean }[] }): boolean {
     return !!commit.parents && commit.parents.some((p) => !p.is_immutable);
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses missing unit tests for the `canAbsorbCommit` function in `src/utils/jj-utils.ts`, which determines whether a commit has any mutable parents and thus can absorb changes.

📊 **Coverage:** What scenarios are now tested
The new tests cover the following scenarios:
- Missing `parents` array on the commit object
- Empty `parents` array
- All parents in the array being immutable
- At least one parent in the array being mutable

✨ **Result:** The improvement in test coverage
We now have comprehensive test coverage for `canAbsorbCommit`, ensuring that its behavior remains reliable and that potential refactors can be performed confidently.

---
*PR created automatically by Jules for task [14444721188006714939](https://jules.google.com/task/14444721188006714939) started by @brychanrobot*

## Summary by Sourcery

Tests:
- Add tests covering missing parents, empty parents array, all-immutable parents, and at-least-one-mutable parent scenarios for canAbsorbCommit.