### PR TITLE
🧪 test: add tests for isMutableCommit

### DIFF
--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -8,8 +8,8 @@ import {
     formatCommitTitle,
     formatDisplayChangeId,
     getChangeIdDisplayLength,
-    shortenChangeId,
     isMutableCommit,
+    shortenChangeId,
 } from '../utils/jj-utils';
 
 describe('JJ Utils', () => {

--- a/src/test/jj-utils.test.ts
+++ b/src/test/jj-utils.test.ts
@@ -9,6 +9,7 @@ import {
     formatDisplayChangeId,
     getChangeIdDisplayLength,
     shortenChangeId,
+    isMutableCommit,
 } from '../utils/jj-utils';
 
 describe('JJ Utils', () => {
@@ -126,6 +127,17 @@ describe('JJ Utils', () => {
                 is_divergent: false,
             };
             expect(formatCommitTitle(commit, 8)).toBe('Commit: abcdef');
+        });
+    });
+
+    describe('isMutableCommit', () => {
+        it('should return true if commit is not immutable', () => {
+            expect(isMutableCommit({ is_immutable: false })).toBe(true);
+            expect(isMutableCommit({})).toBe(true);
+        });
+
+        it('should return false if commit is immutable', () => {
+            expect(isMutableCommit({ is_immutable: true })).toBe(false);
         });
     });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `isMutableCommit` function in `src/utils/jj-utils.ts`.
📊 **Coverage:** The scenarios now tested include when the commit is not immutable, when `is_immutable` is explicitly false, and when `is_immutable` is true.
✨ **Result:** Test coverage for `isMutableCommit` is now complete, acting as a safety net for future refactoring.

---
*PR created automatically by Jules for task [7330448534093529494](https://jules.google.com/task/7330448534093529494) started by @brychanrobot*