### PR TITLE
feat: Add delete bookmark functionality (#305)

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,6 +413,12 @@
                 "icon": "$(bookmark)"
             },
             {
+                "command": "jj-view.deleteBookmark",
+                "title": "Delete Bookmark",
+                "category": "JJ View",
+                "icon": "$(trash)"
+            },
+            {
                 "command": "jj-view.absorb",
                 "title": "Absorb",
                 "category": "JJ View",
@@ -464,42 +470,42 @@
             },
             {
                 "command": "jj-view.toggleCommitAction.newChild.on",
-                "title": "● New Child",
+                "title": "\u25cf New Child",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.newChild.off",
-                "title": "○ New Child",
+                "title": "\u25cb New Child",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.edit.on",
-                "title": "● Edit",
+                "title": "\u25cf Edit",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.edit.off",
-                "title": "○ Edit",
+                "title": "\u25cb Edit",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.squash.on",
-                "title": "● Squash",
+                "title": "\u25cf Squash",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.squash.off",
-                "title": "○ Squash",
+                "title": "\u25cb Squash",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.abandon.on",
-                "title": "● Abandon",
+                "title": "\u25cf Abandon",
                 "category": "JJ View"
             },
             {
                 "command": "jj-view.toggleCommitAction.abandon.off",
-                "title": "○ Abandon",
+                "title": "\u25cb Abandon",
                 "category": "JJ View"
             },
             {
@@ -711,6 +717,11 @@
                     "command": "jj-view.setBookmark",
                     "when": "webviewSection == 'commit'",
                     "group": "3_bookmark@1"
+                },
+                {
+                    "command": "jj-view.deleteBookmark",
+                    "when": "webviewSection == 'jj.bookmark' && !isRemoteBookmark",
+                    "group": "3_bookmark@2"
                 },
                 {
                     "command": "jj-view.hideCommitAction.newChild",
@@ -982,7 +993,6 @@
         "rimraf": "^6.1.2",
         "sinon": "^21.0.1",
         "svgtofont": "^6.5.1",
-
         "typescript": "^5.9.3",
         "vitest": "^4.0.16"
     },

--- a/src/commands/bookmark-delete.ts
+++ b/src/commands/bookmark-delete.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjService } from '../jj-service';
+import { extractBookmarkName, getErrorMessage, withDelayedProgress } from './command-utils';
+
+export async function deleteBookmarkCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    let bookmarkName = extractBookmarkName(args);
+
+    // If not triggered via right click, prompt user to select a bookmark
+    if (!bookmarkName) {
+        try {
+            const bookmarks = await withDelayedProgress('Fetching bookmarks...', jj.getBookmarks());
+            const quickPick = vscode.window.createQuickPick();
+            try {
+                quickPick.placeholder = 'Select a bookmark to delete';
+                quickPick.items = bookmarks
+                    .filter((b) => !b.remote) // Only allow deleting local bookmarks
+                    .map((b) => ({ label: b.name, description: 'Delete bookmark' }));
+
+                if (quickPick.items.length === 0) {
+                    vscode.window.showInformationMessage('No local bookmarks to delete.');
+                    return;
+                }
+
+                bookmarkName = await new Promise<string>((resolve) => {
+                    quickPick.onDidAccept(() => {
+                        const selection = quickPick.selectedItems[0];
+                        resolve(selection ? selection.label : '');
+                    });
+                    quickPick.onDidHide(() => {
+                        resolve('');
+                    });
+                    quickPick.show();
+                });
+            } finally {
+                quickPick.dispose();
+            }
+        } catch (e) {
+            const message = getErrorMessage(e);
+            vscode.window.showErrorMessage(`Failed to fetch bookmarks: ${message}`);
+            scmProvider.outputChannel.appendLine(`[Error] Fetch bookmarks failed: ${message}`);
+            return;
+        }
+    }
+
+    if (!bookmarkName) {
+        return; // User cancelled
+    }
+
+    // Perform deletion
+    try {
+        await vscode.window.withProgress(
+            {
+                location: vscode.ProgressLocation.Notification,
+                title: `Deleting bookmark "${bookmarkName}"...`,
+                cancellable: false,
+            },
+            async () => {
+                await jj.deleteBookmark(bookmarkName);
+            },
+        );
+        scmProvider.refresh({ reason: 'after bookmark delete' });
+    } catch (e) {
+        const message = getErrorMessage(e);
+        vscode.window.showErrorMessage(`Failed to delete bookmark: ${message}`);
+        scmProvider.outputChannel.appendLine(`[Error] Bookmark delete failed: ${message}`);
+    }
+}

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -449,3 +449,29 @@ export function extractUriFromArgs(args: unknown[]): vscode.Uri | undefined {
     }
     return undefined;
 }
+
+interface BookmarkContextArg {
+    webviewSection: string;
+    bookmarkName?: string;
+}
+
+function isBookmarkContextArg(arg: unknown): arg is BookmarkContextArg {
+    return !!arg && typeof arg === 'object' && 'webviewSection' in arg && 'bookmarkName' in arg;
+}
+
+/**
+ * Extracts a bookmark name from command arguments.
+ */
+export function extractBookmarkName(args: unknown[]): string | undefined {
+    const firstArg = args?.[0];
+
+    if (
+        isBookmarkContextArg(firstArg) &&
+        firstArg.webviewSection === 'jj.bookmark' &&
+        typeof firstArg.bookmarkName === 'string'
+    ) {
+        return firstArg.bookmarkName;
+    }
+
+    return undefined;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import type { CodeForgeService } from './code-forge-service';
 import { abandonCommand } from './commands/abandon';
 import { absorbCommand } from './commands/absorb';
 import { setBookmarkCommand } from './commands/bookmark';
+import { deleteBookmarkCommand } from './commands/bookmark-delete';
 import { extractUriFromArgs } from './commands/command-utils';
 import { commitCommand } from './commands/commit';
 import { commitPromptCommand } from './commands/commit-prompt';
@@ -523,6 +524,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         registerWrappedCommand('jj-view.setBookmark', async (scm, jj, ...args) => {
             const arg = args[0] as { commitId: string };
             await setBookmarkCommand(scm, jj, arg);
+        }),
+        registerWrappedCommand('jj-view.deleteBookmark', async (scm, jj, ...args) => {
+            await deleteBookmarkCommand(scm, jj, args);
         }),
         registerWrappedCommand('jj-view.showDetails', async (_scm, _jj, ...args) => {
             await showDetailsCommand(logWebviewProvider, args);

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -320,6 +320,13 @@ export class JjService {
         });
     }
 
+    async deleteBookmark(name: string): Promise<string> {
+        return this.run('bookmark', ['delete', name], {
+            isMutation: true,
+            label: 'deleteBookmark',
+        });
+    }
+
     async getLog(options: JjLogOptions = {}): Promise<JjLogEntry[]> {
         const { revision, limit, omitChanges, includeNearestVisibleAncestors } = options;
 

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -339,6 +339,25 @@ test.describe('JJ Log Context Menu E2E', () => {
         }).toPass();
     });
 
+    test('Delete Bookmark', async () => {
+        await getLogWebview(page);
+
+        // 1. Create a bookmark first via CLI so we have one to delete
+        repo.bookmark('to-be-deleted', nodes.commit1.changeId);
+        await triggerRefresh(page);
+
+        // 2. Wait for the bookmark pill to appear
+        const bookmarkPill = await waitForLogPill(page, 'to-be-deleted', 'bookmark');
+
+        // 3. Right-click the bookmark pill and select "Delete Bookmark"
+        await expect(async () => {
+            await rightClickAndSelect(page, bookmarkPill, 'Delete Bookmark');
+
+            // 4. Verification: the bookmark pill should disappear
+            await expect(bookmarkPill).toBeHidden({ timeout: 10000 });
+        }).toPass({ timeout: 30000 });
+    });
+
     test('Set Bookmark', async () => {
         const webview = await getLogWebview(page);
         const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -13,7 +13,10 @@ import {
     focusJJLog,
     getLogWebview,
     launchVSCode,
+    openQuickInputWithShortcut,
+    pickQuickPickItem,
     ROOT_ID,
+    triggerRefresh,
     waitForLogCommitRow,
     waitForLogPill,
 } from './e2e-helpers';
@@ -284,6 +287,53 @@ test.describe('JJ Log Pane E2E', () => {
                 const parents = repo.getParents(nodes.source.changeId);
                 expect(parents).toContain(nodes.target.changeId);
             }).toPass({ timeout: 10000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
+
+    test('Delete Bookmark (Command Palette/Quick Pick Flow)', async () => {
+        const repo = new TestRepo();
+        repo.init();
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            {
+                label: 'wc',
+                parents: ['initial'],
+                description: 'working tree',
+                files: { 'file.txt': 'mod' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        // 1. Create a local bookmark via CLI
+        repo.bookmark('local-to-delete', nodes.wc.changeId);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusJJLog(page);
+            await triggerRefresh(page);
+
+            // 2. Verify bookmark pill is visible
+            const bookmarkPill = await waitForLogPill(page, 'local-to-delete', 'bookmark');
+            await expect(bookmarkPill).toBeVisible();
+
+            // 3. Open Command Palette and run "Delete Bookmark"
+            const input = await openQuickInputWithShortcut(page, 'F1');
+            await input.focus();
+            await page.keyboard.type('JJ View: Delete Bookmark', { delay: 50 });
+            await page.keyboard.press('Enter');
+
+            // 4. Select the bookmark to delete in the Quick Pick
+            await pickQuickPickItem(page, 'local-to-delete');
+
+            // 5. Verify the bookmark pill disappears from the webview
+            await expect(bookmarkPill).toBeHidden({ timeout: 10000 });
         } finally {
             await app.close();
             try {

--- a/src/webview/components/Bookmark.tsx
+++ b/src/webview/components/Bookmark.tsx
@@ -46,26 +46,35 @@ export const BookmarkPill: React.FC<{ bookmark: JjBookmark; style?: React.CSSPro
     const borderColor = `color-mix(in srgb, ${accentColor}, transparent 50%)`;
 
     return (
-        <BasePill
-            title={displayName}
-            style={{
-                backgroundColor,
-                color: accentColor,
-                border: `1px solid ${borderColor}`,
-                ...style,
-            }}
+        <span
+            data-vscode-context={JSON.stringify({
+                webviewSection: 'jj.bookmark',
+                bookmarkName: bookmark.name,
+                isRemoteBookmark: !!bookmark.remote,
+                preventDefaultContextMenuItems: true,
+            })}
         >
-            <span className="codicon codicon-bookmark" style={{ fontSize: '11px', flexShrink: 0 }} />
-            <span
+            <BasePill
+                title={displayName}
                 style={{
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
+                    backgroundColor,
+                    color: accentColor,
+                    border: `1px solid ${borderColor}`,
+                    ...style,
                 }}
             >
-                {displayName}
-            </span>
-        </BasePill>
+                <span className="codicon codicon-bookmark" style={{ fontSize: '11px', flexShrink: 0 }} />
+                <span
+                    style={{
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {displayName}
+                </span>
+            </BasePill>
+        </span>
     );
 };
 


### PR DESCRIPTION
Added a new `deleteBookmark` method to `JjService` (which delegates to `jj bookmark delete`). I've also wired this up as a new VSCode command (`jj-view.deleteBookmark`) and updated the context menu for `BookmarkPill` to expose the deletion operation seamlessly.

Tests have been added for `context-menu.spec.ts` testing the complete right click deletion flow.

---
*PR created automatically by Jules for task [2224377418168383507](https://jules.google.com/task/2224377418168383507) started by @brychanrobot*

## Summary by Sourcery

Add support for deleting local bookmarks via both the JJ View command palette and bookmark context menu.

New Features:
- Introduce a delete bookmark command in the extension that invokes a new JjService.deleteBookmark API.
- Expose bookmark deletion through a new JJ View command (`jj-view.deleteBookmark`) available from the command palette and bookmark pills in the log webview.

Enhancements:
- Enrich bookmark pills with webview context data to enable bookmark-specific context menu actions.

Tests:
- Extend end-to-end tests to cover deleting bookmarks via the bookmark context menu and via the command palette quick pick flow.