### PR TITLE
fix: use forge provider cache during active repo switches

### DIFF
--- a/package.json
+++ b/package.json
@@ -507,11 +507,6 @@
                 "title": "Manage Code Forge Authentication",
                 "category": "JJ View",
                 "icon": "$(key)"
-            },
-            {
-                "command": "jj-view.gitlab.enterPat",
-                "title": "Enter GitLab Personal Access Token (PAT)",
-                "category": "JJ View"
             }
         ],
         "keybindings": [

--- a/src/code-forge-provider-factory.ts
+++ b/src/code-forge-provider-factory.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type * as vscode from 'vscode';
+import type { CodeForgeProvider } from './code-forge-provider';
+
+export interface CodeForgeProviderFactory {
+    readonly id: string;
+    create(outputChannel?: vscode.OutputChannel): CodeForgeProvider;
+}

--- a/src/code-forge-registry.ts
+++ b/src/code-forge-registry.ts
@@ -3,83 +3,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
-import type { CodeForgeProvider, GitRemote } from './code-forge-provider';
+import type { CodeForgeProviderFactory } from './code-forge-provider-factory';
 
 export class CodeForgeRegistry implements vscode.Disposable {
-    private providers = new Map<string, CodeForgeProvider>();
-    private activeProvider: CodeForgeProvider | undefined;
-    private _onDidActiveProviderChange = new vscode.EventEmitter<CodeForgeProvider | undefined>();
-    public readonly onDidActiveProviderChange = this._onDidActiveProviderChange.event;
+    private factories = new Map<string, CodeForgeProviderFactory>();
+    private _onDidRegisterFactory = new vscode.EventEmitter<CodeForgeProviderFactory>();
+    public readonly onDidRegisterFactory = this._onDidRegisterFactory.event;
 
-    private _onDidProvidersChange = new vscode.EventEmitter<void>();
-    public readonly onDidProvidersChange = this._onDidProvidersChange.event;
-
-    public register(provider: CodeForgeProvider): vscode.Disposable {
-        if (this.providers.has(provider.id)) {
-            throw new Error(`Provider with id '${provider.id}' is already registered.`);
+    public register(factory: CodeForgeProviderFactory): vscode.Disposable {
+        if (this.factories.has(factory.id)) {
+            throw new Error(`Factory with id '${factory.id}' is already registered.`);
         }
-        this.providers.set(provider.id, provider);
-        this._onDidProvidersChange.fire();
+        this.factories.set(factory.id, factory);
+        this._onDidRegisterFactory.fire(factory);
 
         return new vscode.Disposable(() => {
-            if (this.activeProvider?.id === provider.id) {
-                this.activeProvider.deactivate();
-                this.activeProvider = undefined;
-                this._onDidActiveProviderChange.fire(undefined);
-            }
-            this.providers.delete(provider.id);
-            this._onDidProvidersChange.fire();
+            this.factories.delete(factory.id);
         });
     }
 
-    public async autoDetect(workspaceRoot: string, remotes: GitRemote[]): Promise<void> {
-        const preferredId = vscode.workspace.getConfiguration('jj-view').get<string>('codeForge.provider');
-        if (preferredId) {
-            const provider = this.providers.get(preferredId);
-            if (provider) {
-                if (await provider.detect(workspaceRoot, remotes)) {
-                    this.setActive(provider);
-                } else {
-                    this.setActive(undefined);
-                }
-                return;
-            }
-        }
-
-        // Otherwise auto-detect
-        for (const provider of this.providers.values()) {
-            if (await provider.detect(workspaceRoot, remotes)) {
-                this.setActive(provider);
-                return;
-            }
-        }
-        this.setActive(undefined);
-    }
-
-    private setActive(provider: CodeForgeProvider | undefined) {
-        if (this.activeProvider?.id === provider?.id) {
-            return;
-        }
-        this.activeProvider?.deactivate();
-        this.activeProvider = provider;
-        this.activeProvider?.activate();
-        this._onDidActiveProviderChange.fire(provider);
-    }
-
-    public getActive(): CodeForgeProvider | undefined {
-        return this.activeProvider;
-    }
-
-    public getProvider(id: string): CodeForgeProvider | undefined {
-        return this.providers.get(id);
-    }
-
-    public getRegisteredProviders(): CodeForgeProvider[] {
-        return Array.from(this.providers.values());
+    public getFactories(): CodeForgeProviderFactory[] {
+        return Array.from(this.factories.values());
     }
 
     public dispose() {
-        this._onDidActiveProviderChange.dispose();
-        this._onDidProvidersChange.dispose();
+        this._onDidRegisterFactory.dispose();
     }
 }

--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -4,6 +4,7 @@
  */
 import * as vscode from 'vscode';
 import type { ChangeStatusRequest, CodeForgeProvider } from './code-forge-provider';
+import type { CodeForgeProviderFactory } from './code-forge-provider-factory';
 import type { CodeForgeRegistry } from './code-forge-registry';
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo, CommitParent, JjLogEntry } from './jj-types';
@@ -18,10 +19,16 @@ export class CodeForgeService implements vscode.Disposable {
     private _onDidUpdate = new vscode.EventEmitter<void>();
     public readonly onDidUpdate = this._onDidUpdate.event;
 
+    private _onDidActiveProviderChange = new vscode.EventEmitter<CodeForgeProvider | undefined>();
+    public readonly onDidActiveProviderChange = this._onDidActiveProviderChange.event;
+
     private _initPromise: Promise<void>;
     private lastRefreshTime: number = 0;
     private lastDetectionTime = 0;
     private detectPromise: Promise<void> | undefined;
+
+    private providers = new Map<string, CodeForgeProvider>();
+    private activeProviderInstance: CodeForgeProvider | undefined;
 
     constructor(
         private workspaceRoot: string,
@@ -29,17 +36,16 @@ export class CodeForgeService implements vscode.Disposable {
         private registry: CodeForgeRegistry,
         private outputChannel?: vscode.OutputChannel,
     ) {
+        for (const factory of this.registry.getFactories()) {
+            this.providers.set(factory.id, factory.create(this.outputChannel));
+        }
+
         this.disposables.push(
-            this.registry.onDidActiveProviderChange((provider) => {
-                this.activeProviderDisposable?.dispose();
-                if (provider) {
-                    this.activeProviderDisposable = provider.onDidUpdate(() => {
-                        this._onDidUpdate.fire();
-                    });
-                } else {
-                    this.activeProviderDisposable = undefined;
+            this.registry.onDidRegisterFactory((factory: CodeForgeProviderFactory) => {
+                if (!this.providers.has(factory.id)) {
+                    this.providers.set(factory.id, factory.create(this.outputChannel));
+                    this.detectActiveProvider(true);
                 }
-                this._onDidUpdate.fire();
             }),
         );
 
@@ -81,18 +87,24 @@ export class CodeForgeService implements vscode.Disposable {
         this.stopPolling();
         this.backoffTimers.dispose();
         this.activeProviderDisposable?.dispose();
+        this.activeProviderInstance?.deactivate();
         for (const disposable of this.disposables) {
             disposable?.dispose();
         }
+        this._onDidActiveProviderChange.dispose();
         this._onDidUpdate.dispose();
     }
 
     public get isEnabled(): boolean {
-        return !!this.registry.getActive();
+        return !!this.activeProviderInstance;
     }
 
     public get activeProvider(): CodeForgeProvider | undefined {
-        return this.registry.getActive();
+        return this.activeProviderInstance;
+    }
+
+    public getProvider(id: string): CodeForgeProvider | undefined {
+        return this.providers.get(id);
     }
 
     public startPolling() {
@@ -118,8 +130,7 @@ export class CodeForgeService implements vscode.Disposable {
         if (this.isDisposed) {
             return;
         }
-        const activeProvider = this.registry.getActive();
-        if (activeProvider) {
+        if (this.activeProviderInstance) {
             this.outputChannel?.appendLine(`[CodeForgeService] Force refresh triggered`);
             this.lastRefreshTime = Date.now();
             this._onDidUpdate.fire();
@@ -143,7 +154,7 @@ export class CodeForgeService implements vscode.Disposable {
     }
 
     public async detectActiveProvider(force = false): Promise<void> {
-        if (!force && this.registry.getActive()) {
+        if (!force && this.activeProviderInstance) {
             return;
         }
 
@@ -156,15 +167,8 @@ export class CodeForgeService implements vscode.Disposable {
             return this.detectPromise;
         }
 
-        this.detectPromise = (async () => {
-            this.lastDetectionTime = now;
-            try {
-                const remotes = await this.jjService.getGitRemotes();
-                await this.registry.autoDetect(this.workspaceRoot, remotes);
-            } catch (e) {
-                this.outputChannel?.appendLine(`[CodeForgeService] Failed to detect active provider: ${e}`);
-            }
-        })();
+        this.lastDetectionTime = now;
+        this.detectPromise = this.doDetectActiveProvider();
 
         try {
             await this.detectPromise;
@@ -173,12 +177,58 @@ export class CodeForgeService implements vscode.Disposable {
         }
     }
 
+    private async doDetectActiveProvider(): Promise<void> {
+        try {
+            const remotes = await this.jjService.getGitRemotes();
+            const preferredId = vscode.workspace.getConfiguration('jj-view').get<string>('codeForge.provider');
+
+            let detectedProvider: CodeForgeProvider | undefined;
+
+            if (preferredId) {
+                const provider = this.providers.get(preferredId);
+                if (provider && (await provider.detect(this.workspaceRoot, remotes))) {
+                    detectedProvider = provider;
+                }
+            }
+
+            if (!detectedProvider) {
+                for (const provider of this.providers.values()) {
+                    if (await provider.detect(this.workspaceRoot, remotes)) {
+                        detectedProvider = provider;
+                        break;
+                    }
+                }
+            }
+
+            const prevActive = this.activeProviderInstance;
+            if (prevActive?.id !== detectedProvider?.id) {
+                this.activeProviderDisposable?.dispose();
+                prevActive?.deactivate();
+
+                this.activeProviderInstance = detectedProvider;
+
+                if (detectedProvider) {
+                    detectedProvider.activate();
+                    this.activeProviderDisposable = detectedProvider.onDidUpdate(() => {
+                        this._onDidUpdate.fire();
+                    });
+                } else {
+                    this.activeProviderDisposable = undefined;
+                }
+
+                this._onDidActiveProviderChange.fire(detectedProvider);
+                this._onDidUpdate.fire();
+            }
+        } catch (e) {
+            this.outputChannel?.appendLine(`[CodeForgeService] Failed to detect active provider: ${e}`);
+        }
+    }
+
     public async ensureFreshStatuses(changes: ChangeStatusRequest[]): Promise<boolean> {
-        const activeProvider = this.registry.getActive();
-        if (!activeProvider) {
+        if (!this.activeProviderInstance) {
             return false;
         }
-        return activeProvider.fetchStatuses(changes, this.jjService);
+        return this.activeProviderInstance.fetchStatuses(changes, this.jjService);
     }
 
     private verifyStructureSync(
@@ -221,7 +271,7 @@ export class CodeForgeService implements vscode.Disposable {
     }
 
     public populateCodeForgeInfo(commits: JjLogEntry[]): void {
-        const activeProvider = this.registry.getActive();
+        const activeProvider = this.activeProviderInstance;
         if (!activeProvider) {
             return;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { CodeForgeAuthManager } from './code-forge-auth';
 import type { CodeForgeProvider } from './code-forge-provider';
+import type { CodeForgeProviderFactory } from './code-forge-provider-factory';
 import { CodeForgeRegistry } from './code-forge-registry';
 import type { CodeForgeService } from './code-forge-service';
 import { abandonCommand } from './commands/abandon';
@@ -71,7 +72,7 @@ import { JjOutputChannel } from './utils/output-channel';
 
 export interface Api {
     repositoryManager: JjRepositoryManager;
-    registerCodeForgeProvider(provider: CodeForgeProvider): vscode.Disposable;
+    registerCodeForgeProvider(factory: CodeForgeProviderFactory): vscode.Disposable;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<Api> {
@@ -134,13 +135,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     const codeForgeRegistry = new CodeForgeRegistry();
     context.subscriptions.push(codeForgeRegistry);
     const authManager = new CodeForgeAuthManager(context, outputChannel);
-    const gerritProvider = new GerritProvider(outputChannel);
-    const githubProvider = new GitHubProvider(authManager, outputChannel);
-    const gitlabProvider = new GitLabProvider(authManager, outputChannel);
 
-    context.subscriptions.push(codeForgeRegistry.register(gerritProvider));
-    context.subscriptions.push(codeForgeRegistry.register(githubProvider));
-    context.subscriptions.push(codeForgeRegistry.register(gitlabProvider));
+    context.subscriptions.push(
+        codeForgeRegistry.register({
+            id: 'gerrit',
+            create: (outputChannel) => new GerritProvider(outputChannel),
+        }),
+    );
+    context.subscriptions.push(
+        codeForgeRegistry.register({
+            id: 'github',
+            create: (outputChannel) => new GitHubProvider(authManager, outputChannel),
+        }),
+    );
+    context.subscriptions.push(
+        codeForgeRegistry.register({
+            id: 'gitlab',
+            create: (outputChannel) => new GitLabProvider(authManager, outputChannel),
+        }),
+    );
 
     const repositoryManager = new JjRepositoryManager(
         codeForgeRegistry,
@@ -186,12 +199,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             provider?.changeTerm?.toLowerCase() || 'change',
         );
     };
-    updateContextKeys(codeForgeRegistry.getActive());
-    context.subscriptions.push(codeForgeRegistry.onDidActiveProviderChange(updateContextKeys));
+    updateContextKeys(undefined);
 
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.manageAuth', async () => {
-            const activeProvider = codeForgeRegistry.getActive();
+            const focused = repositoryManager.focusedRepository;
+            const activeProvider = focused?.codeForge.activeProvider;
             if (!activeProvider) {
                 vscode.window.showErrorMessage('No active code forge provider detected.');
                 return;
@@ -257,12 +270,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             }
 
             await choice.execute();
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand('jj-view.gitlab.enterPat', async () => {
-            await gitlabProvider.promptForPat();
         }),
     );
 
@@ -366,7 +373,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         scmProviders.delete(repo.rootUri.fsPath);
     });
 
+    let focusedRepoActiveProviderSub: vscode.Disposable | undefined;
     repositoryManager.onDidChangeFocusedRepository((repo) => {
+        focusedRepoActiveProviderSub?.dispose();
         if (repo) {
             logWebviewProvider.updateRepository(repo);
             const scm = scmProviders.get(repo.rootUri.fsPath);
@@ -374,7 +383,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 vscode.commands.executeCommand('setContext', JjContextKey.ParentMutable, scm.parentMutable);
                 vscode.commands.executeCommand('setContext', JjContextKey.HasChild, scm.hasChild);
             }
-            repo.codeForge.detectActiveProvider(true);
+            focusedRepoActiveProviderSub = repo.codeForge.onDidActiveProviderChange((provider) => {
+                updateContextKeys(provider);
+            });
+            // Force active provider detection for the focused repo and then update context keys immediately
+            repo.codeForge.detectActiveProvider(true).then(() => {
+                if (repositoryManager.focusedRepository === repo) {
+                    updateContextKeys(repo.codeForge.activeProvider);
+                }
+            });
+        } else {
+            focusedRepoActiveProviderSub = undefined;
+            updateContextKeys(undefined);
         }
     });
 
@@ -606,7 +626,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
     return {
         repositoryManager,
-        registerCodeForgeProvider: (provider: CodeForgeProvider) => codeForgeRegistry.register(provider),
+        registerCodeForgeProvider: (factory: CodeForgeProviderFactory) => codeForgeRegistry.register(factory),
     };
 }
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -98,7 +98,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         return this._repo?.codeForge;
     }
 
-    public updateRepository(repo: JjRepository | undefined) {
+    public async updateRepository(repo: JjRepository | undefined) {
         if (this._repo?.rootUri.fsPath === repo?.rootUri.fsPath) {
             return;
         }
@@ -107,9 +107,10 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const cf = this._codeForge;
         if (cf) {
             this._codeForgeDisposable = cf.onDidUpdate(() => this.refreshCodeForge());
+            await cf.detectActiveProvider(true);
         }
         this._updateTitle();
-        this.refresh('repoChanged');
+        await this.refresh('repoChanged');
     }
 
     private _updateTitle() {

--- a/src/test/code-forge-service.test.ts
+++ b/src/test/code-forge-service.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// sort-imports-ignore
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+const mockConfigStore = new Map<string, unknown>();
+let mockConfigListener: ((e: { affectsConfiguration(section: string): boolean }) => void) | undefined;
+let mockWindowStateListener: ((e: { focused: boolean }) => void) | undefined;
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    return createVscodeMock({
+        workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/root' } }],
+            getConfiguration: vi.fn().mockReturnValue({
+                get: vi.fn().mockImplementation((key: string, defaultValue: unknown) => {
+                    return mockConfigStore.has(key) ? mockConfigStore.get(key) : defaultValue;
+                }),
+            }),
+            onDidChangeConfiguration: vi.fn().mockImplementation((listener) => {
+                mockConfigListener = listener;
+                return { dispose: vi.fn() };
+            }),
+        },
+        window: {
+            state: { focused: true },
+            onDidChangeWindowState: vi.fn().mockImplementation((listener) => {
+                mockWindowStateListener = listener;
+                return { dispose: vi.fn() };
+            }),
+        },
+    });
+});
+
+import type { CodeForgeProvider, GitRemote } from '../code-forge-provider';
+import { CodeForgeRegistry } from '../code-forge-registry';
+import { CodeForgeService } from '../code-forge-service';
+import { JjService } from '../jj-service';
+import type { CodeForgeChangeInfo, JjLogEntry } from '../jj-types';
+import { TestRepo } from './test-repo';
+import { createMock } from './test-utils';
+
+class MockProvider implements CodeForgeProvider {
+    readonly changeTerm = 'Change';
+    private cache = new Map<string, CodeForgeChangeInfo>();
+    private emitter = new vscode.EventEmitter<void>();
+    readonly onDidUpdate = this.emitter.event;
+
+    constructor(
+        public readonly id = 'mock-provider',
+        public readonly displayName = 'Mock',
+        private detectResult = true,
+    ) {}
+
+    async detect(_workspaceRoot: string, _remotes: GitRemote[]): Promise<boolean> {
+        return this.detectResult;
+    }
+
+    getCachedChangeInfo(changeId?: string): CodeForgeChangeInfo | undefined {
+        return changeId ? this.cache.get(changeId) : undefined;
+    }
+
+    setCachedChangeInfo(changeId: string, info: CodeForgeChangeInfo) {
+        this.cache.set(changeId, info);
+    }
+
+    async fetchStatuses(): Promise<boolean> {
+        return false;
+    }
+
+    activate() {}
+    deactivate() {}
+    clearCache() {
+        this.cache.clear();
+    }
+    fireUpdate() {
+        this.emitter.fire();
+    }
+}
+
+describe('CodeForgeService Tests', () => {
+    let registry: CodeForgeRegistry;
+    let repo1: TestRepo;
+    let repo2: TestRepo;
+    let jjService1: JjService;
+    let jjService2: JjService;
+
+    beforeEach(() => {
+        mockConfigStore.clear();
+        registry = new CodeForgeRegistry();
+
+        repo1 = new TestRepo();
+        repo1.init();
+        jjService1 = new JjService(repo1.path);
+
+        repo2 = new TestRepo();
+        repo2.init();
+        jjService2 = new JjService(repo2.path);
+    });
+
+    afterEach(() => {
+        repo1.dispose();
+        repo2.dispose();
+    });
+
+    test('Each service gets a distinct provider instance with isolated cache', async () => {
+        let provider1: MockProvider | undefined;
+        let provider2: MockProvider | undefined;
+
+        registry.register({
+            id: 'mock-provider',
+            create: () => {
+                const p = new MockProvider();
+                if (!provider1) {
+                    provider1 = p;
+                } else {
+                    provider2 = p;
+                }
+                return p;
+            },
+        });
+
+        const service1 = new CodeForgeService(repo1.path, jjService1, registry);
+        const service2 = new CodeForgeService(repo2.path, jjService2, registry);
+
+        await service1.awaitReady();
+        await service2.awaitReady();
+
+        expect(provider1).toBeDefined();
+        expect(provider2).toBeDefined();
+        expect(provider1).not.toBe(provider2);
+
+        // Verify cache isolation
+        const info: CodeForgeChangeInfo = {
+            id: 'change-1',
+            number: 1,
+            displayLabel: 'Change 1',
+            providerName: 'Mock',
+            status: 'NEW',
+            submittable: true,
+            url: 'http://url',
+            unresolvedComments: 0,
+        };
+
+        if (provider1) {
+            provider1.setCachedChangeInfo('c1', info);
+        }
+        expect(service1.activeProvider?.getCachedChangeInfo('c1')).toEqual(info);
+        expect(service2.activeProvider?.getCachedChangeInfo('c1')).toBeUndefined();
+
+        service1.dispose();
+        service2.dispose();
+    });
+
+    test('dynamic factory registration instantiates provider and triggers detection', async () => {
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        let factoryCreated = false;
+        const dynamicProvider = new MockProvider();
+
+        registry.register({
+            id: 'dynamic-provider',
+            create: () => {
+                factoryCreated = true;
+                return dynamicProvider;
+            },
+        });
+
+        expect(factoryCreated).toBe(true);
+        expect(service.getProvider('dynamic-provider')).toBe(dynamicProvider);
+
+        service.dispose();
+    });
+
+    test('config changes trigger active provider re-detection', async () => {
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        const detectSpy = vi.spyOn(service, 'detectActiveProvider');
+
+        // Fire configuration change event
+        if (mockConfigListener) {
+            mockConfigListener({
+                affectsConfiguration: (section: string) => section === 'jj-view.codeForge',
+            });
+        }
+
+        expect(detectSpy).toHaveBeenCalledWith(true);
+
+        service.dispose();
+    });
+
+    test('window focus triggers throttled refresh if enabled', async () => {
+        vi.useFakeTimers();
+
+        const provider = new MockProvider();
+        registry.register({
+            id: 'mock-provider',
+            create: () => provider,
+        });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        // Must be enabled (have an active provider)
+        expect(service.isEnabled).toBe(true);
+
+        const refreshSpy = vi.spyOn(service, 'forceRefresh');
+
+        // Gaining focus should trigger refresh
+        if (mockWindowStateListener) {
+            mockWindowStateListener({ focused: true });
+        }
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+        // Instant focus again should NOT trigger refresh (throttled to 10s)
+        if (mockWindowStateListener) {
+            mockWindowStateListener({ focused: true });
+        }
+        expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+        // Advance timers by 11 seconds to bypass throttle
+        await vi.advanceTimersByTimeAsync(11000);
+        if (mockWindowStateListener) {
+            mockWindowStateListener({ focused: true });
+        }
+        expect(refreshSpy).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+        service.dispose();
+    });
+
+    test('propagates provider update events', async () => {
+        const provider = new MockProvider();
+        registry.register({
+            id: 'mock-provider',
+            create: () => provider,
+        });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        let serviceUpdated = false;
+        service.onDidUpdate(() => {
+            serviceUpdated = true;
+        });
+
+        // Trigger update on provider
+        provider.fireUpdate();
+        expect(serviceUpdated).toBe(true);
+
+        service.dispose();
+    });
+
+    test('respects preferred provider setting during detection', async () => {
+        const providerA = new MockProvider('provider-a', 'Provider A');
+        const providerB = new MockProvider('provider-b', 'Provider B');
+
+        registry.register({ id: 'provider-a', create: () => providerA });
+        registry.register({ id: 'provider-b', create: () => providerB });
+
+        // Set preferred provider setting
+        mockConfigStore.set('codeForge.provider', 'provider-b');
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        // provider-b should be preferred and active
+        expect(service.activeProvider).toBe(providerB);
+
+        // Reset preferred setting
+        mockConfigStore.delete('codeForge.provider');
+
+        service.dispose();
+    });
+
+    test('populateCodeForgeInfo correctly computes sync and needsUpload statuses', async () => {
+        const provider = new MockProvider();
+        registry.register({ id: 'mock-provider', create: () => provider });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry);
+        await service.awaitReady();
+
+        const change1 = createMock<CodeForgeChangeInfo>({
+            id: 'change-1',
+            number: 1,
+            displayLabel: 'Change 1',
+            providerName: 'Mock',
+            status: 'NEW',
+            currentRevision: 'rev-1',
+            contentSynced: true,
+            parentSynced: true,
+        });
+
+        const change2 = createMock<CodeForgeChangeInfo>({
+            id: 'change-2',
+            number: 2,
+            displayLabel: 'Change 2',
+            providerName: 'Mock',
+            status: 'NEW',
+            currentRevision: 'rev-other', // mismatched
+            contentSynced: false,
+            parentSynced: true,
+        });
+
+        provider.setCachedChangeInfo('change-1', change1);
+        provider.setCachedChangeInfo('change-2', change2);
+
+        const commits: JjLogEntry[] = [
+            createMock<JjLogEntry>({
+                change_id: 'change-1',
+                commit_id: 'rev-1',
+                description: 'Commit 1',
+                is_immutable: false,
+                bookmarks: [],
+            }),
+            createMock<JjLogEntry>({
+                change_id: 'change-2',
+                commit_id: 'rev-2',
+                description: 'Commit 2',
+                is_immutable: false,
+                bookmarks: [],
+            }),
+        ];
+
+        service.populateCodeForgeInfo(commits);
+
+        // Verify commit 1 is fully synced, does not need upload
+        expect(commits[0].codeForgeChange).toEqual(change1);
+        expect(commits[0].codeForgeNeedsUpload).toBe(false);
+
+        // Verify commit 2 is not synced, needs upload
+        expect(commits[1].codeForgeChange).toEqual(change2);
+        expect(commits[1].codeForgeNeedsUpload).toBe(true);
+
+        service.dispose();
+    });
+});

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -98,7 +98,10 @@ describe('GerritService Detection', () => {
     function initService(): CodeForgeService {
         registry = new CodeForgeRegistry();
         provider = new GerritProvider();
-        registry.register(provider);
+        registry.register({
+            id: 'gerrit',
+            create: () => provider,
+        });
         service = new CodeForgeService(repo.path, jjService, registry);
         return service;
     }
@@ -856,36 +859,36 @@ describe('GerritService Detection', () => {
         await service.awaitReady();
         expect(service.isEnabled).toBe(false);
 
-        // Spy on registry.autoDetect (never spy on JjService methods!)
-        const autoDetectSpy = vi.spyOn(registry, 'autoDetect');
+        // Spy on provider.detect (never spy on JjService methods!)
+        const detectSpy = vi.spyOn(provider, 'detect');
 
         // Advance timers by 31 seconds to bypass rate limit from constructor detection
         await vi.advanceTimersByTimeAsync(31000);
 
         // Call detectActiveProvider - should attempt detection because rate limit has passed
         await service.detectActiveProvider();
-        expect(autoDetectSpy).toHaveBeenCalledTimes(1);
+        expect(detectSpy).toHaveBeenCalledTimes(1);
 
         // Call detectActiveProvider again immediately - should NOT run due to 30s limit
         await service.detectActiveProvider();
-        expect(autoDetectSpy).toHaveBeenCalledTimes(1);
+        expect(detectSpy).toHaveBeenCalledTimes(1);
 
         // Call with force = true - should run regardless of time limit
         await service.detectActiveProvider(true);
-        expect(autoDetectSpy).toHaveBeenCalledTimes(2);
+        expect(detectSpy).toHaveBeenCalledTimes(2);
 
         // Advance timers by 31 seconds - should now run again
         await vi.advanceTimersByTimeAsync(31000);
         await service.detectActiveProvider();
-        expect(autoDetectSpy).toHaveBeenCalledTimes(3);
+        expect(detectSpy).toHaveBeenCalledTimes(3);
 
         // Test coalescing: call multiple times in parallel.
-        // We mock registry.autoDetect to return a promise that resolves slowly.
-        let resolveAutoDetect: () => void = () => {};
-        const slowAutoDetectPromise = new Promise<void>((resolve) => {
-            resolveAutoDetect = resolve;
+        // We mock provider.detect to return a promise that resolves slowly.
+        let resolveDetect: () => void = () => {};
+        const slowDetectPromise = new Promise<boolean>((resolve) => {
+            resolveDetect = () => resolve(true);
         });
-        autoDetectSpy.mockImplementation(() => slowAutoDetectPromise);
+        detectSpy.mockImplementation(() => slowDetectPromise);
 
         // Advance timers past rate limit first
         await vi.advanceTimersByTimeAsync(31000);
@@ -894,11 +897,11 @@ describe('GerritService Detection', () => {
         const p2 = service.detectActiveProvider();
         const p3 = service.detectActiveProvider(true); // force doesn't bypass active coalesced promise if already running
 
-        resolveAutoDetect();
+        resolveDetect();
         await Promise.all([p1, p2, p3]);
 
-        // autoDetect should only be called once for these parallel invocations
-        expect(autoDetectSpy).toHaveBeenCalledTimes(4);
+        // detect should only be called once for these parallel invocations
+        expect(detectSpy).toHaveBeenCalledTimes(4);
 
         vi.useRealTimers();
     });

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -82,7 +82,10 @@ describe('Gerrit Sync Verification', () => {
     function initService(): CodeForgeService {
         registry = new CodeForgeRegistry();
         provider = new GerritProvider();
-        registry.register(provider);
+        registry.register({
+            id: 'gerrit',
+            create: () => provider,
+        });
         service = new CodeForgeService(repo.path, jjService, registry);
         return service;
     }


### PR DESCRIPTION
- Refactor CodeForgeRegistry and CodeForgeService to use provider factories, instantiating providers per-repository so cache is retained through active repository switches in multi-repository workspaces.
- Encapsulate active provider detection logic in CodeForgeService.
- Remove unused workspaceRoot constructor parameters from code forge providers.
- Delete the redundant GitLab enterPat command in favor of the shared manageAuth command.
- Add comprehensive unit tests in code-forge-service.test.ts.