### PR TITLE
test: fix flakiness in E2E tests by refining timing and retries

### DIFF
--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -361,6 +361,11 @@ test.describe('Commit Details E2E', () => {
                 timeout: 15000,
             });
 
+            // Wait for the webview to load and render the content to ensure
+            // the custom editor is fully resolved and registered in the provider's panels map.
+            const details = await getDetailsWebview(page);
+            await expect(details.locator('textarea')).toHaveValue(/add feature/);
+
             // Abandon the commit externally
             repo.abandon(nodes.feature.changeId);
 

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -719,7 +719,10 @@ export async function openQuickInputWithShortcut(page: Page, shortcut: string): 
     const input = quickInput.locator('input.input');
 
     // Ensure any leftover quick input is closed first
-    await expect(quickInput).not.toBeVisible({ timeout: 5000 });
+    if (await quickInput.isVisible()) {
+        await page.keyboard.press('Escape');
+    }
+    await expect(quickInput).not.toBeVisible({ timeout: 2000 });
 
     await expect(async () => {
         if (!(await input.isVisible())) {
@@ -734,7 +737,7 @@ export async function openQuickInputWithShortcut(page: Page, shortcut: string): 
             await page.keyboard.press(shortcut);
         }
         await waitForQuickInput(page, 200);
-    }, `Failed to open quick input via shortcut "${shortcut}"`).toPass({ timeout: 20000 });
+    }, `Failed to open quick input via shortcut "${shortcut}"`).toPass({ timeout: 5000 });
     return input;
 }
 
@@ -891,15 +894,10 @@ export async function openFileInEditor(page: Page, fileName: string, repo?: Test
 
             // 4. Wait for the tab to become active and the Monaco editor to mount
             log(`Waiting for editor to mount...`);
-            await expect(async () => {
-                await expect(tab).toBeVisible({ timeout: 0 });
-                await expect(editor).toBeVisible({ timeout: 0 });
-            }).toPass({
-                timeout: 5000,
-                intervals: [200],
-            });
+            await expect(tab).toBeVisible({ timeout: 5000 });
+            await expect(editor).toBeVisible({ timeout: 5000 });
         }).toPass({
-            timeout: 15000,
+            timeout: 30000,
             intervals: [500, 1000, 2000],
         });
     } catch (error: unknown) {
@@ -1094,9 +1092,9 @@ export async function pickQuickPickItem(
             await expect(item).not.toBeVisible({ timeout: 500 });
         }
     }, `Failed to pick QuickPick item "${label}"`).toPass({
-        timeout: 20000,
+        timeout: 5000,
         // Add a backoff so we don't spam if the UI is genuinely stuck
-        intervals: [1000, 2000, 5000],
+        intervals: [500, 1000, 2000],
     });
 }
 

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -224,12 +224,17 @@ test.describe('SCM Pane E2E', () => {
                 'Another very long body text that should be wrapped onto multiple lines when committed from the SCM input box.';
             const messageToFormat2 = `Commit Title\n\n${longBody2}`;
 
-            const scmInput2 = await setScmDescription(page, messageToFormat2);
-            await page.keyboard.press('Control+Enter');
-            await expect(scmInput2).not.toContainText('Commit Title', { timeout: 10000 });
-
-            // Wait for it to be committed, formatted, and appear in log
             await expect(async () => {
+                const scmInput2 = await setScmDescription(page, messageToFormat2);
+
+                // Allow the asynchronous IPC from the renderer to update the SCM inputBox
+                // value on the extension host before committing.
+                await page.waitForTimeout(200);
+
+                await page.keyboard.press('Control+Enter');
+                await expect(scmInput2).not.toContainText('Commit Title', { timeout: 5000 });
+
+                // Wait for it to be committed, formatted, and appear in log
                 const log = repo.log();
                 expect(log).toContain('Commit Title');
                 // Find latest commit description (working copy is parent of the new commit)
@@ -237,7 +242,7 @@ test.describe('SCM Pane E2E', () => {
                 const expectedDesc = `Commit Title\n\nAnother very long body text that should be wrapped onto multiple lines\nwhen committed from the SCM input box.`;
                 expect(desc).toBe(expectedDesc);
                 expect(desc.split('\n').length).toBeGreaterThan(2);
-            }).toPass({ timeout: 15000 });
+            }).toPass({ timeout: 20000 });
         } finally {
             await app.close();
             try {


### PR DESCRIPTION
- In scm.spec.ts: Wraps the entire input, submit, and verification sequence in a retry block, introducing a delay to let SCM inputs update from the renderer before committing.
- In commit-details.spec.ts: Waits for the webview to render before abandoning a commit.
- In e2e-helpers.ts: Optimizes timeout durations and retry assertions when handling quick inputs and waiting for the Monaco editor to mount.