### PR TITLE
Reland "test: add tests for JjEditFileSystemProvider"

### DIFF
--- a/src/commands/squash-revision.ts
+++ b/src/commands/squash-revision.ts
@@ -231,7 +231,8 @@ export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, 
 
         // Close the editor if it's still open
         const tabs = vscode.window.tabGroups.all.flatMap((g) => g.tabs);
-        const tab = tabs.find((t) => t.input instanceof vscode.TabInputText && t.input.uri.fsPath === msgPath);
+        const targetFsPath = vscode.Uri.file(msgPath).fsPath;
+        const tab = tabs.find((t) => t.input instanceof vscode.TabInputText && t.input.uri.fsPath === targetFsPath);
         if (tab) {
             await vscode.window.tabGroups.close(tab);
         }

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVscodeMock } from './vscode-mock';
+
+vi.mock('vscode', () => createVscodeMock());
+
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { CodeForgeRegistry } from '../code-forge-registry';
+import { JjEditFileSystemProvider } from '../jj-edit-fs-provider';
+import { JjRepositoryManager } from '../jj-repository-manager';
+import { buildGraph, TestRepo } from './test-repo';
+import { createMock } from './test-utils';
+
+describe('JjEditFileSystemProvider', () => {
+    let repo: TestRepo;
+    let repoManager: JjRepositoryManager;
+    let provider: JjEditFileSystemProvider;
+    let onDidChangeFileFired: vscode.FileChangeEvent[][] = [];
+
+    function getUri(filename: string, revision: string | null = '@') {
+        const absolutePath = path.join(repo.path, filename);
+        return vscode.Uri.parse(`jj-edit://${absolutePath}${revision ? `?revision=${revision}` : ''}`);
+    }
+
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        const codeForgeRegistry = new CodeForgeRegistry();
+        const outputChannel = createMock<vscode.OutputChannel>({
+            appendLine: () => {},
+        });
+        const workspaceState = createMock<vscode.Memento>({
+            get: vi.fn().mockReturnValue(undefined),
+            update: vi.fn().mockResolvedValue(undefined),
+        });
+
+        repoManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
+
+        // Register the real repository
+        await repoManager.checkAndRegisterUri(vscode.Uri.file(repo.path));
+
+        provider = new JjEditFileSystemProvider(repoManager);
+        provider.onDidChangeFile((events) => {
+            onDidChangeFileFired.push(events);
+        });
+        onDidChangeFileFired = [];
+
+        await buildGraph(repo, [
+            {
+                label: 'base',
+                isCurrentWorkingCopy: true,
+                description: 'base commit',
+                files: { 'file.txt': 'hello\n', 'other.txt': 'hello other\n' },
+            },
+        ]);
+    });
+
+    afterEach(async () => {
+        await repoManager.dispose();
+        repo.dispose();
+    });
+
+    it('stat returns a default file stat', async () => {
+        const uri = getUri('file.txt');
+        const stat = await provider.stat(uri);
+        expect(stat.type).toBe(vscode.FileType.File);
+        expect(stat.size).toBe(0); // It just returns a default object
+    });
+
+    it('readFile reads content from a specific revision', async () => {
+        const uri = getUri('file.txt');
+        const content = await provider.readFile(uri);
+        expect(Buffer.from(content).toString('utf8')).toBe('hello\n');
+        expect(Buffer.from(content).toString('utf8')).toBe(repo.getFileContent('@', 'file.txt'));
+    });
+
+    it('readFile throws for missing file in revision', async () => {
+        const uri = getUri('nonexistent.txt');
+        await expect(provider.readFile(uri)).rejects.toThrow();
+    });
+
+    it('readFile throws for missing revision query param', async () => {
+        const uri = getUri('file.txt', null);
+        await expect(provider.readFile(uri)).rejects.toThrow('Missing revision');
+    });
+
+    it('writeFile modifies file in specific revision', async () => {
+        const uri = getUri('file.txt');
+
+        let writeTriggered = false;
+        provider.onDidWrite = () => {
+            writeTriggered = true;
+        };
+
+        const newContent = Buffer.from('hello world!\n', 'utf8');
+        await provider.writeFile(uri, newContent);
+
+        // writeFile resolves once flushWrites completes
+        expect(writeTriggered).toBe(true);
+
+        const content = await provider.readFile(uri);
+        expect(Buffer.from(content).toString('utf8')).toBe('hello world!\n');
+
+        // Verify the repository itself has the updated content in the revision
+        expect(repo.getFileContent('@', 'file.txt')).toBe('hello world!\n');
+
+        expect(onDidChangeFileFired.length).toBeGreaterThan(0);
+        const lastBatch = onDidChangeFileFired[onDidChangeFileFired.length - 1];
+        expect(lastBatch.length).toBe(1);
+        expect(lastBatch[0].uri.toString()).toBe(uri.toString());
+        expect(lastBatch[0].type).toBe(vscode.FileChangeType.Changed);
+    });
+
+    it('writeFile resolves after batching multiple writes', async () => {
+        const uri1 = getUri('file.txt');
+        const uri2 = getUri('other.txt');
+
+        const newContent1 = Buffer.from('mod1', 'utf8');
+        const newContent2 = Buffer.from('mod2', 'utf8');
+
+        // Fire both writes roughly simultaneously
+        const writePromise1 = provider.writeFile(uri1, newContent1);
+        const writePromise2 = provider.writeFile(uri2, newContent2);
+
+        await Promise.all([writePromise1, writePromise2]);
+
+        const content1 = await provider.readFile(uri1);
+        const content2 = await provider.readFile(uri2);
+
+        expect(Buffer.from(content1).toString('utf8')).toBe('mod1');
+        expect(Buffer.from(content2).toString('utf8')).toBe('mod2');
+
+        // Verify the repository itself has the updated content in the revision
+        expect(repo.getFileContent('@', 'file.txt')).toBe('mod1');
+        expect(repo.getFileContent('@', 'other.txt')).toBe('mod2');
+
+        expect(onDidChangeFileFired.length).toBe(1); // They should be batched together
+        const batch = onDidChangeFileFired[0];
+        expect(batch.length).toBe(2);
+
+        const uris = batch.map((e) => e.uri.toString());
+        expect(uris.some((u) => u.includes('file.txt'))).toBe(true);
+        expect(uris.some((u) => u.includes('other.txt'))).toBe(true);
+    });
+
+    it('invalidateCache triggers onDidChangeFile for known URIs', async () => {
+        const uri1 = getUri('file.txt');
+        const uri2 = getUri('other.txt');
+
+        // Reading files adds them to known URIs
+        const content1 = await provider.readFile(uri1);
+        expect(Buffer.from(content1).toString('utf8')).toBe('hello\n');
+
+        const content2 = await provider.readFile(uri2);
+        expect(Buffer.from(content2).toString('utf8')).toBe('hello other\n');
+
+        expect(onDidChangeFileFired.length).toBe(0);
+
+        provider.invalidateCache();
+
+        expect(onDidChangeFileFired.length).toBe(1);
+        const batch = onDidChangeFileFired[0];
+        expect(batch.length).toBe(2);
+
+        const uris = batch.map((e) => e.uri.toString());
+        expect(uris.some((u) => u.includes('file.txt'))).toBe(true);
+        expect(uris.some((u) => u.includes('other.txt'))).toBe(true);
+
+        // A second invalidation should not refire, as known URIs are cleared
+        provider.invalidateCache();
+        expect(onDidChangeFileFired.length).toBe(1);
+    });
+
+    it('watch returns a disposable', () => {
+        const disposable = provider.watch();
+        expect(disposable).toHaveProperty('dispose');
+    });
+
+    it('unsupported operations throw', () => {
+        expect(() => provider.readDirectory()).toThrow('jj-edit is file-only');
+        expect(() => provider.createDirectory()).toThrow('jj-edit is file-only');
+        expect(() => provider.delete()).toThrow('jj-edit does not support delete');
+        expect(() => provider.rename()).toThrow('jj-edit does not support rename');
+    });
+});

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 // sort-imports-ignore (needed so that we can import after `vscode` is mocked)
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { resolveRepository } from '../extension';
 
@@ -13,61 +13,73 @@ vi.mock('vscode', async () => {
 });
 
 // Import after mock
+import * as path from 'node:path';
+import { CodeForgeRegistry } from '../code-forge-registry';
 import type { JjRepository } from '../jj-repository';
-import type { JjRepositoryManager } from '../jj-repository-manager';
+import { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjScmProvider } from '../jj-scm-provider';
+import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
 
 describe('resolveRepository', () => {
-    let mockRepoManager: JjRepositoryManager;
-    let mockScmProviders: Map<string, JjScmProvider>;
-    let mockRepo: JjRepository;
+    let repo: TestRepo;
+    let repoManager: JjRepositoryManager;
+    let scmProviders: Map<string, JjScmProvider>;
+    let resolvedRepo: JjRepository;
     let mockScm: JjScmProvider;
-    let focusedRepoVal: JjRepository | undefined;
 
-    beforeEach(() => {
-        mockRepo = createMock<JjRepository>({
-            rootUri: vscode.Uri.file('/root/subrepo'),
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        const codeForgeRegistry = new CodeForgeRegistry();
+        const outputChannel = createMock<vscode.OutputChannel>({
+            appendLine: () => {},
         });
+        const workspaceState = createMock<vscode.Memento>({
+            get: vi.fn().mockReturnValue(undefined),
+            update: vi.fn().mockResolvedValue(undefined),
+        });
+
+        repoManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
+        const registered = await repoManager.checkAndRegisterUri(vscode.Uri.file(repo.path));
+        if (!registered) {
+            throw new Error('Failed to register repository');
+        }
+        resolvedRepo = registered;
+
         mockScm = createMock<JjScmProvider>({});
-        mockRepoManager = createMock<JjRepositoryManager>({
-            getRepositoryForUri: vi.fn(),
-        });
-        focusedRepoVal = undefined;
-        Object.defineProperty(mockRepoManager, 'focusedRepository', {
-            get: () => focusedRepoVal,
-            configurable: true,
-        });
-        mockScmProviders = new Map();
-        mockScmProviders.set('/root/subrepo', mockScm);
+        scmProviders = new Map();
+        scmProviders.set(resolvedRepo.rootUri.fsPath, mockScm);
+    });
+
+    afterEach(async () => {
+        await repoManager.dispose();
+        repo.dispose();
     });
 
     it('resolves repository from SourceControlResourceState argument', () => {
-        const mockState = { resourceUri: vscode.Uri.file('/root/subrepo/file.txt') };
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(mockRepo);
+        const mockState = { resourceUri: vscode.Uri.file(path.join(repo.path, 'file.txt')) };
 
-        const result = resolveRepository([mockState], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([mockState], repoManager, scmProviders);
 
         expect(result).toBeDefined();
-        expect(result?.repo).toBe(mockRepo);
+        expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
-        expect(mockRepoManager.getRepositoryForUri).toHaveBeenCalledWith(mockState.resourceUri);
     });
 
     it('resolves repository from SourceControl object argument', () => {
-        const mockSCM = { rootUri: vscode.Uri.file('/root/subrepo') };
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(mockRepo);
+        const mockSCM = { rootUri: vscode.Uri.file(repo.path) };
 
-        const result = resolveRepository([mockSCM], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([mockSCM], repoManager, scmProviders);
 
         expect(result).toBeDefined();
-        expect(result?.repo).toBe(mockRepo);
+        expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
-        expect(mockRepoManager.getRepositoryForUri).toHaveBeenCalledWith(mockSCM.rootUri);
     });
 
     it('resolves repository from active text editor when no arguments provided', () => {
-        const activeUri = vscode.Uri.file('/root/subrepo/other.txt');
+        const activeUri = vscode.Uri.file(path.join(repo.path, 'other.txt'));
         // Set up vscode mock active text editor
         Object.defineProperty(vscode.window, 'activeTextEditor', {
             get: () => ({
@@ -75,14 +87,12 @@ describe('resolveRepository', () => {
             }),
             configurable: true,
         });
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(mockRepo);
 
-        const result = resolveRepository([], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([], repoManager, scmProviders);
 
         expect(result).toBeDefined();
-        expect(result?.repo).toBe(mockRepo);
+        expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
-        expect(mockRepoManager.getRepositoryForUri).toHaveBeenCalledWith(activeUri);
 
         // Reset active text editor
         Object.defineProperty(vscode.window, 'activeTextEditor', {
@@ -95,7 +105,7 @@ describe('resolveRepository', () => {
         const commitUri = vscode.Uri.from({
             scheme: 'jj-commit',
             path: '/Commit:%20abc123',
-            query: `changeId=abc12345&repoRoot=${encodeURIComponent('/root/subrepo')}`,
+            query: `changeId=abc12345&repoRoot=${encodeURIComponent(repo.path)}`,
         });
         Object.defineProperty(vscode.window, 'activeTextEditor', {
             get: () => ({
@@ -103,18 +113,12 @@ describe('resolveRepository', () => {
             }),
             configurable: true,
         });
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(mockRepo);
 
-        const result = resolveRepository([], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([], repoManager, scmProviders);
 
         expect(result).toBeDefined();
-        expect(result?.repo).toBe(mockRepo);
+        expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
-        expect(mockRepoManager.getRepositoryForUri).toHaveBeenCalledWith(
-            expect.objectContaining({
-                fsPath: '/root/subrepo',
-            }),
-        );
 
         Object.defineProperty(vscode.window, 'activeTextEditor', {
             get: () => undefined,
@@ -123,21 +127,19 @@ describe('resolveRepository', () => {
     });
 
     it('falls back to focused repository when arg and active editor are not in any repository', () => {
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(undefined);
-        focusedRepoVal = mockRepo;
+        repoManager.setFocusedRepository(resolvedRepo);
 
-        const result = resolveRepository([], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([], repoManager, scmProviders);
 
         expect(result).toBeDefined();
-        expect(result?.repo).toBe(mockRepo);
+        expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
     });
 
     it('returns undefined if no repository is resolved', () => {
-        vi.mocked(mockRepoManager.getRepositoryForUri).mockReturnValue(undefined);
-        focusedRepoVal = undefined;
+        repoManager.setFocusedRepository(undefined);
 
-        const result = resolveRepository([], mockRepoManager, mockScmProviders);
+        const result = resolveRepository([], repoManager, scmProviders);
 
         expect(result).toBeUndefined();
     });

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -12,7 +12,7 @@ export class TestRepo {
 
     constructor(tmpDir?: string) {
         const rawPath = tmpDir || fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-'));
-        this.path = fs.realpathSync(rawPath);
+        this.path = fs.realpathSync.native ? fs.realpathSync.native(rawPath) : fs.realpathSync(rawPath);
     }
 
     dispose() {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -5,6 +5,49 @@
 import { vi } from 'vitest';
 
 /**
+ * Helper to parse a URI string into components for MockUri.
+ * Example inputs:
+ * - "jj-edit:///foo/bar.txt?revision=@" -> scheme="jj-edit", path="/foo/bar.txt", query="revision=@"
+ * - "jj-edit://foo/bar.txt?revision=@" -> scheme="jj-edit", path="foo/bar.txt", query="revision=@"
+ * - "/foo/bar.txt" -> scheme="file", path="/foo/bar.txt", query=""
+ * - "file:///foo/bar.txt#frag" -> scheme="file", path="/foo/bar.txt", query=""
+ */
+function parseUriString(uriString: string): { scheme: string; path: string; query: string } {
+    let scheme = 'file';
+    let rest = uriString;
+
+    const schemeMatch = uriString.match(/^([a-zA-Z0-9.+-]+):\/\/(.*)$/);
+    if (schemeMatch) {
+        scheme = schemeMatch[1];
+        rest = schemeMatch[2];
+    }
+
+    // Strip fragment
+    const hashIndex = rest.indexOf('#');
+    if (hashIndex !== -1) {
+        rest = rest.substring(0, hashIndex);
+    }
+
+    // Parse query
+    const queryIndex = rest.indexOf('?');
+    let query = '';
+    let pathPart = rest;
+    if (queryIndex !== -1) {
+        pathPart = rest.substring(0, queryIndex);
+        query = rest.substring(queryIndex + 1);
+    }
+
+    let decodedPath = pathPart;
+    try {
+        decodedPath = decodeURIComponent(pathPart);
+    } catch {
+        // Fallback
+    }
+
+    return { scheme, path: decodedPath, query };
+}
+
+/**
  * Creates a base vscode mock with common properties. Override any property
  * by passing a partial object — properties are shallow-merged per namespace.
  *
@@ -80,6 +123,40 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         dispose = vi.fn();
     }
 
+    const onDidChangeTabsEmitter = new EventEmitter<unknown>();
+    const onDidChangeTabGroupsEmitter = new EventEmitter<unknown>();
+    const onDidChangeWindowStateEmitter = new EventEmitter<unknown>();
+    const onDidChangeConfigurationEmitter = new EventEmitter<unknown>();
+    const onDidSaveTextDocumentEmitter = new EventEmitter<unknown>();
+
+    class FileSystemError extends Error {
+        readonly code: string;
+        constructor(messageOrUri?: string | object, code: string = 'Unknown') {
+            const msg = messageOrUri && typeof messageOrUri !== 'string' ? String(messageOrUri) : messageOrUri || '';
+            super(msg);
+            this.code = code;
+            this.name = 'FileSystemError';
+        }
+        static Unavailable(message?: string | object) {
+            return new FileSystemError(message, 'Unavailable');
+        }
+        static FileNotFound(message?: string | object) {
+            return new FileSystemError(message, 'FileNotFound');
+        }
+        static NoPermissions(message?: string | object) {
+            return new FileSystemError(message, 'NoPermissions');
+        }
+        static FileExists(message?: string | object) {
+            return new FileSystemError(message, 'FileExists');
+        }
+        static FileNotADirectory(message?: string | object) {
+            return new FileSystemError(message, 'FileNotADirectory');
+        }
+        static FileIsADirectory(message?: string | object) {
+            return new FileSystemError(message, 'FileIsADirectory');
+        }
+    }
+
     const base: Record<string, unknown> = {
         ProgressLocation: { Notification: 15 },
         Position,
@@ -87,13 +164,44 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         Selection,
         Disposable,
         EventEmitter,
+        FileChangeType: {
+            Changed: 1,
+            Created: 2,
+            Deleted: 3,
+        },
+        FileType: {
+            Unknown: 0,
+            File: 1,
+            Directory: 2,
+            SymbolicLink: 64,
+        },
+        FileSystemError,
+
         Uri: class MockUri {
             constructor(
                 public fsPath: string,
                 public scheme: string = 'file',
                 public query: string = '',
                 public path: string = fsPath,
-            ) {}
+            ) {
+                if (process.platform === 'win32') {
+                    this.fsPath = this.fsPath.replace(/\//g, '\\');
+                    // Strip leading backslash if it precedes a drive letter (e.g., \C:\... -> C:\...)
+                    if (/^\\[a-zA-Z]:\\/.test(this.fsPath)) {
+                        this.fsPath = this.fsPath.substring(1);
+                    }
+                    if (/^[a-zA-Z]:\\/.test(this.fsPath)) {
+                        this.fsPath = this.fsPath[0].toLowerCase() + this.fsPath.substring(1);
+                    }
+                    // For VS Code URIs on Windows, path should always use forward slashes.
+                    // If it has a drive letter, it starts with a slash (e.g. /c:/...).
+                    let normalizedPath = this.fsPath.replace(/\\/g, '/');
+                    if (/^[a-zA-Z]:\//.test(normalizedPath)) {
+                        normalizedPath = `/${normalizedPath}`;
+                    }
+                    this.path = normalizedPath;
+                }
+            }
             static file(fsPath: string) {
                 return new MockUri(fsPath);
             }
@@ -101,7 +209,8 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
                 return new MockUri(components.path, components.scheme, components.query || '', components.path);
             }
             static parse(uriString: string) {
-                return { _isUriBaseCtorMock: true, value: uriString };
+                const parsed = parseUriString(uriString);
+                return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path);
             }
             static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
                 const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
@@ -140,15 +249,33 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             withProgress: vi.fn().mockImplementation(async (_: unknown, task: () => Promise<unknown>) => task()),
             setStatusBarMessage: vi.fn(),
             createOutputChannel: vi.fn().mockReturnValue({ appendLine: vi.fn() }),
+            tabGroups: {
+                activeTabGroup: { activeTab: undefined },
+                onDidChangeTabs: onDidChangeTabsEmitter.event,
+                onDidChangeTabGroups: onDidChangeTabGroupsEmitter.event,
+            },
+            visibleTextEditors: [],
+            onDidChangeWindowState: onDidChangeWindowStateEmitter.event,
+            state: { focused: true },
         },
         workspace: {
             workspaceFolders: [{ uri: { fsPath: '/root' } }],
             getConfiguration: vi.fn().mockReturnValue({
                 get: vi.fn().mockImplementation((_key: string, defaultValue: unknown) => defaultValue),
             }),
+            onDidChangeConfiguration: onDidChangeConfigurationEmitter.event,
+            onDidSaveTextDocument: onDidSaveTextDocumentEmitter.event,
+            findFiles: vi.fn().mockResolvedValue([]),
         },
         commands: {
             executeCommand: vi.fn(),
+        },
+        _emitters: {
+            onDidChangeTabs: onDidChangeTabsEmitter,
+            onDidChangeTabGroups: onDidChangeTabGroupsEmitter,
+            onDidChangeWindowState: onDidChangeWindowStateEmitter,
+            onDidChangeConfiguration: onDidChangeConfigurationEmitter,
+            onDidSaveTextDocument: onDidSaveTextDocumentEmitter,
         },
     };
 


### PR DESCRIPTION
This relands commit c17a28b8daadf169c89e4e831374a722ddeb720e, restoring the unit tests for JjEditFileSystemProvider and the associated mock improvements.

* Add vitest unit tests for JjEditFileSystemProvider
* Mock vscode FileSystemError and FileType properly
* Fix flaky e2e test timeout in clickLogAction

## Summary by Sourcery

Restore and extend testing support for the custom jj-edit file system provider and improve supporting test utilities.

New Features:
- Add unit tests covering the JjEdit file system provider behavior using vitest.

Enhancements:
- Enhance the vscode test mock to more accurately model URIs, file system errors, file types, window/workspace events, and Windows path handling.
- Update the test repository helper to prefer native realpath resolution when available for temporary test directories.

Tests:
- Introduce a dedicated test suite for the JjEdit file system provider that exercises its key operations and interactions.