### PR TITLE
feat: Automatically close diff editors for invalid revisions

### DIFF
--- a/src/diff-tab-cleaner.ts
+++ b/src/diff-tab-cleaner.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { JjService } from './jj-service';
+import { getRevisionFromUri, isJjScheme } from './uri-utils';
+
+interface CollectedTabs {
+    uniqueRevisions: Set<string>;
+    tabToRevisions: Map<vscode.Tab, string[]>;
+}
+
+export class DiffTabCleaner {
+    private readonly revisionsCache = new Map<string, boolean>();
+    private lastOpHeadsSignature = '';
+
+    constructor(
+        private readonly jj: JjService,
+        private readonly belongsToRepo: (uri: vscode.Uri) => boolean,
+        private readonly outputChannel?: vscode.OutputChannel,
+    ) {}
+
+    /**
+     * Coordinates collecting, checking, and closing invalid diff editor tabs.
+     * A diff editor tab is considered invalid if it is displaying a revision or
+     * change ID that is no longer valid (e.g., because the revision has been
+     * squashed, abandoned, or no longer exists in the Jujutsu repository history).
+     */
+    public async closeInvalidDiffEditors(): Promise<void> {
+        try {
+            const tabGroups = vscode.window.tabGroups.all;
+            const { uniqueRevisions, tabToRevisions } = this.collectDiffTabs(tabGroups);
+            if (uniqueRevisions.size === 0) {
+                return;
+            }
+
+            const invalidRevisions = await this.checkRevisionsValidity(uniqueRevisions);
+            const tabsToClose = this.filterTabsToClose(tabToRevisions, invalidRevisions);
+
+            await this.closeTabs(tabsToClose);
+        } catch (err) {
+            this.outputChannel?.appendLine(`[DiffTabCleaner] Failed to check/close invalid diff editors: ${err}`);
+        }
+    }
+
+    /**
+     * Clears the validation cache and signature.
+     */
+    public clearCache(): void {
+        this.revisionsCache.clear();
+        this.lastOpHeadsSignature = '';
+    }
+
+    /**
+     * Helper to read the current op heads and generate a hash of their filenames.
+     */
+    private async getOpHeadsSignature(): Promise<string> {
+        try {
+            const storePath = await this.jj.getRepoStorePath();
+            const opHeadsDir = path.join(storePath, 'op_heads', 'heads');
+            const files = await fs.readdir(opHeadsDir);
+            files.sort();
+            return crypto.createHash('sha256').update(files.join(',')).digest('hex');
+        } catch {
+            return '';
+        }
+    }
+
+    /**
+     * Scans all open tabs and collects those displaying diffs for this repository,
+     * returning their associated revisions.
+     */
+    private collectDiffTabs(tabGroups: readonly vscode.TabGroup[]): CollectedTabs {
+        const uniqueRevisions = new Set<string>();
+        const tabToRevisions = new Map<vscode.Tab, string[]>();
+
+        for (const group of tabGroups) {
+            if (!group.tabs) {
+                continue;
+            }
+            for (const tab of group.tabs) {
+                if (!(tab.input instanceof vscode.TabInputTextDiff)) {
+                    continue;
+                }
+
+                const revs = this.getRevisionsForTab(tab.input);
+                if (revs.length > 0) {
+                    tabToRevisions.set(tab, revs);
+                    for (const rev of revs) {
+                        uniqueRevisions.add(rev);
+                    }
+                }
+            }
+        }
+
+        return { uniqueRevisions, tabToRevisions };
+    }
+
+    /**
+     * Extracts a revision from a URI if it belongs to this repository and is not a working copy revision.
+     */
+    private getRevisionIfRelevant(uri: vscode.Uri): string | undefined {
+        if (isJjScheme(uri) && this.belongsToRepo(uri)) {
+            const rev = getRevisionFromUri(uri);
+            if (rev && rev !== '@' && rev !== '@-') {
+                return rev;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Extracts revision IDs from the original/modified URIs of a diff tab if they belong to this repo.
+     */
+    private getRevisionsForTab(input: vscode.TabInputTextDiff): string[] {
+        const revs: string[] = [];
+        const originalRev = this.getRevisionIfRelevant(input.original);
+        if (originalRev) {
+            revs.push(originalRev);
+        }
+        const modifiedRev = this.getRevisionIfRelevant(input.modified);
+        if (modifiedRev) {
+            revs.push(modifiedRev);
+        }
+        return revs;
+    }
+
+    /**
+     * Evaluates revision validity against JjService, utilizing and maintaining the local cache.
+     */
+    private async checkRevisionsValidity(revisions: Set<string>): Promise<Set<string>> {
+        const invalidRevisions = new Set<string>();
+        if (revisions.size === 0) {
+            return invalidRevisions;
+        }
+
+        const currentSignature = await this.getOpHeadsSignature();
+        if (currentSignature !== this.lastOpHeadsSignature) {
+            this.revisionsCache.clear();
+            this.lastOpHeadsSignature = currentSignature;
+        }
+
+        const promises: Promise<void>[] = [];
+        for (const rev of revisions) {
+            const cached = this.revisionsCache.get(rev);
+            if (cached !== undefined) {
+                if (!cached) {
+                    invalidRevisions.add(rev);
+                }
+                continue;
+            }
+
+            promises.push(
+                (async () => {
+                    try {
+                        const logs = await this.jj.getLogIds({ revision: rev, limit: 1 });
+                        const isValid = logs.length > 0;
+                        this.revisionsCache.set(rev, isValid);
+                        if (!isValid) {
+                            invalidRevisions.add(rev);
+                        }
+                    } catch {
+                        this.revisionsCache.set(rev, false);
+                        invalidRevisions.add(rev);
+                    }
+                })(),
+            );
+        }
+
+        if (promises.length > 0) {
+            await Promise.all(promises);
+        }
+
+        return invalidRevisions;
+    }
+
+    /**
+     * Identifies which tabs need to be closed based on invalid revisions.
+     */
+    private filterTabsToClose(tabToRevisions: Map<vscode.Tab, string[]>, invalidRevisions: Set<string>): vscode.Tab[] {
+        const tabsToClose: vscode.Tab[] = [];
+        for (const [tab, revs] of tabToRevisions.entries()) {
+            if (revs.some((r) => invalidRevisions.has(r))) {
+                tabsToClose.push(tab);
+            }
+        }
+        return tabsToClose;
+    }
+
+    /**
+     * Closes the specified tabs.
+     */
+    private async closeTabs(tabs: vscode.Tab[]): Promise<void> {
+        await Promise.all(
+            tabs.map(async (tab) => {
+                try {
+                    await vscode.window.tabGroups.close(tab);
+                } catch (err) {
+                    this.outputChannel?.appendLine(`[DiffTabCleaner] Failed to close tab: ${err}`);
+                }
+            }),
+        );
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -335,6 +335,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             context,
             repo,
             repoOutputChannel,
+            repositoryManager,
             viewFileSystemProvider,
             editFileSystemProvider,
             () => repositoryManager.focusedRepository?.rootUri.fsPath === repo.rootUri.fsPath,

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { getErrorMessage } from './commands/command-utils';
 import { completeSquashRevisionCommand, isSquashInProgress } from './commands/squash-revision';
+import { DiffTabCleaner } from './diff-tab-cleaner';
 import { JjContextKey, ScmContextValue } from './jj-context-keys';
 import { JjDecorationProvider } from './jj-decoration-provider';
 import type { JjEditFileSystemProvider } from './jj-edit-fs-provider';
@@ -34,6 +35,7 @@ export class JjScmProvider implements vscode.Disposable {
     private _workingCopyStatuses = new Map<string, JjStatusEntry>();
     private _parentMutable = false;
     private _hasChild = false;
+    private _diffTabCleaner: DiffTabCleaner;
 
     get parentMutable(): boolean {
         return this._parentMutable;
@@ -56,6 +58,7 @@ export class JjScmProvider implements vscode.Disposable {
         public readonly context: vscode.ExtensionContext,
         public readonly repo: import('./jj-repository').JjRepository,
         public readonly outputChannel: vscode.OutputChannel,
+        public readonly repositoryManager: import('./jj-repository-manager').JjRepositoryManager,
         public readonly viewFileSystemProvider?: JjViewFileSystemProvider,
         public readonly editProvider?: JjEditFileSystemProvider,
         public readonly isFocused: () => boolean = () => true,
@@ -68,6 +71,11 @@ export class JjScmProvider implements vscode.Disposable {
             repo.rootUri,
         );
         this.decorationProvider = new JjDecorationProvider(this.jj, workspaceRoot);
+
+        const belongsToRepo = (uri: vscode.Uri) => {
+            return this.repositoryManager.getRepositoryForUri(uri) === this.repo;
+        };
+        this._diffTabCleaner = new DiffTabCleaner(this.jj, belongsToRepo, this.outputChannel);
 
         // Create groups in order of display
         this._conflictGroup = this._sourceControl.createResourceGroup(ScmContextValue.ConflictGroup, 'Merge Conflicts');
@@ -505,6 +513,8 @@ export class JjScmProvider implements vscode.Disposable {
                         // Re-assigning quickDiffProvider is a known workaround to force
                         // VS Code to re-evaluate provideOriginalResource for all open editors.
                         this._sourceControl.quickDiffProvider = this;
+
+                        await this._diffTabCleaner.closeInvalidDiffEditors();
                     }
                 }
             })

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -3,18 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as assert from 'node:assert';
-import * as path from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
-import { JjRepository } from '../jj-repository';
 import { JjScmProvider } from '../jj-scm-provider';
+import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { createMock } from './test-utils';
 
 suite('Button Visibility Integration Test', () => {
     let scmProvider: JjScmProvider;
     let executeCommandStub: sinon.SinonStub;
+    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
     let repo: TestRepo;
 
     setup(async () => {
@@ -38,14 +37,13 @@ suite('Button Visibility Integration Test', () => {
             dispose: () => {},
             name: 'mock',
         });
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
 
         // Spy/Stub on vscode.commands.executeCommand to check for setContext
         executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
@@ -57,6 +55,9 @@ suite('Button Visibility Integration Test', () => {
         scmProvider.dispose();
         if (executeCommandStub) {
             executeCommandStub.restore();
+        }
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as assert from 'node:assert';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../../code-forge-registry';
 import { absorbCommand } from '../../commands/absorb';
-import { JjRepository } from '../../jj-repository';
 import { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
@@ -18,6 +15,7 @@ suite('Absorb Integration Test', function () {
     let jj: JjService;
     let scmProvider: JjScmProvider;
     let outputChannel: vscode.OutputChannel;
+    let contextHelper: import('../integration-test-utils').TestRepositoryContext;
 
     setup(async () => {
         repo = new TestRepo();
@@ -31,18 +29,21 @@ suite('Absorb Integration Test', function () {
             extensionUri: vscode.Uri.file(__dirname),
         } as unknown as vscode.ExtensionContext;
 
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        const { createTestRepositoryContext } = await import('../integration-test-utils');
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
     });
 
     teardown(async () => {
         scmProvider.dispose();
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
+        }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { DiffTabCleaner } from '../diff-tab-cleaner';
+import { JjService } from '../jj-service';
+import { createTestRepositoryContext, type TestRepositoryContext } from './integration-test-utils';
+import { buildGraph, TestRepo } from './test-repo';
+import { exposePrivate } from './test-utils';
+
+// Mock vscode
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    const mock = await createVscodeMock();
+    const windowMock = mock.window as { tabGroups: { close: unknown } };
+    windowMock.tabGroups.close = vi.fn().mockResolvedValue(true);
+    return mock;
+});
+
+interface PrivateDiffTabCleaner {
+    getOpHeadsSignature(): Promise<string>;
+    collectDiffTabs(tabGroups: readonly vscode.TabGroup[]): {
+        uniqueRevisions: Set<string>;
+        tabToRevisions: Map<vscode.Tab, string[]>;
+    };
+    checkRevisionsValidity(revisions: Set<string>): Promise<Set<string>>;
+    filterTabsToClose(tabToRevisions: Map<vscode.Tab, string[]>, invalidRevisions: Set<string>): vscode.Tab[];
+    closeTabs(tabs: vscode.Tab[]): Promise<void>;
+}
+
+describe('Diff Tab Cleaner', () => {
+    let repo: TestRepo;
+    let jj: JjService;
+    let cleaner: DiffTabCleaner;
+    let privateCleaner: PrivateDiffTabCleaner;
+    let contextHelper: TestRepositoryContext | undefined;
+
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path);
+
+        const outputChannel = vscode.window.createOutputChannel('Jujutsu Test');
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+
+        const belongsToRepo = (uri: vscode.Uri) => {
+            if (!contextHelper) {
+                return false;
+            }
+            return contextHelper.repositoryManager.getRepositoryForUri(uri) === contextHelper.repository;
+        };
+        cleaner = new DiffTabCleaner(jj, belongsToRepo);
+        privateCleaner = exposePrivate<PrivateDiffTabCleaner>(cleaner);
+    });
+
+    afterEach(() => {
+        if (contextHelper?.repositoryManager) {
+            contextHelper.repositoryManager.dispose();
+        }
+        if (repo) {
+            repo.dispose();
+        }
+    });
+
+    describe('collectDiffTabs', () => {
+        it('collects diff tabs belonging to the repo and extracts their revisions', () => {
+            const repoRoot = repo.path;
+            const uri1 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=rev123&side=left',
+            });
+            const uri2 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=rev123&side=right',
+            });
+
+            // Tab belonging to another repo
+            const uriOther = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: '/other/repo/src/file.ts',
+                query: 'base=rev456&side=left',
+            });
+
+            const tab1 = {
+                input: new vscode.TabInputTextDiff(uri1, uri2),
+            } as unknown as vscode.Tab;
+
+            const tabOther = {
+                input: new vscode.TabInputTextDiff(uriOther, uriOther),
+            } as unknown as vscode.Tab;
+
+            const tabGroups = [
+                {
+                    tabs: [tab1, tabOther],
+                },
+            ] as unknown as vscode.TabGroup[];
+
+            const { uniqueRevisions, tabToRevisions } = privateCleaner.collectDiffTabs(tabGroups);
+
+            expect(uniqueRevisions.has('rev123')).toBe(true);
+            expect(uniqueRevisions.has('rev456')).toBe(false);
+            expect(tabToRevisions.size).toBe(1);
+            expect(tabToRevisions.get(tab1)).toEqual(['rev123', 'rev123']);
+        });
+
+        it('ignores working copy revisions (@ and @-)', () => {
+            const repoRoot = repo.path;
+            const uri1 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=@&side=left',
+            });
+            const uri2 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=@-&side=right',
+            });
+
+            const tab = {
+                input: new vscode.TabInputTextDiff(uri1, uri2),
+            } as unknown as vscode.Tab;
+
+            const tabGroups = [
+                {
+                    tabs: [tab],
+                },
+            ] as unknown as vscode.TabGroup[];
+
+            const { uniqueRevisions, tabToRevisions } = privateCleaner.collectDiffTabs(tabGroups);
+
+            expect(uniqueRevisions.size).toBe(0);
+            expect(tabToRevisions.size).toBe(0);
+        });
+
+        it('ignores tabs with non jj view or jj edit schemas', () => {
+            const repoRoot = repo.path;
+            const uri1 = vscode.Uri.from({
+                scheme: 'file',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=rev123&side=left',
+            });
+            const uri2 = vscode.Uri.from({
+                scheme: 'git',
+                path: `${repoRoot}/src/file1.ts`,
+                query: 'base=rev123&side=right',
+            });
+
+            const tab = {
+                input: new vscode.TabInputTextDiff(uri1, uri2),
+            } as unknown as vscode.Tab;
+
+            const tabGroups = [
+                {
+                    tabs: [tab],
+                },
+            ] as unknown as vscode.TabGroup[];
+
+            const { uniqueRevisions, tabToRevisions } = privateCleaner.collectDiffTabs(tabGroups);
+
+            expect(uniqueRevisions.size).toBe(0);
+            expect(tabToRevisions.size).toBe(0);
+        });
+    });
+
+    describe('checkRevisionsValidity', () => {
+        it('identifies invalid revisions using a real JjService', async () => {
+            const ids = await buildGraph(repo, [{ label: 'commitA', description: 'desc A' }]);
+            const validRev = ids.commitA.changeId;
+            const invalidRev = 'non-existent-rev';
+
+            const revisions = new Set([validRev, invalidRev]);
+            const invalid = await privateCleaner.checkRevisionsValidity(revisions);
+
+            expect(invalid.has(validRev)).toBe(false);
+            expect(invalid.has(invalidRev)).toBe(true);
+        });
+
+        it('caches validated (valid) revisions', async () => {
+            const ids = await buildGraph(repo, [{ label: 'commitA', description: 'desc A' }]);
+            const validRev = ids.commitA.changeId;
+
+            // Pin the signature to prevent the abandon operation from invalidating the cache
+            vi.spyOn(privateCleaner, 'getOpHeadsSignature').mockResolvedValue('constant-sig');
+
+            // 1. Initial check - validRev is valid
+            const invalid1 = await privateCleaner.checkRevisionsValidity(new Set([validRev]));
+            expect(invalid1.has(validRev)).toBe(false);
+
+            // 2. Abandon the commit to make it invalid
+            await jj.abandon([validRev]);
+
+            // 3. Check again - should still be considered valid due to caching
+            const invalid2 = await privateCleaner.checkRevisionsValidity(new Set([validRev]));
+            expect(invalid2.has(validRev)).toBe(false);
+
+            // 4. Clear cache and check again - now it should be recognized as invalid
+            cleaner.clearCache();
+            const invalid3 = await privateCleaner.checkRevisionsValidity(new Set([validRev]));
+            expect(invalid3.has(validRev)).toBe(true);
+        });
+
+        it('invalidates cache when op-heads signature changes', async () => {
+            const ids = await buildGraph(repo, [{ label: 'commitA', description: 'desc A' }]);
+            const validRev = ids.commitA.changeId;
+            const revisions = new Set([validRev]);
+
+            const getOpHeadsSignatureSpy = vi.spyOn(privateCleaner, 'getOpHeadsSignature');
+            getOpHeadsSignatureSpy.mockResolvedValueOnce('signature-1');
+
+            // 1. Initial check - validRev is valid
+            let invalid = await privateCleaner.checkRevisionsValidity(revisions);
+            expect(invalid.has(validRev)).toBe(false);
+
+            // 2. Force a different signature on next check
+            getOpHeadsSignatureSpy.mockResolvedValueOnce('signature-2');
+
+            // 3. Make revision invalid by abandoning it
+            await jj.abandon([validRev]);
+
+            // 4. Check again - cache should be bypassed/cleared and revision is invalid
+            invalid = await privateCleaner.checkRevisionsValidity(revisions);
+            expect(invalid.has(validRev)).toBe(true);
+
+            getOpHeadsSignatureSpy.mockRestore();
+        });
+    });
+
+    describe('filterTabsToClose', () => {
+        it('identifies which tabs to close based on invalid revisions', () => {
+            const tab1 = { label: 'tab1' } as unknown as vscode.Tab;
+            const tab2 = { label: 'tab2' } as unknown as vscode.Tab;
+
+            const tabToRevisions = new Map<vscode.Tab, string[]>();
+            tabToRevisions.set(tab1, ['rev-a']);
+            tabToRevisions.set(tab2, ['rev-b']);
+
+            const invalidRevisions = new Set(['rev-b']);
+            const result = privateCleaner.filterTabsToClose(tabToRevisions, invalidRevisions);
+
+            expect(result).toEqual([tab2]);
+        });
+
+        it('closes tabs that have multiple revisions where only one is invalid', () => {
+            const tab = { label: 'tab' } as unknown as vscode.Tab;
+            const tabToRevisions = new Map<vscode.Tab, string[]>();
+            tabToRevisions.set(tab, ['rev-a', 'rev-b']);
+
+            const invalidRevisions = new Set(['rev-b']);
+            const result = privateCleaner.filterTabsToClose(tabToRevisions, invalidRevisions);
+
+            expect(result).toEqual([tab]);
+        });
+    });
+
+    describe('closeTabs', () => {
+        it('closes tabs using vscode API', async () => {
+            const closeSpy = vscode.window.tabGroups.close as unknown as { mockClear: () => void };
+            closeSpy.mockClear();
+
+            const tab = { label: 'tab' } as unknown as vscode.Tab;
+            await privateCleaner.closeTabs([tab]);
+
+            expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(tab);
+        });
+    });
+
+    describe('closeInvalidDiffEditors', () => {
+        it('orchestrates collecting, checking, and closing invalid tabs using real repository state', async () => {
+            const closeSpy = vscode.window.tabGroups.close as unknown as { mockClear: () => void };
+            closeSpy.mockClear();
+
+            const ids = await buildGraph(repo, [{ label: 'commitA', description: 'desc A' }]);
+            const validRev = ids.commitA.changeId;
+            const invalidRev = 'non-existent-rev-xyz';
+
+            const uri1 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repo.path}/src/file1.ts`,
+                query: `base=${validRev}&side=left`,
+            });
+            const uri2 = vscode.Uri.from({
+                scheme: 'jj-view',
+                path: `${repo.path}/src/file1.ts`,
+                query: `base=${invalidRev}&side=left`,
+            });
+
+            const tab1 = {
+                input: new vscode.TabInputTextDiff(uri1, uri1),
+            } as unknown as vscode.Tab;
+
+            const tab2 = {
+                input: new vscode.TabInputTextDiff(uri2, uri2),
+            } as unknown as vscode.Tab;
+
+            (vscode.window.tabGroups as unknown as { all: unknown[] }).all = [{ tabs: [tab1, tab2] }];
+
+            await cleaner.closeInvalidDiffEditors();
+
+            expect(vscode.window.tabGroups.close).toHaveBeenCalledWith(tab2);
+            expect(vscode.window.tabGroups.close).not.toHaveBeenCalledWith(tab1);
+        });
+    });
+});

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -1073,4 +1073,59 @@ test.describe('SCM Pane E2E', () => {
             repo.dispose();
         }
     });
+
+    test('Closes diff editor automatically when the revision is squashed', async () => {
+        const repo = new TestRepo();
+        repo.init();
+
+        const fileName = 'squashed-diff-close-e2e.txt';
+        const commits = await buildGraph(repo, [
+            {
+                label: 'initial',
+                files: { [fileName]: 'initial content' },
+            },
+            {
+                label: 'target',
+                parents: ['initial'],
+                description: 'target commit message',
+                files: { [fileName]: 'modified content' },
+            },
+            {
+                label: 'wc',
+                parents: ['target'],
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const { app, page, userDataDir } = await launchVSCode(repo);
+
+        try {
+            await focusSCM(page);
+
+            // 1. Open Diff Editor for the target commit
+            await openScmDiff(page, fileName, /target commit message/);
+
+            // 2. Verify tab is open
+            const tab = page.getByRole('tab', { name: fileName });
+            await expect(tab).toBeVisible();
+
+            // 3. Squash target commit into parent using SCM action
+            await clickScmAction(page, /target commit message/, SCM_ACTIONS.SquashRevisionIntoParent);
+
+            // 4. Verify that the tab gets closed automatically
+            await expect(tab).not.toBeVisible({ timeout: 15000 });
+
+            // 5. Verify target is actually squashed (changeId no longer exists) in jj
+            await expect(async () => {
+                const log = repo.log();
+                expect(log).not.toContain(commits.target.changeId);
+            }).toPass({ timeout: 10000 });
+        } finally {
+            await app.close();
+            try {
+                fs.rmSync(userDataDir, { recursive: true, force: true });
+            } catch {}
+            repo.dispose();
+        }
+    });
 });

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -5,14 +5,14 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
-import { JjRepository } from '../jj-repository';
 import { JjScmProvider } from '../jj-scm-provider';
+import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ Decoration Integration Test', () => {
     let scmProvider: JjScmProvider;
+    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
     let repo: TestRepo;
 
     // Helper to normalize paths for Windows using robust URI comparison
@@ -38,19 +38,21 @@ suite('JJ Decoration Integration Test', () => {
             name: 'mock',
         });
 
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
     });
 
     teardown(async () => {
         if (scmProvider) {
             scmProvider.dispose();
+        }
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -7,23 +7,23 @@ import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
 import { compareAllFilesWithRevisionCommand } from '../commands/compare-all-files-with-revision';
 import { squashFilesIntoParentCommand } from '../commands/squash-files';
 import { completeSquashRevisionCommand, squashRevisionIntoParentCommand } from '../commands/squash-revision';
 import { squashSelectionIntoParentCommand } from '../commands/squash-selection';
 import { ScmContextValue } from '../jj-context-keys';
-import { JjRepository } from '../jj-repository';
 import type { JjRepositoryManager } from '../jj-repository-manager';
 import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
+import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ SCM Provider Integration Test', () => {
     let jj: JjService;
     let scmProvider: JjScmProvider;
+    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
 
     let repo: TestRepo;
 
@@ -55,19 +55,21 @@ suite('JJ SCM Provider Integration Test', () => {
             dispose: () => {},
             name: 'mock',
         });
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
     });
 
     teardown(async () => {
         if (scmProvider) {
             scmProvider.dispose();
+        }
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -3,17 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as assert from 'node:assert';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
 import { ScmContextValue } from '../jj-context-keys';
-import { JjRepository } from '../jj-repository';
 import { JjScmProvider } from '../jj-scm-provider';
+import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
 
 suite('JJ SCM Visibility Integration Test', () => {
     let scmProvider: JjScmProvider;
+    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
     let outputChannel: vscode.OutputChannel;
     let repo: TestRepo;
 
@@ -37,18 +36,20 @@ suite('JJ SCM Visibility Integration Test', () => {
             dispose: () => {},
             name: 'mock',
         });
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
     });
 
     teardown(async () => {
         scmProvider.dispose();
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
+        }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 

--- a/src/test/provide-original-resource.integration.test.ts
+++ b/src/test/provide-original-resource.integration.test.ts
@@ -5,14 +5,14 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
-import { JjRepository } from '../jj-repository';
 import { JjScmProvider } from '../jj-scm-provider';
+import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { createMock } from './test-utils';
 
 suite('JjScmProvider provideOriginalResource Integration Test', () => {
     let scmProvider: JjScmProvider;
+    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
     let repo: TestRepo;
 
     setup(async () => {
@@ -33,19 +33,21 @@ suite('JjScmProvider provideOriginalResource Integration Test', () => {
             dispose: () => {},
             name: 'mock',
         });
-        const codeForgeRegistry = new CodeForgeRegistry();
-        const repository = new JjRepository(
-            vscode.Uri.file(repo.path),
-            path.join(repo.path, '.jj', 'repo'),
-            codeForgeRegistry,
+        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
             outputChannel,
+            contextHelper.repositoryManager,
         );
-        scmProvider = new JjScmProvider(context, repository, outputChannel);
     });
 
     teardown(async () => {
         if (scmProvider) {
             scmProvider.dispose();
+        }
+        if (contextHelper) {
+            await contextHelper.repositoryManager.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/quick-diff.integration.test.ts
+++ b/src/test/quick-diff.integration.test.ts
@@ -43,7 +43,13 @@ suite('Quick Diff Integration Test', () => {
         contextHelper = await createTestRepositoryContext(canonicalPath, outputChannel);
 
         viewFileSystemProvider = new JjViewFileSystemProvider(contextHelper.repositoryManager);
-        scmProvider = new JjScmProvider(context, contextHelper.repository, outputChannel, viewFileSystemProvider);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
+            outputChannel,
+            contextHelper.repositoryManager,
+            viewFileSystemProvider,
+        );
 
         disposable = vscode.workspace.registerFileSystemProvider('jj-view-test', viewFileSystemProvider);
 

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -48,7 +48,13 @@ suite('Quick Diff Commands Integration Test', () => {
         contextHelper = await createTestRepositoryContext(canonicalPath, outputChannel);
 
         viewFileSystemProvider = new JjViewFileSystemProvider(contextHelper.repositoryManager);
-        scmProvider = new JjScmProvider(context, contextHelper.repository, outputChannel, viewFileSystemProvider);
+        scmProvider = new JjScmProvider(
+            context,
+            contextHelper.repository,
+            outputChannel,
+            contextHelper.repositoryManager,
+            viewFileSystemProvider,
+        );
 
         // Register a test-specific content provider to handle a unique scheme per test
         // This avoids conflict with the main extension's 'jj-view' provider and parallel tests

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -223,6 +223,12 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
                 return new MockUri(this.fsPath, change.scheme ?? this.scheme, change.query ?? this.query, this.path);
             }
         },
+        TabInputTextDiff: class MockTabInputTextDiff {
+            constructor(
+                public original: unknown,
+                public modified: unknown,
+            ) {}
+        },
         env: {
             openExternal: vi.fn(),
         },
@@ -250,9 +256,11 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             setStatusBarMessage: vi.fn(),
             createOutputChannel: vi.fn().mockReturnValue({ appendLine: vi.fn() }),
             tabGroups: {
+                all: [],
                 activeTabGroup: { activeTab: undefined },
                 onDidChangeTabs: onDidChangeTabsEmitter.event,
                 onDidChangeTabGroups: onDidChangeTabGroupsEmitter.event,
+                close: vi.fn(),
             },
             visibleTextEditors: [],
             onDidChangeWindowState: onDidChangeWindowStateEmitter.event,

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -88,7 +88,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
         disposables.push(contextHelper.repositoryManager);
 
-        scm = new JjScmProvider(mockContext, contextHelper.repository, outputChannel);
+        scm = new JjScmProvider(mockContext, contextHelper.repository, outputChannel, contextHelper.repositoryManager);
         disposables.push(scm);
 
         const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, contextHelper.repositoryManager);

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -102,3 +102,10 @@ export function getRevisionFromUri(uri: vscode.Uri): string | undefined {
     const query = new URLSearchParams(uri.query);
     return query.get('jj-revision') || query.get('revision') || query.get('base') || undefined;
 }
+
+/**
+ * Checks if a URI uses a Jujutsu-specific scheme.
+ */
+export function isJjScheme(uri: vscode.Uri): boolean {
+    return uri.scheme === 'jj-view' || uri.scheme === 'jj-edit';
+}


### PR DESCRIPTION
Introduces a background helper that scans open VS Code tabs and automatically closes any diff editors displaying Jujutsu revisions that are no longer valid (e.g., after being squashed, abandoned, or deleted). Instantiates `JjScmProvider` with the repository manager to query repository-specific revision validity on update, and updates integration/E2E test suites to align with the new provider signature and verify tab-cleanup behavior.

## Summary by Sourcery

Automatically close open diff editors that reference invalid Jujutsu revisions and wire this behavior into the SCM provider lifecycle.

New Features:
- Introduce a background DiffTabCleaner that scans open diff tabs for Jujutsu URIs and closes those tied to invalid revisions.

Enhancements:
- Extend JjScmProvider to depend on the repository manager so it can determine repository ownership of diff URIs and trigger tab cleanup after SCM updates.
- Add a utility to detect Jujutsu-specific URI schemes used in diff editors and extend the VS Code mock surface to support diff tab testing.

Tests:
- Add E2E coverage to verify diff editors are auto-closed when a revision is squashed from the SCM pane.
- Add unit tests for DiffTabCleaner, including revision collection, caching behavior, and integration with the mocked VS Code tab API.
- Update existing integration tests to construct JjScmProvider with a test repository context and repository manager, and to dispose these resources appropriately.