### PR TITLE
test: Reduce E2E test flakiness in divergent and workspace specs

### DIFF
--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -8,9 +8,9 @@ import { expect, type Page, test } from '@playwright/test';
 import type { ElectronApplication } from 'playwright';
 import { TestRepo } from '../test-repo';
 import {
+    clickLogAction,
     focusJJLog,
     getDetailsWebview,
-    hoverAndClick,
     launchVSCode,
     triggerRefresh,
     waitForLogCommitRow,
@@ -115,10 +115,7 @@ test.describe('Divergent Commits E2E', () => {
         // 4. Abandon the "zombie" commit (A v1) to resolve divergence
         await focusJJLog(page);
 
-        // Re-get webview because focus might refresh it
-        const rowToAbandon = await waitForLogCommitRow(page, 'commit A v1');
-
-        await hoverAndClick(rowToAbandon, rowToAbandon.locator('.icon-button[title="Abandon"]'));
+        await clickLogAction(page, 'commit A v1', 'Abandon');
 
         // 5. Verify divergence is resolved
         await expect(async () => {

--- a/src/test/e2e/workspace.spec.ts
+++ b/src/test/e2e/workspace.spec.ts
@@ -5,7 +5,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { buildGraph, TestRepo } from '../test-repo';
 import {
     clickLogTitleButton,
@@ -88,9 +88,23 @@ test.describe('Workspace Management E2E', () => {
             await waitForLogPill(page, workspaceName, 'workspace');
 
             // 4. Click "Open Workspace" in the notification and verify a new window opens
-            const nextWindowPromise = app.waitForEvent('window');
-            await clickNotificationButton(page, 'Open Workspace');
-            const newPage = await nextWindowPromise;
+            const openWorkspace = async (): Promise<Page> => {
+                let newPage: Page | undefined;
+                await expect(async () => {
+                    const [window] = await Promise.all([
+                        app.waitForEvent('window', { timeout: 8000 }),
+                        clickNotificationButton(page, 'Open Workspace'),
+                    ]);
+                    newPage = window;
+                }, 'Failed to open new workspace window').toPass({ timeout: 25000 });
+
+                if (!newPage) {
+                    throw new Error('New workspace window was not captured');
+                }
+                return newPage;
+            };
+
+            const newPage = await openWorkspace();
 
             // Wait for workbench to load in new window
             await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
Refactors the divergent commits E2E test to use the `clickLogAction` helper for abandoning commits, and wraps the notification-triggered workspace window open and click assertions in a robust `expect.toPass` block to stabilize playwright test execution.

## Summary by Sourcery

Stabilize E2E tests for workspace notifications and divergent commits by using more robust helpers and retry logic.

Tests:
- Wrap the workspace notification-triggered window-opening flow in an expect.toPass retry block to reduce flakiness.
- Use the clickLogAction helper for abandoning divergent commits in the log to make the E2E scenario more reliable and consistent.