### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/.agents/skills/generate-release/SKILL.md
+++ b/.agents/skills/generate-release/SKILL.md
@@ -21,7 +21,15 @@ Use this skill when the user wants to cut a new release of the extension. It req
     - Analyze the commit messages to determine the correct next version (patch, minor, or major bump) based on standard conventions (e.g., `feat:` is minor, `fix:` is patch).
     - Update the `version` field in `package.json` with the new version.
 5.  **Fetch Commits (If No Match):** If they _do not match_, assume the version in `package.json` was already bumped manually and is correct. Fetch the commit messages since the most recent tag using `jj log -r '<previous_tag>..@' -T 'description "\n"' --no-graph`.
-6.  **Draft Release Notes:** Generate nicely formatted, categorized release notes (e.g., Features, Fixes, Chores) from the commits. **CRITICAL:** Adopt the canonical style for changelog entries by starting each bullet with a bolded component or feature name, followed by a colon and the description: `- **[Component/Feature Name]**: [Description]`.
+6.  **Draft Release Notes:** Generate nicely formatted, categorized release notes (e.g., Features, Fixes, Chores) from the commits. **CRITICAL:** Adopt the canonical style for changelog entries by starting each bullet with a bolded component or feature name:
+    - If there is only a single change for a component, use a single line:
+      `- **[Component/Feature Name]**: [Description]`
+    - If there are multiple changes for the same component, group them as nested bullets under that component:
+      ```markdown
+      - **[Component/Feature Name]**:
+          - [Description of first change]
+          - [Description of second change]
+      ```
 7.  **Update Changelog:** Update `CHANGELOG.md` by prepending the new version and the drafted release notes.
 8.  **CRITICAL - User Review:** Use the `notify_user` tool to present the proposed changes (updated `CHANGELOG.md` and `package.json`) to the user. **Wait for their approval before proceeding.**
 9.  **Commit Changes:** After user approval, commit the changes using `jj commit -m "chore: bump version to <new_version>"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2.0.0
+
+### Features
+
+- **Multi-Repository**: Support multi-repository workspaces and recursive repository discovery.
+- **Bookmarks**: Add delete bookmark functionality.
+- **SCM**:
+    - Support tracking PR/MR from forks targeting mainline repositories.
+    - Add focus SCM description input command.
+- **Diff Editor**: Automatically close diff editors for invalid or abandoned revisions.
+
+### Fixes
+
+- **Multi-Repository**: Use forge provider cache during active repository switches.
+- **SCM**: Show only the subject line of ancestor commit descriptions in SCM group headers.
+- **File Watcher**: Check for watchman availability on PATH to avoid flashing the terminal window on Windows.
+
+### Chores & Testing
+
+- **Testing**:
+    - Add test coverage for `JjEditFileSystemProvider`, `canAbsorbCommit`, `isMutableCommit`, and `canSquashCommit`.
+    - Stabilize E2E tests by refining timing, adding retries, and reducing flakiness in divergent, workspace, and arbitrary diff spec suites.
+
 ## 1.29.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Visualize your `jj` repo history with a clear, interactive graph.
     - **Multi-Select**: `Ctrl+Click` (or `⌘+Click`) to select multiple commits.
     - **Contextual Commands**: Perform bulk actions like "Abandon" on all selected commits.
     - **Clear**: Press `Escape` to clear the selection.
+- **Ghost Nodes**: Displays visual representations of hidden commits in the graph.
+- **Divergent Commits**: Highlights divergent revisions with distinct visual styling (e.g. purple highlights and change ID offsets like `/1`).
+- **Multi-Workspace Support**: Displays workspace indicators (working copy pills) for all workspaces associated with a commit in the log view.
+- **Customizable Graph Lanes**: Choose from multiple built-in color themes (Oceanic, Sunset, Neon, Pastel, Monochrome) for log lanes.
 
 ### 📝 Commit Details Panel
 
@@ -42,6 +46,7 @@ Full integration with VS Code's Source Control view (SCM).
 - **Commit Management**: Create new changes (revisions), set descriptions, and squash modifications directly from the SCM panel.
 - **Merge Conflicts**: Identify and resolve conflicts using VS Code's merge editor.
 - **File Decorations**: Automatically highlights modified, added, conflicted, and ignored files in the Explorer with color-coded badges.
+- **Code Forge Integration**: Track pull request (GitHub), merge request (GitLab), and change list (Gerrit) review status directly in the Source Control view, with contextual upload actions that visually indicate if a change is dirty (needs to be uploaded).
 
 ![SCM View](media/screenshots/scm-view.png)
 _Source Control view managing `jj` changes._
@@ -56,7 +61,17 @@ Support for common and advanced `jj` operations:
 - **Absorbing**: Automatically move changes into the mutable ancestor where they were introduced.
 - **Rebasing**: Rebase changes onto other revisions.
 - **Workspace Management**: Create new `jj` workspaces directly from the UI, with configurable default locations.
+- **Workspace Actions**: Add, forget, or delete workspaces directly from the Log View context menu or workspace pills.
 - **Editable Diffs**: Edit any mutable commit directly in the diff editor. Changes are batched and applied on save, with full support for single and multi-file diffs.
+
+### 🗂️ Multi-Repository Support
+
+Full support for working with multiple `jj` repositories in the same workspace.
+
+- **Automatic Repository Detection**: Recursively scans workspace folders to discover and register all `jj` repositories.
+- **Automatic Active Repository Switching**: Dynamically switches the active/focused repository when switching between editor tabs or files belonging to different repositories.
+- **Manual Switching**: Focus specific repositories in the JJ Log view via SCM title actions or the `Show Repository in JJ Log` command.
+- **Customizable Detection**: Fine-tune detection with settings to ignore specific folders or target explicit paths.
 
 ## Commands
 
@@ -67,13 +82,15 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 - `JJ View: Refresh`: Refresh the current status and log.
 - `JJ View: Show Current Change`: Focus the graph on the current working copy change.
 - `JJ View: Show Details`: Open a dedicated panel with full details of the selected commit.
+- `JJ View: Show Repository in JJ Log`: Focus the repository in the JJ Log view.
 - `JJ View: Focus SCM Description Input`: Focus the description input field in the Source Control view.
 - `JJ View: Undo`: Undo the last `jj` operation.
 - `JJ View: Redo`: Redo the last undone `jj` operation.
+- `JJ View: Manage Code Forge Authentication`: Manage authentication preferences for code forge integrations.
 
 ### Change Management
 
-- `JJ View: New Change`: Create a new empty change at the current head.
+- `JJ View: New`: Create a new empty change at the current head.
 - `JJ View: New Before`: Create a new change _before_ the current revisions (inserts a new parent).
 - `JJ View: New After`: Create a new change _after_ the current revisions (inserts a new child).
 - `JJ View: Edit`: Edit a specific revision.
@@ -85,10 +102,14 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 - `JJ View: Set Description (Prompt)`: Edit the description of the current change using an interactive prompt.
 - `JJ View: Upload`: Upload the current change (runs configured upload command).
 - `JJ View: Set Bookmark`: Create or move a bookmark to a specific revision.
+- `JJ View: Delete Bookmark`: Delete a bookmark.
 - `JJ View: Commit`: Commit the current changes in the working copy (Ctrl+Enter in SCM input).
 - `JJ View: Commit (Prompt)`: Commit the current changes in the working copy, prompting for a description message first.
 - `JJ View: Open File`: Open the file associated with a change.
+- `JJ View: Open Changes`: Open the diff view for a file.
 - `JJ View: Add Workspace`: Create a new `jj` workspace.
+- `JJ View: Forget Workspace`: Forget a workspace without deleting its directory.
+- `JJ View: Delete Workspace Directory`: Forget a workspace and delete its directory from disk.
 - `JJ View: Show Multi-File Diff`: Open a comprehensive multi-file diff view for the selected revision. These views are editable for mutable commits.
 - `JJ View: Compare All Files with Revision...`: Compare all files between a selected revision and the working copy.
 - `JJ View: Compare File with Revision...`: Compare a specific file against a selected revision.
@@ -96,7 +117,7 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 ### History & Merging
 
 - `JJ View: Squash Revision into Parent`: Squash the current change into its parent.
-- `JJ View: Squash Revision into Ancestor`: Squash the current change into an ancestor.
+- `JJ View: Squash Revision into Ancestor...`: Squash the current change into an ancestor.
 - `JJ View: Absorb`: Move changes into the mutable ancestor where they belong.
 - `JJ View: New Merge Change`: Create a merge commit.
 - `JJ View: Open Merge Editor`: Open the merge editor for conflicted files.
@@ -152,7 +173,7 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.refreshDebounceMillis`        | `100`         | Base debounce time (ms) for SCM refresh based on file events.                                                                                                                                                                                                                                        |
 | `jj-view.refreshDebounceMaxMultiplier` | `4`           | Maximum multiplier for the debounce timeout when events continue to occur.                                                                                                                                                                                                                           |
 | `jj-view.fileWatcherMode`              | `"polling"`   | Controls how the extension detects external file changes. `"polling"` uses periodic status checks. `"watch"` uses a native file watcher ([parcel-watcher](https://github.com/parcel-bundler/watcher)) for more efficient, event-driven updates. Falls back to polling if the watcher fails to start. |
-| `jj-view.gerrit.host`                  | `null`        | Gerrit host URL (e.g., https://experiment-review.googlesource.com). If not set, extension attempts to detect it from .gitreview or git remotes.                                                                                                                                                      |
+| `jj-view.gerrit.host`                  | `null`        | Gerrit host URL (e.g., https://gerrit-review.googlesource.com). If not set, extension attempts to detect it from .gitreview or git remotes.                                                                                                                                                      |
 | `jj-view.gerrit.project`               | `null`        | Gerrit project name. If not set, extension attempts to detect it from git remotes.                                                                                                                                                                                                                   |
 | `jj-view.gitlab.host`                  | `null`        | GitLab host URL (e.g., https://gitlab.com). If not set, extension attempts to detect it from git remotes.                                                                                                                                                                                            |
 | `jj-view.uploadCommand`                | `null`        | Custom command to run for upload. Example: 'git push'. The command will be prefixed with 'jj' and suffixed with '-r <revision>'.                                                                                                                                                                     |
@@ -162,8 +183,8 @@ Customize **JJ View** behavior in VS Code settings.
 | `jj-view.graphLabelAlignment`          | `"aligned"`   | Controls the horizontal alignment of commit messages in the log view. Available options: `aligned`, `compact`.                                                                                                                                                                                       |
 | `jj-view.commit.titleWidthRuler`       | `50`          | Width at which to display a ruler in the commit details description editor for the title line.                                                                                                                                                                                                       |
 | `jj-view.commit.bodyWidthRuler`        | `72`          | Width at which to display a ruler in the commit details description editor for the body.                                                                                                                                                                                                             |
-| `jj-view.commit.formatDescriptionOnSave`| `false`       | Automatically format and wrap the commit description body when saving.                                                                                                                                                                                                                               |
-| `jj-view.binaryPath`                   | `""`          | Optional absolute path to the 'jj' binary. If empty, the extension will search for it in your PATH                                                                                                                                                                                                   |
+| `jj-view.commit.formatDescriptionOnSave` | `false`       | Automatically format and wrap the commit description body when saving.                                                                                                                                                                                                                               |
+| `jj-view.binaryPath`                   | `""`          | Optional absolute path to the 'jj' binary. If empty, the extension will search for it in your PATH.                                                                                                                                                                                                  |
 | `jj-view.suppressGitColocationWarning` | `false`       | Suppress the warning to disable the built-in Git extension in colocated repositories.                                                                                                                                                                                                                |
 | `jj-view.workspacesLocation`           | `.workspaces` | Directory where new workspaces are created. Relative paths are resolved against the main repository root.                                                                                                                                                                                            |
 | `jj-view.openDiffOnClick`              | `true`        | Controls whether the diff editor should be opened when clicking a change. Otherwise the regular editor will be opened.                                                                                                                                                                                |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "jj-view",
     "displayName": "JJ View",
     "description": "Integrates Jujutsu (jj) version control into VS Code.",
-    "version": "1.29.0",
+    "version": "2.0.0",
     "repository": {
         "type": "git",
         "url": "https://github.com/brychanrobot/jj-view"


### PR DESCRIPTION
- Bump extension version to 2.0.0.
- Update README.md to fully cover all features, commands, and settings, including multi-repository support and active switching.
- Update generate-release skill instructions to support nested bullet grouping for multiple changes in a single component.

## Summary by Sourcery

Prepare 2.0.0 release with updated documentation and release tooling guidance.

New Features:
- Document new graph view capabilities, SCM integrations, workspace actions, and multi-repository support in the README.
- Describe new and updated JJ View commands, including repository focus, code forge auth management, and workspace/bookmark operations.
- Add a Multi-Repository Support section outlining detection, switching, and configuration behaviors.

Bug Fixes:
- Clarify Gerrit host example and tidy formatting in README settings table.

Enhancements:
- Add 2.0.0 changelog entry summarizing new multi-repository, SCM, diff editor, and testing improvements.
- Refine the generate-release skill instructions to support nested bullets for multiple changes per component in changelog entries.
- Bump the extension version to 2.0.0 in package.json.