### PR TITLE
chore: silence biome formatting errors on ignored assets in esbuild

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -4,7 +4,7 @@
  */
 
 const esbuild = require('esbuild');
-const { execSync } = require('node:child_process');
+const { execSync, execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
@@ -32,9 +32,14 @@ const esbuildProblemMatcherPlugin = {
     },
 };
 
-function formatFile(filePath) {
+function formatFile(filePath, { ignoreUnmatched = false } = {}) {
     try {
-        execSync(`pnpm biome format --write "${filePath}"`, { stdio: 'inherit' });
+        const pnpmCmd = os.platform() === 'win32' ? 'pnpm.cmd' : 'pnpm';
+        const args = ['biome', 'format', '--write', filePath];
+        if (ignoreUnmatched) {
+            args.push('--no-errors-on-unmatched');
+        }
+        execFileSync(pnpmCmd, args, { stdio: 'inherit' });
         console.log(`[build] Formatted ${filePath}`);
     } catch (e) {
         console.error(`[build] Failed to format ${filePath}: ${e.message}`);
@@ -111,7 +116,7 @@ async function copyAssets() {
         console.log(`[build] Copied ${asset.src} to ${asset.dest}`);
 
         if (destPath.endsWith('.css') || destPath.endsWith('.ts') || destPath.endsWith('.js')) {
-            formatFile(destPath);
+            formatFile(destPath, { ignoreUnmatched: true });
         }
     }
 }


### PR DESCRIPTION
Adds `--no-errors-on-unmatched` to the `biome format` command inside `esbuild.js`. This prevents build failures/errors when attempting to format copied assets (like `media/codicons/codicon.css`) that are ignored by biome/git configurations.

## Summary by Sourcery

Bug Fixes:
- Prevent build failures when Biome attempts to format files that are ignored or otherwise unmatched, such as copied asset files.