### PR TITLE
fix: optimize repository scanning and prevent unrelated or duplicate …

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -17,6 +17,8 @@ export class ChangeDetectionManager implements vscode.Disposable {
 
     private _workingCopyWatcher: DirectoryWatcher | undefined;
     private _opHeadsWatcher: DirectoryWatcher | undefined;
+    private _opHeadsWatcherPromise: Promise<void> | undefined;
+    private _workingCopyWatcherPromise: Promise<void> | undefined;
     private _poller: Poller;
     private _fileWatcherMode: 'polling' | 'watch' = 'polling';
     private _isFocused = true;
@@ -76,19 +78,21 @@ export class ChangeDetectionManager implements vscode.Disposable {
 
         // Listen for configuration changes
         this.disposables.push(
-            vscode.workspace.onDidChangeConfiguration((e) => {
+            vscode.workspace.onDidChangeConfiguration(async (e) => {
                 if (e.affectsConfiguration('jj-view.fileWatcherMode')) {
-                    this.updateFileWatcherMode();
+                    await this.updateFileWatcherMode();
                 }
             }),
         );
 
         // Initialize watchers
-        this.startOpHeadsWatcher();
-        this.updateFileWatcherMode();
+        this._opHeadsWatcherPromise = this.startOpHeadsWatcher();
+        this.updateFileWatcherMode().catch((err) => {
+            this.outputChannel.appendLine(`[ChangeDetectionManager] Error during initialization: ${err}`);
+        });
     }
 
-    private updateFileWatcherMode() {
+    private async updateFileWatcherMode() {
         const config = vscode.workspace.getConfiguration('jj-view');
         const mode = config.get<'polling' | 'watch'>('fileWatcherMode', 'polling');
         this.outputChannel.appendLine(`[ChangeDetectionManager] File watcher mode: ${mode}`);
@@ -97,8 +101,8 @@ export class ChangeDetectionManager implements vscode.Disposable {
         this._fileWatcherMode = mode;
 
         if (modeChanged) {
-            this.stopWorkingCopyWatching();
-            this.startWorkingCopyWatching();
+            await this.stopWorkingCopyWatching();
+            this._workingCopyWatcherPromise = this.startWorkingCopyWatching();
         }
 
         // Always ensure polling state is correct
@@ -140,47 +144,47 @@ export class ChangeDetectionManager implements vscode.Disposable {
 
         try {
             await this.jj.getRepoRoot();
-        } catch {
-            return;
+
+            // Handle non-default workspaces where .jj/repo might be a file containing a path
+            const repoStorePath = await this.jj.getRepoStorePath();
+            if (this._disposed) {
+                return;
+            }
+
+            const opHeadsPath = path.join(repoStorePath, 'op_heads');
+
+            // Final check that the directory exists and we have a real path
+            let realOpHeadsPath: string;
+            try {
+                realOpHeadsPath = await fs.realpath(opHeadsPath);
+            } catch {
+                return;
+            }
+
+            if (this._disposed) {
+                return;
+            }
+
+            this._opHeadsWatcher = new DirectoryWatcher(
+                realOpHeadsPath,
+                () => {
+                    if (this.hasActiveOrRecentWrites) {
+                        return;
+                    }
+                    this.lastExternalOpTime = Date.now();
+                    this.triggerRefresh({ forceSnapshot: false, reason: 'jj operation' });
+                },
+                this.outputChannel,
+                'OpHeads Watcher',
+                this.watcherBackend,
+            );
+
+            await this._opHeadsWatcher.start().catch((err) => {
+                this.outputChannel.appendLine(`Failed to start op_heads watcher: ${err}`);
+            });
+        } catch (err) {
+            this.outputChannel.appendLine(`Failed to setup op_heads watcher: ${err}`);
         }
-
-        // Handle non-default workspaces where .jj/repo might be a file containing a path
-        const repoStorePath = await this.jj.getRepoStorePath();
-        if (this._disposed) {
-            return;
-        }
-
-        const opHeadsPath = path.join(repoStorePath, 'op_heads');
-
-        // Final check that the directory exists and we have a real path
-        let realOpHeadsPath: string;
-        try {
-            realOpHeadsPath = await fs.realpath(opHeadsPath);
-        } catch {
-            return;
-        }
-
-        if (this._disposed) {
-            return;
-        }
-
-        this._opHeadsWatcher = new DirectoryWatcher(
-            realOpHeadsPath,
-            () => {
-                if (this.hasActiveOrRecentWrites) {
-                    return;
-                }
-                this.lastExternalOpTime = Date.now();
-                this.triggerRefresh({ forceSnapshot: false, reason: 'jj operation' });
-            },
-            this.outputChannel,
-            'OpHeads Watcher',
-            this.watcherBackend,
-        );
-
-        this._opHeadsWatcher.start().catch((err) => {
-            this.outputChannel.appendLine(`Failed to start op_heads watcher: ${err}`);
-        });
     }
 
     private async startWorkingCopyWatching() {
@@ -200,6 +204,11 @@ export class ChangeDetectionManager implements vscode.Disposable {
         // Also stop polling if it was active
         this._poller.stop();
 
+        if (this._workingCopyWatcherPromise) {
+            await this._workingCopyWatcherPromise.catch(() => {});
+            this._workingCopyWatcherPromise = undefined;
+        }
+
         if (this._workingCopyWatcher) {
             await this._workingCopyWatcher.stop();
             this._workingCopyWatcher = undefined;
@@ -216,7 +225,7 @@ export class ChangeDetectionManager implements vscode.Disposable {
             this.getGitModulesPatterns(),
             this.getSecondaryWorkspacePatterns(),
         ]);
-        if (this._disposed) {
+        if (this._disposed || this._fileWatcherMode !== 'watch') {
             return;
         }
 
@@ -320,6 +329,11 @@ export class ChangeDetectionManager implements vscode.Disposable {
 
         await this.stopWorkingCopyWatching();
         this._poller.dispose();
+
+        if (this._opHeadsWatcherPromise) {
+            await this._opHeadsWatcherPromise.catch(() => {});
+            this._opHeadsWatcherPromise = undefined;
+        }
 
         if (this._opHeadsWatcher) {
             await this._opHeadsWatcher.dispose();

--- a/src/directory-watcher.ts
+++ b/src/directory-watcher.ts
@@ -12,6 +12,7 @@ export class DirectoryWatcher implements vscode.Disposable {
     private _subscription: AsyncSubscription | undefined;
     private _startPromise: Promise<void> | undefined;
     private _disposed = false;
+    private _stopped = false;
     private _backend: Promise<BackendType | undefined>;
 
     constructor(
@@ -39,17 +40,22 @@ export class DirectoryWatcher implements vscode.Disposable {
     }
 
     async start(ignores: string[] = []) {
+        this._stopped = false;
         if (this._startPromise) {
             return this._startPromise;
         }
 
         this._startPromise = (async () => {
-            if (this._subscription || this._disposed) {
+            if (this._subscription || this._disposed || this._stopped) {
                 return;
             }
 
             try {
-                this.log(`[${this.name}] Starting (${await this._backend}) watcher on: ${this.path}`);
+                const backend = await this._backend;
+                if (this._disposed || this._stopped) {
+                    return;
+                }
+                this.log(`[${this.name}] Starting (${backend}) watcher on: ${this.path}`);
 
                 const sub = await subscribe(
                     this.path,
@@ -63,10 +69,10 @@ export class DirectoryWatcher implements vscode.Disposable {
                             this.callback(events);
                         }
                     },
-                    { ignore: ignores, backend: await this._backend },
+                    { ignore: ignores, backend: backend },
                 );
 
-                if (this._disposed) {
+                if (this._disposed || this._stopped) {
                     await sub.unsubscribe();
                     return;
                 }
@@ -102,6 +108,7 @@ export class DirectoryWatcher implements vscode.Disposable {
     }
 
     async stop() {
+        this._stopped = true;
         if (this._startPromise) {
             await this._startPromise.catch(() => {});
             this._startPromise = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         vscode.workspace.onDidChangeConfiguration(async (e) => {
             if (e.affectsConfiguration('jj-view.binaryPath')) {
                 await updateBinaryPath();
-                await repositoryManager.scan();
+                await repositoryManager.scanForRepositories();
             }
             if (e.affectsConfiguration('jj-view.openDiffOnClick')) {
                 setOpenDiffOnClickContext();
@@ -182,7 +182,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 e.affectsConfiguration('jj-view.scanRepositories') ||
                 e.affectsConfiguration('jj-view.ignoredRepositories')
             ) {
-                await repositoryManager.scan();
+                await repositoryManager.scanForRepositories();
             }
         }),
     );
@@ -616,13 +616,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     );
 
     // Load cached repositories immediately
-    await repositoryManager.initializeFromCache();
+    await repositoryManager.restoreCachedRepositories();
 
     // Trigger initial scan (non-blocking)
     if (!resolvedBinaryPath) {
-        updateBinaryPath().then(() => repositoryManager.scan());
+        updateBinaryPath().then(() => repositoryManager.scanForRepositories());
     } else {
-        repositoryManager.scan();
+        repositoryManager.scanForRepositories();
     }
 
     return {

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -66,10 +66,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
         return this._repositoryManager.focusedRepository?.jj;
     }
 
-    public async refresh(reason?: string): Promise<void> {
-        const reasonStr = reason ? ` (reason: ${reason})` : '';
-        console.log(`[JjCommitDetailsEditorProvider] Refreshing${reasonStr}...`);
-
+    public async refresh(_reason?: string): Promise<void> {
         const config = vscode.workspace.getConfiguration('jj-view');
         const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
         const logTheme = config.get<string>('logTheme', 'default');
@@ -346,9 +343,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                         break;
                     }
                     case 'openDiff': {
-                        const file = message.payload.file;
-                        const changeId = message.payload.changeId;
-                        const isImmutable = message.payload.isImmutable;
+                        const { file, changeId, isImmutable } = message.payload;
 
                         const state = createJjResourceState(file, changeId, jj.workspaceRoot, {
                             editable: !isImmutable,
@@ -394,7 +389,7 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
         const oldText = state.lastPushedText;
         const oldSelection = state.lastPushedSelection;
 
-        const document = state.document;
+        const { document } = state;
 
         this._onDidChangeCustomDocument.fire({
             document,

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -245,7 +245,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
                 const oldStatus = this.trackedStatusCache.get(item.path)?.isTracked;
                 this.trackedStatusCache.set(item.path, { isTracked, uri: item.uri });
 
-                const resolve = item.resolve;
+                const { resolve } = item;
                 if (resolve) {
                     if (isTracked) {
                         resolve(undefined);

--- a/src/jj-merge-provider.ts
+++ b/src/jj-merge-provider.ts
@@ -33,8 +33,7 @@ export class JjMergeContentProvider implements vscode.TextDocumentContentProvide
             let parts = this.cache.get(fsPath);
             if (!parts) {
                 // Get conflict parts from jj resolve
-                const relativePath = vscode.workspace.asRelativePath(fsPath);
-                parts = await this.jjService.getConflictParts(relativePath);
+                parts = await this.jjService.getConflictParts(fsPath);
                 this.cache.set(fsPath, parts);
 
                 // Clear cache after a short delay (file may change)

--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -11,6 +11,12 @@ import { JjRepository } from './jj-repository';
 import { JjService } from './jj-service';
 import { JjOutputChannel } from './utils/output-channel';
 
+interface DetectedRepoInfo {
+    rootPath: string;
+    storePath: string;
+    isMain: boolean;
+}
+
 /**
  * Discovers and manages multiple Jujutsu repositories within the workspace.
  */
@@ -22,6 +28,12 @@ export class JjRepositoryManager implements vscode.Disposable {
     private readonly _dirToRepoRoot = new Map<string, string | null>();
     private readonly _ignoredAbsolutePaths = new Set<string>();
     private readonly _pendingRegistrations = new Map<string, Promise<JjRepository | undefined>>();
+    private _lastActiveTab?: vscode.Tab;
+    private _activeScan: Promise<void> | undefined;
+    private _scanPending = false;
+    private _disposed = false;
+    private _normalizedWorkspaceFolders: string[] | undefined;
+    private readonly _realNormalizedPathCache = new Map<string, Promise<string>>();
 
     private readonly _onDidOpenRepository = new vscode.EventEmitter<JjRepository>();
     readonly onDidOpenRepository = this._onDidOpenRepository.event;
@@ -46,43 +58,69 @@ export class JjRepositoryManager implements vscode.Disposable {
     ) {
         this._binaryPath = initialBinaryPath;
         this.updateIgnoredPaths();
-        // Track active tab changes across all editor groups and tab changes
-        let lastActiveTab: vscode.Tab | undefined;
+
+        const { activeTab } = vscode.window.tabGroups.activeTabGroup;
+        const activeUri = activeTab ? this.getUriFromTab(activeTab) : undefined;
+        this._lastActiveTab = activeTab;
+
+        // 1. Scan and register open editors at startup (only if configured to detect from open editors)
+        if (this.shouldDetectFromOpenEditors()) {
+            for (const uri of this.getOpenEditorUris()) {
+                this.maybeRegisterRepositoryContainingUri(uri)
+                    .then(() => {
+                        if (activeUri && activeUri.toString() === uri.toString()) {
+                            this.tryAutoSwitch(uri);
+                        }
+                    })
+                    .catch((err) => {
+                        this._outputChannel.appendLine(
+                            `[RepositoryManager] Error checking open editor URI at start: ${err}`,
+                        );
+                    });
+            }
+        }
+
+        // 2. Track active tab changes
         const handleActiveTabChange = async () => {
-            const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
-            if (activeTab && activeTab !== lastActiveTab) {
-                lastActiveTab = activeTab;
-                const uri = this.getUriFromTab(activeTab);
-                if (uri) {
-                    try {
-                        await this.checkAndRegisterUri(uri);
-                        this.tryAutoSwitch(uri);
-                    } catch (err) {
-                        this._outputChannel.appendLine(`[RepositoryManager] Error checking active tab URI: ${err}`);
-                    }
+            const currentTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+            if (currentTab === this._lastActiveTab) {
+                return;
+            }
+            this._lastActiveTab = currentTab;
+
+            if (!currentTab) {
+                return;
+            }
+
+            if (!this.shouldDetectFromOpenEditors()) {
+                return;
+            }
+
+            const uri = this.getUriFromTab(currentTab);
+            if (!uri) {
+                return;
+            }
+
+            try {
+                await this.maybeRegisterRepositoryContainingUri(uri);
+                // Verify the active tab hasn't changed during the async call
+                const activeTabNow = vscode.window.tabGroups.activeTabGroup.activeTab;
+                if (activeTabNow && this.getUriFromTab(activeTabNow)?.toString() === uri.toString()) {
+                    this.tryAutoSwitch(uri);
                 }
+            } catch (err) {
+                this._outputChannel.appendLine(`[RepositoryManager] Error checking active tab URI: ${err}`);
             }
         };
 
         this._disposables.push(
             vscode.window.tabGroups.onDidChangeTabs(handleActiveTabChange),
             vscode.window.tabGroups.onDidChangeTabGroups(handleActiveTabChange),
+            vscode.workspace.onDidChangeWorkspaceFolders(() => {
+                this._normalizedWorkspaceFolders = undefined;
+                this._realNormalizedPathCache.clear();
+            }),
         );
-
-        // Also check already visible text editors at start
-        for (const editor of vscode.window.visibleTextEditors) {
-            this.checkAndRegisterUri(editor.document.uri)
-                .then(() => {
-                    if (editor === vscode.window.activeTextEditor) {
-                        this.tryAutoSwitch(editor.document.uri);
-                    }
-                })
-                .catch((err) => {
-                    this._outputChannel.appendLine(
-                        `[RepositoryManager] Error checking visible editor URI at start: ${err}`,
-                    );
-                });
-        }
     }
 
     get repositories(): readonly JjRepository[] {
@@ -114,7 +152,9 @@ export class JjRepositoryManager implements vscode.Disposable {
      * Set the focused repository. Fires `onDidChangeFocusedRepository` if changed.
      */
     setFocusedRepository(repo: JjRepository | undefined): void {
-        if (this._focusedRepository?.rootUri.fsPath === repo?.rootUri.fsPath) {
+        const currentPath = this._focusedRepository?.rootUri.fsPath;
+        const newPath = repo?.rootUri.fsPath;
+        if (this.isSamePath(currentPath, newPath)) {
             return;
         }
 
@@ -135,7 +175,12 @@ export class JjRepositoryManager implements vscode.Disposable {
         this._workspaceState.update(JjRepositoryManager.DISCOVERED_REPOS_KEY, data);
     }
 
-    async initializeFromCache(): Promise<void> {
+    /**
+     * Restores previously cached repository configurations on startup.
+     * Validates that the cached directories exist, instantiates them,
+     * and registers them in bulk.
+     */
+    async restoreCachedRepositories(): Promise<void> {
         const stored = this._workspaceState.get<Array<{ rootPath: string; storePath: string }>>(
             JjRepositoryManager.DISCOVERED_REPOS_KEY,
             [],
@@ -149,23 +194,16 @@ export class JjRepositoryManager implements vscode.Disposable {
 
         const loaded: JjRepository[] = [];
         for (const item of stored) {
+            if (!(await this.isPathInOrAncestorOfWorkspace(item.rootPath))) {
+                continue;
+            }
             try {
                 const stats = await fs.stat(item.rootPath);
                 if (!stats.isDirectory()) {
                     continue;
                 }
 
-                const repoPrefix = path.basename(item.rootPath);
-                const repoOutputChannel = new JjOutputChannel(this._outputChannel, repoPrefix);
-                const repo = new JjRepository(
-                    vscode.Uri.file(item.rootPath),
-                    item.storePath,
-                    this._codeForgeRegistry,
-                    repoOutputChannel,
-                );
-                if (this._binaryPath) {
-                    repo.jj.binaryPath = this._binaryPath;
-                }
+                const repo = await this.createRepository(item.rootPath, item.storePath);
                 loaded.push(repo);
             } catch (err) {
                 this._outputChannel.appendLine(
@@ -175,49 +213,77 @@ export class JjRepositoryManager implements vscode.Disposable {
         }
 
         if (loaded.length > 0) {
-            this._repositories = loaded;
-            for (const repo of loaded) {
-                this._onDidOpenRepository.fire(repo);
-            }
-            this._onDidChangeRepositories.fire(this._repositories);
+            this.registerRepositories(loaded);
 
             const lastPath = this._workspaceState.get<string>(JjRepositoryManager.LAST_FOCUSED_REPO_KEY);
-            const matched = loaded.find((r) => r.rootUri.fsPath === lastPath) || loaded[0];
+            const matched =
+                (lastPath ? loaded.find((r) => this.isSamePath(r.rootUri.fsPath, lastPath)) : undefined) || loaded[0];
             this.setFocusedRepository(matched);
         }
     }
 
     /**
-     * Scan the workspace for repositories according to configurations.
+     * Scans the workspace folders, explicit configuration paths, and open editor tabs
+     * to discover and update the list of registered Jujutsu repositories.
      */
-    async scan(): Promise<void> {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const autoDetect = config.get<boolean | string>('autoRepositoryDetection', true);
-        const scanPaths = config.get<string[]>('scanRepositories', []);
+    async scanForRepositories(): Promise<void> {
+        if (this._disposed) {
+            return;
+        }
+        if (this._activeScan) {
+            this._scanPending = true;
+            return this._activeScan;
+        }
 
-        const candidates: JjRepository[] = [];
+        this._scanPending = true;
+        const scanPromise = (async () => {
+            while (this._scanPending && !this._disposed) {
+                this._scanPending = false;
+                await this.doScan();
+            }
+        })();
+
+        this._activeScan = scanPromise;
+        try {
+            await scanPromise;
+        } finally {
+            if (this._activeScan === scanPromise) {
+                this._activeScan = undefined;
+            }
+        }
+    }
+
+    private async doScan(): Promise<void> {
+        const autoDetect = this.getAutoRepositoryDetectionConfig();
+        const scanPaths = this.getScanRepositoriesConfig();
+
+        const candidates: DetectedRepoInfo[] = [];
         const seenRoots = new Set<string>();
 
         // 1. Resolve ignore list absolute paths
         this.updateIgnoredPaths();
 
-        // Helper to check if a path is ignored
-        const isIgnored = (testPath: string): boolean => {
-            return this._ignoredAbsolutePaths.has(testPath);
+        const addCandidate = async (rootDir: string) => {
+            const info = await this.probeRepository(rootDir);
+            if (info) {
+                const normalizedRoot = this.normalizePath(info.rootPath);
+                if (!seenRoots.has(normalizedRoot)) {
+                    candidates.push(info);
+                    seenRoots.add(normalizedRoot);
+                }
+            }
         };
 
         // Pre-populate candidates with valid cached/discovered repositories
         for (const repo of this._repositories) {
             const rootPath = repo.rootUri.fsPath;
-            if (!isIgnored(rootPath)) {
-                try {
-                    const stats = await fs.stat(rootPath);
-                    if (stats.isDirectory() && (await repo.isValid())) {
-                        await this.addCandidate(rootPath, candidates, seenRoots, isIgnored);
-                    }
-                } catch {
-                    // Directory doesn't exist anymore, let it be cleaned up
+            try {
+                const stats = await fs.stat(rootPath);
+                if (stats.isDirectory() && (await repo.isValid())) {
+                    await addCandidate(rootPath);
                 }
+            } catch {
+                // Directory doesn't exist anymore, let it be cleaned up
             }
         }
 
@@ -227,28 +293,20 @@ export class JjRepositoryManager implements vscode.Disposable {
             const rootPath = folder.uri.fsPath;
             const rootReal = await fs.realpath(rootPath).catch(() => rootPath);
 
-            if (autoDetect !== 'openEditors') {
+            if (this.shouldScanWorkspaceRoots()) {
                 const rootDir = await this.findRepoRoot(rootReal);
                 if (rootDir) {
-                    await this.addCandidate(rootDir, candidates, seenRoots, isIgnored);
+                    await addCandidate(rootDir);
                 }
             }
 
-            if (autoDetect === true) {
-                // Recursively search all subfolders
-                const pattern = new vscode.RelativePattern(folder, '**/.jj/working_copy/type');
+            if (autoDetect === true || autoDetect === 'subFolders') {
+                const glob = autoDetect === true ? '**/.jj/working_copy/type' : '*/.jj/working_copy/type';
+                const pattern = new vscode.RelativePattern(folder, glob);
                 const files = await vscode.workspace.findFiles(pattern, null, 1000);
                 for (const file of files) {
                     const rootDir = path.dirname(path.dirname(path.dirname(file.fsPath)));
-                    await this.addCandidate(rootDir, candidates, seenRoots, isIgnored);
-                }
-            } else if (autoDetect === 'subFolders') {
-                // Search immediate subfolders only
-                const pattern = new vscode.RelativePattern(folder, '*/.jj/working_copy/type');
-                const files = await vscode.workspace.findFiles(pattern, null, 1000);
-                for (const file of files) {
-                    const rootDir = path.dirname(path.dirname(path.dirname(file.fsPath)));
-                    await this.addCandidate(rootDir, candidates, seenRoots, isIgnored);
+                    await addCandidate(rootDir);
                 }
             }
         }
@@ -259,65 +317,92 @@ export class JjRepositoryManager implements vscode.Disposable {
             if (!path.isAbsolute(p) && folders.length > 0) {
                 absPath = path.resolve(folders[0].uri.fsPath, p);
             }
+            if (!(await this.isPathInOrAncestorOfWorkspace(absPath))) {
+                this._outputChannel.appendLine(
+                    `[RepositoryManager] Warning: Skipping configured scan path outside workspace folders: ${p}`,
+                );
+                continue;
+            }
             try {
                 const realAbs = await fs.realpath(absPath);
                 const selfCheck = path.join(realAbs, '.jj', 'working_copy', 'type');
                 await fs.access(selfCheck);
-                await this.addCandidate(realAbs, candidates, seenRoots, isIgnored);
+                await addCandidate(realAbs);
             } catch {
                 // Path not accessible or not a repo
             }
         }
 
-        // 3.5. Also include repositories of currently visible text editors (so they aren't closed)
-        const editorRoots = await Promise.all(
-            vscode.window.visibleTextEditors
-                .filter(
-                    (editor) => editor.document.uri.scheme === 'file' || editor.document.uri.scheme.startsWith('jj-'),
-                )
-                .map((editor) => this.findRepoRoot(this.getPathForUri(editor.document.uri))),
-        );
-        for (const rootDir of editorRoots) {
-            if (rootDir) {
-                await this.addCandidate(rootDir, candidates, seenRoots, isIgnored);
+        // 3.5. Also include repositories of currently open editors (so they aren't closed)
+        if (this.shouldDetectFromOpenEditors()) {
+            const openUris = this.getOpenEditorUris();
+            const uriChecks = await Promise.all(
+                openUris.map(async (uri) => ({
+                    uri,
+                    valid: await this.isUriInWorkspaceFolder(uri),
+                })),
+            );
+            const validUris = uriChecks.filter((check) => check.valid).map((check) => check.uri);
+            const editorRoots = await Promise.all(validUris.map((uri) => this.findRepoRoot(this.getPathForUri(uri))));
+            for (const rootDir of editorRoots) {
+                if (rootDir) {
+                    await addCandidate(rootDir);
+                }
             }
         }
 
         // 4. Reconcile repositories
-        const filtered = await this.filterRepositories(candidates);
+        const filteredInfos = await this.filterRepositoryInfos(candidates);
         const oldRepos = this._repositories;
-        this._repositories = filtered;
+        const newRepos: JjRepository[] = [];
+
+        // For each filtered info, either reuse existing repo or instantiate a new one
+        for (const info of filteredInfos) {
+            if (this._disposed) {
+                break;
+            }
+            const existing = oldRepos.find((r) => this.isSamePath(r.rootUri.fsPath, info.rootPath));
+            if (existing) {
+                if (this._binaryPath) {
+                    existing.jj.binaryPath = this._binaryPath;
+                }
+                newRepos.push(existing);
+            } else {
+                try {
+                    const repo = await this.createRepository(info.rootPath, info.storePath);
+                    newRepos.push(repo);
+                } catch (err) {
+                    this._outputChannel.appendLine(
+                        `[RepositoryManager] Error creating repository for ${info.rootPath}: ${err}`,
+                    );
+                }
+            }
+        }
+
+        if (this._disposed) {
+            // If disposed, dispose all newly created repositories
+            for (const repo of newRepos) {
+                if (!oldRepos.some((r) => this.isSamePath(r.rootUri.fsPath, repo.rootUri.fsPath))) {
+                    await repo.dispose();
+                }
+            }
+            return;
+        }
+
+        this._repositories = newRepos;
         this.persistRepositories();
 
-        // Track repositories to dispose
-        const toDispose = new Set<JjRepository>();
-
-        // Any candidate that is not in the final filtered list must be disposed
-        for (const repo of candidates) {
-            if (!filtered.some((r) => r.rootUri.fsPath === repo.rootUri.fsPath)) {
-                toDispose.add(repo);
+        // Any repository in oldRepos that is not in newRepos must be disposed
+        for (const oldRepo of oldRepos) {
+            if (!newRepos.some((r) => this.isSamePath(r.rootUri.fsPath, oldRepo.rootUri.fsPath))) {
+                this._onDidCloseRepository.fire(oldRepo);
+                await oldRepo.dispose();
             }
         }
 
-        // Any previously registered repository that is not in the filtered list must be disposed
-        for (const repo of oldRepos) {
-            if (!filtered.some((r) => r.rootUri.fsPath === repo.rootUri.fsPath)) {
-                toDispose.add(repo);
-            }
-        }
-
-        // Dispose and fire close events for closed/filtered-out repositories
-        for (const repo of toDispose) {
-            const wasRegistered = oldRepos.some((r) => r.rootUri.fsPath === repo.rootUri.fsPath);
-            if (wasRegistered) {
-                this._onDidCloseRepository.fire(repo);
-            }
-            await repo.dispose();
-        }
-
-        // Find opened
-        const opened = filtered.filter(
-            (newRepo) => !oldRepos.some((oldRepo) => oldRepo.rootUri.fsPath === newRepo.rootUri.fsPath),
+        // Find opened (present in newRepos but not in oldRepos)
+        const opened = newRepos.filter(
+            (newRepo) => !oldRepos.some((oldRepo) => this.isSamePath(oldRepo.rootUri.fsPath, newRepo.rootUri.fsPath)),
         );
         for (const repo of opened) {
             this._onDidOpenRepository.fire(repo);
@@ -332,7 +417,9 @@ export class JjRepositoryManager implements vscode.Disposable {
         if (this._repositories.length > 0) {
             if (
                 !this._focusedRepository ||
-                !this._repositories.some((r) => r.rootUri.fsPath === this._focusedRepository?.rootUri.fsPath)
+                !this._repositories.some((r) =>
+                    this.isSamePath(r.rootUri.fsPath, this._focusedRepository?.rootUri.fsPath),
+                )
             ) {
                 const activeUri = vscode.window.activeTextEditor?.document.uri;
                 const matched = activeUri ? this.getRepositoryForUri(activeUri) : undefined;
@@ -343,95 +430,45 @@ export class JjRepositoryManager implements vscode.Disposable {
         }
     }
 
-    private async addCandidate(
-        rootDir: string,
-        candidates: JjRepository[],
-        seenRoots: Set<string>,
-        isIgnored: (p: string) => boolean,
-    ): Promise<void> {
-        try {
-            const realRoot = await fs.realpath(rootDir);
-            if (seenRoots.has(realRoot) || isIgnored(realRoot)) {
-                return;
-            }
-
-            // Verify .jj/working_copy/type exists to ensure it's a valid, initialized repository
-            try {
-                await fs.access(path.join(realRoot, '.jj', 'working_copy', 'type'));
-            } catch {
-                return; // Not a valid repository
-            }
-
-            const existing = this._repositories.find((r) => r.rootUri.fsPath === realRoot);
-            if (existing) {
-                if (this._binaryPath) {
-                    existing.jj.binaryPath = this._binaryPath;
-                }
-                candidates.push(existing);
-                seenRoots.add(realRoot);
-                return;
-            }
-
-            const repoFilePath = path.join(realRoot, '.jj', 'repo');
-            const storePath = await this.resolveStorePath(repoFilePath);
-            const repoPrefix = path.basename(realRoot);
-            const repoOutputChannel = new JjOutputChannel(this._outputChannel, repoPrefix);
-            const repo = new JjRepository(
-                vscode.Uri.file(realRoot),
-                storePath,
-                this._codeForgeRegistry,
-                repoOutputChannel,
-            );
-            if (this._binaryPath) {
-                repo.jj.binaryPath = this._binaryPath;
-            }
-
-            candidates.push(repo);
-            seenRoots.add(realRoot);
-        } catch {
-            // Ignore
-        }
-    }
-
     /**
-     * Filters out secondary workspaces if their main workspace is already registered.
+     * Filters out secondary workspaces if their main workspace is already registered or candidate.
+     *
+     * @param candidates The list of candidate DetectedRepoInfo instances.
+     * @returns A filtered array of DetectedRepoInfo instances.
      */
-    private async filterRepositories(candidates: JjRepository[]): Promise<JjRepository[]> {
-        const storePathToRepo = new Map<string, JjRepository>();
+    private async filterRepositoryInfos(candidates: DetectedRepoInfo[]): Promise<DetectedRepoInfo[]> {
         const mainStores = new Set<string>();
 
-        // First pass: Identify main repositories
-        for (const repo of candidates) {
-            const expectedMainStore = path.join(repo.rootUri.fsPath, '.jj', 'repo');
-            try {
-                const realExpected = await fs.realpath(expectedMainStore);
-                if (realExpected === repo.storePath || expectedMainStore === repo.storePath) {
-                    mainStores.add(repo.storePath);
-                    storePathToRepo.set(repo.storePath, repo);
-                }
-            } catch {
-                // Not a main store
+        // Identify all main repositories' store paths in the active repositories list
+        for (const repo of this._repositories) {
+            if (await this.isMainWorkspace(repo.rootUri.fsPath, repo.storePath)) {
+                mainStores.add(this.normalizePath(repo.storePath));
+            }
+        }
+        // And also from candidates
+        for (const info of candidates) {
+            if (info.isMain) {
+                mainStores.add(this.normalizePath(info.storePath));
             }
         }
 
-        const filtered: JjRepository[] = [];
+        const filtered: DetectedRepoInfo[] = [];
         const seenRoots = new Set<string>();
 
         // Second pass: Filter and deduplicate
-        for (const repo of candidates) {
-            if (seenRoots.has(repo.rootUri.fsPath)) {
+        for (const info of candidates) {
+            const normalizedRoot = this.normalizePath(info.rootPath);
+            if (seenRoots.has(normalizedRoot)) {
                 continue;
             }
 
-            if (mainStores.has(repo.storePath) && storePathToRepo.get(repo.storePath) !== repo) {
-                this._outputChannel.appendLine(
-                    `[RepositoryManager] Skipping secondary workspace: ${repo.rootUri.fsPath}`,
-                );
+            if (!info.isMain && mainStores.has(this.normalizePath(info.storePath))) {
+                this._outputChannel.appendLine(`[RepositoryManager] Skipping secondary workspace: ${info.rootPath}`);
                 continue;
             }
 
-            filtered.push(repo);
-            seenRoots.add(repo.rootUri.fsPath);
+            filtered.push(info);
+            seenRoots.add(normalizedRoot);
         }
 
         return filtered;
@@ -468,8 +505,9 @@ export class JjRepositoryManager implements vscode.Disposable {
             dir = path.dirname(fsPath);
         }
 
-        if (this._dirToRepoRoot.has(dir)) {
-            const cached = this._dirToRepoRoot.get(dir);
+        const normalizedDir = this.normalizePath(dir);
+        if (this._dirToRepoRoot.has(normalizedDir)) {
+            const cached = this._dirToRepoRoot.get(normalizedDir);
             return cached === null ? undefined : cached;
         }
 
@@ -495,19 +533,27 @@ export class JjRepositoryManager implements vscode.Disposable {
         try {
             const resolvedRoot = await jj.getRepoRoot();
             const realRoot = await fs.realpath(resolvedRoot).catch(() => resolvedRoot);
-            this._dirToRepoRoot.set(dir, realRoot);
+            this._dirToRepoRoot.set(normalizedDir, realRoot);
             return realRoot;
         } catch {
-            this._dirToRepoRoot.set(dir, null);
+            this._dirToRepoRoot.set(normalizedDir, null);
             return undefined;
         }
     }
 
     /**
-     * Walk up from a file URI to dynamically register a repository if found.
+     * Conditionally detects and registers a repository containing the given file or directory URI.
+     * This is used for on-demand repository registration when a file is opened or becomes active.
+     *
+     * @param uri The VS Code Uri of the file or directory.
+     * @returns The registered JjRepository instance, or undefined if not in a valid workspace or if filtered.
      */
-    async checkAndRegisterUri(uri: vscode.Uri): Promise<JjRepository | undefined> {
-        if (uri.scheme !== 'file' && !uri.scheme.startsWith('jj-')) {
+    async maybeRegisterRepositoryContainingUri(uri: vscode.Uri): Promise<JjRepository | undefined> {
+        if (this._disposed) {
+            return undefined;
+        }
+
+        if (!(await this.isUriInWorkspaceFolder(uri))) {
             return undefined;
         }
 
@@ -517,72 +563,246 @@ export class JjRepositoryManager implements vscode.Disposable {
             return existing;
         }
 
-        const fsPath = this.getPathForUri(uri);
-        const realRoot = await this.findRepoRoot(fsPath);
-        if (!realRoot || this._ignoredAbsolutePaths.has(realRoot)) {
+        if (!this.shouldDetectFromOpenEditors()) {
             return undefined;
         }
 
+        const fsPath = this.getPathForUri(uri);
+
+        const realRoot = await this.findRepoRoot(fsPath);
+        if (!realRoot) {
+            return undefined;
+        }
+
+        const info = await this.probeRepository(realRoot);
+        if (!info) {
+            return undefined;
+        }
+
+        return this.registerRepository(info);
+    }
+
+    /**
+     * Registers a repository with the manager, handling concurrency, storage checks,
+     * and workspace constraints.
+     */
+    private async registerRepository(info: DetectedRepoInfo): Promise<JjRepository | undefined> {
+        const normalizedRoot = this.normalizePath(info.rootPath);
+
         // Check if already registered (concurrency check)
-        const existingRepo = this._repositories.find((r) => r.rootUri.fsPath === realRoot);
+        const existingRepo = this._repositories.find((r) => this.isSamePath(r.rootUri.fsPath, normalizedRoot));
         if (existingRepo) {
             return existingRepo;
         }
 
         // Check if there is already a pending registration for this root
-        const pending = this._pendingRegistrations.get(realRoot);
+        const pending = this._pendingRegistrations.get(normalizedRoot);
         if (pending) {
             return pending;
         }
 
         const registrationPromise = (async () => {
+            if (this._disposed) {
+                return undefined;
+            }
             // Check if already registered (concurrency check)
-            const existingRepo = this._repositories.find((r) => r.rootUri.fsPath === realRoot);
+            const existingRepo = this._repositories.find((r) => this.isSamePath(r.rootUri.fsPath, normalizedRoot));
             if (existingRepo) {
                 return existingRepo;
             }
 
-            const repoFilePath = path.join(realRoot, '.jj', 'repo');
-            const storePath = await this.resolveStorePath(repoFilePath);
             // Filter out secondary workspaces if their main workspace is already registered
-            const expectedMainStore = path.join(realRoot, '.jj', 'repo');
-            const realExpected = await fs.realpath(expectedMainStore).catch(() => expectedMainStore);
-            const isMain = realExpected === storePath || expectedMainStore === storePath;
-            if (!isMain) {
-                const hasMain = this._repositories.some(
-                    (r) => r.storePath === storePath && r.rootUri.fsPath !== realRoot,
-                );
-                if (hasMain) {
-                    return undefined;
-                }
-            }
-            const repoPrefix = path.basename(realRoot);
-            const repoOutputChannel = new JjOutputChannel(this._outputChannel, repoPrefix);
-            const repo = new JjRepository(
-                vscode.Uri.file(realRoot),
-                storePath,
-                this._codeForgeRegistry,
-                repoOutputChannel,
-            );
-            if (this._binaryPath) {
-                repo.jj.binaryPath = this._binaryPath;
+            if (this.hasRegisteredWorkspaceForStore(info.storePath, info.rootPath) && !info.isMain) {
+                return undefined;
             }
 
-            this._repositories.push(repo);
-            this.persistRepositories();
-            this._onDidOpenRepository.fire(repo);
-            this._onDidChangeRepositories.fire(this._repositories);
-            this._outputChannel.appendLine(`[RepositoryManager] Dynamically registered repo: ${realRoot}`);
+            const repo = await this.createRepository(info.rootPath, info.storePath);
+            if (this._disposed) {
+                await repo.dispose();
+                return undefined;
+            }
+
+            this.registerRepositories([repo]);
+            this._outputChannel.appendLine(`[RepositoryManager] Dynamically registered repo: ${info.rootPath}`);
 
             return repo;
         })();
 
-        this._pendingRegistrations.set(realRoot, registrationPromise);
+        this._pendingRegistrations.set(normalizedRoot, registrationPromise);
         try {
             return await registrationPromise;
         } finally {
-            this._pendingRegistrations.delete(realRoot);
+            this._pendingRegistrations.delete(normalizedRoot);
         }
+    }
+
+    /**
+     * Instantiates and configures a JjRepository representation for a workspace path.
+     *
+     * @param rootPath The absolute path to the workspace root directory.
+     * @param storePath Optional pre-resolved store path. If omitted, it will be resolved from disk.
+     * @returns A Promise resolving to the configured JjRepository instance.
+     */
+    private async createRepository(rootPath: string, storePath?: string): Promise<JjRepository> {
+        const resolvedStorePath = storePath ?? (await this.resolveStorePath(path.join(rootPath, '.jj', 'repo')));
+        const repoPrefix = path.basename(rootPath);
+        const repoOutputChannel = new JjOutputChannel(this._outputChannel, repoPrefix);
+        const repo = new JjRepository(
+            vscode.Uri.file(rootPath),
+            resolvedStorePath,
+            this._codeForgeRegistry,
+            repoOutputChannel,
+        );
+        if (this._binaryPath) {
+            repo.jj.binaryPath = this._binaryPath;
+        }
+        return repo;
+    }
+
+    /**
+     * Checks if a path is inside, equivalent to, or an ancestor of any active VS Code workspace folder.
+     * This allows managing repositories whose roots are ancestors of workspace folders.
+     *
+     * @param fsPath The absolute file path to check.
+     * @returns True if the path is related to a workspace folder, false otherwise.
+     */
+    private getRealNormalizedPath(p: string): Promise<string> {
+        const key = this.normalizePath(p);
+        let promise = this._realNormalizedPathCache.get(key);
+        if (!promise) {
+            promise = (async () => {
+                try {
+                    const resolved = await fs.realpath(p);
+                    return this.normalizePath(resolved);
+                } catch {
+                    return key;
+                }
+            })();
+            this._realNormalizedPathCache.set(key, promise);
+        }
+        return promise;
+    }
+
+    private async getNormalizedWorkspaceFolders(): Promise<string[]> {
+        if (this._normalizedWorkspaceFolders !== undefined) {
+            return this._normalizedWorkspaceFolders;
+        }
+        const folders = vscode.workspace.workspaceFolders || [];
+        this._normalizedWorkspaceFolders = await Promise.all(
+            folders.map((folder) => this.getRealNormalizedPath(folder.uri.fsPath)),
+        );
+        return this._normalizedWorkspaceFolders;
+    }
+
+    private async isPathInOrAncestorOfWorkspace(fsPath: string): Promise<boolean> {
+        const normalizedPath = await this.getRealNormalizedPath(fsPath);
+        const normalizedFolders = await this.getNormalizedWorkspaceFolders();
+        for (const normalizedFolder of normalizedFolders) {
+            if (
+                normalizedPath === normalizedFolder ||
+                normalizedPath.startsWith(`${normalizedFolder}/`) ||
+                normalizedFolder.startsWith(`${normalizedPath}/`)
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Probes a directory path to see if it represents a valid Jujutsu repository.
+     * Returns resolved metadata if valid, otherwise undefined.
+     *
+     * @param rootDir The directory path to check.
+     * @returns The DetectedRepoInfo if valid, otherwise undefined.
+     */
+    private async probeRepository(rootDir: string): Promise<DetectedRepoInfo | undefined> {
+        if (this._disposed) {
+            return undefined;
+        }
+        try {
+            const realRoot = await fs.realpath(rootDir);
+            if (this._disposed) {
+                return undefined;
+            }
+            const normalizedRoot = this.normalizePath(realRoot);
+            if (this._ignoredAbsolutePaths.has(normalizedRoot)) {
+                return undefined;
+            }
+
+            if (!(await this.isPathInOrAncestorOfWorkspace(realRoot))) {
+                return undefined;
+            }
+
+            // Verify .jj/working_copy/type exists to ensure it's a valid, initialized repository
+            try {
+                await fs.access(path.join(realRoot, '.jj', 'working_copy', 'type'));
+            } catch {
+                return undefined; // Not a valid repository
+            }
+
+            const storePath = await this.resolveStorePath(path.join(realRoot, '.jj', 'repo'));
+            if (this._disposed) {
+                return undefined;
+            }
+            const isMain = await this.isMainWorkspace(realRoot, storePath);
+
+            return {
+                rootPath: realRoot,
+                storePath,
+                isMain,
+            };
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Registers one or more repositories with the manager, appending them to the
+     * active repositories list, persisting them, and firing SCM change events.
+     *
+     * @param repos The array of JjRepository instances to register.
+     */
+    private registerRepositories(repos: JjRepository[]): void {
+        if (repos.length === 0) {
+            return;
+        }
+        this._repositories.push(...repos);
+        this.persistRepositories();
+        for (const repo of repos) {
+            this._onDidOpenRepository.fire(repo);
+        }
+        this._onDidChangeRepositories.fire(this._repositories);
+    }
+
+    /**
+     * Determines whether the workspace at `rootPath` is the main workspace for the repository store.
+     * A workspace is the main workspace if its store path is located directly inside it.
+     *
+     * @param rootPath The absolute path of the workspace.
+     * @param storePath The absolute path of the repository's store.
+     * @returns True if the workspace is the main workspace, false otherwise.
+     */
+    private async isMainWorkspace(rootPath: string, storePath: string): Promise<boolean> {
+        const expectedMainStore = path.join(rootPath, '.jj', 'repo');
+        const realExpected = await fs.realpath(expectedMainStore).catch(() => expectedMainStore);
+        return this.isSamePath(realExpected, storePath) || this.isSamePath(expectedMainStore, storePath);
+    }
+
+    /**
+     * Checks if there is already a registered repository/workspace in the manager
+     * that shares the same underlying store (repository).
+     *
+     * @param storePath The store path to search for.
+     * @param excludeRootPath Optional workspace root path to exclude from the check.
+     * @returns True if a repository sharing the same store is registered, false otherwise.
+     */
+    private hasRegisteredWorkspaceForStore(storePath: string, excludeRootPath?: string): boolean {
+        return this._repositories.some(
+            (r) =>
+                this.isSamePath(r.storePath, storePath) &&
+                (!excludeRootPath || !this.isSamePath(r.rootUri.fsPath, excludeRootPath)),
+        );
     }
 
     private getPathForUri(uri: vscode.Uri): string {
@@ -599,6 +819,34 @@ export class JjRepositoryManager implements vscode.Disposable {
             }
         }
         return rawPath;
+    }
+
+    private async isUriInWorkspaceFolder(uri: vscode.Uri): Promise<boolean> {
+        if (uri.scheme !== 'file' && !uri.scheme.startsWith('jj-')) {
+            return false;
+        }
+        const fsPath = this.getPathForUri(uri);
+        const normalizedPath = await this.getRealNormalizedPath(fsPath);
+        const normalizedFolders = await this.getNormalizedWorkspaceFolders();
+        for (const normalizedFolder of normalizedFolders) {
+            if (normalizedPath === normalizedFolder || normalizedPath.startsWith(`${normalizedFolder}/`)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private getOpenEditorUris(): vscode.Uri[] {
+        const uris: vscode.Uri[] = [];
+        for (const tabGroup of vscode.window.tabGroups.all) {
+            for (const tab of tabGroup.tabs) {
+                const uri = this.getUriFromTab(tab);
+                if (uri) {
+                    uris.push(uri);
+                }
+            }
+        }
+        return uris;
     }
 
     /**
@@ -637,15 +885,20 @@ export class JjRepositoryManager implements vscode.Disposable {
         let bestMatch: JjRepository | undefined;
         let bestLength = 0;
 
+        const normalizedFsPath = this.normalizePath(fsPath);
+
         for (const repo of this._repositories) {
             const repoRoot = repo.rootUri.fsPath;
+            const normalizedRepoRoot = this.normalizePath(repoRoot);
             if (
-                fsPath.startsWith(repoRoot) &&
-                (fsPath.length === repoRoot.length || fsPath[repoRoot.length] === path.sep)
+                normalizedFsPath.startsWith(normalizedRepoRoot) &&
+                (normalizedFsPath.length === normalizedRepoRoot.length ||
+                    normalizedFsPath[normalizedRepoRoot.length] === '/' ||
+                    normalizedFsPath[normalizedRepoRoot.length] === path.sep)
             ) {
-                if (repoRoot.length > bestLength) {
+                if (normalizedRepoRoot.length > bestLength) {
                     bestMatch = repo;
-                    bestLength = repoRoot.length;
+                    bestLength = normalizedRepoRoot.length;
                 }
             }
         }
@@ -654,8 +907,7 @@ export class JjRepositoryManager implements vscode.Disposable {
     }
 
     private updateIgnoredPaths(): void {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const ignoredPaths = config.get<string[]>('ignoredRepositories', []);
+        const ignoredPaths = this.getIgnoredRepositoriesConfig();
         const folders = vscode.workspace.workspaceFolders || [];
 
         this._ignoredAbsolutePaths.clear();
@@ -663,9 +915,9 @@ export class JjRepositoryManager implements vscode.Disposable {
             const abs = !path.isAbsolute(p) && folders.length > 0 ? path.resolve(folders[0].uri.fsPath, p) : p;
             try {
                 const real = realpathSync(abs);
-                this._ignoredAbsolutePaths.add(real);
+                this._ignoredAbsolutePaths.add(this.normalizePath(real));
             } catch {
-                this._ignoredAbsolutePaths.add(abs);
+                this._ignoredAbsolutePaths.add(this.normalizePath(abs));
             }
         }
     }
@@ -675,7 +927,10 @@ export class JjRepositoryManager implements vscode.Disposable {
      */
     tryAutoSwitch(uri: vscode.Uri): boolean {
         const repo = this.getRepositoryForUri(uri);
-        if (repo && repo.rootUri.fsPath !== this._focusedRepository?.rootUri.fsPath) {
+        if (
+            repo &&
+            (!this._focusedRepository || !this.isSamePath(repo.rootUri.fsPath, this._focusedRepository.rootUri.fsPath))
+        ) {
             this.setFocusedRepository(repo);
             return true;
         }
@@ -683,7 +938,7 @@ export class JjRepositoryManager implements vscode.Disposable {
     }
 
     private getUriFromTab(tab: vscode.Tab): vscode.Uri | undefined {
-        const input = tab.input;
+        const { input } = tab;
         if (input instanceof vscode.TabInputText) {
             return input.uri;
         }
@@ -702,17 +957,181 @@ export class JjRepositoryManager implements vscode.Disposable {
         return undefined;
     }
 
+    /**
+     * Normalizes a directory/file path by resolving dots and converting to lowercase.
+     * This provides case-insensitive comparisons to avoid duplicate repository registrations.
+     *
+     * @param p The path to normalize.
+     * @returns The normalized path string.
+     */
+    private normalizePath(p: string): string {
+        return path.normalize(p).replace(/\\/g, '/').toLowerCase();
+    }
+
+    /**
+     * Compares two paths to determine if they point to the same location, case-insensitively.
+     * Supports undefined arguments for clean focused repository comparisons.
+     *
+     * @param pathA The first path.
+     * @param pathB The second path.
+     * @returns True if paths are equivalent, false otherwise.
+     */
+    private isSamePath(pathA: string | undefined, pathB: string | undefined): boolean {
+        if (pathA === pathB) {
+            return true;
+        }
+        if (pathA === undefined || pathB === undefined) {
+            return false;
+        }
+        return this.normalizePath(pathA) === this.normalizePath(pathB);
+    }
+
+    /**
+     * Retrieves the current configuration for automatic repository detection.
+     *
+     * @returns The autoRepositoryDetection configuration value:
+     * - true: recursively scan subfolders.
+     * - false: only scan workspace roots.
+     * - 'subFolders': scan immediate subfolders.
+     * - 'openEditors': only register on-demand when files are opened.
+     */
+    private getAutoRepositoryDetectionConfig(): boolean | string {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        return config.get<boolean | string>('autoRepositoryDetection', true);
+    }
+
+    /**
+     * Retrieves the list of paths to scan for repositories.
+     *
+     * @returns An array of path strings configured to scan.
+     */
+    private getScanRepositoriesConfig(): string[] {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        return config.get<string[]>('scanRepositories', []);
+    }
+
+    /**
+     * Retrieves the list of repository paths to ignore.
+     *
+     * @returns An array of path strings configured to ignore.
+     */
+    private getIgnoredRepositoriesConfig(): string[] {
+        const config = vscode.workspace.getConfiguration('jj-view');
+        return config.get<string[]>('ignoredRepositories', []);
+    }
+
+    /**
+     * Determines whether open editors should be used to discover and register repositories.
+     * Open editors are used for discovery only if autoRepositoryDetection is true or 'openEditors'.
+     *
+     * @returns True if open editors should be scanned/tracked, false otherwise.
+     */
+    private shouldDetectFromOpenEditors(): boolean {
+        const configValue = this.getAutoRepositoryDetectionConfig();
+        return configValue === true || configValue === 'openEditors';
+    }
+
+    /**
+     * Determines whether workspace roots should be scanned to discover repositories.
+     * Workspace roots are scanned unless autoRepositoryDetection is 'openEditors'.
+     *
+     * @returns True if workspace roots should be scanned, false otherwise.
+     */
+    private shouldScanWorkspaceRoots(): boolean {
+        const autoDetect = this.getAutoRepositoryDetectionConfig();
+        return autoDetect !== 'openEditors';
+    }
+
+    /**
+     * Clears all registered repositories, firing didClose events and disposing of them.
+     * Keeps the manager itself active for subsequent use.
+     */
+    async clear(): Promise<void> {
+        this._outputChannel.appendLine(`[RepositoryManager] Clearing ${this._repositories.length} repositories`);
+
+        // 1. Await any active scan
+        if (this._activeScan) {
+            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active scan before clearing...`);
+            await this._activeScan.catch(() => {});
+        }
+
+        // 2. Await any pending registrations
+        const pendingPromises = Array.from(this._pendingRegistrations.values());
+        this._pendingRegistrations.clear();
+        const pendingRepos = await Promise.all(pendingPromises);
+
+        // 3. Clear and dispose registered repositories
+        const repos = [...this._repositories];
+        this._repositories = [];
+        this.setFocusedRepository(undefined);
+        for (const repo of repos) {
+            this._outputChannel.appendLine(
+                `[RepositoryManager] Closing and disposing repository: ${repo.rootUri.fsPath}`,
+            );
+            this._onDidCloseRepository.fire(repo);
+            await repo.dispose();
+        }
+
+        // 4. Dispose pending repositories
+        for (const repo of pendingRepos) {
+            if (repo) {
+                this._outputChannel.appendLine(
+                    `[RepositoryManager] Closing and disposing pending repository: ${repo.rootUri.fsPath}`,
+                );
+                await repo.dispose();
+            }
+        }
+
+        await this._workspaceState.update(JjRepositoryManager.DISCOVERED_REPOS_KEY, undefined);
+        await this._workspaceState.update(JjRepositoryManager.LAST_FOCUSED_REPO_KEY, undefined);
+        this._onDidChangeRepositories.fire([]);
+        this._outputChannel.appendLine(`[RepositoryManager] Clear complete`);
+    }
+
     async dispose(): Promise<void> {
+        if (this._disposed) {
+            return;
+        }
+        this._disposed = true;
+        this._outputChannel.appendLine(`[RepositoryManager] Disposing JjRepositoryManager`);
+
         this._onDidOpenRepository.dispose();
         this._onDidCloseRepository.dispose();
         this._onDidChangeFocusedRepository.dispose();
         this._onDidChangeRepositories.dispose();
 
+        // 1. Await any active scan
+        if (this._activeScan) {
+            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active scan before disposing...`);
+            await this._activeScan.catch(() => {});
+        }
+
+        // 2. Await any pending registrations
+        const pendingPromises = Array.from(this._pendingRegistrations.values());
+        this._pendingRegistrations.clear();
+        const pendingRepos = await Promise.all(pendingPromises);
+
+        // 3. Dispose registered repositories
         for (const repo of this._repositories) {
+            this._outputChannel.appendLine(`[RepositoryManager] Disposing repository: ${repo.rootUri.fsPath}`);
             await repo.dispose();
         }
+        this._repositories = [];
+
+        // 4. Dispose pending repositories
+        for (const repo of pendingRepos) {
+            if (repo) {
+                this._outputChannel.appendLine(
+                    `[RepositoryManager] Disposing pending repository: ${repo.rootUri.fsPath}`,
+                );
+                await repo.dispose();
+            }
+        }
+
         for (const d of this._disposables) {
             d.dispose();
         }
+        this._disposables = [];
+        this._outputChannel.appendLine(`[RepositoryManager] JjRepositoryManager disposed`);
     }
 }

--- a/src/jj-repository.ts
+++ b/src/jj-repository.ts
@@ -54,6 +54,7 @@ export class JjRepository implements Disposable {
         return this._watcher;
     }
 
+    private _disposed = false;
     private _isValid: boolean | undefined;
     async isValid(): Promise<boolean> {
         if (this._isValid !== undefined) {
@@ -69,19 +70,30 @@ export class JjRepository implements Disposable {
     }
 
     async refresh(options: { forceSnapshot?: boolean; reason?: string } = {}): Promise<void> {
+        if (this._disposed) {
+            return;
+        }
         const { forceSnapshot = false, reason = 'manual' } = options;
         this._isValid = undefined;
-        await this._jj.clearCache();
+        try {
+            await this._jj.clearCache();
+            if (forceSnapshot) {
+                await this._jj.status();
+            }
+            await this._jj.getRepoRoot(); // Warm the cache
 
-        if (forceSnapshot) {
-            await this._jj.status();
+            if (!this._disposed) {
+                await this._onDidStatusChange.fire({ reason });
+            }
+        } catch (err) {
+            if (!this._disposed) {
+                throw err;
+            }
         }
-        await this._jj.getRepoRoot(); // Warm the cache
-
-        await this._onDidStatusChange.fire({ reason });
     }
 
     async dispose() {
+        this._disposed = true;
         this._codeForge.dispose();
         await this._watcher.dispose();
         this._refreshScheduler.dispose();

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -206,7 +206,6 @@ export class JjScmProvider implements vscode.Disposable {
                 const reasonStr = event.reason ? ` (reason: ${event.reason})` : '';
                 const msg = `Updating JJ Scm${reasonStr}...`;
                 this.outputChannel.appendLine(msg);
-                console.log(`[Extension Host] ${msg}`);
                 const start = performance.now();
                 try {
                     // 1. Fetch data in parallel for performance

--- a/src/jj-view-fs-provider.ts
+++ b/src/jj-view-fs-provider.ts
@@ -46,8 +46,6 @@ export class JjViewFileSystemProvider implements vscode.FileSystemProvider {
         }
         this._knownUris.clear();
         if (events.length > 0) {
-            const msg = `[JjViewFS] Invalidation firing for ${events.length} URIs: ${events.map((e) => e.uri.toString()).join(', ')}`;
-            console.log(msg); // Direct stdout for CI logs
             this._onDidChangeFile.fire(events);
         }
     }

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -52,6 +52,10 @@ suite('Button Visibility Integration Test', () => {
 
     teardown(async () => {
         // Cleanup
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        // Allow VS Code to settle before disposing repository
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
         scmProvider.dispose();
         if (executeCommandStub) {
             executeCommandStub.restore();
@@ -59,7 +63,6 @@ suite('Button Visibility Integration Test', () => {
         if (contextHelper) {
             await contextHelper.repositoryManager.dispose();
         }
-        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('Sets jj.parentMutable to true when parent is mutable', async () => {

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -40,11 +40,14 @@ suite('Absorb Integration Test', function () {
     });
 
     teardown(async () => {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        // Allow VS Code to settle before disposing repository
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
         scmProvider.dispose();
         if (contextHelper) {
             await contextHelper.repositoryManager.dispose();
         }
-        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
     test('absorb working copy changes into parent', async () => {

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -55,9 +55,9 @@ describe('Diff Tab Cleaner', () => {
         privateCleaner = exposePrivate<PrivateDiffTabCleaner>(cleaner);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         if (contextHelper?.repositoryManager) {
-            contextHelper.repositoryManager.dispose();
+            await contextHelper.repositoryManager.dispose();
         }
         if (repo) {
             repo.dispose();

--- a/src/test/integration-test-utils.ts
+++ b/src/test/integration-test-utils.ts
@@ -16,10 +16,62 @@ export interface TestRepositoryContext {
     workspaceState: vscode.Memento;
 }
 
+async function updateWorkspaceFoldersWithRetry(
+    start: number,
+    deleteCount: number | undefined | null,
+    ...workspaceFoldersToAdd: { uri: vscode.Uri; name?: string }[]
+): Promise<boolean> {
+    for (let attempt = 0; attempt < 20; attempt++) {
+        if (attempt > 0) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        let eventDisposable: vscode.Disposable | undefined;
+        const changePromise = new Promise<void>((resolve) => {
+            eventDisposable = vscode.workspace.onDidChangeWorkspaceFolders(() => {
+                resolve();
+            });
+        });
+
+        const success = vscode.workspace.updateWorkspaceFolders(start, deleteCount, ...workspaceFoldersToAdd);
+
+        if (success) {
+            await Promise.race([changePromise, new Promise((resolve) => setTimeout(resolve, 200))]);
+            eventDisposable?.dispose();
+            return true;
+        } else {
+            eventDisposable?.dispose();
+        }
+    }
+    return false;
+}
+
 export async function createTestRepositoryContext(
     repoPath: string,
     outputChannel: vscode.OutputChannel,
 ): Promise<TestRepositoryContext> {
+    const originalFolders = vscode.workspace.workspaceFolders || [];
+    const uri = vscode.Uri.file(repoPath);
+
+    // Add repoPath as a workspace folder if not already present
+    const isPresent = originalFolders.some((f) => f.uri.fsPath === uri.fsPath);
+    if (!isPresent) {
+        if ('onDidChangeWorkspaceFolders' in vscode.workspace) {
+            const success = await updateWorkspaceFoldersWithRetry(originalFolders.length, 0, {
+                uri,
+                name: path.basename(repoPath),
+            });
+            if (!success) {
+                throw new Error(`Failed to add workspace folder: ${repoPath}`);
+            }
+        } else if ('updateWorkspaceFolders' in vscode.workspace) {
+            vscode.workspace.updateWorkspaceFolders(originalFolders.length, 0, {
+                uri,
+                name: path.basename(repoPath),
+            });
+        }
+    }
+
     const codeForgeRegistry = new CodeForgeRegistry();
     const store = new Map<string, unknown>();
     const workspaceState = createMock<vscode.Memento>({
@@ -31,12 +83,29 @@ export async function createTestRepositoryContext(
         keys: () => Array.from(store.keys()),
     });
     const repositoryManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
-    const repository = await repositoryManager.checkAndRegisterUri(
+    const repository = await repositoryManager.maybeRegisterRepositoryContainingUri(
         vscode.Uri.file(path.join(repoPath, 'placeholder.txt')),
     );
     if (!repository) {
         throw new Error(`Failed to dynamically register repository at ${repoPath}`);
     }
+
+    // Intercept dispose to remove the workspace folder and release locks
+    const originalDispose = repositoryManager.dispose.bind(repositoryManager);
+    repositoryManager.dispose = async () => {
+        await originalDispose();
+        if (!isPresent) {
+            const currentFolders = vscode.workspace.workspaceFolders || [];
+            const index = currentFolders.findIndex((f) => f.uri.fsPath === uri.fsPath);
+            if (index !== -1) {
+                if ('onDidChangeWorkspaceFolders' in vscode.workspace) {
+                    await updateWorkspaceFoldersWithRetry(index, 1);
+                } else if ('updateWorkspaceFolders' in vscode.workspace) {
+                    vscode.workspace.updateWorkspaceFolders(index, 1);
+                }
+            }
+        }
+    };
 
     return {
         codeForgeRegistry,

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -42,7 +42,10 @@ describe('JjEditFileSystemProvider', () => {
         repoManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
 
         // Register the real repository
-        await repoManager.checkAndRegisterUri(vscode.Uri.file(repo.path));
+        vscode.workspace.updateWorkspaceFolders(0, vscode.workspace.workspaceFolders?.length, {
+            uri: vscode.Uri.file(repo.path),
+        });
+        await repoManager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(repo.path));
 
         provider = new JjEditFileSystemProvider(repoManager);
         provider.onDidChangeFile((events) => {

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -4,13 +4,14 @@
  */
 import * as assert from 'node:assert';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { CodeForgeRegistry } from '../code-forge-registry';
 import { JjRepositoryManager } from '../jj-repository-manager';
 import { TestRepo } from './test-repo';
-import { createMock } from './test-utils';
+import { createMock, exposePrivate } from './test-utils';
 
 suite('JjRepositoryManager Integration Test', () => {
     let registry: CodeForgeRegistry;
@@ -25,6 +26,7 @@ suite('JjRepositoryManager Integration Test', () => {
     let extraDirs: string[] = [];
 
     suiteSetup(() => {
+        process.env.VSCODE_TEST = '1';
         initialFolders = (vscode.workspace.workspaceFolders || []).map((f) => f.uri);
     });
 
@@ -134,21 +136,24 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('caching and loading repositories from workspace storage', async () => {
         // 1. Scan to discover and populate repositories
-        await manager.scan();
+        await manager.scanForRepositories();
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
+
+        // Dispose the initial manager to prevent background watchers/pollers from interfering with the restart simulation
+        await manager.dispose();
 
         // 2. Create a new manager with the same workspaceState to simulate restart
         const restartManager = new JjRepositoryManager(registry, outputChannel, workspaceState);
         try {
             // 3. Initialize from cache - should restore immediately
-            await restartManager.initializeFromCache();
+            await restartManager.restoreCachedRepositories();
             assert.strictEqual(restartManager.repositories.length, 1, 'Should load repo from cache');
             assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
             assert.strictEqual(restartManager.focusedRepository?.rootUri.fsPath, mainRepo.path);
 
             // 4. Run scan on restartManager to verify reconciliation
-            await restartManager.scan();
+            await restartManager.scanForRepositories();
             assert.strictEqual(restartManager.repositories.length, 1, 'Reconciliation should keep the repository');
             assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
         } finally {
@@ -158,21 +163,24 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('reconciliation disposes of invalid/missing cached repositories', async () => {
         // 1. Scan to discover and populate repositories
-        await manager.scan();
+        await manager.scanForRepositories();
         assert.strictEqual(manager.repositories.length, 1);
+
+        // Dispose the initial manager to prevent background watchers/pollers from interfering with the restart simulation
+        await manager.dispose();
 
         // 2. Create restartManager
         const restartManager = new JjRepositoryManager(registry, outputChannel, workspaceState);
         try {
             // 3. Initialize from cache
-            await restartManager.initializeFromCache();
+            await restartManager.restoreCachedRepositories();
             assert.strictEqual(restartManager.repositories.length, 1);
 
             // 4. Delete the .jj/working_copy/type file to make the cached repo invalid/missing
             fs.rmSync(path.join(mainRepo.path, '.jj', 'working_copy', 'type'), { force: true });
 
             // 5. Run scan - should reconcile and dispose of the now-missing repository
-            await restartManager.scan();
+            await restartManager.scanForRepositories();
             assert.strictEqual(
                 restartManager.repositories.length,
                 0,
@@ -183,45 +191,10 @@ suite('JjRepositoryManager Integration Test', () => {
         }
     });
 
-    test('scan preserves valid cached repositories even if not in workspace folders', async () => {
-        // 1. Scan to discover and populate repositories
-        await manager.scan();
-        assert.strictEqual(manager.repositories.length, 1);
-
-        // 2. Create restartManager
-        const restartManager = new JjRepositoryManager(registry, outputChannel, workspaceState);
-        try {
-            // 3. Initialize from cache
-            await restartManager.initializeFromCache();
-            assert.strictEqual(restartManager.repositories.length, 1);
-
-            // 4. Change workspace folders to something empty
-            const emptyParent = fs.realpathSync(
-                fs.mkdtempSync(path.join(path.dirname(mainRepo.path), 'jj-view-empty-')),
-            );
-            try {
-                await setWorkspaceFolders([vscode.Uri.file(emptyParent)]);
-
-                // 5. Run scan - should preserve the valid cached repository since it exists on disk
-                await restartManager.scan();
-                assert.strictEqual(
-                    restartManager.repositories.length,
-                    1,
-                    'Should preserve valid repo outside workspace',
-                );
-                assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
-            } finally {
-                fs.rmSync(emptyParent, { recursive: true, force: true });
-            }
-        } finally {
-            await restartManager.dispose();
-        }
-    });
-
     test('getRepositoryForUri works for repo and subfolders', async () => {
         // Manually trigger dynamic registry
         const fileUri = vscode.Uri.file(path.join(mainRepo.path, 'sub', 'file.txt'));
-        const repo = await manager.checkAndRegisterUri(fileUri);
+        const repo = await manager.maybeRegisterRepositoryContainingUri(fileUri);
         assert.ok(repo, 'Should dynamically register repository');
         assert.strictEqual(repo.rootUri.fsPath, mainRepo.path);
 
@@ -231,7 +204,7 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     test('scan discovers a single repository', async () => {
-        await manager.scan();
+        await manager.scanForRepositories();
 
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
@@ -243,7 +216,7 @@ suite('JjRepositoryManager Integration Test', () => {
         extraRepos.push(secondaryRepo);
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(secondaryRepo.path)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         // Should filter out the secondary workspace and only register the main one
         assert.strictEqual(manager.repositories.length, 1);
@@ -252,7 +225,7 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('checkAndRegisterUri filters out secondary workspaces when main is present', async () => {
         // Register main repository first
-        await manager.scan();
+        await manager.scanForRepositories();
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
 
@@ -261,7 +234,7 @@ suite('JjRepositoryManager Integration Test', () => {
         extraRepos.push(secondaryRepo);
 
         const fileUri = vscode.Uri.file(path.join(secondaryRepo.path, 'file.txt'));
-        const repo = await manager.checkAndRegisterUri(fileUri);
+        const repo = await manager.maybeRegisterRepositoryContainingUri(fileUri);
         // It may return the main repository by prefix match, but the secondary workspace itself must not be registered
         assert.ok(repo === undefined || repo.rootUri.fsPath === mainRepo.path);
         assert.strictEqual(manager.repositories.length, 1);
@@ -273,7 +246,7 @@ suite('JjRepositoryManager Integration Test', () => {
         extraRepos.push(secondaryRepo);
         await setWorkspaceFolders([vscode.Uri.file(secondaryRepo.path)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, secondaryRepo.path);
@@ -288,7 +261,7 @@ suite('JjRepositoryManager Integration Test', () => {
 
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(subRepo.path)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
         assert.strictEqual(manager.repositories.length, 2);
 
         // File in subproject should match subRepo (longest prefix match)
@@ -323,7 +296,7 @@ suite('JjRepositoryManager Integration Test', () => {
 
         await setWorkspaceFolders([vscode.Uri.file(parentPath)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         assert.strictEqual(manager.repositories.length, 2);
         const roots = manager.repositories.map((r) => r.rootUri.fsPath).sort();
@@ -337,7 +310,7 @@ suite('JjRepositoryManager Integration Test', () => {
 
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(otherRepo.path)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
         assert.strictEqual(manager.focusedRepository?.rootUri.fsPath, mainRepo.path);
 
         const fileUri = vscode.Uri.file(path.join(otherRepo.path, 'file.ts'));
@@ -353,7 +326,7 @@ suite('JjRepositoryManager Integration Test', () => {
         try {
             fs.symlinkSync(mainRepo.path, symlinkPath, 'dir');
 
-            await manager.scan();
+            await manager.scanForRepositories();
 
             // A file URI inside the symlink path should match the repository
             const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
@@ -391,14 +364,15 @@ suite('JjRepositoryManager Integration Test', () => {
             }),
         );
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
     });
 
     test('scan registers repositories in scanRepositories config even if autoDetect is false', async () => {
-        const otherRepo = new TestRepo();
+        const otherRepoPath = path.join(mainRepo.path, 'other-project');
+        const otherRepo = new TestRepo(otherRepoPath);
         extraRepos.push(otherRepo);
         otherRepo.init();
 
@@ -419,7 +393,7 @@ suite('JjRepositoryManager Integration Test', () => {
             }),
         );
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         // Should discover both main (due to autoDetect=false on workspace folders) and otherRepo (due to scanRepositories)
         assert.strictEqual(manager.repositories.length, 2);
@@ -427,46 +401,13 @@ suite('JjRepositoryManager Integration Test', () => {
         assert.deepStrictEqual(roots, [mainRepo.path, otherRepo.path].sort());
     });
 
-    test('scan keeps repositories of visible text editors even if not in workspace folders', async () => {
-        const otherRepo = new TestRepo();
-        extraRepos.push(otherRepo);
-        otherRepo.init();
-
-        await setWorkspaceFolders([vscode.Uri.file(mainRepo.path)]);
-
-        // Stub visibleTextEditors to contain a file from otherRepo
-        sandbox.stub(vscode.window, 'visibleTextEditors').get(() => [
-            createMock<vscode.TextEditor>({
-                document: createMock<vscode.TextDocument>({
-                    uri: vscode.Uri.file(path.join(otherRepo.path, 'somefile.txt')),
-                }),
-            }),
-        ]);
-
-        // First scan discovers mainRepo and registers it
-        await manager.scan();
-
-        // Register otherRepo dynamically
-        await manager.checkAndRegisterUri(vscode.Uri.file(path.join(otherRepo.path, 'somefile.txt')));
-
-        assert.strictEqual(manager.repositories.length, 2);
-
-        // Scan again (like configuration changes or startup scan finishing)
-        await manager.scan();
-
-        // Should still keep both repositories because otherRepo is open in a visible text editor!
-        assert.strictEqual(manager.repositories.length, 2);
-        const roots = manager.repositories.map((r) => r.rootUri.fsPath).sort();
-        assert.deepStrictEqual(roots, [mainRepo.path, otherRepo.path].sort());
-    });
-
-    test('scan discovers parent repository if workspace root is a child directory', async () => {
+    test('scan registers parent repository if workspace root is a child directory', async () => {
         const subfolder = path.join(mainRepo.path, 'src');
         fs.mkdirSync(subfolder, { recursive: true });
 
         await setWorkspaceFolders([vscode.Uri.file(subfolder)]);
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         assert.strictEqual(manager.repositories.length, 1);
         assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
@@ -476,7 +417,7 @@ suite('JjRepositoryManager Integration Test', () => {
         const subfolder = path.join(mainRepo.path, 'src');
         fs.mkdirSync(subfolder, { recursive: true });
 
-        const registered = await manager.checkAndRegisterUri(vscode.Uri.file(subfolder));
+        const registered = await manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(subfolder));
         assert.ok(registered);
         assert.strictEqual(registered.rootUri.fsPath, mainRepo.path);
     });
@@ -486,15 +427,15 @@ suite('JjRepositoryManager Integration Test', () => {
         const sub1 = path.join(mainRepo.path, 'subproject1');
         const sub2 = path.join(mainRepo.path, 'nested', 'subproject2');
 
-        fs.mkdirSync(path.join(sub1, '.jj', 'working_copy'), { recursive: true });
-        fs.writeFileSync(path.join(sub1, '.jj', 'working_copy', 'type'), 'git');
-        fs.mkdirSync(path.join(sub1, '.jj', 'repo'), { recursive: true });
+        const sub1Repo = new TestRepo(sub1);
+        sub1Repo.init();
+        extraRepos.push(sub1Repo);
 
-        fs.mkdirSync(path.join(sub2, '.jj', 'working_copy'), { recursive: true });
-        fs.writeFileSync(path.join(sub2, '.jj', 'working_copy', 'type'), 'git');
-        fs.mkdirSync(path.join(sub2, '.jj', 'repo'), { recursive: true });
+        const sub2Repo = new TestRepo(sub2);
+        sub2Repo.init();
+        extraRepos.push(sub2Repo);
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         const roots = manager.repositories.map((r) => r.rootUri.fsPath);
 
@@ -512,13 +453,13 @@ suite('JjRepositoryManager Integration Test', () => {
         const sub1 = path.join(mainRepo.path, 'subproject1');
         const sub2 = path.join(mainRepo.path, 'nested', 'subproject2');
 
-        fs.mkdirSync(path.join(sub1, '.jj', 'working_copy'), { recursive: true });
-        fs.writeFileSync(path.join(sub1, '.jj', 'working_copy', 'type'), 'git');
-        fs.mkdirSync(path.join(sub1, '.jj', 'repo'), { recursive: true });
+        const sub1Repo = new TestRepo(sub1);
+        sub1Repo.init();
+        extraRepos.push(sub1Repo);
 
-        fs.mkdirSync(path.join(sub2, '.jj', 'working_copy'), { recursive: true });
-        fs.writeFileSync(path.join(sub2, '.jj', 'working_copy', 'type'), 'git');
-        fs.mkdirSync(path.join(sub2, '.jj', 'repo'), { recursive: true });
+        const sub2Repo = new TestRepo(sub2);
+        sub2Repo.init();
+        extraRepos.push(sub2Repo);
 
         const getStub = sandbox.stub();
         getStub.withArgs('autoRepositoryDetection', true).returns('subFolders');
@@ -534,7 +475,7 @@ suite('JjRepositoryManager Integration Test', () => {
             }),
         );
 
-        await manager.scan();
+        await manager.scanForRepositories();
 
         const roots = manager.repositories.map((r) => r.rootUri.fsPath);
 
@@ -545,5 +486,90 @@ suite('JjRepositoryManager Integration Test', () => {
         assert.ok(roots.includes(mainRepo.path), 'Should discover mainRepo');
         assert.ok(roots.includes(sub1), 'Should discover sub1');
         assert.ok(!roots.includes(sub2), 'Should NOT discover sub2');
+    });
+
+    test('maybeRegisterRepositoryContainingUri resolves concurrent calls for the same path to the same repository', async () => {
+        const subfolder = path.join(mainRepo.path, 'src');
+        fs.mkdirSync(subfolder, { recursive: true });
+
+        const [repo1, repo2] = await Promise.all([
+            manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(subfolder)),
+            manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(subfolder)),
+        ]);
+
+        assert.ok(repo1);
+        assert.ok(repo2);
+        assert.strictEqual(
+            repo1,
+            repo2,
+            'Concurrent registrations for same path must resolve to same repository instance',
+        );
+        assert.strictEqual(manager.repositories.length, 1);
+    });
+
+    test('isPathInOrAncestorOfWorkspace rejects repositories in unrelated directories', async () => {
+        const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-unrelated-'));
+        extraDirs.push(tempParent);
+
+        const unrelatedRepo = new TestRepo(tempParent);
+        extraRepos.push(unrelatedRepo);
+        unrelatedRepo.init();
+
+        const registered = await manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(unrelatedRepo.path));
+        assert.strictEqual(
+            registered,
+            undefined,
+            'Should reject repository in unrelated directory outside workspace folders',
+        );
+    });
+
+    test('maybeRegisterRepositoryContainingUri registers parent repository if workspace root is a child directory', async () => {
+        const subfolder = path.join(mainRepo.path, 'src');
+        fs.mkdirSync(subfolder, { recursive: true });
+
+        await setWorkspaceFolders([vscode.Uri.file(subfolder)]);
+
+        // Try dynamically registering a file inside the subfolder, which is part of the parent repository
+        const fileUri = vscode.Uri.file(path.join(subfolder, 'file.txt'));
+        const registered = await manager.maybeRegisterRepositoryContainingUri(fileUri);
+
+        assert.ok(registered, 'Should register parent repository');
+        assert.strictEqual(registered.rootUri.fsPath, mainRepo.path);
+    });
+
+    test('concurrent scanForRepositories calls run at most twice (one active, one queued)', async () => {
+        const managerPriv = exposePrivate<{ doScan(): Promise<void> }>(manager);
+        const doScanSpy = sandbox.spy(managerPriv, 'doScan');
+        const scan1 = manager.scanForRepositories();
+        const scan2 = manager.scanForRepositories();
+        const scan3 = manager.scanForRepositories();
+        await Promise.all([scan1, scan2, scan3]);
+
+        assert.ok(
+            doScanSpy.callCount <= 2,
+            `doScan should be called at most twice, called ${doScanSpy.callCount} times`,
+        );
+        assert.strictEqual(manager.repositories.length, 1);
+    });
+
+    test('clear() disposes of all repositories, and subsequent scan re-discovers them', async () => {
+        await manager.scanForRepositories();
+        assert.strictEqual(manager.repositories.length, 1);
+        const repoInstance = manager.repositories[0];
+
+        const closeSpy = sandbox.spy();
+        const disposable = manager.onDidCloseRepository(closeSpy);
+
+        await manager.clear();
+        disposable.dispose();
+
+        assert.strictEqual(manager.repositories.length, 0);
+        assert.strictEqual(manager.focusedRepository, undefined);
+        assert.ok(closeSpy.calledWith(repoInstance));
+
+        // Subsequent scan can cleanly re-discover it
+        await manager.scanForRepositories();
+        assert.strictEqual(manager.repositories.length, 1);
+        assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
     });
 });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -12,7 +12,6 @@ import { squashFilesIntoParentCommand } from '../commands/squash-files';
 import { completeSquashRevisionCommand, squashRevisionIntoParentCommand } from '../commands/squash-revision';
 import { squashSelectionIntoParentCommand } from '../commands/squash-selection';
 import { ScmContextValue } from '../jj-context-keys';
-import type { JjRepositoryManager } from '../jj-repository-manager';
 import { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
@@ -65,13 +64,19 @@ suite('JJ SCM Provider Integration Test', () => {
     });
 
     teardown(async () => {
+        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        // Allow VS Code to settle before disposing repository
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
         if (scmProvider) {
             scmProvider.dispose();
         }
         if (contextHelper) {
             await contextHelper.repositoryManager.dispose();
         }
-        await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        if (repo) {
+            repo.dispose();
+        }
     });
 
     test('hideWhenEmpty is false for working copy group and true for conflict group', async () => {
@@ -186,7 +191,7 @@ suite('JJ SCM Provider Integration Test', () => {
             );
             assert.ok(resourceState, 'Should find resource state for modified file');
 
-            const command = resourceState.command;
+            const { command } = resourceState;
             assert.ok(command, 'Resource state should have a command');
             assert.strictEqual(
                 command.command,
@@ -198,11 +203,11 @@ suite('JJ SCM Provider Integration Test', () => {
             assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
             assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
 
-            const diffTitle = (resourceState as JjResourceState).diffTitle;
+            const { diffTitle } = resourceState as JjResourceState;
             assert.ok(diffTitle, 'diffTitle should be set');
 
-            const leftUri = (resourceState as JjResourceState).leftUri;
-            const rightUri = (resourceState as JjResourceState).rightUri;
+            const { leftUri } = resourceState as JjResourceState;
+            const { rightUri } = resourceState as JjResourceState;
             assert.ok(leftUri && rightUri, 'leftUri and rightUri should be set');
 
             assert.strictEqual(leftUri.scheme, 'jj-view', 'left URI scheme should be jj-view');
@@ -716,98 +721,6 @@ suite('JJ SCM Provider Integration Test', () => {
         }
 
         // It should proceed without error for single parent case
-    });
-
-    test('Webview moveBookmark message updates bookmark', async () => {
-        // Register mock command
-        const refreshDisposable = vscode.commands.registerCommand('jj-view.refresh', async () => {});
-
-        try {
-            // Setup: Bookmark on Parent, Squash File to Child
-            repo.describe('parent');
-            repo.bookmark('integrated-bookmark', '@');
-
-            repo.new([], 'child');
-            const childId = repo.getChangeId('@');
-
-            // Use JjLogWebviewProvider
-            const { JjLogWebviewProvider } = await import('../jj-log-webview-provider');
-            const { JjCommitDetailsEditorProvider } = await import('../jj-commit-details-editor-provider');
-            const extensionUri = vscode.Uri.file(__dirname); // Mock URI
-            const repositoryManager = createMock<JjRepositoryManager>({
-                repositories: [scmProvider.repo],
-                focusedRepository: scmProvider.repo,
-                getRepositoryForUri: () => scmProvider.repo,
-            });
-            const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, repositoryManager);
-            const provider = new JjLogWebviewProvider(
-                extensionUri,
-                scmProvider.repo,
-                commitDetailsProvider,
-                () => {},
-                createMock<vscode.ExtensionContext>({
-                    globalState: createMock<vscode.ExtensionContext['globalState']>({
-                        get: () => [],
-                        update: () => Promise.resolve(),
-                        setKeysForSync: () => {},
-                    }),
-                }),
-                scmProvider.outputChannel,
-            );
-
-            // Mock Webview
-            let messageHandler: (m: unknown) => void = () => {};
-            const webview = createMock<vscode.Webview>({
-                options: {},
-                html: '',
-                onDidReceiveMessage: (handler: (m: unknown) => void) => {
-                    messageHandler = handler;
-                    return { dispose: () => {} };
-                },
-                asWebviewUri: (uri: vscode.Uri) => uri,
-                cspSource: '',
-                postMessage: async () => {
-                    return true;
-                },
-            });
-
-            const webviewView = createMock<vscode.WebviewView>({
-                webview,
-                viewType: 'jj-view.logView',
-                onDidChangeVisibility: () => {
-                    return { dispose: () => {} };
-                },
-                onDidDispose: () => {
-                    return { dispose: () => {} };
-                },
-                visible: true,
-            });
-
-            // Resolve (binds handler)
-            provider.resolveWebviewView(
-                webviewView,
-                createMock<vscode.WebviewViewResolveContext>({}),
-                createMock<vscode.CancellationToken>({}),
-            );
-
-            // Simulate Message
-            await messageHandler({
-                type: 'moveBookmark',
-                payload: {
-                    bookmark: 'integrated-bookmark',
-                    targetChangeId: childId,
-                },
-            });
-
-            // Verify Bookmark Moved
-            const [childLog] = await jj.getLog({ revision: '@' });
-            assert.ok(
-                childLog.bookmarks?.some((b) => b.name === 'integrated-bookmark'),
-                'Bookmark should be on child now',
-            );
-        } finally {
-            refreshDisposable.dispose();
-        }
     });
 
     test('SCM count includes only Working Copy changes', async () => {

--- a/src/test/quick-diff.integration.test.ts
+++ b/src/test/quick-diff.integration.test.ts
@@ -94,10 +94,6 @@ suite('Quick Diff Integration Test', () => {
             }, timeout);
             const handle = event((e) => {
                 const matched = predicate(e);
-                console.log(`[Test Log] Received ${e.length} file changes. Matched: ${matched}`);
-                for (const change of e) {
-                    console.log(`[Test Log]   - URI: ${change.uri.toString()} (Scheme: ${change.uri.scheme})`);
-                }
                 if (matched) {
                     clearTimeout(timer);
                     handle.dispose();
@@ -193,7 +189,6 @@ suite('Quick Diff Integration Test', () => {
         const fileUri = vscode.Uri.file(path.join(canonicalPath, fileName));
         const originalUri = (await scmProvider.provideOriginalResource(fileUri)) as vscode.Uri;
         assert.ok(originalUri, `provideOriginalResource should return a URI for ${fileUri.fsPath}`);
-        console.log(`[Test Log] Registered original resource: ${originalUri.toString()}`);
 
         // Register URI by reading once
         await viewFileSystemProvider.readFile(originalUri);

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -42,7 +42,10 @@ describe('resolveRepository', () => {
         });
 
         repoManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
-        const registered = await repoManager.checkAndRegisterUri(vscode.Uri.file(repo.path));
+        vscode.workspace.updateWorkspaceFolders(0, vscode.workspace.workspaceFolders?.length, {
+            uri: vscode.Uri.file(repo.path),
+        });
+        const registered = await repoManager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(repo.path));
         if (!registered) {
             throw new Error('Failed to register repository');
         }

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -12,6 +12,9 @@ export class TestRepo {
 
     constructor(tmpDir?: string) {
         const rawPath = tmpDir || fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-'));
+        if (tmpDir) {
+            fs.mkdirSync(rawPath, { recursive: true });
+        }
         this.path = fs.realpathSync.native ? fs.realpathSync.native(rawPath) : fs.realpathSync(rawPath);
     }
 

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -157,6 +157,62 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         }
     }
 
+    class MockUri {
+        constructor(
+            public fsPath: string,
+            public scheme: string = 'file',
+            public query: string = '',
+            public path: string = fsPath,
+        ) {
+            if (process.platform === 'win32') {
+                this.fsPath = this.fsPath.replace(/\//g, '\\');
+                // Strip leading backslash if it precedes a drive letter (e.g., \C:\... -> C:\...)
+                if (/^\\[a-zA-Z]:\\/.test(this.fsPath)) {
+                    this.fsPath = this.fsPath.substring(1);
+                }
+                if (/^[a-zA-Z]:\\/.test(this.fsPath)) {
+                    this.fsPath = this.fsPath[0].toLowerCase() + this.fsPath.substring(1);
+                }
+                // For VS Code URIs on Windows, path should always use forward slashes.
+                // If it has a drive letter, it starts with a slash (e.g. /c:/...).
+                let normalizedPath = this.fsPath.replace(/\\/g, '/');
+                if (/^[a-zA-Z]:\//.test(normalizedPath)) {
+                    normalizedPath = `/${normalizedPath}`;
+                }
+                this.path = normalizedPath;
+            }
+        }
+        static file(fsPath: string) {
+            return new MockUri(fsPath);
+        }
+        static from(components: { scheme: string; path: string; query?: string }) {
+            return new MockUri(components.path, components.scheme, components.query || '', components.path);
+        }
+        static parse(uriString: string) {
+            const parsed = parseUriString(uriString);
+            return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path);
+        }
+        static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
+            const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
+            return new MockUri(combined, base.scheme, '', combined);
+        }
+        toString() {
+            return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}`;
+        }
+        with(change: { scheme?: string; query?: string }) {
+            return new MockUri(this.fsPath, change.scheme ?? this.scheme, change.query ?? this.query, this.path);
+        }
+    }
+
+    let mockWorkspaceFolders: { uri: MockUri; name: string; index: number }[] = [
+        {
+            uri: new MockUri('/root'),
+            name: 'mock-folder',
+            index: 0,
+        },
+    ];
+    const onDidChangeWorkspaceFoldersEmitter = new EventEmitter<unknown>();
+
     const base: Record<string, unknown> = {
         ProgressLocation: { Notification: 15 },
         Position,
@@ -177,52 +233,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         },
         FileSystemError,
 
-        Uri: class MockUri {
-            constructor(
-                public fsPath: string,
-                public scheme: string = 'file',
-                public query: string = '',
-                public path: string = fsPath,
-            ) {
-                if (process.platform === 'win32') {
-                    this.fsPath = this.fsPath.replace(/\//g, '\\');
-                    // Strip leading backslash if it precedes a drive letter (e.g., \C:\... -> C:\...)
-                    if (/^\\[a-zA-Z]:\\/.test(this.fsPath)) {
-                        this.fsPath = this.fsPath.substring(1);
-                    }
-                    if (/^[a-zA-Z]:\\/.test(this.fsPath)) {
-                        this.fsPath = this.fsPath[0].toLowerCase() + this.fsPath.substring(1);
-                    }
-                    // For VS Code URIs on Windows, path should always use forward slashes.
-                    // If it has a drive letter, it starts with a slash (e.g. /c:/...).
-                    let normalizedPath = this.fsPath.replace(/\\/g, '/');
-                    if (/^[a-zA-Z]:\//.test(normalizedPath)) {
-                        normalizedPath = `/${normalizedPath}`;
-                    }
-                    this.path = normalizedPath;
-                }
-            }
-            static file(fsPath: string) {
-                return new MockUri(fsPath);
-            }
-            static from(components: { scheme: string; path: string; query?: string }) {
-                return new MockUri(components.path, components.scheme, components.query || '', components.path);
-            }
-            static parse(uriString: string) {
-                const parsed = parseUriString(uriString);
-                return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path);
-            }
-            static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
-                const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
-                return new MockUri(combined, base.scheme, '', combined);
-            }
-            toString() {
-                return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}`;
-            }
-            with(change: { scheme?: string; query?: string }) {
-                return new MockUri(this.fsPath, change.scheme ?? this.scheme, change.query ?? this.query, this.path);
-            }
-        },
+        Uri: MockUri,
         TabInputTextDiff: class MockTabInputTextDiff {
             constructor(
                 public original: unknown,
@@ -267,7 +278,49 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             state: { focused: true },
         },
         workspace: {
-            workspaceFolders: [{ uri: { fsPath: '/root' } }],
+            get workspaceFolders() {
+                return mockWorkspaceFolders;
+            },
+            set workspaceFolders(val) {
+                mockWorkspaceFolders = val;
+            },
+            updateWorkspaceFolders: vi
+                .fn()
+                .mockImplementation(
+                    (
+                        start: number,
+                        deleteCount: number | undefined | null,
+                        ...workspaceFoldersToAdd: { uri: MockUri; name?: string }[]
+                    ) => {
+                        const added = workspaceFoldersToAdd.map((f, i) => ({
+                            uri: f.uri,
+                            name: f.name || `folder-${start + i}`,
+                            index: start + i,
+                        }));
+                        const removed = mockWorkspaceFolders.slice(start, start + (deleteCount ?? 0));
+
+                        const newFolders = [...mockWorkspaceFolders];
+                        newFolders.splice(start, deleteCount ?? 0, ...added);
+                        newFolders.forEach((f, i) => {
+                            f.index = i;
+                        });
+                        mockWorkspaceFolders = newFolders;
+
+                        onDidChangeWorkspaceFoldersEmitter.fire({
+                            added,
+                            removed,
+                        });
+                        return true;
+                    },
+                ),
+            onDidChangeWorkspaceFolders: onDidChangeWorkspaceFoldersEmitter.event,
+            getWorkspaceFolder: vi.fn().mockImplementation((uri: { fsPath: string }) => {
+                return mockWorkspaceFolders.find((f) => {
+                    const folderPath = f.uri.fsPath.replace(/\\/g, '/').toLowerCase();
+                    const filePath = uri.fsPath.replace(/\\/g, '/').toLowerCase();
+                    return filePath === folderPath || filePath.startsWith(`${folderPath}/`);
+                });
+            }),
             getConfiguration: vi.fn().mockReturnValue({
                 get: vi.fn().mockImplementation((_key: string, defaultValue: unknown) => defaultValue),
             }),

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -140,13 +140,13 @@ suite('Webview Commands End-to-End Integration Test', () => {
         if (executeCommandStub) {
             executeCommandStub.restore();
         }
-        if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+        for (const d of disposables) {
+            await d.dispose();
         }
-        disposables.forEach((d) => {
-            d.dispose();
-        });
         disposables = [];
+        if (repo) {
+            repo.dispose();
+        }
         if (outputChannel) {
             outputChannel.dispose();
         }

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -74,10 +74,13 @@ suite('Webview Initialization Integration Test', () => {
     });
 
     teardown(async () => {
-        disposables.forEach((d) => {
-            d.dispose();
-        });
+        for (const d of disposables) {
+            await d.dispose();
+        }
         disposables = [];
+        if (repo) {
+            repo.dispose();
+        }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 


### PR DESCRIPTION
…registrations

Implements key improvements to repository detection and management:

- **Prevent unrelated repositories**: Restricts repository registration to paths that reside within or are ancestors of active workspace folders. Addresses #349
- **Case-insensitive matching**: Standardizes path comparisons case-insensitively to avoid registering duplicate repository instances. Addresses #348
- **Respecting config**: open editors detection wasn't respecting the auto detection config. That's been fixed.
- **Scan optimization**: Probes directory path validity first on disk, only instantiating a `JjRepository` if it is actually needed and will be used, rather than creating and immediately disposing of redundant instances.

## Summary by Sourcery

Restrict repository discovery to workspace-related paths, make path handling case-insensitive, and improve scanning, watching, and lifecycle behavior to avoid redundant or unstable repository registrations.

New Features:
- Add support for treating workspace ancestors as valid repository roots and dynamically registering repositories based on open editors only when configured.

Bug Fixes:
- Prevent repositories from being registered when they reside outside workspace folders or represent secondary workspaces for an already-registered store.
- Ensure open-editor-based repository detection respects the autoRepositoryDetection configuration and avoids duplicate registrations due to case differences.
- Stabilize file watching and polling behavior during configuration changes and disposal to avoid races and dangling watchers in integration tests.
- Fix merge content resolution by requesting conflict parts using full file paths instead of workspace-relative paths.

Enhancements:
- Refactor repository scanning into a debounced, reusable scanForRepositories flow that reuses existing instances, validates candidates via cheap filesystem probes, and centralizes repository creation and registration.
- Normalize paths and comparisons to be case-insensitive, deduplicating repositories and aligning workspace-folder checks across the manager and tests.
- Improve repository, watcher, and SCM provider disposal semantics in tests and production code to reduce flakiness and resource leaks.
- Simplify commit-details editor refresh and webview command handling and remove noisy debug logging from filesystem and SCM components.

Tests:
- Update and extend integration tests for repository discovery, workspace-folder changes, open-editor behavior, and concurrency around dynamic registration, including new helpers for test workspace management and URIs.
- Adjust multiple integration suites to use the new repository manager APIs, improved teardown flows, and more realistic test repositories and workspace folder mocks.