### PR TITLE
fix: resolve repository resolution under nested symlinked directories

### DIFF
--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -784,6 +784,17 @@ export class JjRepositoryManager implements vscode.Disposable {
      * @returns True if the workspace is the main workspace, false otherwise.
      */
     private async isMainWorkspace(rootPath: string, storePath: string): Promise<boolean> {
+        try {
+            const jjPath = path.join(rootPath, '.jj');
+            const realJjPath = await fs.realpath(jjPath);
+            const realJjParent = path.dirname(realJjPath);
+            if (!this.isSamePath(realJjParent, rootPath)) {
+                return false;
+            }
+        } catch {
+            return false;
+        }
+
         const expectedMainStore = path.join(rootPath, '.jj', 'repo');
         const realExpected = await fs.realpath(expectedMainStore).catch(() => expectedMainStore);
         return this.isSamePath(realExpected, storePath) || this.isSamePath(expectedMainStore, storePath);

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -420,6 +420,13 @@ export async function rightClickAndSelect(page: Page, target: Locator, label: st
  * Triggers a manual refresh of the JJ Log view by clicking the refresh button in the view title.
  */
 export async function triggerRefresh(page: Page) {
+    // Clear focus from any active iframe/webview to allow top-level keybinding to work.
+    await page
+        .getByRole('tab', { name: /Explorer/i })
+        .first()
+        .focus()
+        .catch(() => {});
+
     // Use the custom keybinding registered in launchVSCode
     await page.keyboard.press('Control+Alt+R');
 

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -342,6 +342,58 @@ suite('JjRepositoryManager Integration Test', () => {
         }
     });
 
+    test('getRepositoryForUri matches files in nested symlinked directory layout (issue 348)', async () => {
+        // Test layout:
+        // mainRepo.path ($root)
+        // ├── .jj/ (real directory)
+        // ├── bazel-core -> targetDir (symlink to directory)
+        // └── targetDir (real directory created by mkdtempSync)
+        //     └── .jj -> mainRepo.path/.jj (symlink to directory)
+
+        // Create a target directory inside the repository
+        const targetDir = fs.realpathSync(fs.mkdtempSync(path.join(mainRepo.path, 'jj-view-nested-')));
+
+        const symlinkPath = path.join(mainRepo.path, 'bazel-core');
+        const jjSymlinkPath = path.join(targetDir, '.jj');
+
+        try {
+            // Create symlink: bazel-core -> targetDir
+            fs.symlinkSync(targetDir, symlinkPath, 'dir');
+
+            // Create symlink: targetDir/.jj -> mainRepo.path/.jj
+            fs.symlinkSync(path.join(mainRepo.path, '.jj'), jjSymlinkPath, 'dir');
+
+            // Scan to discover repositories
+            await manager.scanForRepositories();
+
+            // Verify that we only have the main repository registered, not the nested one
+            assert.strictEqual(manager.repositories.length, 1);
+            assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
+
+            // A file URI inside the symlink path should match the repository
+            const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
+            const matched = manager.getRepositoryForUri(symlinkFileUri);
+            assert.ok(matched, 'Should match repository through nested symlink path');
+            assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
+        } finally {
+            try {
+                fs.unlinkSync(symlinkPath);
+            } catch {
+                // Ignore
+            }
+            try {
+                fs.unlinkSync(jjSymlinkPath);
+            } catch {
+                // Ignore
+            }
+            try {
+                fs.rmdirSync(targetDir);
+            } catch {
+                // Ignore
+            }
+        }
+    });
+
     test('scan ignores repositories listed in ignoredRepositories config', async () => {
         const otherRepo = new TestRepo();
         extraRepos.push(otherRepo);

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -13,6 +13,7 @@ vi.mock('vscode', async () => {
 });
 
 // Import after mock
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { CodeForgeRegistry } from '../code-forge-registry';
 import type { JjRepository } from '../jj-repository';
@@ -145,5 +146,46 @@ describe('resolveRepository', () => {
         const result = resolveRepository([], repoManager, scmProviders);
 
         expect(result).toBeUndefined();
+    });
+
+    it('resolves repository from SourceControlResourceState with nested symlinked directory (issue 348)', () => {
+        // Test layout:
+        // repo.path ($root)
+        // ├── .jj/ (real directory)
+        // ├── bazel-core -> targetDir (symlink to directory)
+        // └── targetDir (real directory created by mkdtempSync)
+        //     └── .jj -> repo.path/.jj (symlink to directory)
+
+        // Create a target directory inside the repository
+        const targetDir = fs.realpathSync(fs.mkdtempSync(path.join(repo.path, 'jj-view-nested-')));
+        const symlinkPath = path.join(repo.path, 'bazel-core');
+        const jjSymlinkPath = path.join(targetDir, '.jj');
+
+        try {
+            // Create symlink: bazel-core -> targetDir
+            fs.symlinkSync(targetDir, symlinkPath, 'dir');
+
+            // Create symlink: targetDir/.jj -> repo.path/.jj
+            fs.symlinkSync(path.join(repo.path, '.jj'), jjSymlinkPath, 'dir');
+
+            // Resource URI is inside the symlink path
+            const mockState = { resourceUri: vscode.Uri.file(path.join(symlinkPath, 'file.txt')) };
+
+            const result = resolveRepository([mockState], repoManager, scmProviders);
+
+            expect(result).toBeDefined();
+            expect(result?.repo).toBe(resolvedRepo);
+            expect(result?.scm).toBe(mockScm);
+        } finally {
+            try {
+                fs.unlinkSync(symlinkPath);
+            } catch {}
+            try {
+                fs.unlinkSync(jjSymlinkPath);
+            } catch {}
+            try {
+                fs.rmdirSync(targetDir);
+            } catch {}
+        }
     });
 });


### PR DESCRIPTION
Corrects `isMainWorkspace` in `JjRepositoryManager` to verify that the real path of the `.jj` directory actually has its parent directory matching the candidate repository root. This prevents subdirectories that have symlinked `.jj` folders (like bazel-core layouts) from being incorrectly detected as separate main workspaces and causing duplicate repository registration.

Also updates the integration and unit tests to create the target directories nested inside the workspace itself to ensure complete coverage of this scenario.

Addresses #348

## Summary by Sourcery

Ensure repository detection treats nested symlinked .jj directories as part of the main workspace to avoid duplicate repository registration.

Bug Fixes:
- Prevent nested directories with symlinked .jj folders from being misidentified as separate main workspaces during repository scanning.

Tests:
- Add integration and unit tests covering repository resolution and SCM resource mapping in nested symlinked directory layouts within the workspace.