### PR TITLE
feat: parallelize repository scanning

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -328,6 +328,7 @@ export class ChangeDetectionManager implements vscode.Disposable {
         this._disposed = true;
 
         await this.stopWorkingCopyWatching();
+
         this._poller.dispose();
 
         if (this._opHeadsWatcherPromise) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,7 @@ import { JjOutputChannel } from './utils/output-channel';
 
 export interface Api {
     repositoryManager: JjRepositoryManager;
+    scmProviders: Map<string, JjScmProvider>;
     registerCodeForgeProvider(factory: CodeForgeProviderFactory): vscode.Disposable;
 }
 
@@ -627,6 +628,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
     return {
         repositoryManager,
+        scmProviders,
         registerCodeForgeProvider: (factory: CodeForgeProviderFactory) => codeForgeRegistry.register(factory),
     };
 }

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -21,6 +21,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
     // Cache to prevent re-evaluating the same file status repeatedly
     private trackedStatusCache = new Map<string, { isTracked: boolean; uri: vscode.Uri }>();
     private resolveCallbacks = new Map<string, (decoration: vscode.FileDecoration | undefined) => void>();
+    private pendingPromises = new Map<string, Promise<vscode.FileDecoration | undefined>>();
 
     constructor(
         private jjService: JjService,
@@ -34,6 +35,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
             callback(undefined);
         }
         this.resolveCallbacks.clear();
+        this.pendingPromises.clear();
         this._onDidChangeFileDecorations.fire(undefined);
     }
 
@@ -130,9 +132,9 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
             return undefined;
         }
 
-        // 3. Ignore paths outside our workspace entirely
+        // 3. Ignore paths outside our workspace entirely or the workspace root itself
         const relativePath = this.getWorkspaceRelativePath(uri);
-        if (relativePath === undefined) {
+        if (relativePath === undefined || relativePath === '') {
             return undefined;
         }
 
@@ -164,11 +166,19 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
                   );
         }
 
-        // 5. Not in cache, schedule a batched check
-        return new Promise<vscode.FileDecoration | undefined>((resolve) => {
+        // 5. Check if there's already a pending promise for this path
+        const pending = this.pendingPromises.get(relativePath);
+        if (pending) {
+            return pending;
+        }
+
+        // 6. Not in cache and no pending promise, create a new promise and schedule a batched check
+        const promise = new Promise<vscode.FileDecoration | undefined>((resolve) => {
             this.resolveCallbacks.set(relativePath, resolve);
             this.queueCheck(uri, relativePath);
         });
+        this.pendingPromises.set(relativePath, promise);
+        return promise;
     }
 
     private queueCheck(uri: vscode.Uri, relativePath: string) {
@@ -207,6 +217,9 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
 
         this.pendingChecks.clear();
         this.resolveCallbacks.clear();
+        for (const p of pathsToCheck) {
+            this.pendingPromises.delete(p);
+        }
 
         try {
             // Ask JJ which of these paths are tracked

--- a/src/jj-edit-fs-provider.ts
+++ b/src/jj-edit-fs-provider.ts
@@ -64,7 +64,10 @@ export class JjEditFileSystemProvider implements vscode.FileSystemProvider {
     invalidateCache() {
         const events: vscode.FileChangeEvent[] = [];
         for (const uriStr of this._knownUris) {
-            events.push({ type: vscode.FileChangeType.Changed, uri: vscode.Uri.parse(uriStr) });
+            const uri = vscode.Uri.parse(uriStr);
+            if (this._repositoryManager.getRepositoryForUri(uri)) {
+                events.push({ type: vscode.FileChangeType.Changed, uri });
+            }
         }
         this._knownUris.clear();
         if (events.length > 0) {

--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import type { CodeForgeRegistry } from './code-forge-registry';
 import { JjRepository } from './jj-repository';
 import { JjService } from './jj-service';
+import { CoalescingQueue } from './utils/coalescing-queue';
 import { JjOutputChannel } from './utils/output-channel';
 
 interface DetectedRepoInfo {
@@ -27,10 +28,11 @@ export class JjRepositoryManager implements vscode.Disposable {
     private _disposables: vscode.Disposable[] = [];
     private readonly _dirToRepoRoot = new Map<string, string | null>();
     private readonly _ignoredAbsolutePaths = new Set<string>();
+    private readonly _closingPaths = new Set<string>();
     private readonly _pendingRegistrations = new Map<string, Promise<JjRepository | undefined>>();
+    private readonly _pendingRepoRoots = new Map<string, Promise<string | undefined>>();
     private _lastActiveTab?: vscode.Tab;
-    private _activeScan: Promise<void> | undefined;
-    private _scanPending = false;
+    private readonly _scanQueue = new CoalescingQueue(() => this.doScan());
     private _disposed = false;
     private _normalizedWorkspaceFolders: string[] | undefined;
     private readonly _realNormalizedPathCache = new Map<string, Promise<string>>();
@@ -119,6 +121,9 @@ export class JjRepositoryManager implements vscode.Disposable {
             vscode.workspace.onDidChangeWorkspaceFolders(() => {
                 this._normalizedWorkspaceFolders = undefined;
                 this._realNormalizedPathCache.clear();
+                this.scanForRepositories().catch((err) => {
+                    this._outputChannel.appendLine(`[RepositoryManager] Error scanning on workspace change: ${err}`);
+                });
             }),
         );
     }
@@ -131,13 +136,23 @@ export class JjRepositoryManager implements vscode.Disposable {
         return this._focusedRepository;
     }
 
+    get codeForgeRegistry(): CodeForgeRegistry {
+        return this._codeForgeRegistry;
+    }
+
+    get workspaceState(): vscode.Memento {
+        return this._workspaceState;
+    }
+
     /**
-     * Updates the Jujutsu binary path for all managed repositories and stores it
+     * Set the binary path configuration, updating all managed repositories.
+     * Keeps cached roots, but clears verified repo path mappings to ensure we re-probe
      * for future discovered repositories.
      */
     setBinaryPath(binPath: string): void {
         this._binaryPath = binPath;
         this._dirToRepoRoot.clear();
+        this._pendingRepoRoots.clear();
         for (const repo of this._repositories) {
             repo.jj.binaryPath = binPath;
             repo.refresh({ reason: 'binary path set' }).catch((err) => {
@@ -152,6 +167,9 @@ export class JjRepositoryManager implements vscode.Disposable {
      * Set the focused repository. Fires `onDidChangeFocusedRepository` if changed.
      */
     setFocusedRepository(repo: JjRepository | undefined): void {
+        if (this._disposed) {
+            return;
+        }
         const currentPath = this._focusedRepository?.rootUri.fsPath;
         const newPath = repo?.rootUri.fsPath;
         if (this.isSamePath(currentPath, newPath)) {
@@ -160,7 +178,7 @@ export class JjRepositoryManager implements vscode.Disposable {
 
         this._focusedRepository = repo;
         this._outputChannel.appendLine(`[RepositoryManager] Focused repository: ${repo?.rootUri.fsPath ?? 'none'}`);
-        this._onDidChangeFocusedRepository.fire(repo);
+        this.fireEvent(this._onDidChangeFocusedRepository, repo);
 
         if (repo) {
             this._workspaceState.update(JjRepositoryManager.LAST_FOCUSED_REPO_KEY, repo.rootUri.fsPath);
@@ -225,35 +243,20 @@ export class JjRepositoryManager implements vscode.Disposable {
     /**
      * Scans the workspace folders, explicit configuration paths, and open editor tabs
      * to discover and update the list of registered Jujutsu repositories.
+     * Concurrent calls are coalesced: if a scan is already in progress,
+     * the returned promise resolves when that scan completes.
      */
     async scanForRepositories(): Promise<void> {
         if (this._disposed) {
             return;
         }
-        if (this._activeScan) {
-            this._scanPending = true;
-            return this._activeScan;
-        }
-
-        this._scanPending = true;
-        const scanPromise = (async () => {
-            while (this._scanPending && !this._disposed) {
-                this._scanPending = false;
-                await this.doScan();
-            }
-        })();
-
-        this._activeScan = scanPromise;
-        try {
-            await scanPromise;
-        } finally {
-            if (this._activeScan === scanPromise) {
-                this._activeScan = undefined;
-            }
-        }
+        return this._scanQueue.run();
     }
 
     private async doScan(): Promise<void> {
+        if (this._disposed) {
+            return;
+        }
         const autoDetect = this.getAutoRepositoryDetectionConfig();
         const scanPaths = this.getScanRepositoriesConfig();
 
@@ -263,75 +266,104 @@ export class JjRepositoryManager implements vscode.Disposable {
         // 1. Resolve ignore list absolute paths
         this.updateIgnoredPaths();
 
+        // Clean up _closingPaths for folders that are no longer in the workspace
+        const folders = vscode.workspace.workspaceFolders || [];
+        const normalizedFolders = await Promise.all(
+            folders.map((folder) => this.getRealNormalizedPath(folder.uri.fsPath)),
+        );
+        for (const closedPath of this._closingPaths) {
+            if (!normalizedFolders.some((f) => f === closedPath || f.startsWith(`${closedPath}/`))) {
+                this._closingPaths.delete(closedPath);
+            }
+        }
+
         const addCandidate = async (rootDir: string) => {
-            const info = await this.probeRepository(rootDir);
+            const realRoot = await fs.realpath(rootDir).catch(() => rootDir);
+            const normalizedRoot = this.normalizePath(realRoot);
+            if (seenRoots.has(normalizedRoot)) {
+                return;
+            }
+            seenRoots.add(normalizedRoot);
+
+            const info = await this.probeRepository(realRoot);
             if (info) {
-                const normalizedRoot = this.normalizePath(info.rootPath);
-                if (!seenRoots.has(normalizedRoot)) {
-                    candidates.push(info);
-                    seenRoots.add(normalizedRoot);
-                }
+                candidates.push(info);
+            } else {
+                seenRoots.delete(normalizedRoot);
             }
         };
 
         // Pre-populate candidates with valid cached/discovered repositories
-        for (const repo of this._repositories) {
-            const rootPath = repo.rootUri.fsPath;
-            try {
-                const stats = await fs.stat(rootPath);
-                if (stats.isDirectory() && (await repo.isValid())) {
-                    await addCandidate(rootPath);
+        await Promise.all(
+            this._repositories.map(async (repo) => {
+                const rootPath = repo.rootUri.fsPath;
+                try {
+                    const stats = await fs.stat(rootPath);
+                    if (stats.isDirectory() && (await repo.isValid())) {
+                        await addCandidate(rootPath);
+                    }
+                } catch {
+                    // Directory doesn't exist anymore, let it be cleaned up
                 }
-            } catch {
-                // Directory doesn't exist anymore, let it be cleaned up
-            }
-        }
+            }),
+        );
 
-        // discover via auto-detection setting
-        const folders = vscode.workspace.workspaceFolders || [];
-        for (const folder of folders) {
-            const rootPath = folder.uri.fsPath;
-            const rootReal = await fs.realpath(rootPath).catch(() => rootPath);
-
-            if (this.shouldScanWorkspaceRoots()) {
-                const rootDir = await this.findRepoRoot(rootReal);
-                if (rootDir) {
-                    await addCandidate(rootDir);
+        // Discover via auto-detection setting
+        await Promise.all(
+            folders.map(async (folder) => {
+                if (this._disposed) {
+                    return;
                 }
-            }
+                const rootPath = folder.uri.fsPath;
+                const rootReal = await fs.realpath(rootPath).catch(() => rootPath);
 
-            if (autoDetect === true || autoDetect === 'subFolders') {
-                const glob = autoDetect === true ? '**/.jj/working_copy/type' : '*/.jj/working_copy/type';
-                const pattern = new vscode.RelativePattern(folder, glob);
-                const files = await vscode.workspace.findFiles(pattern, null, 1000);
-                for (const file of files) {
-                    const rootDir = path.dirname(path.dirname(path.dirname(file.fsPath)));
-                    await addCandidate(rootDir);
+                if (this.shouldScanWorkspaceRoots()) {
+                    const rootDir = await this.findRepoRoot(rootReal);
+                    if (rootDir) {
+                        await addCandidate(rootDir);
+                    }
                 }
-            }
-        }
+
+                if (autoDetect === true || autoDetect === 'subFolders') {
+                    const glob = autoDetect === true ? '**/.jj/working_copy/type' : '*/.jj/working_copy/type';
+                    const pattern = new vscode.RelativePattern(folder, glob);
+                    const files = await vscode.workspace.findFiles(pattern, null, 1000);
+                    await Promise.all(
+                        files.map((file) => {
+                            if (this._disposed) {
+                                return Promise.resolve();
+                            }
+                            const rootDir = path.dirname(path.dirname(path.dirname(file.fsPath)));
+                            return addCandidate(rootDir);
+                        }),
+                    );
+                }
+            }),
+        );
 
         // 3. Scan explicit paths
-        for (const p of scanPaths) {
-            let absPath = p;
-            if (!path.isAbsolute(p) && folders.length > 0) {
-                absPath = path.resolve(folders[0].uri.fsPath, p);
-            }
-            if (!(await this.isPathInOrAncestorOfWorkspace(absPath))) {
-                this._outputChannel.appendLine(
-                    `[RepositoryManager] Warning: Skipping configured scan path outside workspace folders: ${p}`,
-                );
-                continue;
-            }
-            try {
-                const realAbs = await fs.realpath(absPath);
-                const selfCheck = path.join(realAbs, '.jj', 'working_copy', 'type');
-                await fs.access(selfCheck);
-                await addCandidate(realAbs);
-            } catch {
-                // Path not accessible or not a repo
-            }
-        }
+        await Promise.all(
+            scanPaths.map(async (p) => {
+                let absPath = p;
+                if (!path.isAbsolute(p) && folders.length > 0) {
+                    absPath = path.resolve(folders[0].uri.fsPath, p);
+                }
+                if (!(await this.isPathInOrAncestorOfWorkspace(absPath))) {
+                    this._outputChannel.appendLine(
+                        `[RepositoryManager] Warning: Skipping configured scan path outside workspace folders: ${p}`,
+                    );
+                    return;
+                }
+                try {
+                    const realAbs = await fs.realpath(absPath);
+                    const selfCheck = path.join(realAbs, '.jj', 'working_copy', 'type');
+                    await fs.access(selfCheck);
+                    await addCandidate(realAbs);
+                } catch {
+                    // Path not accessible or not a repo
+                }
+            }),
+        );
 
         // 3.5. Also include repositories of currently open editors (so they aren't closed)
         if (this.shouldDetectFromOpenEditors()) {
@@ -344,11 +376,11 @@ export class JjRepositoryManager implements vscode.Disposable {
             );
             const validUris = uriChecks.filter((check) => check.valid).map((check) => check.uri);
             const editorRoots = await Promise.all(validUris.map((uri) => this.findRepoRoot(this.getPathForUri(uri))));
-            for (const rootDir of editorRoots) {
-                if (rootDir) {
-                    await addCandidate(rootDir);
-                }
-            }
+            await Promise.all(
+                editorRoots
+                    .filter((rootDir): rootDir is string => rootDir !== undefined)
+                    .map((rootDir) => addCandidate(rootDir)),
+            );
         }
 
         // 4. Reconcile repositories
@@ -390,14 +422,19 @@ export class JjRepositoryManager implements vscode.Disposable {
         }
 
         this._repositories = newRepos;
+        this.sortRepositories();
         this.persistRepositories();
 
         // Any repository in oldRepos that is not in newRepos must be disposed
         for (const oldRepo of oldRepos) {
             if (!newRepos.some((r) => this.isSamePath(r.rootUri.fsPath, oldRepo.rootUri.fsPath))) {
-                this._onDidCloseRepository.fire(oldRepo);
                 await oldRepo.dispose();
+                this.fireEvent(this._onDidCloseRepository, oldRepo);
             }
+        }
+
+        if (this._disposed) {
+            return;
         }
 
         // Find opened (present in newRepos but not in oldRepos)
@@ -405,10 +442,10 @@ export class JjRepositoryManager implements vscode.Disposable {
             (newRepo) => !oldRepos.some((oldRepo) => this.isSamePath(oldRepo.rootUri.fsPath, newRepo.rootUri.fsPath)),
         );
         for (const repo of opened) {
-            this._onDidOpenRepository.fire(repo);
+            this.fireEvent(this._onDidOpenRepository, repo);
         }
 
-        this._onDidChangeRepositories.fire(this._repositories);
+        this.fireEvent(this._onDidChangeRepositories, this._repositories);
         this._outputChannel.appendLine(
             `[RepositoryManager] Total registered repositories: ${this._repositories.length}`,
         );
@@ -511,33 +548,47 @@ export class JjRepositoryManager implements vscode.Disposable {
             return cached === null ? undefined : cached;
         }
 
-        // Find the closest existing parent directory
-        let existingDir = dir;
-        while (existingDir) {
-            try {
-                await fs.access(existingDir);
-                break;
-            } catch {
-                const parent = path.dirname(existingDir);
-                // Guard against infinite loops on Windows/UNC roots where path.dirname('C:\\') === 'C:\\'
-                if (parent === existingDir) {
-                    break;
-                }
-                existingDir = parent;
-            }
+        const pending = this._pendingRepoRoots.get(normalizedDir);
+        if (pending) {
+            return pending;
         }
 
-        const realDir = await fs.realpath(existingDir).catch(() => existingDir);
+        const promise = (async () => {
+            // Find the closest existing parent directory
+            let existingDir = dir;
+            while (existingDir) {
+                try {
+                    await fs.access(existingDir);
+                    break;
+                } catch {
+                    const parent = path.dirname(existingDir);
+                    // Guard against infinite loops on Windows/UNC roots where path.dirname('C:\\') === 'C:\\'
+                    if (parent === existingDir) {
+                        break;
+                    }
+                    existingDir = parent;
+                }
+            }
 
-        const jj = new JjService(realDir, () => {}, this._binaryPath || 'jj');
+            const realDir = await fs.realpath(existingDir).catch(() => existingDir);
+
+            const jj = new JjService(realDir, () => {}, this._binaryPath || 'jj');
+            try {
+                const resolvedRoot = await jj.getRepoRoot();
+                const realRoot = await fs.realpath(resolvedRoot).catch(() => resolvedRoot);
+                this._dirToRepoRoot.set(normalizedDir, realRoot);
+                return realRoot;
+            } catch {
+                this._dirToRepoRoot.set(normalizedDir, null);
+                return undefined;
+            }
+        })();
+
+        this._pendingRepoRoots.set(normalizedDir, promise);
         try {
-            const resolvedRoot = await jj.getRepoRoot();
-            const realRoot = await fs.realpath(resolvedRoot).catch(() => resolvedRoot);
-            this._dirToRepoRoot.set(normalizedDir, realRoot);
-            return realRoot;
-        } catch {
-            this._dirToRepoRoot.set(normalizedDir, null);
-            return undefined;
+            return await promise;
+        } finally {
+            this._pendingRepoRoots.delete(normalizedDir);
         }
     }
 
@@ -726,7 +777,7 @@ export class JjRepositoryManager implements vscode.Disposable {
                 return undefined;
             }
             const normalizedRoot = this.normalizePath(realRoot);
-            if (this._ignoredAbsolutePaths.has(normalizedRoot)) {
+            if (this._ignoredAbsolutePaths.has(normalizedRoot) || this._closingPaths.has(normalizedRoot)) {
                 return undefined;
             }
 
@@ -757,22 +808,41 @@ export class JjRepositoryManager implements vscode.Disposable {
         }
     }
 
-    /**
-     * Registers one or more repositories with the manager, appending them to the
-     * active repositories list, persisting them, and firing SCM change events.
-     *
-     * @param repos The array of JjRepository instances to register.
-     */
     private registerRepositories(repos: JjRepository[]): void {
-        if (repos.length === 0) {
+        if (this._disposed || repos.length === 0) {
             return;
         }
         this._repositories.push(...repos);
+        this.sortRepositories();
         this.persistRepositories();
         for (const repo of repos) {
-            this._onDidOpenRepository.fire(repo);
+            this.fireEvent(this._onDidOpenRepository, repo);
         }
-        this._onDidChangeRepositories.fire(this._repositories);
+        this.fireEvent(this._onDidChangeRepositories, this._repositories);
+    }
+
+    private sortRepositories(): void {
+        const workspaceFolders = vscode.workspace.workspaceFolders || [];
+        const folderPaths = workspaceFolders.map((f) => this.normalizePath(f.uri.fsPath));
+
+        this._repositories.sort((a, b) => {
+            const aPath = this.normalizePath(a.rootUri.fsPath);
+            const bPath = this.normalizePath(b.rootUri.fsPath);
+
+            const aIdx = folderPaths.findIndex((f) => aPath === f || aPath.startsWith(`${f}/`));
+            const bIdx = folderPaths.findIndex((f) => bPath === f || bPath.startsWith(`${f}/`));
+
+            if (aIdx !== -1 && bIdx !== -1) {
+                if (aIdx !== bIdx) {
+                    return aIdx - bIdx;
+                }
+            } else if (aIdx !== -1) {
+                return -1;
+            } else if (bIdx !== -1) {
+                return 1;
+            }
+            return aPath.localeCompare(bPath);
+        });
     }
 
     /**
@@ -997,6 +1067,12 @@ export class JjRepositoryManager implements vscode.Disposable {
         return this.normalizePath(pathA) === this.normalizePath(pathB);
     }
 
+    private fireEvent<T>(emitter: vscode.EventEmitter<T>, value: T): void {
+        if (!this._disposed) {
+            emitter.fire(value);
+        }
+    }
+
     /**
      * Retrieves the current configuration for automatic repository detection.
      *
@@ -1054,16 +1130,50 @@ export class JjRepositoryManager implements vscode.Disposable {
     }
 
     /**
+     * Closes and disposes a specific repository by its root URI.
+     * Fires didClose events and removes it from the managed list.
+     */
+    async closeRepository(uri: vscode.Uri): Promise<void> {
+        const targetPath = uri.fsPath;
+        const normalizedTarget = this.normalizePath(targetPath);
+        this._closingPaths.add(normalizedTarget);
+
+        const index = this._repositories.findIndex((r) => this.isSamePath(r.rootUri.fsPath, normalizedTarget));
+        if (index !== -1) {
+            const repo = this._repositories[index];
+            this._repositories.splice(index, 1);
+            this.persistRepositories();
+
+            this._outputChannel.appendLine(
+                `[RepositoryManager] Closing and disposing repository explicitly: ${repo.rootUri.fsPath}`,
+            );
+            await repo.dispose();
+            this.fireEvent(this._onDidCloseRepository, repo);
+            this.fireEvent(this._onDidChangeRepositories, this._repositories);
+
+            // Re-evaluate focus if we closed the focused repository
+            if (this._focusedRepository && this.isSamePath(this._focusedRepository.rootUri.fsPath, normalizedTarget)) {
+                if (this._repositories.length > 0) {
+                    this.setFocusedRepository(this._repositories[0]);
+                } else {
+                    this.setFocusedRepository(undefined);
+                }
+            }
+        }
+    }
+
+    /**
      * Clears all registered repositories, firing didClose events and disposing of them.
      * Keeps the manager itself active for subsequent use.
      */
     async clear(): Promise<void> {
         this._outputChannel.appendLine(`[RepositoryManager] Clearing ${this._repositories.length} repositories`);
 
-        // 1. Await any active scan
-        if (this._activeScan) {
-            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active scan before clearing...`);
-            await this._activeScan.catch(() => {});
+        // 1. Await any active or queued scan
+        const currentScan = this._scanQueue.currentRun;
+        if (currentScan) {
+            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active/queued scan before clearing...`);
+            await currentScan.catch(() => {});
         }
 
         // 2. Await any pending registrations
@@ -1071,19 +1181,26 @@ export class JjRepositoryManager implements vscode.Disposable {
         this._pendingRegistrations.clear();
         const pendingRepos = await Promise.all(pendingPromises);
 
-        // 3. Clear and dispose registered repositories
+        // 3. Clear caches
+        this._dirToRepoRoot.clear();
+        this._realNormalizedPathCache.clear();
+        this._pendingRepoRoots.clear();
+
+        // 4. Clear and dispose registered repositories
         const repos = [...this._repositories];
         this._repositories = [];
+
         this.setFocusedRepository(undefined);
+
         for (const repo of repos) {
             this._outputChannel.appendLine(
                 `[RepositoryManager] Closing and disposing repository: ${repo.rootUri.fsPath}`,
             );
-            this._onDidCloseRepository.fire(repo);
             await repo.dispose();
+            this.fireEvent(this._onDidCloseRepository, repo);
         }
 
-        // 4. Dispose pending repositories
+        // 5. Dispose pending repositories
         for (const repo of pendingRepos) {
             if (repo) {
                 this._outputChannel.appendLine(
@@ -1095,10 +1212,11 @@ export class JjRepositoryManager implements vscode.Disposable {
 
         await this._workspaceState.update(JjRepositoryManager.DISCOVERED_REPOS_KEY, undefined);
         await this._workspaceState.update(JjRepositoryManager.LAST_FOCUSED_REPO_KEY, undefined);
-        this._onDidChangeRepositories.fire([]);
+
+        this.fireEvent(this._onDidChangeRepositories, []);
+
         this._outputChannel.appendLine(`[RepositoryManager] Clear complete`);
     }
-
     async dispose(): Promise<void> {
         if (this._disposed) {
             return;
@@ -1111,10 +1229,11 @@ export class JjRepositoryManager implements vscode.Disposable {
         this._onDidChangeFocusedRepository.dispose();
         this._onDidChangeRepositories.dispose();
 
-        // 1. Await any active scan
-        if (this._activeScan) {
-            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active scan before disposing...`);
-            await this._activeScan.catch(() => {});
+        // 1. Await any active or queued scan
+        const currentScan = this._scanQueue.currentRun;
+        if (currentScan) {
+            this._outputChannel.appendLine(`[RepositoryManager] Awaiting active/queued scan before disposing...`);
+            await currentScan.catch(() => {});
         }
 
         // 2. Await any pending registrations
@@ -1128,6 +1247,7 @@ export class JjRepositoryManager implements vscode.Disposable {
             await repo.dispose();
         }
         this._repositories = [];
+        this._pendingRepoRoots.clear();
 
         // 4. Dispose pending repositories
         for (const repo of pendingRepos) {

--- a/src/jj-repository.ts
+++ b/src/jj-repository.ts
@@ -93,6 +93,9 @@ export class JjRepository implements Disposable {
     }
 
     async dispose() {
+        if (this._disposed) {
+            return;
+        }
         this._disposed = true;
         this._codeForge.dispose();
         await this._watcher.dispose();

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -281,11 +281,9 @@ export class JjService {
             const result = typeof stdout === 'string' ? stdout : stdout.toString();
             return shouldTrim ? result.trim() : result;
         } finally {
-            if (isMutation) {
-                if (timeout) {
-                    clearTimeout(timeout);
-                    this._operationTimeouts.delete(opId);
-                }
+            if (isMutation && timeout) {
+                clearTimeout(timeout);
+                this._operationTimeouts.delete(opId);
             }
         }
     }
@@ -819,7 +817,8 @@ export class JjService {
      * directories, it returns the tracked files contained within them.
      */
     async checkTrackedPaths(paths: string[]): Promise<string[]> {
-        if (paths.length === 0) {
+        const nonEmptyPaths = paths.filter((p) => p.length > 0);
+        if (nonEmptyPaths.length === 0) {
             return [];
         }
 
@@ -827,7 +826,7 @@ export class JjService {
         // Paths are passed as positional arguments (filesets).
         // Since paths is just an array of workspace-relative strings, they act as implicit fileset matches.
         // E.g., jj file list path/to/a path/to/b
-        const args = ['list', '-T', 'path.display() ++ "\\n"', ...paths];
+        const args = ['list', '-T', 'path.display() ++ "\\n"', ...nonEmptyPaths];
         try {
             const output = await this.run('file', args, { useCachedSnapshot: true, label: 'checkTrackedPaths' });
             return output
@@ -835,7 +834,7 @@ export class JjService {
                 .map((line) => line.trim())
                 .filter((line) => line.length > 0);
         } catch {
-            return paths;
+            return nonEmptyPaths;
         }
     }
 

--- a/src/jj-view-fs-provider.ts
+++ b/src/jj-view-fs-provider.ts
@@ -42,7 +42,10 @@ export class JjViewFileSystemProvider implements vscode.FileSystemProvider {
         this._cache.clear();
         const events: vscode.FileChangeEvent[] = [];
         for (const uriStr of this._knownUris) {
-            events.push({ type: vscode.FileChangeType.Changed, uri: vscode.Uri.parse(uriStr) });
+            const uri = vscode.Uri.parse(uriStr);
+            if (this._repositoryManager.getRepositoryForUri(uri)) {
+                events.push({ type: vscode.FileChangeType.Changed, uri });
+            }
         }
         this._knownUris.clear();
         if (events.length > 0) {

--- a/src/test/button-visibility.integration.test.ts
+++ b/src/test/button-visibility.integration.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'node:assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { createMock } from './test-utils';
@@ -22,10 +22,6 @@ suite('Button Visibility Integration Test', () => {
         repo.init();
 
         // Initialize Service and Provider
-        // Mock context
-        const context = createMock<vscode.ExtensionContext>({
-            subscriptions: [],
-        });
 
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
@@ -38,12 +34,7 @@ suite('Button Visibility Integration Test', () => {
             name: 'mock',
         });
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
 
         // Spy/Stub on vscode.commands.executeCommand to check for setContext
         executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
@@ -56,12 +47,11 @@ suite('Button Visibility Integration Test', () => {
         // Allow VS Code to settle before disposing repository
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        scmProvider.dispose();
         if (executeCommandStub) {
             executeCommandStub.restore();
         }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
     });
 

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -85,7 +85,7 @@ describe('ChangeDetectionManager', () => {
     const waitForLog = async (pattern: string) => {
         await vi.waitFor(
             () => {
-                const calls = (outputChannel.appendLine as Mock).mock.calls;
+                const { calls } = (outputChannel.appendLine as Mock).mock;
                 const found = calls.some((call) => call[0].includes(pattern));
                 if (!found) {
                     throw new Error(`Log pattern "${pattern}" not found`);

--- a/src/test/commands/absorb.integration.test.ts
+++ b/src/test/commands/absorb.integration.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import { absorbCommand } from '../../commands/absorb';
-import { JjScmProvider } from '../../jj-scm-provider';
+import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 
@@ -23,20 +23,9 @@ suite('Absorb Integration Test', function () {
         jj = new JjService(repo.path);
 
         outputChannel = vscode.window.createOutputChannel('JJ Test');
-
-        const context = {
-            subscriptions: [],
-            extensionUri: vscode.Uri.file(__dirname),
-        } as unknown as vscode.ExtensionContext;
-
         const { createTestRepositoryContext } = await import('../integration-test-utils');
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
     });
 
     teardown(async () => {
@@ -44,9 +33,8 @@ suite('Absorb Integration Test', function () {
         // Allow VS Code to settle before disposing repository
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        scmProvider.dispose();
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
     });
 

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -6,7 +6,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { DiffTabCleaner } from '../diff-tab-cleaner';
 import { JjService } from '../jj-service';
-import { createTestRepositoryContext, type TestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { exposePrivate } from './test-utils';
 
@@ -35,30 +34,22 @@ describe('Diff Tab Cleaner', () => {
     let jj: JjService;
     let cleaner: DiffTabCleaner;
     let privateCleaner: PrivateDiffTabCleaner;
-    let contextHelper: TestRepositoryContext | undefined;
 
     beforeEach(async () => {
         repo = new TestRepo();
         repo.init();
         jj = new JjService(repo.path);
 
-        const outputChannel = vscode.window.createOutputChannel('Jujutsu Test');
-        contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-
         const belongsToRepo = (uri: vscode.Uri) => {
-            if (!contextHelper) {
-                return false;
-            }
-            return contextHelper.repositoryManager.getRepositoryForUri(uri) === contextHelper.repository;
+            const normalizedUri = uri.fsPath.replace(/\\/g, '/').toLowerCase();
+            const normalizedRepo = repo.path.replace(/\\/g, '/').toLowerCase();
+            return normalizedUri.startsWith(normalizedRepo);
         };
         cleaner = new DiffTabCleaner(jj, belongsToRepo);
         privateCleaner = exposePrivate<PrivateDiffTabCleaner>(cleaner);
     });
 
     afterEach(async () => {
-        if (contextHelper?.repositoryManager) {
-            await contextHelper.repositoryManager.dispose();
-        }
         if (repo) {
             repo.dispose();
         }

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -468,40 +468,34 @@ export const SCM_ACTIONS = {
  * Robustly clicks an inline action button on an SCM tree item (row or group) by its title.
  */
 export async function clickScmAction(page: Page, rowName: string | RegExp, actionTitle: string) {
-    await expect(async () => {
-        const row = page.getByRole('treeitem', { name: rowName }).first();
-        await expect(row).toBeVisible({ timeout: 5000 });
-        await row.hover();
-        await page.waitForTimeout(500); // Give it more time to settle
+    const row = page.getByRole('treeitem', { name: rowName }).first();
+    await expect(row).toBeVisible({ timeout: 5000 });
 
-        const iconMap: Record<string, string> = {
-            [SCM_ACTIONS.Abandon]: '.codicon-trash',
-            [SCM_ACTIONS.SquashRevisionIntoParent]: '.codicon-arrow-down',
-            [SCM_ACTIONS.SquashRevisionIntoAncestor]: '.codicon-jj-icon-squash-into',
-            [SCM_ACTIONS.SquashFilesIntoParent]: '.codicon-arrow-down',
-            [SCM_ACTIONS.SquashFilesIntoAncestor]: '.codicon-jj-icon-squash-into',
-            [SCM_ACTIONS.SquashFilesIntoChild]: '.codicon-arrow-up',
-            [SCM_ACTIONS.Absorb]: '.codicon-magnet',
-            [SCM_ACTIONS.DiscardChanges]: '.codicon-discard',
-            [SCM_ACTIONS.ShowDetails]: '.codicon-list-selection',
-            [SCM_ACTIONS.Edit]: '.codicon-edit',
-            [SCM_ACTIONS.MultiFileDiff]: '.codicon-diff-multiple',
-            [SCM_ACTIONS.CompleteSquashRevision]: '.codicon-check',
-            [SCM_ACTIONS.FocusRepository]: '.codicon-eye',
-        };
+    const iconMap: Record<string, string> = {
+        [SCM_ACTIONS.Abandon]: '.codicon-trash',
+        [SCM_ACTIONS.SquashRevisionIntoParent]: '.codicon-arrow-down',
+        [SCM_ACTIONS.SquashRevisionIntoAncestor]: '.codicon-jj-icon-squash-into',
+        [SCM_ACTIONS.SquashFilesIntoParent]: '.codicon-arrow-down',
+        [SCM_ACTIONS.SquashFilesIntoAncestor]: '.codicon-jj-icon-squash-into',
+        [SCM_ACTIONS.SquashFilesIntoChild]: '.codicon-arrow-up',
+        [SCM_ACTIONS.Absorb]: '.codicon-magnet',
+        [SCM_ACTIONS.DiscardChanges]: '.codicon-discard',
+        [SCM_ACTIONS.ShowDetails]: '.codicon-list-selection',
+        [SCM_ACTIONS.Edit]: '.codicon-edit',
+        [SCM_ACTIONS.MultiFileDiff]: '.codicon-diff-multiple',
+        [SCM_ACTIONS.CompleteSquashRevision]: '.codicon-check',
+        [SCM_ACTIONS.FocusRepository]: '.codicon-eye',
+    };
 
-        const cls = iconMap[actionTitle];
-        let button: Locator;
+    const cls = iconMap[actionTitle];
+    let button: Locator;
+    if (cls) {
+        button = row.locator('.action-item', { has: page.locator(cls) }).first();
+    } else {
+        button = row.getByRole('button', { name: new RegExp(actionTitle, 'i') }).first();
+    }
 
-        if (cls) {
-            button = row.locator('.action-item', { has: page.locator(cls) }).first();
-        } else {
-            button = row.getByRole('button', { name: new RegExp(actionTitle, 'i') }).first();
-        }
-
-        await expect(button).toBeVisible({ timeout: 1000 });
-        await button.click({ force: true });
-    }, `Failed to click SCM action "${actionTitle}" on row "${rowName}"`).toPass({ timeout: 10000 });
+    await hoverAndClick(row, button);
 }
 
 export const isMac = process.platform === 'darwin';

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -846,10 +846,8 @@ test.describe('SCM Pane E2E', () => {
             await openScmMerge(page, /conflict\.txt/i);
 
             // 4. Open File via inline button -> should open regular editor
-            await modifiedRow.hover();
             const openFileIcon = modifiedRow.getByRole('button', { name: 'Open File', exact: true }).first();
-            await expect(openFileIcon).toBeVisible();
-            await openFileIcon.click();
+            await hoverAndClick(modifiedRow, openFileIcon);
             await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
             await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
         } finally {
@@ -907,10 +905,8 @@ test.describe('SCM Pane E2E', () => {
             await openScmMerge(page, /conflict\.txt/i);
 
             // 4. Open Changes via inline button (for modified file) -> should open diff editor
-            await modifiedRow.hover();
             const openChangesIcon = modifiedRow.getByRole('button', { name: 'Open Changes', exact: true }).first();
-            await expect(openChangesIcon).toBeVisible();
-            await openChangesIcon.click();
+            await hoverAndClick(modifiedRow, openChangesIcon);
             await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
         } finally {
             await app.close();

--- a/src/test/integration-test-utils.ts
+++ b/src/test/integration-test-utils.ts
@@ -2,18 +2,23 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { CodeForgeRegistry } from '../code-forge-registry';
+import type { CodeForgeRegistry } from '../code-forge-registry';
+import type { Api } from '../extension';
 import type { JjRepository } from '../jj-repository';
-import { JjRepositoryManager } from '../jj-repository-manager';
-import { createMock } from './test-utils';
+import type { JjRepositoryManager } from '../jj-repository-manager';
+import type { JjScmProvider } from '../jj-scm-provider';
 
 export interface TestRepositoryContext {
     codeForgeRegistry: CodeForgeRegistry;
     repository: JjRepository;
     repositoryManager: JjRepositoryManager;
     workspaceState: vscode.Memento;
+    scmProvider: JjScmProvider;
+    dispose(): Promise<void>;
 }
 
 async function updateWorkspaceFoldersWithRetry(
@@ -50,6 +55,7 @@ export async function createTestRepositoryContext(
     repoPath: string,
     outputChannel: vscode.OutputChannel,
 ): Promise<TestRepositoryContext> {
+    void outputChannel;
     const originalFolders = vscode.workspace.workspaceFolders || [];
     const uri = vscode.Uri.file(repoPath);
 
@@ -72,45 +78,108 @@ export async function createTestRepositoryContext(
         }
     }
 
-    const codeForgeRegistry = new CodeForgeRegistry();
-    const store = new Map<string, unknown>();
-    const workspaceState = createMock<vscode.Memento>({
-        get: (key: string) => store.get(key),
-        update: (key: string, value: unknown) => {
-            store.set(key, value);
-            return Promise.resolve();
-        },
-        keys: () => Array.from(store.keys()),
-    });
-    const repositoryManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
-    const repository = await repositoryManager.maybeRegisterRepositoryContainingUri(
-        vscode.Uri.file(path.join(repoPath, 'placeholder.txt')),
-    );
+    // Get the global extension API
+    const extension = vscode.extensions.getExtension<Api>('jj-view.jj-view');
+    if (!extension) {
+        throw new Error('Extension jj-view.jj-view not found');
+    }
+    const api = await extension.activate();
+    const repositoryManager = api.repositoryManager;
+
+    // Wait for the repository to be registered by the global manager's scan
+    const realRoot = await fs.realpath(repoPath);
+
+    let repository = repositoryManager.getRepositoryForUri(vscode.Uri.file(realRoot));
     if (!repository) {
-        throw new Error(`Failed to dynamically register repository at ${repoPath}`);
+        await new Promise<void>((resolve, reject) => {
+            const disposable = repositoryManager.onDidChangeRepositories(() => {
+                repository = repositoryManager.getRepositoryForUri(vscode.Uri.file(realRoot));
+                if (repository) {
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+            repositoryManager.scanForRepositories();
+            setTimeout(() => {
+                disposable.dispose();
+                reject(new Error(`Timed out waiting for repository registration: ${realRoot}`));
+            }, 10000);
+        });
+    }
+    if (!repository) {
+        throw new Error(`Repository not found at path: ${realRoot}`);
+    }
+    const finalRepo = repository;
+
+    const scmProvider = api.scmProviders.get(finalRepo.rootUri.fsPath);
+    if (!scmProvider) {
+        throw new Error(`SCM provider not found for registered repository: ${finalRepo.rootUri.fsPath}`);
     }
 
-    // Intercept dispose to remove the workspace folder and release locks
-    const originalDispose = repositoryManager.dispose.bind(repositoryManager);
-    repositoryManager.dispose = async () => {
-        await originalDispose();
-        if (!isPresent) {
-            const currentFolders = vscode.workspace.workspaceFolders || [];
-            const index = currentFolders.findIndex((f) => f.uri.fsPath === uri.fsPath);
-            if (index !== -1) {
-                if ('onDidChangeWorkspaceFolders' in vscode.workspace) {
-                    await updateWorkspaceFoldersWithRetry(index, 1);
-                } else if ('updateWorkspaceFolders' in vscode.workspace) {
-                    vscode.workspace.updateWorkspaceFolders(index, 1);
+    const testContext: TestRepositoryContext = {
+        codeForgeRegistry: repositoryManager.codeForgeRegistry,
+        repository: finalRepo,
+        repositoryManager,
+        workspaceState: repositoryManager.workspaceState,
+        scmProvider,
+        dispose: async () => {
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+            await waitUntil(
+                () => {
+                    return vscode.window.tabGroups.all.every((group) => group.tabs.length === 0);
+                },
+                /*timeoutMs=*/ 2000,
+                /*intervalMs=*/ 50,
+            );
+            const normalizedTarget = path.normalize(realRoot).toLowerCase();
+            // Wait for the repository to be closed by the manager after removing the workspace folder
+            const closePromise = new Promise<void>((resolve) => {
+                const disposable = repositoryManager.onDidCloseRepository((r) => {
+                    if (path.normalize(r.rootUri.fsPath).toLowerCase() === normalizedTarget) {
+                        disposable.dispose();
+                        resolve();
+                    }
+                });
+                // Safety timeout
+                setTimeout(() => {
+                    disposable.dispose();
+                    resolve();
+                }, 10000);
+            });
+
+            if (!isPresent) {
+                const currentFolders = vscode.workspace.workspaceFolders || [];
+                const index = currentFolders.findIndex((f) => f.uri.fsPath === uri.fsPath);
+                if (index !== -1) {
+                    if ('onDidChangeWorkspaceFolders' in vscode.workspace) {
+                        await updateWorkspaceFoldersWithRetry(index, 1);
+                    } else if ('updateWorkspaceFolders' in vscode.workspace) {
+                        vscode.workspace.updateWorkspaceFolders(index, 1);
+                    }
                 }
+                await closePromise;
             }
-        }
+        },
     };
 
-    return {
-        codeForgeRegistry,
-        repository,
-        repositoryManager,
-        workspaceState,
-    };
+    return testContext;
+}
+
+/**
+ * Polls the given condition until it returns true or the timeout is reached.
+ * Returns true if the condition was met, false if it timed out.
+ */
+export async function waitUntil(
+    condition: () => boolean | Promise<boolean>,
+    timeoutMs = 2000,
+    intervalMs = 50,
+): Promise<boolean> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeoutMs) {
+        if (await condition()) {
+            return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return await condition();
 }

--- a/src/test/jj-decoration-provider.test.ts
+++ b/src/test/jj-decoration-provider.test.ts
@@ -337,4 +337,51 @@ describe('JjDecorationProvider', () => {
         // If it's considered tracked, it returns undefined instead of the 'Ignored' decoration
         expect(resDir).toBeUndefined();
     });
+
+    it('should coalesce concurrent calls for the same path and clear pendingPromises afterwards', async () => {
+        const mockJjService = createMock<JjService>({
+            checkTrackedPaths: vi.fn().mockResolvedValue([]),
+        });
+        provider = new JjDecorationProvider(mockJjService, '/ws');
+        const uri = (await import('vscode')).Uri.file('/ws/coalesce.txt');
+        const mockToken = createMock<vscode.CancellationToken>({});
+
+        // 1. Call twice in quick succession
+        const p1 = provider.provideFileDecoration(uri, mockToken);
+        const p2 = provider.provideFileDecoration(uri, mockToken);
+
+        // They should return the exact same promise (coalesced)
+        expect(p1).toBe(p2);
+
+        // 2. Wait for flush
+        await new Promise((r) => setTimeout(r, 60));
+
+        const res1 = await p1;
+        const res2 = await p2;
+
+        expect(res1?.tooltip).toBe('Ignored');
+        expect(res2?.tooltip).toBe('Ignored');
+
+        // checkTrackedPaths should only have been called once
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalledTimes(1);
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalledWith(['coalesce.txt']);
+
+        // Clear mock calls and manually delete from cache to force a re-check
+        vi.mocked(mockJjService.checkTrackedPaths).mockClear();
+        const cache = accessPrivate<Map<string, unknown>>(provider, 'trackedStatusCache');
+        cache.delete('coalesce.txt');
+
+        // Verify pendingPromises map is empty for this path
+        const pendingPromises = accessPrivate<Map<string, unknown>>(provider, 'pendingPromises');
+        expect(pendingPromises.has('coalesce.txt')).toBe(false);
+
+        // 3. A later call should issue a new query because the pending promise has been cleared
+        const p3 = provider.provideFileDecoration(uri, mockToken);
+
+        // Wait for flush
+        await new Promise((r) => setTimeout(r, 60));
+        await p3;
+
+        expect(mockJjService.checkTrackedPaths).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
@@ -25,8 +25,6 @@ suite('JJ Decoration Integration Test', () => {
         repo = new TestRepo();
         repo.init();
 
-        // Instantiate services manually for control
-        const context = createMock<vscode.ExtensionContext>({ subscriptions: [] });
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
             append: () => {},
@@ -39,20 +37,12 @@ suite('JJ Decoration Integration Test', () => {
         });
 
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
     });
 
     teardown(async () => {
-        if (scmProvider) {
-            scmProvider.dispose();
-        }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -184,6 +184,18 @@ describe('JjEditFileSystemProvider', () => {
         expect(disposable).toHaveProperty('dispose');
     });
 
+    it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {
+        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt?revision=@');
+        await expect(provider.readFile(outsideUri)).rejects.toThrowError('No Jujutsu repository found');
+    });
+
+    it('writeFile throws FileSystemError.Unavailable when no repository is found', async () => {
+        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt?revision=@');
+        await expect(provider.writeFile(outsideUri, Buffer.from('content'))).rejects.toThrowError(
+            'No Jujutsu repository found',
+        );
+    });
+
     it('unsupported operations throw', () => {
         expect(() => provider.readDirectory()).toThrow('jj-edit is file-only');
         expect(() => provider.createDirectory()).toThrow('jj-edit is file-only');

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -101,6 +101,12 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     teardown(async () => {
+        const extension = vscode.extensions.getExtension<import('../extension').Api>('jj-view.jj-view');
+        if (extension) {
+            const api = await extension.activate();
+            await api.repositoryManager.clear();
+        }
+
         await manager.dispose();
         registry.dispose();
 
@@ -311,12 +317,18 @@ suite('JjRepositoryManager Integration Test', () => {
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(otherRepo.path)]);
 
         await manager.scanForRepositories();
-        assert.strictEqual(manager.focusedRepository?.rootUri.fsPath, mainRepo.path);
+        const initialFocus = manager.focusedRepository?.rootUri.fsPath;
+        assert.ok(
+            initialFocus === mainRepo.path || initialFocus === otherRepo.path,
+            'Should focus one of the registered repositories',
+        );
 
-        const fileUri = vscode.Uri.file(path.join(otherRepo.path, 'file.ts'));
+        const targetPath = initialFocus === mainRepo.path ? otherRepo.path : mainRepo.path;
+
+        const fileUri = vscode.Uri.file(path.join(targetPath, 'file.ts'));
         manager.tryAutoSwitch(fileUri);
 
-        assert.strictEqual(manager.focusedRepository?.rootUri.fsPath, otherRepo.path);
+        assert.strictEqual(manager.focusedRepository?.rootUri.fsPath, targetPath);
     });
 
     test('getRepositoryForUri matches files through symbolic links', async () => {
@@ -555,6 +567,27 @@ suite('JjRepositoryManager Integration Test', () => {
             repo1,
             repo2,
             'Concurrent registrations for same path must resolve to same repository instance',
+        );
+        assert.strictEqual(manager.repositories.length, 1);
+    });
+
+    test('maybeRegisterRepositoryContainingUri resolves concurrent calls for different paths under the same repository', async () => {
+        const subfolder1 = path.join(mainRepo.path, 'src');
+        const subfolder2 = path.join(mainRepo.path, 'test');
+        fs.mkdirSync(subfolder1, { recursive: true });
+        fs.mkdirSync(subfolder2, { recursive: true });
+
+        const [repo1, repo2] = await Promise.all([
+            manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(subfolder1)),
+            manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(subfolder2)),
+        ]);
+
+        assert.ok(repo1);
+        assert.ok(repo2);
+        assert.strictEqual(
+            repo1,
+            repo2,
+            'Concurrent registrations for different paths in same repo must resolve to same repository instance',
         );
         assert.strictEqual(manager.repositories.length, 1);
     });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -12,10 +12,10 @@ import { squashFilesIntoParentCommand } from '../commands/squash-files';
 import { completeSquashRevisionCommand, squashRevisionIntoParentCommand } from '../commands/squash-revision';
 import { squashSelectionIntoParentCommand } from '../commands/squash-selection';
 import { ScmContextValue } from '../jj-context-keys';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
-import { createTestRepositoryContext } from './integration-test-utils';
+import { createTestRepositoryContext, waitUntil } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
 
@@ -36,13 +36,6 @@ suite('JJ SCM Provider Integration Test', () => {
         repo = new TestRepo();
         repo.init();
 
-        // Initialize Service and Provider
-        // Mock context
-        const context = createMock<vscode.ExtensionContext>({
-            subscriptions: [],
-            storageUri: vscode.Uri.file(path.join(repo.path, '.vscode-storage')),
-        });
-
         jj = new JjService(repo.path);
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
@@ -55,12 +48,7 @@ suite('JJ SCM Provider Integration Test', () => {
             name: 'mock',
         });
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
     });
 
     teardown(async () => {
@@ -68,11 +56,8 @@ suite('JJ SCM Provider Integration Test', () => {
         // Allow VS Code to settle before disposing repository
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        if (scmProvider) {
-            scmProvider.dispose();
-        }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         if (repo) {
             repo.dispose();
@@ -710,7 +695,7 @@ suite('JJ SCM Provider Integration Test', () => {
         // This validates the fix for "Cannot use 'in' operator to search for 'resourceUri' in string"
         // Setup: Ensure we have a clean state with a parent
         repo.describe('parent');
-        repo.new([], 'child');
+        repo.new([]);
         const revision = repo.getChangeId('@');
 
         // Call squash with just the revision string
@@ -889,6 +874,16 @@ suite('JJ SCM Provider Integration Test', () => {
 
         try {
             await compareAllFilesWithRevisionCommand(jj, scmProvider.outputChannel, ids.v1.changeId);
+            // Wait for the comparison editor to be open before finishing the test
+            await waitUntil(
+                () => {
+                    return vscode.window.tabGroups.all.some((group) => {
+                        return group.tabs.some((tab) => tab.label.includes('Compare'));
+                    });
+                },
+                /*timeoutMs=*/ 2000,
+                /*intervalMs=*/ 50,
+            );
         } catch (e: unknown) {
             assert.fail(`compareAllFilesWithRevisionCommand failed: ${(e as Error).message}`);
         }

--- a/src/test/jj-view-fs-provider.test.ts
+++ b/src/test/jj-view-fs-provider.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createVscodeMock } from './vscode-mock';
+
+vi.mock('vscode', () => createVscodeMock());
+
+import * as vscode from 'vscode';
+import { CodeForgeRegistry } from '../code-forge-registry';
+import { JjRepositoryManager } from '../jj-repository-manager';
+import { JjViewFileSystemProvider } from '../jj-view-fs-provider';
+import { TestRepo } from './test-repo';
+import { createMock } from './test-utils';
+
+describe('JjViewFileSystemProvider', () => {
+    let repo: TestRepo;
+    let repoManager: JjRepositoryManager;
+    let provider: JjViewFileSystemProvider;
+
+    beforeEach(async () => {
+        repo = new TestRepo();
+        repo.init();
+
+        const codeForgeRegistry = new CodeForgeRegistry();
+        const outputChannel = createMock<vscode.OutputChannel>({
+            appendLine: () => {},
+        });
+        const workspaceState = createMock<vscode.Memento>({
+            get: vi.fn().mockReturnValue(undefined),
+            update: vi.fn().mockResolvedValue(undefined),
+        });
+
+        repoManager = new JjRepositoryManager(codeForgeRegistry, outputChannel, workspaceState);
+
+        // Register the real repository
+        vscode.workspace.updateWorkspaceFolders(0, vscode.workspace.workspaceFolders?.length, {
+            uri: vscode.Uri.file(repo.path),
+        });
+        await repoManager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(repo.path));
+
+        provider = new JjViewFileSystemProvider(repoManager);
+    });
+
+    afterEach(async () => {
+        await repoManager.dispose();
+        repo.dispose();
+    });
+
+    it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {
+        const outsideUri = vscode.Uri.parse('jj-view:///outside/file.txt?revision=@');
+        await expect(provider.readFile(outsideUri)).rejects.toThrowError('No Jujutsu repository found');
+    });
+});

--- a/src/test/jj-visibility.integration.test.ts
+++ b/src/test/jj-visibility.integration.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import { ScmContextValue } from '../jj-context-keys';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { accessPrivate, createMock } from './test-utils';
@@ -21,11 +21,6 @@ suite('JJ SCM Visibility Integration Test', () => {
         repo = new TestRepo();
         repo.init();
 
-        // Initialize Service and Provider
-        const context = createMock<vscode.ExtensionContext>({
-            subscriptions: [],
-        });
-
         outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
             append: () => {},
@@ -37,18 +32,12 @@ suite('JJ SCM Visibility Integration Test', () => {
             name: 'mock',
         });
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
     });
 
     teardown(async () => {
-        scmProvider.dispose();
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/provide-original-resource.integration.test.ts
+++ b/src/test/provide-original-resource.integration.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { createMock } from './test-utils';
@@ -19,10 +19,6 @@ suite('JjScmProvider provideOriginalResource Integration Test', () => {
         repo = new TestRepo();
         repo.init();
 
-        const context = createMock<vscode.ExtensionContext>({
-            subscriptions: [],
-        });
-
         const outputChannel = createMock<vscode.OutputChannel>({
             appendLine: () => {},
             append: () => {},
@@ -34,20 +30,12 @@ suite('JjScmProvider provideOriginalResource Integration Test', () => {
             name: 'mock',
         });
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-        );
+        scmProvider = contextHelper.scmProvider;
     });
 
     teardown(async () => {
-        if (scmProvider) {
-            scmProvider.dispose();
-        }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/quick-diff.integration.test.ts
+++ b/src/test/quick-diff.integration.test.ts
@@ -6,9 +6,9 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
-import { JjViewFileSystemProvider } from '../jj-view-fs-provider';
+import type { JjViewFileSystemProvider } from '../jj-view-fs-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { createMock } from './test-utils';
@@ -20,6 +20,8 @@ suite('Quick Diff Integration Test', () => {
     let repo: TestRepo;
     let canonicalPath: string;
     let disposable: vscode.Disposable;
+    let originalProvideOriginalResource: typeof scmProvider.provideOriginalResource | undefined;
+    let originalReadFile: typeof viewFileSystemProvider.readFile | undefined;
     let contextHelper: import('./integration-test-utils').TestRepositoryContext;
 
     setup(async () => {
@@ -27,10 +29,6 @@ suite('Quick Diff Integration Test', () => {
         repo.init();
         // Canonicalize path to resolve RUNNER~1 short names on Windows
         canonicalPath = fs.realpathSync(repo.path);
-
-        const context = createMock<vscode.ExtensionContext>({
-            subscriptions: [],
-        });
 
         jj = new JjService(canonicalPath);
         const outputChannel = createMock<vscode.OutputChannel>({
@@ -42,16 +40,16 @@ suite('Quick Diff Integration Test', () => {
 
         contextHelper = await createTestRepositoryContext(canonicalPath, outputChannel);
 
-        viewFileSystemProvider = new JjViewFileSystemProvider(contextHelper.repositoryManager);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-            viewFileSystemProvider,
-        );
+        scmProvider = contextHelper.scmProvider;
+        if (!scmProvider.viewFileSystemProvider) {
+            throw new Error('viewFileSystemProvider is not defined on scmProvider');
+        }
+        viewFileSystemProvider = scmProvider.viewFileSystemProvider;
 
         disposable = vscode.workspace.registerFileSystemProvider('jj-view-test', viewFileSystemProvider);
+
+        originalProvideOriginalResource = scmProvider.provideOriginalResource;
+        originalReadFile = viewFileSystemProvider.readFile;
 
         // Override provideOriginalResource to return the test scheme
         scmProvider.provideOriginalResource = (uri: vscode.Uri) => {
@@ -67,11 +65,15 @@ suite('Quick Diff Integration Test', () => {
         // Small delay to allow VS Code to settle before disposing providers
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        if (scmProvider) {
-            scmProvider.dispose();
+        if (originalProvideOriginalResource && scmProvider) {
+            scmProvider.provideOriginalResource = originalProvideOriginalResource;
         }
+        if (originalReadFile && viewFileSystemProvider) {
+            viewFileSystemProvider.readFile = originalReadFile;
+        }
+
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         if (disposable) {
             disposable.dispose();

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -8,9 +8,9 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { discardChangeCommand } from '../commands/discard-change';
 import { squashHunkIntoParentCommand } from '../commands/squash-selection';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
-import { JjViewFileSystemProvider } from '../jj-view-fs-provider';
+import type { JjViewFileSystemProvider } from '../jj-view-fs-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { createMock } from './test-utils';
@@ -47,14 +47,11 @@ suite('Quick Diff Commands Integration Test', () => {
         });
         contextHelper = await createTestRepositoryContext(canonicalPath, outputChannel);
 
-        viewFileSystemProvider = new JjViewFileSystemProvider(contextHelper.repositoryManager);
-        scmProvider = new JjScmProvider(
-            context,
-            contextHelper.repository,
-            outputChannel,
-            contextHelper.repositoryManager,
-            viewFileSystemProvider,
-        );
+        scmProvider = contextHelper.scmProvider;
+        if (!scmProvider.viewFileSystemProvider) {
+            throw new Error('viewFileSystemProvider is not defined on scmProvider');
+        }
+        viewFileSystemProvider = scmProvider.viewFileSystemProvider;
 
         // Register a test-specific content provider to handle a unique scheme per test
         // This avoids conflict with the main extension's 'jj-view' provider and parallel tests
@@ -75,11 +72,8 @@ suite('Quick Diff Commands Integration Test', () => {
         // Small delay to allow VS Code to settle before disposing providers
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        if (scmProvider) {
-            scmProvider.dispose();
-        }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         if (jjViewProviderDisposable) {
             jjViewProviderDisposable.dispose();

--- a/src/test/utils/coalescing-queue.test.ts
+++ b/src/test/utils/coalescing-queue.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, test } from 'vitest';
+import { CoalescingQueue } from '../../utils/coalescing-queue';
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('CoalescingQueue', () => {
+    test('runs a task when queue is idle', async () => {
+        let runCount = 0;
+        const queue = new CoalescingQueue(async () => {
+            runCount++;
+        });
+
+        await queue.run();
+        expect(runCount).toBe(1);
+    });
+
+    test('coalesces concurrent requests during active task', async () => {
+        let runCount = 0;
+        const resolveTasks: (() => void)[] = [];
+
+        const queue = new CoalescingQueue(() => {
+            runCount++;
+            return new Promise<void>((resolve) => {
+                resolveTasks.push(resolve);
+            });
+        });
+
+        // Start task 1
+        const p1 = queue.run();
+        expect(runCount).toBe(1);
+
+        // Queue task 2 (while task 1 is active)
+        const p2 = queue.run();
+        const p3 = queue.run();
+        expect(runCount).toBe(1); // Task 2 has not started yet
+
+        // Complete task 1
+        resolveTasks.shift()?.();
+        await p1;
+        await tick(); // Allow task 2 to start
+
+        // At this point, task 2 should have started
+        expect(runCount).toBe(2);
+
+        // Complete task 2
+        resolveTasks.shift()?.();
+        await p2;
+        await p3;
+
+        expect(runCount).toBe(2);
+    });
+
+    test('properly queues task 3 when requested while task 2 is running', async () => {
+        let runCount = 0;
+        const resolveTasks: (() => void)[] = [];
+
+        const queue = new CoalescingQueue(() => {
+            runCount++;
+            return new Promise<void>((resolve) => {
+                resolveTasks.push(resolve);
+            });
+        });
+
+        // 1. Start task 1
+        const p1 = queue.run();
+        expect(runCount).toBe(1);
+
+        // 2. Queue task 2
+        const p2 = queue.run();
+
+        // 3. Resolve task 1, starting task 2
+        resolveTasks.shift()?.();
+        await p1;
+        await tick(); // Allow task 2 to start
+
+        expect(runCount).toBe(2);
+
+        // 4. While task 2 is active, request run() again. This should queue task 3!
+        const p3 = queue.run();
+        expect(runCount).toBe(2); // Task 3 not started yet
+
+        // 5. Resolve task 2, starting task 3
+        resolveTasks.shift()?.();
+        await p2;
+        await tick(); // Allow task 3 to start
+
+        expect(runCount).toBe(3);
+
+        // 6. Complete task 3
+        resolveTasks.shift()?.();
+        await p3;
+
+        expect(runCount).toBe(3);
+    });
+
+    test('handles errors thrown by task and continues', async () => {
+        let runCount = 0;
+        const queue = new CoalescingQueue(async () => {
+            runCount++;
+            if (runCount === 1) {
+                throw new Error('Task failed');
+            }
+        });
+
+        await expect(queue.run()).rejects.toThrow('Task failed');
+        expect(runCount).toBe(1);
+
+        await queue.run();
+        expect(runCount).toBe(2);
+    });
+
+    test('handles synchronous exceptions thrown by task', async () => {
+        let runCount = 0;
+        const queue = new CoalescingQueue(() => {
+            runCount++;
+            throw new Error('Sync Task failed');
+        });
+
+        await expect(queue.run()).rejects.toThrow('Sync Task failed');
+        expect(runCount).toBe(1);
+        expect(queue.currentRun).toBeUndefined();
+
+        // Check that subsequent runs are still handled correctly
+        const queue2 = new CoalescingQueue(async () => {
+            runCount++;
+        });
+        await queue2.run();
+        expect(runCount).toBe(2);
+    });
+
+    test('queues subsequent run request while a synchronous error run is settling', async () => {
+        let runCount = 0;
+        let shouldThrow = true;
+        const queue = new CoalescingQueue(() => {
+            runCount++;
+            if (shouldThrow) {
+                throw new Error('Sync Task failed');
+            }
+            return Promise.resolve();
+        });
+
+        // 1. Start task 1 (which throws synchronously)
+        const p1 = queue.run();
+        expect(runCount).toBe(1);
+
+        // 2. Queue task 2 (before p1 settles/rejects in the microtask loop)
+        shouldThrow = false;
+        const p2 = queue.run();
+
+        // Task 2 should not have run yet since task 1's promise has not settled
+        expect(runCount).toBe(1);
+
+        // 3. Let task 1 settle and task 2 run
+        await expect(p1).rejects.toThrow('Sync Task failed');
+        await p2;
+
+        // Task 2 should have run and completed
+        expect(runCount).toBe(2);
+    });
+});

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -13,7 +13,7 @@ import { squashRevisionIntoParentCommand } from '../commands/squash-revision';
 import { undoCommand } from '../commands/undo';
 import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 import { JjLogWebviewProvider } from '../jj-log-webview-provider';
-import { JjScmProvider } from '../jj-scm-provider';
+import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
@@ -86,10 +86,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
 
         const extensionUri = vscode.Uri.file(__dirname);
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
-        disposables.push(contextHelper.repositoryManager);
-
-        scm = new JjScmProvider(mockContext, contextHelper.repository, outputChannel, contextHelper.repositoryManager);
-        disposables.push(scm);
+        scm = contextHelper.scmProvider;
 
         const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, contextHelper.repositoryManager);
         provider = new JjLogWebviewProvider(
@@ -144,6 +141,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
             await d.dispose();
         }
         disposables = [];
+        if (contextHelper) {
+            await contextHelper.dispose();
+        }
         if (repo) {
             repo.dispose();
         }

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -54,7 +54,7 @@ suite('Webview Initialization Integration Test', () => {
         });
         const extensionUri = vscode.Uri.file(__dirname);
         const context = await createTestRepositoryContext(repo.path, outputChannel);
-        disposables.push(context.repositoryManager);
+        disposables.push(context);
 
         const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, context.repositoryManager);
         provider = new JjLogWebviewProvider(

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -95,7 +95,7 @@ suite('Webview Selection Integration Test', () => {
             executeCommandStub.restore();
         }
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -90,7 +90,7 @@ suite('Webview Visibility Integration Test', () => {
         });
         disposables = [];
         if (contextHelper) {
-            await contextHelper.repositoryManager.dispose();
+            await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
         repo.dispose();

--- a/src/utils/coalescing-queue.ts
+++ b/src/utils/coalescing-queue.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A queue that runs an async task sequentially, ensuring at most one execution is active at a time.
+ * If another run is requested while one is active, it runs exactly one more time after the current
+ * run completes. Multiple concurrent requests coalesce to return the promise of that next run.
+ */
+export class CoalescingQueue {
+    private _active: Promise<void> | undefined;
+    private _queued: Promise<void> | undefined;
+
+    constructor(private readonly _task: () => Promise<void>) {}
+
+    get currentRun(): Promise<void> | undefined {
+        return this._queued || this._active;
+    }
+
+    private runTask(): Promise<void> {
+        try {
+            this._active = this._task().finally(() => {
+                this._active = undefined;
+            });
+            return this._active;
+        } catch (err) {
+            this._active = Promise.reject(err).finally(() => {
+                this._active = undefined;
+            });
+            return this._active;
+        }
+    }
+
+    run(): Promise<void> {
+        if (this._queued) {
+            return this._queued;
+        }
+
+        if (this._active) {
+            this._queued = this._active
+                .catch(() => {})
+                .then(() => {
+                    this._queued = undefined;
+                    return this.runTask();
+                });
+            return this._queued;
+        }
+
+        return this.runTask();
+    }
+}


### PR DESCRIPTION
Refactor repository detection to run probe operations concurrently using `Promise.all` instead of sequentially.

- Introduce `CoalescingQueue` to coalesce concurrent scanning requests and coordinate execution.
- Add `_pendingRepoRoots` to deduplicate concurrent root-resolution paths.
- Prevent event emissions after repository manager disposal.

## Summary by Sourcery

Parallelize and coalesce repository scanning and related filesystem operations while hardening disposal behavior and integrating tests with the extension’s global repository manager.

New Features:
- Introduce a CoalescingQueue utility to serialize async tasks with coalesced concurrent requests.
- Expose extension API access to the global repository manager’s SCM providers for tests and consumers.
- Add an explicit closeRepository method on the repository manager to remove and dispose a single repository by URI.

Bug Fixes:
- Prevent repository and event-emitter operations from running after the manager or repository has been disposed.
- Ensure edit and view file system providers only emit change events for URIs that still belong to a known repository.
- Fix JjService timeout cleanup so operation timeouts are always cleared for mutating commands.
- Make jj-edit file system provider throw clear errors when no repository is found for a URI.

Enhancements:
- Refactor repository scanning to run probe operations concurrently while coalescing overlapping scans and repo-root resolution requests.
- Sort repositories by workspace folder and path for more predictable ordering and focus behavior.
- Reuse the activated extension’s repository manager and SCM provider in integration tests instead of constructing separate instances.
- Improve SCM, webview, and decoration tests to wait for VS Code UI state and coalesce decoration requests, reducing flakiness.

Tests:
- Add unit tests for CoalescingQueue and decoration coalescing behavior.
- Update numerous integration and E2E tests to work against the global repository manager and SCM providers and to use new helpers like waitUntil and hoverAndClick.