### PR TITLE
fix: restrict merge editor to conflict resource group

### DIFF
--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -380,7 +380,10 @@ export class JjScmProvider implements vscode.Disposable {
                     // 4. Update Conflict Group (conflictedPaths fetched above)
                     this._conflictGroup.resourceStates = conflictedPaths.map((path) => {
                         const entry: JjStatusEntry = { path, status: 'modified', conflicted: true };
-                        const state = this.toResourceState(entry, currentEntry?.change_id || '@', { openDiffOnClick });
+                        const state = this.toResourceState(entry, currentEntry?.change_id || '@', {
+                            openDiffOnClick,
+                            inConflictGroup: true,
+                        });
                         decorationMap.set(state.resourceUri.toString(), entry);
                         return state;
                     });

--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -25,6 +25,7 @@ export function createJjResourceState(
         multipleAncestors?: boolean;
         openDiffOnClick?: boolean;
         hasChild?: boolean;
+        inConflictGroup?: boolean;
     } = {},
 ): JjResourceState {
     const isCurrentWorkingCopy = revision === '@' || revision === options.workingCopyChangeId;
@@ -41,25 +42,26 @@ export function createJjResourceState(
         arguments: [leftUri, rightUri, diffTitle],
     };
 
-    const command: vscode.Command = entry.conflicted
-        ? {
-              command: 'jj-view.openMergeEditor',
-              title: 'Open 3-Way Merge',
-              arguments: [{ resourceUri }],
-          }
-        : openDiffOnClick || isDeleted
-          ? diffCommand
-          : {
-                command: 'vscode.open',
-                title: 'Open File',
-                arguments: [resourceUri.with({ query: '' })],
-            };
+    const command: vscode.Command =
+        entry.conflicted && options.inConflictGroup
+            ? {
+                  command: 'jj-view.openMergeEditor',
+                  title: 'Open 3-Way Merge',
+                  arguments: [{ resourceUri }],
+              }
+            : openDiffOnClick || isDeleted
+              ? diffCommand
+              : {
+                    command: 'vscode.open',
+                    title: 'Open File',
+                    arguments: [resourceUri.with({ query: '' })],
+                };
 
     const flags: string[] = [];
 
     flags.push(ScmContextValue.ResourceAllowRestore);
 
-    if (entry.conflicted) {
+    if (entry.conflicted && options.inConflictGroup) {
         flags.push(ScmContextValue.ResourceAllowOpenMergeEditor);
     } else {
         flags.push(ScmContextValue.ResourceAllowOpen);

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -863,6 +863,11 @@ suite('JJ SCM Provider Integration Test', () => {
             (conflictState.contextValue as string).includes(ScmContextValue.ResourceAllowOpenMergeEditor),
             'Conflict Resource State mismatch',
         );
+        assert.strictEqual(
+            conflictState.command?.command,
+            'jj-view.openMergeEditor',
+            'Conflicted file in conflict group should default to openMergeEditor',
+        );
 
         // 5. Assert Parent Resource Group
         assert.ok(parentGroups.length > 0, 'Should have parent group');

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -106,16 +106,32 @@ describe('createJjResourceState', () => {
     describe('Command Routing', () => {
         const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
 
-        it('routes to merge editor if conflicted, ignoring openDiffOnClick settings', () => {
+        it('routes to merge editor if conflicted in conflict group, ignoring openDiffOnClick settings', () => {
             const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
             const state = createJjResourceState(conflictedEntry, 'rev123', root, {
                 openDiffOnClick: false,
+                inConflictGroup: true,
             });
 
             expect(state.command?.command).toBe('jj-view.openMergeEditor');
             expect(state.command?.arguments?.[0]).toEqual({
                 resourceUri: state.resourceUri,
             });
+        });
+
+        it('routes to diff/open for conflicted files not in conflict group', () => {
+            const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
+            const stateDiff = createJjResourceState(conflictedEntry, 'rev123', root, {
+                openDiffOnClick: true,
+                inConflictGroup: false,
+            });
+            expect(stateDiff.command?.command).toBe('vscode.diff');
+
+            const stateOpen = createJjResourceState(conflictedEntry, 'rev123', root, {
+                openDiffOnClick: false,
+                inConflictGroup: false,
+            });
+            expect(stateOpen.command?.command).toBe('vscode.open');
         });
 
         it('routes to diff command if openDiffOnClick is true', () => {
@@ -176,9 +192,10 @@ describe('createJjResourceState', () => {
     describe('Context Capabilities (ContextValue)', () => {
         const entry: JjStatusEntry = { path: 'file.txt', status: 'modified' };
 
-        it('gives conflicted entries restore and openMergeEditor flags, but no open or squash flags', () => {
+        it('gives conflicted entries in conflict group restore and openMergeEditor flags, but no open or squash flags', () => {
             const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
             const state = createJjResourceState(conflictedEntry, 'rev123', root, {
+                inConflictGroup: true,
                 squashable: true,
                 multipleAncestors: true,
                 hasChild: true,
@@ -191,6 +208,41 @@ describe('createJjResourceState', () => {
             expect(flags).not.toContain('jj.resource.allowSquashIntoParent');
             expect(flags).not.toContain('jj.resource.allowSquashIntoAncestor');
             expect(flags).not.toContain('jj.resource.allowSquashIntoChild');
+        });
+
+        it('gives conflicted entries not in conflict group normal restore, open, and squash flags', () => {
+            const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
+            const state = createJjResourceState(conflictedEntry, 'rev123', root, {
+                inConflictGroup: false,
+                squashable: true,
+                multipleAncestors: true,
+                hasChild: true,
+            });
+
+            const flags = state.contextValue?.split(' ') || [];
+            expect(flags).toContain('jj.resource.allowRestore');
+            expect(flags).not.toContain('jj.resource.allowOpenMergeEditor');
+            expect(flags).toContain('jj.resource.allowOpen');
+            expect(flags).toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).toContain('jj.resource.allowSquashIntoAncestor');
+            expect(flags).toContain('jj.resource.allowSquashIntoChild');
+        });
+
+        it('gives conflicted entries with omitted inConflictGroup normal restore, open, and squash flags', () => {
+            const conflictedEntry: JjStatusEntry = { ...entry, conflicted: true };
+            const state = createJjResourceState(conflictedEntry, 'rev123', root, {
+                squashable: true,
+                multipleAncestors: true,
+                hasChild: true,
+            });
+
+            const flags = state.contextValue?.split(' ') || [];
+            expect(flags).toContain('jj.resource.allowRestore');
+            expect(flags).not.toContain('jj.resource.allowOpenMergeEditor');
+            expect(flags).toContain('jj.resource.allowOpen');
+            expect(flags).toContain('jj.resource.allowSquashIntoParent');
+            expect(flags).toContain('jj.resource.allowSquashIntoAncestor');
+            expect(flags).toContain('jj.resource.allowSquashIntoChild');
         });
 
         it('gives basic non-conflicted entries restore and open flags', () => {


### PR DESCRIPTION
Only route to the merge editor and apply the open-merge-editor context flag for conflicted files that belong to the conflict resource group. Conflicted files in other resource groups will fall back to normal diff/open click behavior and receive normal command flags.

Fixes #352

## Summary by Sourcery

Restrict conflicted file handling so that only entries in the conflict resource group open the merge editor and receive merge-editor-specific context, while conflicted files in other groups use normal diff/open behavior and flags.

Bug Fixes:
- Ensure conflicted files outside the conflict resource group no longer route to the merge editor and instead follow configured diff/open click behavior.
- Limit merge-editor context flags to conflicted entries in the conflict resource group so other conflicted entries retain standard restore/open/squash capabilities.

Tests:
- Extend SCM resource state unit tests and JJ SCM integration tests to cover conflict-group-specific command routing and context flags for conflicted files.