### PR TITLE
feat: add abandonDescendants command

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,6 +334,12 @@
                 "icon": "$(trash)"
             },
             {
+                "command": "jj-view.abandonDescendants",
+                "title": "Abandon Descendants",
+                "category": "JJ View",
+                "icon": "$(trash)"
+            },
+            {
                 "command": "jj-view.edit",
                 "title": "Edit",
                 "category": "JJ View",
@@ -789,9 +795,14 @@
                     "group": "4_changes@2"
                 },
                 {
+                    "command": "jj-view.abandonDescendants",
+                    "when": "webviewSection == 'commit' && jj.canAbandon",
+                    "group": "4_changes@3"
+                },
+                {
                     "command": "jj-view.absorb",
                     "when": "webviewSection == 'commit' && jj.canAbsorb",
-                    "group": "4_changes@3"
+                    "group": "4_changes@4"
                 },
                 {
                     "command": "jj-view.upload",
@@ -934,23 +945,28 @@
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowAbandon\\b/"
                 },
                 {
-                    "command": "jj-view.squashRevisionIntoAncestor",
+                    "command": "jj-view.abandonDescendants",
                     "group": "inline@3",
-                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowAbandon\\b/"
                 },
                 {
-                    "command": "jj-view.squashRevisionIntoParent",
+                    "command": "jj-view.squashRevisionIntoAncestor",
                     "group": "inline@4",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
                 },
                 {
-                    "command": "jj-view.showDetails",
+                    "command": "jj-view.squashRevisionIntoParent",
                     "group": "inline@5",
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowSquash\\b/"
+                },
+                {
+                    "command": "jj-view.showDetails",
+                    "group": "inline@6",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowShowDetails\\b/"
                 },
                 {
                     "command": "jj-view.edit",
-                    "group": "inline@6",
+                    "group": "inline@7",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowEdit\\b/"
                 }
             ],

--- a/src/commands/abandon-descendants.ts
+++ b/src/commands/abandon-descendants.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjService } from '../jj-service';
+import { extractRevision, isCurrentWorkingCopyResourceGroup, showJjError, withDelayedProgress } from './command-utils';
+
+const MAX_LISTED = 10;
+
+export async function abandonDescendantsCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    let revision: string | undefined;
+
+    // 1. Check if triggered from Working Copy header
+    if (args.some((arg) => isCurrentWorkingCopyResourceGroup(arg))) {
+        revision = '@';
+    } else {
+        // 2. Check explicit argument (e.g. context menu click)
+        revision = extractRevision(args);
+
+        // 3. Check selection
+        if (!revision) {
+            const selectedRevisions = scmProvider.getSelectedCommitIds();
+            if (selectedRevisions.length > 0) {
+                revision = selectedRevisions[0];
+            }
+        }
+
+        // 4. Prompt the user
+        if (!revision) {
+            const input = await vscode.window.showInputBox({
+                prompt: 'Enter revision to abandon descendants of',
+                placeHolder: 'Revision ID (e.g. @, change_id)',
+            });
+            if (input) {
+                revision = input;
+            }
+        }
+    }
+
+    if (!revision) {
+        return;
+    }
+
+    const descendants = await jj.getDescendants(revision);
+    const count = descendants.length;
+
+    const lines: string[] = [];
+    const shown = descendants.slice(0, MAX_LISTED);
+    for (const d of shown) {
+        const desc = d.description || '(no description)';
+        lines.push(`  ${d.changeId}  ${desc}`);
+    }
+    if (count > MAX_LISTED) {
+        lines.push(`  ...and ${count - MAX_LISTED} more`);
+    }
+
+    const label =
+        count === 0
+            ? `${revision}`
+            : count === 1
+              ? `${revision} and 1 descendant`
+              : `${revision} and ${count} descendants`;
+
+    const choice = await vscode.window.showWarningMessage(
+        `Abandon ${label}?\n\n${lines.join('\n')}`,
+        { modal: true },
+        'Abandon',
+    );
+
+    if (choice !== 'Abandon') {
+        return;
+    }
+
+    try {
+        await withDelayedProgress('Abandoning descendants...', jj.abandon([`${revision}::`]));
+        await scmProvider.refresh();
+        vscode.window.showInformationMessage(`Abandoned ${label}.`);
+    } catch (e: unknown) {
+        await showJjError(e, 'Failed to abandon descendants', jj, scmProvider.outputChannel);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import type { CodeForgeProviderFactory } from './code-forge-provider-factory';
 import { CodeForgeRegistry } from './code-forge-registry';
 import type { CodeForgeService } from './code-forge-service';
 import { abandonCommand } from './commands/abandon';
+import { abandonDescendantsCommand } from './commands/abandon-descendants';
 import { absorbCommand } from './commands/absorb';
 import { setBookmarkCommand } from './commands/bookmark';
 import { advanceBookmarkCommand } from './commands/bookmark-advance';
@@ -510,6 +511,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     context.subscriptions.push(
         registerWrappedCommand('jj-view.abandon', async (scm, jj, ...args) => {
             await abandonCommand(scm, jj, args);
+        }),
+        registerWrappedCommand('jj-view.abandonDescendants', async (scm, jj, ...args) => {
+            await abandonDescendantsCommand(scm, jj, args);
         }),
         registerWrappedCommand('jj-view.restore', async (scm, jj, ...args) => {
             const states = args as vscode.SourceControlResourceState[];

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -850,6 +850,39 @@ export class JjService {
     }
 
     /**
+     * Returns mutable descendants of the given revision, excluding the revision itself.
+     *
+     * Uses the revset `(revision:: ~ revision) & mutable()` to ensure the root
+     * is excluded at the query level.
+     */
+    async getDescendants(revision: string): Promise<{ changeId: string; description: string }[]> {
+        try {
+            const output = await this.run(
+                'log',
+                [
+                    '-r',
+                    `(${revision}:: ~ ${revision}) & mutable()`,
+                    '--no-graph',
+                    '-T',
+                    'change_id.shortest() ++ "\\t" ++ description.first_line() ++ "\\n"',
+                ],
+                { useCachedSnapshot: true, label: 'getDescendants' },
+            );
+            return output
+                .trim()
+                .split('\n')
+                .filter((line) => line.length > 0)
+                .map((line) => {
+                    const [changeId, ...descParts] = line.split('\t');
+                    return { changeId, description: descParts.join('\t') };
+                });
+        } catch (e) {
+            console.error('Failed to query descendants for', revision, e);
+            return [];
+        }
+    }
+
+    /**
      * Checks which of the provided paths are tracked by jj.
      * @param paths An array of workspace-relative paths to check.
      * @returns A subset of the input `paths` that are tracked. Note that for

--- a/src/test/commands/abandon-descendants.test.ts
+++ b/src/test/commands/abandon-descendants.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { abandonDescendantsCommand } from '../../commands/abandon-descendants';
+import { ScmContextValue } from '../../jj-context-keys';
+import type { JjScmProvider } from '../../jj-scm-provider';
+import { JjService, NO_OP_LOGGER } from '../../jj-service';
+import { buildGraph, TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock({
+        window: { showInputBox: vi.fn(), showWarningMessage: vi.fn() },
+    });
+});
+
+describe('abandonDescendantsCommand', () => {
+    let jj: JjService;
+    let repo: TestRepo;
+    let scmProvider: JjScmProvider;
+
+    beforeEach(() => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path, NO_OP_LOGGER);
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn(),
+            getSelectedCommitIds: vi.fn().mockReturnValue([]),
+        });
+    });
+
+    afterEach(() => {
+        repo.dispose();
+        vi.clearAllMocks();
+    });
+
+    const expectAbandoned = (changeId: string) => {
+        const visibleIds = repo.getLog('all()', 'change_id');
+        expect(visibleIds).not.toContain(changeId);
+    };
+
+    test('abandons revision and all its descendants', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'root' },
+            { label: 'B', description: 'child A', parents: ['A'] },
+            { label: 'C', description: 'child B', parents: ['B'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        await abandonDescendantsCommand(scmProvider, jj, [graph.A.changeId]);
+
+        // rev:: includes rev itself, so A, B, C are all abandoned
+        expectAbandoned(graph.A.changeId);
+        expectAbandoned(graph.B.changeId);
+        expectAbandoned(graph.C.changeId);
+    });
+
+    test('abandons only the revision when it has no descendants', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'root' },
+            { label: 'B', description: 'leaf', parents: ['A'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        await abandonDescendantsCommand(scmProvider, jj, [graph.B.changeId]);
+
+        // B has no descendants, so only B is abandoned (rev:: = just rev)
+        expectAbandoned(graph.B.changeId);
+        const visible = repo.getLog('all()', 'change_id');
+        expect(visible).toContain(graph.A.changeId);
+    });
+
+    test('abandons working copy from resource group header', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'base' },
+            { label: 'B', description: 'wc', parents: ['A'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        const resourceGroup = { id: ScmContextValue.WorkingCopyGroup, label: 'Working Copy', resourceStates: [] };
+        await abandonDescendantsCommand(scmProvider, jj, [resourceGroup]);
+
+        // @ has no descendants, so only @ is abandoned
+        expectAbandoned(graph.B.changeId);
+        const visible = repo.getLog('all()', 'change_id');
+        expect(visible).toContain(graph.A.changeId);
+    });
+
+    test('falls back to selection when no explicit arg', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'root' },
+            { label: 'B', description: 'middle', parents: ['A'] },
+            { label: 'C', description: 'leaf', parents: ['B'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([graph.A.changeId]);
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        await abandonDescendantsCommand(scmProvider, jj, []);
+
+        // Selected A → abandons A and all descendants (B, C)
+        expectAbandoned(graph.A.changeId);
+        expectAbandoned(graph.B.changeId);
+        expectAbandoned(graph.C.changeId);
+    });
+
+    test('prompts for input when no args and no selection', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'root' },
+            { label: 'B', description: 'leaf', parents: ['A'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showInputBox).mockResolvedValue(graph.A.changeId);
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        await abandonDescendantsCommand(scmProvider, jj, []);
+
+        expect(vscode.window.showInputBox).toHaveBeenCalledWith(
+            expect.objectContaining({ prompt: 'Enter revision to abandon descendants of' }),
+        );
+
+        // A and B both abandoned (A:: includes A and B)
+        expectAbandoned(graph.A.changeId);
+        expectAbandoned(graph.B.changeId);
+    });
+
+    test('does nothing when user cancels input prompt', async () => {
+        await buildGraph(repo, [{ label: 'A', isCurrentWorkingCopy: true }]);
+
+        asMock(vscode.window.showInputBox).mockResolvedValue(undefined);
+
+        await abandonDescendantsCommand(scmProvider, jj, []);
+
+        expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when user cancels warning dialog', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'base' },
+            { label: 'B', description: 'child', parents: ['A'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showWarningMessage).mockResolvedValue(undefined);
+
+        await abandonDescendantsCommand(scmProvider, jj, [graph.A.changeId]);
+
+        // Nothing should be abandoned
+        const visible = repo.getLog('all()', 'change_id');
+        expect(visible).toContain(graph.A.changeId);
+        expect(visible).toContain(graph.B.changeId);
+    });
+
+    test('warning message includes descendant descriptions', async () => {
+        const graph = await buildGraph(repo, [
+            { label: 'A', description: 'root' },
+            { label: 'B', description: 'fix login', parents: ['A'] },
+            { label: 'C', description: 'add tests', parents: ['B'], isCurrentWorkingCopy: true },
+        ]);
+
+        asMock(vscode.window.showWarningMessage).mockResolvedValue('Abandon');
+
+        await abandonDescendantsCommand(scmProvider, jj, [graph.A.changeId]);
+
+        const call = asMock(vscode.window.showWarningMessage).mock.calls[0];
+        const message = call[0] as string;
+        expect(message).toContain('fix login');
+        expect(message).toContain('add tests');
+        expect(message).toContain('2 descendants');
+    });
+
+    test('shows warning dialog for nonexistent revision', async () => {
+        await buildGraph(repo, [{ label: 'A', isCurrentWorkingCopy: true }]);
+
+        asMock(vscode.window.showInputBox).mockResolvedValue('nonexistent');
+
+        // getDescendants catches the error, returns [], count=0
+        await abandonDescendantsCommand(scmProvider, jj, []);
+
+        expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+            expect.stringContaining('Abandon nonexistent'),
+            expect.any(Object),
+            'Abandon',
+        );
+    });
+});


### PR DESCRIPTION
Added a `jj-view.abandonDescendants` command after `jj-view.abandon`, which abandons all descendant changes (including self) for a given rev.

One small concern: better display the rev, as the long name is too verbose.

## Summary by Sourcery

Add a new command to abandon a revision and all its descendant changes from the JJ View integration.

New Features:
- Introduce a jj-view.abandonDescendants command that abandons a selected revision and all its mutable descendants with confirmation and progress feedback.

Enhancements:
- Expose the abandon-descendants action in the JJ View command palette, commit webview actions, and inline SCM resource context menus with adjusted action ordering.