### PR TITLE
feat: add change description to tooltip of commit nodes

### DIFF
--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -85,7 +85,6 @@ export function createJjResourceState(
         rightUri,
         diffTitle,
         decorations: {
-            tooltip: entry.conflicted ? 'Conflicted' : entry.status,
             faded: false,
             strikeThrough: entry.status === 'removed',
         },

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -750,11 +750,18 @@ export async function expectFileInScmGroup(
     page: Page,
     groupNamePattern: RegExp | string,
     fileNamePattern: RegExp | string,
-) {
+): Promise<Locator> {
     const start = Date.now();
-    const locator = await getScmItemLocator(page, fileNamePattern, groupNamePattern);
-    await expect(locator).toBeVisible();
+    let locator: Locator | undefined;
+    await expect(async () => {
+        locator = await getScmItemLocator(page, fileNamePattern, groupNamePattern);
+        await expect(locator).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15000 });
     logPerf('expectFileInScmGroup', start);
+    if (!locator) {
+        throw new Error(`File "${fileNamePattern}" not found in group "${groupNamePattern}"`);
+    }
+    return locator;
 }
 
 /**

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -341,7 +341,7 @@ test.describe('SCM Pane E2E', () => {
 
         await focusSCM(page);
         // Discard Changes (file3.txt)
-        const wcFile3Row = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
+        const wcFile3Row = await expectFileInScmGroup(page, /Working Copy/i, 'file3.txt');
         const discardIcon = wcFile3Row.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
         await hoverAndClick(wcFile3Row, discardIcon);
 
@@ -353,7 +353,7 @@ test.describe('SCM Pane E2E', () => {
         // File-Level Squash (file.txt)
         // Hover over file.txt in Working Copy and click Squash
         // file.txt and the group squash action share the same codicon-arrow-down icon
-        const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
+        const wcFileRow = await expectFileInScmGroup(page, /Working Copy/i, 'file.txt');
         const squashFileIcon = wcFileRow
             .getByRole('button', { name: 'Squash File(s) into Parent', exact: true })
             .first();
@@ -416,8 +416,7 @@ test.describe('SCM Pane E2E', () => {
         await refreshButton.click();
 
         // Wait for file3.txt to appear in SCM Working Copy
-        const newWcFileRow = page.getByRole('treeitem', { name: /file3\.txt, modified/ }).first();
-        await expect(newWcFileRow).toBeVisible({ timeout: 5000 });
+        const newWcFileRow = await expectFileInScmGroup(page, /Working Copy/i, 'file3.txt');
 
         // Hover to reveal inline actions
         await newWcFileRow.hover();
@@ -440,7 +439,8 @@ test.describe('SCM Pane E2E', () => {
 
         // Verify the squash happened by waiting for there to be only ONE file3.txt row (the ancestor one)
         await expect(async () => {
-            const rows = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
+            await expectFileInScmGroup(page, /initial/i, 'file3.txt');
+            const rows = page.getByRole('treeitem', { name: 'file3.txt' });
             const count = await rows.count();
             expect(count).toBe(1);
         }).toPass({ timeout: 10000 });
@@ -586,8 +586,7 @@ test.describe('SCM Pane E2E', () => {
         repo.writeFile('tracked.txt', 'modified');
 
         // 2. Wait for it to appear with "Modified" decoration
-        const trackedRow = page.getByRole('treeitem', { name: /tracked\.txt.*modified/i });
-        await expect(trackedRow).toBeVisible({ timeout: 15000 });
+        await expectFileInScmGroup(page, /Working Copy/i, 'tracked.txt');
 
         // 3. Create a completely untracked file and add it to .gitignore
         repo.writeFile('.gitignore', 'totally-untracked.txt\n');
@@ -678,8 +677,7 @@ test.describe('SCM Pane E2E', () => {
 
         await focusSCM(page);
 
-        const ancestorFileRow = page.getByRole('treeitem', { name: /file_ancestor\.txt.*modified/i });
-        await expect(ancestorFileRow).toBeVisible();
+        const ancestorFileRow = await expectFileInScmGroup(page, /ancestor/i, 'file_ancestor.txt');
 
         const discardIcon = ancestorFileRow.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
         await hoverAndClick(ancestorFileRow, discardIcon);

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -120,7 +120,6 @@ suite('JJ SCM Provider Integration Test', () => {
         );
 
         assert.ok(resourceState, 'Should find resource state for modified file');
-        assert.strictEqual(workingCopyGroup.resourceStates[0].decorations?.tooltip, 'modified');
 
         const { command } = workingCopyGroup.resourceStates[0];
         assert.ok(command, 'Resource state should have a command');

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -164,18 +164,6 @@ describe('createJjResourceState', () => {
     });
 
     describe('Decorations', () => {
-        it('sets Conflicted tooltip for conflicted entries', () => {
-            const entry: JjStatusEntry = { path: 'file.txt', status: 'modified', conflicted: true };
-            const state = createJjResourceState(entry, 'rev123', root);
-            expect(state.decorations?.tooltip).toBe('Conflicted');
-        });
-
-        it('sets status as tooltip for non-conflicted entries', () => {
-            const entry: JjStatusEntry = { path: 'file.txt', status: 'added' };
-            const state = createJjResourceState(entry, 'rev123', root);
-            expect(state.decorations?.tooltip).toBe('added');
-        });
-
         it('sets strikeThrough for removed entries', () => {
             const entry: JjStatusEntry = { path: 'file.txt', status: 'removed' };
             const state = createJjResourceState(entry, 'rev123', root);

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -113,8 +113,16 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
     const textOpacity = isDragging ? 0.5 : 1;
     const fontStyle = isImmutable ? 'italic' : 'normal';
 
-    const description = commit.description.split('\n')[0] || '(no description)';
-    const displayDescription = isEmpty ? `(empty) ${description}` : description;
+    const MAX_TOOLTIP_LENGTH = 500;
+    let descriptionFull = commit.description.trim() || '(no description)';
+    if (isEmpty) {
+        descriptionFull = `(empty) ${descriptionFull}`;
+    }
+    const descriptionFirstLine = descriptionFull.split('\n')[0];
+    const descriptionTooltip =
+        descriptionFull.length <= MAX_TOOLTIP_LENGTH
+            ? descriptionFull
+            : `${descriptionFull.slice(0, MAX_TOOLTIP_LENGTH)}…`;
 
     // Merge refs for draggable and droppable
     // We need both on the same element
@@ -351,6 +359,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                 >
                     <span
                         className="commit-desc"
+                        title={descriptionTooltip}
                         style={{
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
@@ -374,7 +383,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                 (divergent)
                             </span>
                         )}
-                        {displayDescription}
+                        {descriptionFirstLine}
                     </span>
 
                     {/* Right-aligned Bookmarks */}


### PR DESCRIPTION
Now on hovering a commit node in the log view, the tooltip will show the change description.

Sadly, due to limitations of the VSCode API, we cannot have a tooltip for the change description in the source control view.

## Summary by Sourcery

Add change descriptions to tooltips for commit-related UI elements.

New Features:
- Display commit change descriptions in the tooltip of commit nodes in the log webview.
- Include optional change descriptions in SCM resource tooltips alongside status and conflict information.