### PR TITLE
feat: squash selected change into ancestor

### DIFF
--- a/package.json
+++ b/package.json
@@ -357,6 +357,12 @@
                 "category": "JJ View"
             },
             {
+                "command": "jj-view.squashSelectionIntoAncestor",
+                "title": "Squash Selection into Ancestor...",
+                "category": "JJ View",
+                "icon": "$(jj-icon-squash-into)"
+            },
+            {
                 "command": "jj-view.openMergeEditor",
                 "title": "Open Merge Editor",
                 "category": "JJ View"
@@ -1015,6 +1021,11 @@
             "editor/context": [
                 {
                     "command": "jj-view.squashSelectionIntoParent",
+                    "group": "jj-view",
+                    "when": "isInDiffEditor && jj.parentMutable"
+                },
+                {
+                    "command": "jj-view.squashSelectionIntoAncestor",
                     "group": "jj-view",
                     "when": "isInDiffEditor && jj.parentMutable"
                 },

--- a/src/commands/squash-selection.ts
+++ b/src/commands/squash-selection.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
 import { getRevisionFromUri } from '../uri-utils';
-import { showJjError } from './command-utils';
+import { promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
 interface LineChange {
     readonly originalStartLineNumber: number;
@@ -71,7 +71,7 @@ export async function squashHunkIntoParentCommand(
     const revision = getRevisionFromUri(uri) || '@';
 
     try {
-        await jj.squashSelectionIntoParent(relPath, ranges, revision);
+        await jj.squashSelectionIntoAncestor(relPath, ranges, revision);
         vscode.window.showInformationMessage('Squashed hunk into parent.');
 
         await scmProvider.refresh({ reason: 'after squash hunk into parent' });
@@ -109,11 +109,59 @@ export async function squashSelectionIntoParentCommand(
     const ranges = editor.selections.map((s) => ({ startLine: s.start.line, endLine: s.end.line }));
 
     try {
-        await jj.squashSelectionIntoParent(relPath, ranges, revision);
+        await jj.squashSelectionIntoAncestor(relPath, ranges, revision);
         vscode.window.showInformationMessage(`Squashed selection from ${revision} into parent.`);
     } catch (e: unknown) {
         await showJjError(e, 'Failed to squash selection', jj, scmProvider.outputChannel);
     } finally {
         await scmProvider.refresh({ reason: 'after squash selection into parent' });
+    }
+}
+
+/**
+ * Command to squash selected lines from a diff editor into a chosen ancestor.
+ */
+export async function squashSelectionIntoAncestorCommand(
+    scmProvider: JjScmProvider,
+    jj: JjService,
+    editor: vscode.TextEditor,
+) {
+    if (!editor) {
+        return;
+    }
+
+    const docUri = editor.document.uri;
+    const fsPath = docUri.fsPath;
+    const relPath = path.relative(jj.workspaceRoot, fsPath);
+
+    const revision = getRevisionFromUri(docUri) || '@';
+
+    let selectedAncestorRev: string | undefined;
+    try {
+        selectedAncestorRev = await promptForRevision(jj, {
+            placeHolder: 'Select which ancestor to squash into',
+            emptyPrompt: 'Enter ancestor revision',
+            revisionQuery: RevisionQuery.ancestorsExcluding(revision),
+        });
+    } catch (e: unknown) {
+        await showJjError(e, 'Failed to squash selection into ancestor', jj, scmProvider.outputChannel);
+        return;
+    }
+
+    if (!selectedAncestorRev) {
+        return;
+    }
+
+    const ranges = editor.selections.map((s) => ({ startLine: s.start.line, endLine: s.end.line }));
+
+    try {
+        await jj.squashSelectionIntoAncestor(relPath, ranges, revision, selectedAncestorRev);
+        vscode.window.showInformationMessage(
+            `Squashed selection from ${revision} into ${selectedAncestorRev.substring(0, 8)}.`,
+        );
+    } catch (e: unknown) {
+        await showJjError(e, 'Failed to squash selection into ancestor', jj, scmProvider.outputChannel);
+    } finally {
+        await scmProvider.refresh({ reason: 'after squash selection into ancestor' });
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,11 @@ import {
     squashRevisionIntoAncestorCommand,
     squashRevisionIntoParentCommand,
 } from './commands/squash-revision';
-import { squashHunkIntoParentCommand, squashSelectionIntoParentCommand } from './commands/squash-selection';
+import {
+    squashHunkIntoParentCommand,
+    squashSelectionIntoAncestorCommand,
+    squashSelectionIntoParentCommand,
+} from './commands/squash-selection';
 import { undoCommand } from './commands/undo';
 import { uploadCommand } from './commands/upload';
 import { workspaceAddCommand } from './commands/workspace-add';
@@ -539,6 +543,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             const editor = vscode.window.activeTextEditor;
             if (editor) {
                 await squashSelectionIntoParentCommand(scm, jj, editor);
+            }
+        }),
+        registerWrappedCommand('jj-view.squashSelectionIntoAncestor', async (scm, jj) => {
+            const editor = vscode.window.activeTextEditor;
+            if (editor) {
+                await squashSelectionIntoAncestorCommand(scm, jj, editor);
             }
         }),
         registerWrappedCommand('jj-view.refresh', async (scm) => {

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -1146,24 +1146,29 @@ export class JjService {
     }
 
     /**
-     * Squash specific line ranges (selection) from a file to its parent revision.
+     * Squash specific line ranges (selection) from a file into an ancestor revision.
+     *
+     * If `intoRevision` is omitted, the selection is squashed into the direct
+     * parent of `revision`.
      *
      * @param fileRelPath Path relative to the workspace root.
      * @param ranges 0-indexed line ranges in the 'revision' to move.
      * @param revision The revision to move changes from (default: @).
+     * @param intoRevision The ancestor revision to squash into (default: parent).
      */
-    async squashSelectionIntoParent(
+    async squashSelectionIntoAncestor(
         fileRelPath: string,
         ranges: SelectionRange[],
         revision: string = '@',
+        intoRevision?: string,
     ): Promise<void> {
-        const parentRev = `${revision}-`;
+        const targetRevision = intoRevision ?? `${revision}-`;
         const { left: baseContent } = await this.getDiffContent(revision, fileRelPath);
         const diffOutput = await this.getDiff(revision, fileRelPath);
 
         const wantedContent = PatchHelper.applySelectedLines(baseContent, diffOutput, ranges);
 
-        await this.runPartialSquash(revision, parentRev, fileRelPath, wantedContent);
+        await this.runPartialSquash(revision, targetRevision, fileRelPath, wantedContent);
     }
 
     private async runPartialSquash(

--- a/src/test/commands/squash-selection.test.ts
+++ b/src/test/commands/squash-selection.test.ts
@@ -5,11 +5,16 @@
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { squashHunkIntoParentCommand, squashSelectionIntoParentCommand } from '../../commands/squash-selection';
+import {
+    squashHunkIntoParentCommand,
+    squashSelectionIntoAncestorCommand,
+    squashSelectionIntoParentCommand,
+} from '../../commands/squash-selection';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock, createMockLogOutputChannel } from '../test-utils';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {
@@ -51,6 +56,7 @@ describe('squash-selection commands', () => {
     describe('squashHunkIntoParentCommand', () => {
         test('squashes hunk based on index', async () => {
             const fileName = 'file.txt';
+            // Keep the parent and child edits in separate hunks so jj can merge them cleanly.
             const ids = await buildGraph(repo, [
                 {
                     label: 'root',
@@ -250,6 +256,71 @@ describe('squash-selection commands', () => {
             // Parent (root) should have the modification
             const parentContent = repo.getFileContent(ids.root.changeId, fileName);
             expect(parentContent).toBe('line1\nmodified2\nline3\n');
+        });
+    });
+
+    describe('squashSelectionIntoAncestorCommand', () => {
+        test('squashes the selected change into a chosen grandparent', async () => {
+            const fileName = 'file.txt';
+            const ids = await buildGraph(repo, [
+                {
+                    label: 'grandparent',
+                    files: {
+                        [fileName]: 'line1\ngrandparent2\nline3\nline4\nline5\nline6\nline7\nline8\n',
+                    },
+                },
+                {
+                    label: 'parent',
+                    parents: ['grandparent'],
+                    files: {
+                        [fileName]: 'line1\nparent2\nline3\nline4\nline5\nline6\nline7\nline8\n',
+                    },
+                },
+                {
+                    label: 'child',
+                    parents: ['parent'],
+                    files: {
+                        [fileName]: 'line1\nparent2\nline3\nline4\nline5\nline6\nline7\nchild8\n',
+                    },
+                    isCurrentWorkingCopy: true,
+                },
+            ]);
+
+            const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+            resetMockQuickPick(mockQuickPick);
+
+            let acceptCallback: () => void = () => {};
+            vi.mocked(mockQuickPick.onDidAccept).mockImplementation((callback) => {
+                acceptCallback = callback;
+                return { dispose: () => {} };
+            });
+            vi.mocked(mockQuickPick.show).mockImplementation(() => {
+                acceptCallback();
+            });
+            setSelectedItems(mockQuickPick, [{ label: 'grandparent', detail: ids.grandparent.changeId }]);
+            setActiveItems(mockQuickPick, [{ label: 'grandparent', detail: ids.grandparent.changeId }]);
+
+            const uri = vscode.Uri.file(path.join(repo.path, fileName)).with({
+                query: `jj-revision=${ids.child.changeId}`,
+            });
+            const mockEditor = createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({ uri }),
+                selections: [new vscode.Selection(new vscode.Position(7, 0), new vscode.Position(7, 10))],
+            });
+
+            await squashSelectionIntoAncestorCommand(scmProvider, jj, mockEditor);
+
+            expect(repo.getFileContent(ids.grandparent.changeId, fileName)).toBe(
+                'line1\ngrandparent2\nline3\nline4\nline5\nline6\nline7\nchild8\n',
+            );
+            // The ancestor squash rebases descendants while preserving their diffs.
+            expect(repo.getFileContent(ids.parent.changeId, fileName)).toBe(
+                'line1\nparent2\nline3\nline4\nline5\nline6\nline7\nchild8\n',
+            );
+            expect(repo.getFileContent('@', fileName)).toBe(
+                'line1\nparent2\nline3\nline4\nline5\nline6\nline7\nchild8\n',
+            );
+            expect(scmProvider.refresh).toHaveBeenCalled();
         });
     });
 });

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1080,7 +1080,7 @@ log = "none()"
 
         const ranges = [{ startLine: 0, endLine: 1 }];
 
-        await jjService.squashSelectionIntoParent(fileName, ranges);
+        await jjService.squashSelectionIntoAncestor(fileName, ranges);
 
         const parentContent = repo.getFileContent('@-', fileName);
         expect(parentContent).toBe(content);
@@ -1092,7 +1092,7 @@ log = "none()"
         expect(diff).toBe('');
     });
 
-    test('squashSelectionIntoParent moves subset of changes', async () => {
+    test('squashSelectionIntoAncestor moves subset of changes into the parent', async () => {
         const fileName = 'partial.txt';
 
         repo.writeFile(fileName, 'line1\nline2\nline3\n');
@@ -1109,7 +1109,7 @@ log = "none()"
         // Select 'mod1' (line 1, index 0)
         const ranges = [{ startLine: 0, endLine: 0 }];
 
-        await jjService.squashSelectionIntoParent(fileName, ranges);
+        await jjService.squashSelectionIntoAncestor(fileName, ranges);
 
         // Verify Parent Content
         const parentContent = await jjService.getFileContent(fileName, '@-');
@@ -1120,7 +1120,7 @@ log = "none()"
         expect(childContent).toBe('mod1\nline2\nmod3\n');
     });
 
-    test('squashSelectionIntoParent moves deletion', async () => {
+    test('squashSelectionIntoAncestor moves deletion into the parent', async () => {
         const fileName = 'deletion.txt';
 
         // Parent
@@ -1134,14 +1134,14 @@ log = "none()"
         // Select the deletion (approximate range covering the area)
         const ranges = [{ startLine: 1, endLine: 2 }];
 
-        await jjService.squashSelectionIntoParent(fileName, ranges);
+        await jjService.squashSelectionIntoAncestor(fileName, ranges);
 
         // Parent should now have deleted the line
         const parentContent = await jjService.getFileContent(fileName, '@-');
         expect(parentContent).toBe('keep\n');
     });
 
-    test('squashSelectionIntoParent moves selected lines and PRESERVES others in a stack', async () => {
+    test('squashSelectionIntoAncestor moves selected lines and PRESERVES others in a stack', async () => {
         // Setup: Grandparent -> Parent -> Child
         const ids = await buildGraph(repo, [
             { label: 'grandparent', description: 'grandparent', files: { 'file.txt': 'line 0\n' } },
@@ -1170,7 +1170,7 @@ log = "none()"
         expect(initialChildDiff).toContain('+line 3');
 
         // Target: We want to move 'line 2' from Child to Parent, but keep 'line 3' in child.
-        await jjService.squashSelectionIntoParent('file.txt', [{ startLine: 2, endLine: 2 }], childId);
+        await jjService.squashSelectionIntoAncestor('file.txt', [{ startLine: 2, endLine: 2 }], childId);
 
         // After move:
         // Parent should have 'line 0\nline 1\nline 2\n'


### PR DESCRIPTION
Added a context menu command to squash selected changes into any ancestor via the existing picker, in parallel to the `Squash to parent` command.

Also refined the item displayed in the picker: Added a prefix `@-n` or `id-n` to make it easy to follow.

## Summary by Sourcery

Add support for squashing selected changes into an arbitrary ancestor revision and improve ancestor picker labelling for easier selection.

New Features:
- Introduce a command to squash selected lines from a diff editor into a chosen ancestor revision using the existing ancestor picker.

Enhancements:
- Extend the ancestor picker items with positional prefixes relative to the base revision to make ancestor selection clearer.
- Wire the new squash-into-ancestor command into the extension activation, package contributions, and JJ service to support partial squashes into non-parent ancestors.