### PR TITLE
feat: add buttons for easy change description editing in source control and log view

### DIFF
--- a/package.json
+++ b/package.json
@@ -502,6 +502,11 @@
                 "category": "JJ View"
             },
             {
+                "command": "jj-view.hideCommitAction.describe",
+                "title": "Hide 'Describe'",
+                "category": "JJ View"
+            },
+            {
                 "command": "jj-view.toggleCommitAction.newChild.on",
                 "title": "\u25cf New Child",
                 "category": "JJ View"
@@ -539,6 +544,16 @@
             {
                 "command": "jj-view.toggleCommitAction.abandon.off",
                 "title": "\u25cb Abandon",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.describe.on",
+                "title": "\u25cf Describe",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.toggleCommitAction.describe.off",
+                "title": "\u25cb Describe",
                 "category": "JJ View"
             },
             {
@@ -716,6 +731,18 @@
                 {
                     "command": "jj-view.toggleCommitAction.abandon.off",
                     "when": "false"
+                },
+                {
+                    "command": "jj-view.hideCommitAction.describe",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.describe.on",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.describe.off",
+                    "when": "false"
                 }
             ],
             "view/title": [
@@ -882,6 +909,11 @@
                     "group": "9_visibility_1_hide"
                 },
                 {
+                    "command": "jj-view.hideCommitAction.describe",
+                    "when": "webviewSection == 'commitAction' && jj.actionId == 'describe' && jj.describeVisible",
+                    "group": "9_visibility_1_hide"
+                },
+                {
                     "command": "jj-view.toggleCommitAction.newChild.on",
                     "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.newChild",
                     "group": "9_visibility_2_toggle@1"
@@ -920,6 +952,16 @@
                     "command": "jj-view.toggleCommitAction.abandon.off",
                     "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.abandon",
                     "group": "9_visibility_2_toggle@4"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.describe.on",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && jj.commitActionVisible.describe",
+                    "group": "9_visibility_2_toggle@5"
+                },
+                {
+                    "command": "jj-view.toggleCommitAction.describe.off",
+                    "when": "(webviewSection == 'commitAction' || webviewSection == 'commitActions') && !jj.commitActionVisible.describe",
+                    "group": "9_visibility_2_toggle@5"
                 }
             ],
             "scm/title": [

--- a/package.json
+++ b/package.json
@@ -248,6 +248,12 @@
                 "icon": "$(save)"
             },
             {
+                "command": "jj-view.describe",
+                "title": "Describe",
+                "category": "JJ View",
+                "icon": "$(edit)"
+            },
+            {
                 "command": "jj-view.focusDescriptionInput",
                 "title": "Focus SCM Description Input",
                 "category": "JJ View"
@@ -801,6 +807,11 @@
                     "group": "2_edit@4"
                 },
                 {
+                    "command": "jj-view.describe",
+                    "when": "webviewSection == 'commit'",
+                    "group": "2_edit@5"
+                },
+                {
                     "command": "jj-view.duplicate",
                     "when": "webviewSection == 'commit' && jj.canDuplicate",
                     "group": "4_changes@1"
@@ -974,6 +985,11 @@
                     "command": "jj-view.edit",
                     "group": "inline@6",
                     "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowEdit\\b/"
+                },
+                {
+                    "command": "jj-view.describe",
+                    "group": "inline@7",
+                    "when": "scmResourceGroupState =~ /\\bjj\\.group\\.allowShowDetails\\b/"
                 }
             ],
             "scm/resourceState/context": [

--- a/src/commands/describe-dialog.ts
+++ b/src/commands/describe-dialog.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as vscode from 'vscode';
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjService } from '../jj-service';
+import { extractRevisions, showJjError, withDelayedProgress } from './command-utils';
+
+export async function describeDialogCommand(scmProvider: JjScmProvider, jj: JjService, ...args: unknown[]) {
+    const revision = extractRevisions(args)[0] ?? '@';
+
+    const currentDescription = await jj.getDescription(revision);
+
+    const input = await vscode.window.showInputBox({
+        prompt: `Edit description for ${revision === '@' ? 'working copy' : revision}`,
+        placeHolder: 'Description of the changes...',
+        value: currentDescription,
+    });
+
+    if (input === undefined) {
+        return; // User cancelled
+    }
+
+    try {
+        await withDelayedProgress('Setting description...', jj.describe(input, revision));
+        await scmProvider.refresh({ reason: 'after describe' });
+    } catch (err: unknown) {
+        await showJjError(err, 'Error setting description', jj, scmProvider.outputChannel);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { commitPromptCommand } from './commands/commit-prompt';
 import { compareAllFilesWithRevisionCommand } from './commands/compare-all-files-with-revision';
 import { compareFileWithRevisionCommand } from './commands/compare-file-with-revision';
 import { setDescriptionCommand } from './commands/describe';
+import { describeDialogCommand } from './commands/describe-dialog';
 import { describePromptCommand } from './commands/describe-prompt';
 import { showDetailsCommand } from './commands/details';
 import { discardChangeCommand } from './commands/discard-change';
@@ -465,6 +466,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         }),
         registerWrappedCommand('jj-view.describePrompt', async (scm, jj) => {
             await describePromptCommand(scm, jj);
+        }),
+        registerWrappedCommand('jj-view.describe', async (scm, jj, ...args) => {
+            await describeDialogCommand(scm, jj, ...args);
         }),
     );
 

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -198,6 +198,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 case 'edit':
                     await vscode.commands.executeCommand('jj-view.edit', data.payload);
                     break;
+                case 'describe':
+                    await vscode.commands.executeCommand('jj-view.describe', data.payload);
+                    break;
                 case 'select': {
                     if (!this.jj) {
                         break;

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -14,9 +14,9 @@ import type {
 
 export type { CodeForgeChangeInfo, CommitParent, JjBookmark, JjLogEntry, JjStatusEntry, JjWorkspace };
 
-export type CommitAction = 'newChild' | 'edit' | 'squash' | 'abandon' | 'openCodeForge' | 'upload';
+export type CommitAction = 'newChild' | 'edit' | 'squash' | 'abandon' | 'openCodeForge' | 'upload' | 'describe';
 
-export const TOGGLEABLE_COMMIT_ACTIONS = ['newChild', 'edit', 'squash', 'abandon'] as const;
+export const TOGGLEABLE_COMMIT_ACTIONS = ['newChild', 'edit', 'squash', 'abandon', 'describe'] as const;
 export type ToggleableCommitAction = (typeof TOGGLEABLE_COMMIT_ACTIONS)[number];
 
 export interface ActionPayload {

--- a/src/test/commit-utils.test.ts
+++ b/src/test/commit-utils.test.ts
@@ -42,6 +42,7 @@ describe('computeCommitActions', () => {
             edit: true,
             squash: true,
             abandon: true,
+            describe: true,
         });
         expect(result.vscodeContext['jj.canEdit']).toBe(true);
         expect(result.vscodeContext['jj.canAbandon']).toBe(true);
@@ -55,6 +56,7 @@ describe('computeCommitActions', () => {
 
         expect(result.visibleActions.edit).toBe(false);
         expect(result.visibleActions.abandon).toBe(false);
+        expect(result.visibleActions.describe).toBe(false);
         expect(result.vscodeContext['jj.canEdit']).toBe(false);
         expect(result.vscodeContext['jj.canAbandon']).toBe(false);
     });

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -248,6 +248,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                             'jj.editVisible': visibleActions.edit,
                             'jj.squashVisible': visibleActions.squash,
                             'jj.abandonVisible': visibleActions.abandon,
+                            'jj.describeVisible': visibleActions.describe,
                             preventDefaultContextMenuItems: true,
                         })}
                         style={{
@@ -270,6 +271,38 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                             paddingLeft: '0',
                         }}
                     >
+                        {visibleActions.describe && (
+                            <IconButton
+                                title="Describe"
+                                icon="codicon-edit"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAction('describe', { changeId: commit.change_id });
+                                }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'describe',
+                                    actionTitle: 'Describe',
+                                }}
+                            />
+                        )}
+
+                        {visibleActions.edit && (
+                            <IconButton
+                                title="Edit Commit"
+                                icon="codicon-sign-in"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onAction('edit', { changeId: commit.change_id });
+                                }}
+                                contextData={{
+                                    webviewSection: 'commitAction',
+                                    'jj.actionId': 'edit',
+                                    actionTitle: 'Edit',
+                                }}
+                            />
+                        )}
+
                         {visibleActions.newChild && (
                             <IconButton
                                 title="New Child"
@@ -282,22 +315,6 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                                     webviewSection: 'commitAction',
                                     'jj.actionId': 'newChild',
                                     actionTitle: 'New Child',
-                                }}
-                            />
-                        )}
-
-                        {visibleActions.edit && (
-                            <IconButton
-                                title="Edit Commit"
-                                icon="codicon-edit"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    onAction('edit', { changeId: commit.change_id });
-                                }}
-                                contextData={{
-                                    webviewSection: 'commitAction',
-                                    'jj.actionId': 'edit',
-                                    actionTitle: 'Edit',
                                 }}
                             />
                         )}

--- a/src/webview/utils/commit-utils.ts
+++ b/src/webview/utils/commit-utils.ts
@@ -10,6 +10,7 @@ export interface CommitActionStates {
     edit: boolean;
     squash: boolean;
     abandon: boolean;
+    describe: boolean;
 }
 
 /**
@@ -29,6 +30,7 @@ export function computeCommitActions(
         edit: isMutableCommit(commit) && !commit.is_current_working_copy && !hiddenActions.has('edit'),
         squash: !hiddenActions.has('squash') && canSquashCommit(commit),
         abandon: isMutableCommit(commit) && !hiddenActions.has('abandon'),
+        describe: isMutableCommit(commit) && !hiddenActions.has('describe'),
     };
 
     const vscodeContext = {
@@ -39,6 +41,7 @@ export function computeCommitActions(
         'jj.editVisible': visibleActions.edit,
         'jj.squashVisible': visibleActions.squash,
         'jj.abandonVisible': visibleActions.abandon,
+        'jj.describeVisible': visibleActions.describe,
         viewItem: isSelected ? 'jj-commit-selected' : 'jj-commit',
         commitId: commit.commit_id,
         changeId: commit.change_id,


### PR DESCRIPTION
Added a command to launch a dialog to edit descriptions easily.

Limitations: The native VSCode input box does not support multiline text.

Adjusted the order of action buttons in the log view. It might be more intuitive than before.

Note on icon: The icon `edit` I chose is more intuitive for me (and consistent with jjk / jj-graph). The existing icon for change editing might need adjustment, as it is a bit counterintuitive. Consider `sign-in` as a substitute (used in jjk), or `edit-session`.

## Summary by Sourcery

Add a new describe command and dialog for editing change descriptions from both the log view and SCM, and expose it as a toggleable commit action alongside existing actions.

New Features:
- Introduce a describe dialog command that lets users edit a change description for a selected revision or the working copy.
- Add a Describe action button to commit nodes in the log view and to SCM inline actions for quickly editing descriptions.
- Make the Describe commit action toggleable and configurable via commands and context menu visibility settings.

Enhancements:
- Reorder commit action buttons in the log view so Describe and Edit appear more intuitively, and adjust the Edit icon to better distinguish it from Describe.