### PR TITLE
Fix sync alias

### DIFF
--- a/tooling/jj/repo-config.toml
+++ b/tooling/jj/repo-config.toml
@@ -1,5 +1,5 @@
 [aliases]
-sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s 'roots(mutable())' -d main --skip-emptied && jj log"]
+sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s 'roots(mutable())' -d main@origin --skip-emptied && jj log"]
 upload = ["util", "exec", "--", "node", "tooling/jj/upload.ts"]
 
 [fix.tools.biome]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust the jj `sync` alias to use `main@origin` as the rebase destination for repository synchronization.