### PR TITLE
feat: Implement "Advance Bookmark" and "Advance Bookmark & Upload" ac…

### DIFF
--- a/package.json
+++ b/package.json
@@ -416,6 +416,18 @@
                 "icon": "$(bookmark)"
             },
             {
+                "command": "jj-view.advanceBookmark",
+                "title": "Advance Bookmark",
+                "category": "JJ View",
+                "icon": "$(bookmark)"
+            },
+            {
+                "command": "jj-view.advanceBookmarkAndUpload",
+                "title": "Advance Bookmark & Upload",
+                "category": "JJ View",
+                "icon": "$(cloud-upload)"
+            },
+            {
                 "command": "jj-view.deleteBookmark",
                 "title": "Delete Bookmark",
                 "category": "JJ View",
@@ -720,6 +732,16 @@
                     "command": "jj-view.setBookmark",
                     "when": "webviewSection == 'commit'",
                     "group": "3_bookmark@1"
+                },
+                {
+                    "command": "jj-view.advanceBookmark",
+                    "when": "webviewSection == 'commit'",
+                    "group": "3_bookmark@1.5"
+                },
+                {
+                    "command": "jj-view.advanceBookmarkAndUpload",
+                    "when": "webviewSection == 'commit' && jj.canUpload",
+                    "group": "3_bookmark@1.6"
                 },
                 {
                     "command": "jj-view.deleteBookmark",

--- a/src/commands/bookmark-advance-upload.ts
+++ b/src/commands/bookmark-advance-upload.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjService } from '../jj-service';
+import { advanceBookmarkCommand } from './bookmark-advance';
+import { uploadCommand } from './upload';
+
+export async function advanceBookmarkAndUploadCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+    let revision: string | undefined;
+    try {
+        revision = await advanceBookmarkCommand(scmProvider, jj, args);
+    } catch (_e: unknown) {
+        // Errors from advanceBookmarkCommand are already handled and shown by showJjError inside it
+        return;
+    }
+
+    if (!revision) {
+        return; // Cancelled
+    }
+
+    // After advancing bookmarks successfully, run upload in sequence targeting the advanced revision
+    await uploadCommand(scmProvider, jj, scmProvider.repo.codeForge, [revision], scmProvider.outputChannel);
+}

--- a/src/commands/bookmark-advance.ts
+++ b/src/commands/bookmark-advance.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjService } from '../jj-service';
+import { extractRevision, promptForRevision, showJjError, withDelayedProgress } from './command-utils';
+
+export async function advanceBookmarkCommand(
+    scmProvider: JjScmProvider,
+    jj: JjService,
+    args: unknown[],
+): Promise<string | undefined> {
+    let revision = extractRevision(args);
+
+    if (!revision) {
+        revision = await promptForRevision(jj, '@', 'Select target revision to advance bookmarks to');
+    }
+
+    if (!revision) {
+        return undefined; // User cancelled
+    }
+
+    try {
+        await withDelayedProgress(
+            `Advancing bookmarks to ${revision.substring(0, 8)}...`,
+            jj.advanceBookmark(revision),
+        );
+        await scmProvider.refresh({ reason: 'after bookmark advance' });
+        return revision;
+    } catch (e: unknown) {
+        await showJjError(e, 'Error advancing bookmarks', jj, scmProvider.outputChannel);
+        throw e;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ import type { CodeForgeService } from './code-forge-service';
 import { abandonCommand } from './commands/abandon';
 import { absorbCommand } from './commands/absorb';
 import { setBookmarkCommand } from './commands/bookmark';
+import { advanceBookmarkCommand } from './commands/bookmark-advance';
+import { advanceBookmarkAndUploadCommand } from './commands/bookmark-advance-upload';
 import { deleteBookmarkCommand } from './commands/bookmark-delete';
 import { resolveRepository } from './commands/command-utils';
 import { commitCommand } from './commands/commit';
@@ -529,6 +531,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         registerWrappedCommand('jj-view.setBookmark', async (scm, jj, ...args) => {
             const arg = args[0] as { commitId: string };
             await setBookmarkCommand(scm, jj, arg);
+        }),
+        registerWrappedCommand('jj-view.advanceBookmark', async (scm, jj, ...args) => {
+            await advanceBookmarkCommand(scm, jj, args);
+        }),
+        registerWrappedCommand('jj-view.advanceBookmarkAndUpload', async (scm, jj, ...args) => {
+            await advanceBookmarkAndUploadCommand(scm, jj, args);
         }),
         registerWrappedCommand('jj-view.deleteBookmark', async (scm, jj, ...args) => {
             await deleteBookmarkCommand(scm, jj, args);

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -318,6 +318,17 @@ export class JjService {
         });
     }
 
+    async advanceBookmark(toRevision: string, names?: string[]): Promise<string> {
+        const args = ['advance', '--to', toRevision];
+        if (names && names.length > 0) {
+            args.push(...names);
+        }
+        return this.run('bookmark', args, {
+            isMutation: true,
+            label: 'advanceBookmark',
+        });
+    }
+
     async deleteBookmark(name: string): Promise<string> {
         return this.run('bookmark', ['delete', name], {
             isMutation: true,

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 import { promptForRevision, withDelayedProgress } from '../commands/command-utils';
 import { JjService } from '../jj-service';
 import { buildGraph, TestRepo } from './test-repo';
-import { createMock } from './test-utils';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from './vitest-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {
@@ -96,24 +96,19 @@ describe('promptForRevision', () => {
         ]);
         const changeId = ids.v4.changeId;
 
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+
         let acceptCallback: () => void = () => {};
-        const mockQuickPick = {
-            items: [],
-            selectedItems: [{ label: 'any', detail: changeId }],
-            activeItems: [{ label: 'any', detail: changeId }],
-            onDidChangeValue: vi.fn(),
-            onDidAccept: vi.fn().mockImplementation((cb) => {
-                acceptCallback = cb;
-            }),
-            onDidHide: vi.fn(),
-            show: vi.fn().mockImplementation(() => {
-                acceptCallback();
-            }),
-            dispose: vi.fn(),
-        };
-        vi.mocked(vscode.window.createQuickPick).mockReturnValue(
-            createMock<vscode.QuickPick<vscode.QuickPickItem>>(mockQuickPick),
-        );
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        setSelectedItems(mockQuickPick, [{ label: 'any', detail: changeId }]);
+        setActiveItems(mockQuickPick, [{ label: 'any', detail: changeId }]);
 
         const result = await promptForRevision(jj, '@');
 
@@ -123,25 +118,18 @@ describe('promptForRevision', () => {
     it('returns arbitrary typed text if not in list', async () => {
         await buildGraph(repo, [{ label: 'v1', files: { 'file1.txt': 'v1\n' } }]);
 
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+
         let acceptCallback: () => void = () => {};
-        const mockQuickPick = {
-            items: [],
-            selectedItems: [],
-            activeItems: [],
-            onDidChangeValue: vi.fn(),
-            value: 'custom-revision',
-            onDidAccept: vi.fn().mockImplementation((cb) => {
-                acceptCallback = cb;
-            }),
-            onDidHide: vi.fn(),
-            show: vi.fn().mockImplementation(() => {
-                acceptCallback();
-            }),
-            dispose: vi.fn(),
-        };
-        vi.mocked(vscode.window.createQuickPick).mockReturnValue(
-            createMock<vscode.QuickPick<vscode.QuickPickItem>>(mockQuickPick),
-        );
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        mockQuickPick.value = 'custom-revision';
 
         const result = await promptForRevision(jj, '@');
 
@@ -174,36 +162,21 @@ describe('promptForRevision', () => {
     it('configures quick pick to match on description and detail', async () => {
         await buildGraph(repo, [{ label: 'v1', files: { 'file1.txt': 'v1\n' } }]);
 
-        const state = {
-            createdQuickPick: null as vscode.QuickPick<vscode.QuickPickItem> | null,
-        };
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+
         let acceptCallback: () => void = () => {};
-        const mockQuickPick = {
-            items: [],
-            selectedItems: [],
-            activeItems: [],
-            onDidChangeValue: vi.fn(),
-            value: 'custom-revision',
-            onDidAccept: vi.fn().mockImplementation((cb) => {
-                acceptCallback = cb;
-            }),
-            onDidHide: vi.fn(),
-            show: vi.fn().mockImplementation(() => {
-                acceptCallback();
-            }),
-            dispose: vi.fn(),
-            matchOnDescription: false,
-            matchOnDetail: false,
-        };
-        vi.mocked(vscode.window.createQuickPick).mockImplementation(() => {
-            state.createdQuickPick = createMock<vscode.QuickPick<vscode.QuickPickItem>>(mockQuickPick);
-            return state.createdQuickPick;
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
         });
 
         await promptForRevision(jj, '@');
 
-        expect(state.createdQuickPick).not.toBeNull();
-        expect(state.createdQuickPick?.matchOnDescription).toBe(true);
-        expect(state.createdQuickPick?.matchOnDetail).toBe(true);
+        expect(mockQuickPick.matchOnDescription).toBe(true);
+        expect(mockQuickPick.matchOnDetail).toBe(true);
     });
 });

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -9,7 +9,8 @@ import { ScmContextValue } from '../../jj-context-keys';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/bookmark-advance-upload.test.ts
+++ b/src/test/commands/bookmark-advance-upload.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import type { CodeForgeService } from '../../code-forge-service';
+import { advanceBookmarkAndUploadCommand } from '../../commands/bookmark-advance-upload';
+import type { JjRepository } from '../../jj-repository';
+import type { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
+import { resetMockQuickPick } from '../vitest-utils';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock();
+});
+
+describe('advanceBookmarkAndUploadCommand', () => {
+    let jj: JjService;
+    let repo: TestRepo;
+    let remoteRepo: TestRepo;
+    let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
+
+    beforeEach(() => {
+        repo = new TestRepo();
+        repo.init();
+
+        remoteRepo = new TestRepo();
+        remoteRepo.init();
+
+        jj = new JjService(repo.path);
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn(),
+            outputChannel: createMock<vscode.OutputChannel>({
+                appendLine: vi.fn((msg: string) => console.log('OUTPUT CHANNEL:', msg)),
+            }),
+            repo: createMock<JjRepository>({
+                codeForge: createMock<CodeForgeService>({
+                    activeProvider: undefined,
+                    requestRefreshWithBackoffs: vi.fn(),
+                }),
+            }),
+        });
+
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+    });
+
+    afterEach(() => {
+        repo.dispose();
+        remoteRepo.dispose();
+        vi.clearAllMocks();
+    });
+
+    test('advances bookmark and uploads to remote in sequence', async () => {
+        // Setup: Link local repo to remote repo
+        repo.addRemote('origin', remoteRepo.path);
+        repo.config('remotes.origin.auto-track-bookmarks', '"*"');
+        repo.config('git.push-new-bookmarks', 'true');
+
+        // Describe initial commit so it can be pushed
+        await jj.describe('initial');
+
+        // Create bookmark on initial commit
+        repo.bookmark('sync-bookmark', '@');
+
+        // Create child commit
+        await jj.new({ message: 'child' });
+        const [child] = await jj.getLog({ revision: '@' });
+
+        // Run sequential advance and upload
+        await advanceBookmarkAndUploadCommand(scmProvider, jj, [child.change_id]);
+
+        // 1. Verify local bookmark advanced to child
+        const [childLog] = await jj.getLog({ revision: '@' });
+        expect(childLog.bookmarks).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'sync-bookmark' })]),
+        );
+
+        // 2. Verify remote repository received the advanced bookmark
+        remoteRepo.gitImport();
+        const pushedCommitId = repo.getCommitId('sync-bookmark');
+        const remoteCommitId = remoteRepo.getCommitId('sync-bookmark');
+        expect(remoteCommitId).toBe(pushedCommitId);
+
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+});

--- a/src/test/commands/bookmark-advance.test.ts
+++ b/src/test/commands/bookmark-advance.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { advanceBookmarkCommand } from '../../commands/bookmark-advance';
+import type { JjScmProvider } from '../../jj-scm-provider';
+import { JjService } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { createMock } from '../test-utils';
+import { resetMockQuickPick, setSelectedItems } from '../vitest-utils';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock();
+});
+
+describe('advanceBookmarkCommand', () => {
+    let jj: JjService;
+    let repo: TestRepo;
+    let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
+
+    beforeEach(() => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path);
+        scmProvider = createMock<JjScmProvider>({
+            refresh: vi.fn(),
+            outputChannel: createMock<vscode.OutputChannel>({ appendLine: vi.fn() }),
+        });
+
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+    });
+
+    afterEach(() => {
+        repo.dispose();
+        vi.clearAllMocks();
+    });
+
+    test('advances bookmark with revision argument directly', async () => {
+        repo.bookmark('test-bookmark', '@');
+        await jj.new({ message: 'child' });
+        const [child] = await jj.getLog({ revision: '@' });
+
+        await advanceBookmarkCommand(scmProvider, jj, [child.change_id]);
+
+        const [childLog] = await jj.getLog({ revision: '@' });
+        expect(childLog.bookmarks).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'test-bookmark' })]),
+        );
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+
+    test('prompts for revision if not provided, and advances bookmark', async () => {
+        repo.bookmark('test-bookmark', '@');
+        await jj.new({ message: 'child' });
+        const [child] = await jj.getLog({ revision: '@' });
+
+        let acceptCallback: () => Promise<void> = async () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb: () => Promise<void>) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            setSelectedItems(mockQuickPick, [{ label: child.commit_id, detail: child.commit_id }]);
+            acceptCallback();
+        });
+
+        await advanceBookmarkCommand(scmProvider, jj, []);
+
+        const [childLog] = await jj.getLog({ revision: '@' });
+        expect(childLog.bookmarks).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'test-bookmark' })]),
+        );
+        expect(scmProvider.refresh).toHaveBeenCalled();
+    });
+});

--- a/src/test/commands/bookmark.test.ts
+++ b/src/test/commands/bookmark.test.ts
@@ -2,38 +2,26 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { setBookmarkCommand } from '../../commands/bookmark';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-
-// Mock QuickPick
-const { mockQuickPick } = vi.hoisted(() => ({
-    mockQuickPick: {
-        show: vi.fn(),
-        hide: vi.fn(),
-        onDidAccept: vi.fn(),
-        selectedItems: [] as { label: string; description?: string }[],
-        value: '',
-        items: [] as { label: string; description?: string }[],
-        placeholder: '',
-        matchOnDescription: false,
-    },
-}));
+import { resetMockQuickPick, setSelectedItems } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
-    return createVscodeMock({
-        window: { createQuickPick: vi.fn(() => mockQuickPick) },
-    });
+    return createVscodeMock();
 });
 
 describe('setBookmarkCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
     let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
 
     beforeEach(() => {
         repo = new TestRepo();
@@ -41,11 +29,8 @@ describe('setBookmarkCommand', () => {
         jj = new JjService(repo.path);
         scmProvider = createMock<JjScmProvider>({ refresh: vi.fn() });
 
-        mockQuickPick.show.mockClear();
-        mockQuickPick.hide.mockClear();
-        mockQuickPick.onDidAccept.mockClear();
-        mockQuickPick.selectedItems = [];
-        mockQuickPick.value = '';
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
     });
 
     afterEach(() => {
@@ -66,14 +51,14 @@ describe('setBookmarkCommand', () => {
         repo.bookmark('feature-a', '@');
 
         let acceptCallback: () => Promise<void> = async () => {};
-        mockQuickPick.onDidAccept.mockImplementation((cb: () => Promise<void>) => {
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb: () => Promise<void>) => {
             acceptCallback = cb;
             return { dispose: () => {} };
         });
 
         await setBookmarkCommand(scmProvider, jj, { commitId: repo.getChangeId('@') });
 
-        mockQuickPick.selectedItems = [{ label: 'feature-a' }];
+        setSelectedItems(mockQuickPick, [{ label: 'feature-a' }]);
         await acceptCallback();
 
         expect(mockQuickPick.hide).toHaveBeenCalled();
@@ -82,7 +67,7 @@ describe('setBookmarkCommand', () => {
 
     test('creates new bookmark when typed', async () => {
         let acceptCallback: () => Promise<void> = async () => {};
-        mockQuickPick.onDidAccept.mockImplementation((cb: () => Promise<void>) => {
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb: () => Promise<void>) => {
             acceptCallback = cb;
             return { dispose: () => {} };
         });
@@ -90,7 +75,7 @@ describe('setBookmarkCommand', () => {
         const commitId = repo.getChangeId('@');
         await setBookmarkCommand(scmProvider, jj, { commitId });
 
-        mockQuickPick.selectedItems = [];
+        setSelectedItems(mockQuickPick, []);
         mockQuickPick.value = 'new-feature';
         await acceptCallback();
 

--- a/src/test/commands/compare-file-with-revision.test.ts
+++ b/src/test/commands/compare-file-with-revision.test.ts
@@ -7,18 +7,12 @@ import * as vscode from 'vscode';
 import { compareFileWithRevisionCommand } from '../../commands/compare-file-with-revision';
 import { JjService } from '../../jj-service';
 import { TestRepo } from '../test-repo';
-import { createMock } from '../test-utils';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
     return createVscodeMock({
         commands: { executeCommand: vi.fn() },
-        window: {
-            showInformationMessage: vi.fn(),
-            showErrorMessage: vi.fn(),
-            showInputBox: vi.fn(),
-            showQuickPick: vi.fn(),
-        },
     });
 });
 
@@ -43,24 +37,19 @@ describe('compareFileWithRevisionCommand', () => {
         repo.writeFile('file1.txt', 'content');
         const fileUri = vscode.Uri.file(`${repo.path}/file1.txt`);
 
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+
         let acceptCallback: () => void = () => {};
-        const mockQuickPick = {
-            items: [],
-            selectedItems: [{ label: 'main', detail: 'main' }],
-            activeItems: [{ label: 'main', detail: 'main' }],
-            onDidChangeValue: vi.fn(),
-            onDidAccept: vi.fn().mockImplementation((cb) => {
-                acceptCallback = cb;
-            }),
-            onDidHide: vi.fn(),
-            show: vi.fn().mockImplementation(() => {
-                acceptCallback();
-            }),
-            dispose: vi.fn(),
-        };
-        vi.mocked(vscode.window.createQuickPick).mockReturnValue(
-            createMock<vscode.QuickPick<vscode.QuickPickItem>>(mockQuickPick),
-        );
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        setSelectedItems(mockQuickPick, [{ label: 'main', detail: 'main' }]);
+        setActiveItems(mockQuickPick, [{ label: 'main', detail: 'main' }]);
 
         await compareFileWithRevisionCommand(jj, mockOutputChannel, fileUri);
 

--- a/src/test/commands/merge-editor.test.ts
+++ b/src/test/commands/merge-editor.test.ts
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { openMergeEditorCommand } from '../../commands/merge-editor';
 import type { JjScmProvider } from '../../jj-scm-provider';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 vi.mock('vscode', () => ({
     window: {

--- a/src/test/commands/merge.test.ts
+++ b/src/test/commands/merge.test.ts
@@ -8,7 +8,8 @@ import { newMergeChangeCommand } from '../../commands/merge';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 vi.mock('vscode', () => ({
     Uri: { file: (path: string) => ({ fsPath: path }) },

--- a/src/test/commands/rebase.test.ts
+++ b/src/test/commands/rebase.test.ts
@@ -8,7 +8,8 @@ import { rebaseOntoSelectedCommand } from '../../commands/rebase';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/refresh.test.ts
+++ b/src/test/commands/refresh.test.ts
@@ -6,7 +6,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { refreshCommand } from '../../commands/refresh';
 import type { JjScmProvider } from '../../jj-scm-provider';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');

--- a/src/test/commands/squash-files.test.ts
+++ b/src/test/commands/squash-files.test.ts
@@ -13,7 +13,8 @@ import {
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
-import { asMock, createMock } from '../test-utils';
+import { createMock } from '../test-utils';
+import { asMock } from '../vitest-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -16,6 +16,7 @@ import {
     selectCommits,
     test,
     triggerRefresh,
+    waitForBookmark,
     waitForLogCommitRow,
     waitForLogPill,
     waitForTab,
@@ -471,21 +472,57 @@ test.describe('JJ Log Context Menu E2E', () => {
             // 6. Verify the commit reached the remote repo
             const pushedCommitId = repo.getCommitId('test-branch');
 
-            await expect
-                .poll(
-                    async () => {
-                        try {
-                            // Import git changes into the remote jj repo so it sees the push
-                            remoteRepo.gitImport();
-                            const remoteCommitId = remoteRepo.getCommitId('test-branch');
-                            return remoteCommitId === pushedCommitId;
-                        } catch {
-                            return false;
-                        }
-                    },
-                    { timeout: 20000 },
-                )
-                .toBe(true);
+            await waitForBookmark(repo, 'test-branch', pushedCommitId, { remoteRepo, timeout: 20000 });
+
+            remoteRepo.dispose();
+        });
+
+        test('Advance Bookmark', async () => {
+            const webview = await getLogWebview(page);
+            const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+
+            // 1. Create a bookmark on initial commit
+            const initialChangeId = nodes.initial.changeId;
+            repo.bookmark('to-advance', initialChangeId);
+
+            // 2. Trigger "Advance Bookmark" on commit1
+            await rightClickAndSelect(page, commit1Row, 'Advance Bookmark');
+
+            // 3. Verify bookmark moved to commit1 locally
+            const targetCommitId = repo.getCommitId(nodes.commit1.changeId);
+            await waitForBookmark(repo, 'to-advance', targetCommitId);
+        });
+
+        test('Advance Bookmark & Upload', async () => {
+            const webview = await getLogWebview(page);
+            const commit1Row = webview.locator('.commit-row', { hasText: 'commit1' });
+
+            // 1. Create and initialize a remote repository
+            const remoteRepo = new TestRepo();
+            remoteRepo.init();
+
+            // 2. Add as 'origin' to the main repo
+            repo.addRemote('origin', remoteRepo.path);
+
+            // 3. Configure jj
+            repo.config('remotes.origin.auto-track-bookmarks', '"*"');
+            repo.config('git.push-new-bookmarks', 'true');
+
+            // 4. Create a bookmark on initial commit
+            const initialChangeId = nodes.initial.changeId;
+            repo.bookmark('sync-branch', initialChangeId);
+
+            // 5. Trigger "Advance Bookmark & Upload" on commit1
+            await rightClickAndSelect(page, commit1Row, 'Advance Bookmark & Upload');
+
+            // 6. Verify bookmark was advanced locally and pushed to remote
+            const pushedCommitId = repo.getCommitId(nodes.commit1.changeId);
+
+            // Local verification
+            await waitForBookmark(repo, 'sync-branch', pushedCommitId);
+
+            // Remote verification
+            await waitForBookmark(repo, 'sync-branch', pushedCommitId, { remoteRepo, timeout: 20000 });
 
             remoteRepo.dispose();
         });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -442,6 +442,32 @@ export async function rightClickAndSelect(page: Page, target: Locator, label: st
 }
 
 /**
+ * Simulates a drag and drop action between two locators.
+ */
+export async function dragAndDrop(page: Page, options: { source: Locator; target: Locator }) {
+    const { source, target } = options;
+    await source.scrollIntoViewIfNeeded();
+    await target.scrollIntoViewIfNeeded();
+
+    const sourceBox = await source.boundingBox();
+    const targetBox = await target.boundingBox();
+
+    if (!sourceBox) {
+        throw new Error('Could not get bounding box for source locator');
+    }
+    if (!targetBox) {
+        throw new Error('Could not get bounding box for target locator');
+    }
+
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
+        steps: 10,
+    });
+    await page.mouse.up();
+}
+
+/**
  * Triggers a manual refresh of the JJ Log view by clicking the refresh button in the view title.
  */
 export async function triggerRefresh(page: Page) {
@@ -1330,4 +1356,31 @@ export function maybePrintExtensionLogs(userDataDir: string) {
     } catch (err) {
         console.error('Failed to read logs:', err);
     }
+}
+
+/**
+ * Polls the repository until the bookmark points to the expected commit ID.
+ */
+export async function waitForBookmark(
+    repo: TestRepo,
+    name: string,
+    expectedCommitId: string,
+    options: { timeout?: number; remoteRepo?: TestRepo } = {},
+) {
+    await expect
+        .poll(
+            async () => {
+                try {
+                    if (options.remoteRepo) {
+                        options.remoteRepo.gitImport();
+                        return options.remoteRepo.getCommitId(name) === expectedCommitId;
+                    }
+                    return repo.getCommitId(name) === expectedCommitId;
+                } catch {
+                    return false;
+                }
+            },
+            { timeout: options.timeout ?? 10000 },
+        )
+        .toBe(true);
 }

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -7,6 +7,7 @@ import { expect } from '@playwright/test';
 import { buildGraph, TestRepo } from '../test-repo';
 import {
     clickLogAction,
+    dragAndDrop,
     entry,
     expectTree,
     focusJJLog,
@@ -260,20 +261,8 @@ test.describe('JJ Log Pane E2E', () => {
             await sourceRow.scrollIntoViewIfNeeded();
             await targetRow.scrollIntoViewIfNeeded();
 
-            const sourceBox = await sourceRow.boundingBox();
-            const targetBox = await targetRow.boundingBox();
-
             // Drag source onto target to rebase
-            if (sourceBox && targetBox) {
-                // Move to source
-                await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
-                await page.mouse.down();
-                // Move to target
-                await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
-                    steps: 10,
-                });
-                await page.mouse.up();
-            }
+            await dragAndDrop(page, { source: sourceRow, target: targetRow });
 
             // Verify rebase via repo
             await expect(async () => {
@@ -321,6 +310,57 @@ test.describe('JJ Log Pane E2E', () => {
 
             // 5. Verify the bookmark pill disappears from the webview
             await expect(bookmarkPill).toBeHidden({ timeout: 10000 });
+        } finally {
+            repo.dispose();
+        }
+    });
+
+    test('Drag & Drop Bookmark (Advance/Move)', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            {
+                label: 'wc',
+                parents: ['initial'],
+                description: 'working tree',
+                files: { 'file.txt': 'mod' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        // 1. Create a bookmark on initial commit
+        repo.bookmark('drag-bookmark', nodes.initial.changeId);
+
+        const { page } = await vscode.openWorkspace(repo);
+
+        try {
+            await focusJJLog(page);
+
+            // 2. Locate the draggable bookmark pill and target commit row (move forward)
+            const bookmarkPill = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
+            const wcRow = await waitForLogCommitRow(page, { changeId: nodes.wc.changeId });
+
+            // 3. Drag the bookmark pill onto the wc commit row (move forward)
+            await dragAndDrop(page, { source: bookmarkPill, target: wcRow });
+
+            // 4. Verify bookmark moved to wc in local repository
+            const wcCommitId = repo.getCommitId(nodes.wc.changeId);
+            await expect(async () => {
+                expect(repo.getCommitId('drag-bookmark')).toBe(wcCommitId);
+            }).toPass({ timeout: 10000 });
+
+            // 5. Drag it backward (from wc back onto initial commit)
+            const initialRow = await waitForLogCommitRow(page, { changeId: nodes.initial.changeId });
+            // Re-fetch the bookmark pill since the webview refreshes after the move command
+            const bookmarkPillAfterMove = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
+            await dragAndDrop(page, { source: bookmarkPillAfterMove, target: initialRow });
+
+            // 6. Verify bookmark moved back to initial commit in local repository
+            const initialCommitId = repo.getCommitId(nodes.initial.changeId);
+            await expect(async () => {
+                expect(repo.getCommitId('drag-bookmark')).toBe(initialCommitId);
+            }).toPass({ timeout: 10000 });
         } finally {
             repo.dispose();
         }

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -13,7 +13,8 @@ import { GerritProvider } from '../gerrit-provider';
 import { JjService } from '../jj-service';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
 import { TestRepo } from './test-repo';
-import { accessPrivate, asMock, exposePrivate } from './test-utils';
+import { accessPrivate, exposePrivate } from './test-utils';
+import { asMock } from './vitest-utils';
 
 // Mock VS Code
 const mockConfig = {

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1259,6 +1259,53 @@ log = "none()"
         );
     });
 
+    test('advanceBookmark advances all bookmarks to target revision', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'initial', description: 'initial' },
+            { label: 'child1', parents: ['initial'], description: 'child1' },
+            { label: 'child2', parents: ['child1'], description: 'child2' },
+        ]);
+
+        repo.bookmark('bookmark-a', ids.initial.changeId);
+        repo.bookmark('bookmark-b', ids.initial.changeId);
+
+        // Advance all bookmarks to child2
+        await jjService.advanceBookmark(ids.child2.changeId);
+
+        const [child2Log] = await jjService.getLog({ revision: ids.child2.changeId });
+        expect(child2Log.bookmarks).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: 'bookmark-a' }),
+                expect.objectContaining({ name: 'bookmark-b' }),
+            ]),
+        );
+    });
+
+    test('advanceBookmark advances only specified bookmarks to target revision', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'initial', description: 'initial' },
+            { label: 'child1', parents: ['initial'], description: 'child1' },
+            { label: 'child2', parents: ['child1'], description: 'child2' },
+        ]);
+
+        repo.bookmark('bookmark-a', ids.initial.changeId);
+        repo.bookmark('bookmark-b', ids.initial.changeId);
+
+        // Advance only bookmark-a to child2
+        await jjService.advanceBookmark(ids.child2.changeId, ['bookmark-a']);
+
+        // Verify bookmark-a moved to child2
+        const [child2Log] = await jjService.getLog({ revision: ids.child2.changeId });
+        expect(child2Log.bookmarks).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'bookmark-a' })]));
+        expect(child2Log.bookmarks).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: 'bookmark-b' })]),
+        );
+
+        // Verify bookmark-b remained on initial
+        const [initialLog] = await jjService.getLog({ revision: ids.initial.changeId });
+        expect(initialLog.bookmarks).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'bookmark-b' })]));
+    });
+
     test('rebase command supports source and revision modes with children', async () => {
         // Setup: Root -> Target
         //       -> Grandparent -> Parent -> Child

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -2,8 +2,8 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
 import type { SinonStub } from 'sinon';
-import type { Mock } from 'vitest';
 
 export /**
  * Creates a partial mock of type T.
@@ -11,10 +11,6 @@ export /**
  */
 function createMock<T>(partial: Partial<T> = {}): T {
     return partial as unknown as T;
-}
-
-export function asMock(fn: unknown): Mock {
-    return fn as Mock;
 }
 
 export function asSinonStub(fn: unknown): SinonStub {

--- a/src/test/vitest-utils.ts
+++ b/src/test/vitest-utils.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Mock } from 'vitest';
+import { vi } from 'vitest';
+import type * as vscode from 'vscode';
+
+export function resetMockQuickPick(mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>) {
+    mockQuickPick.value = '';
+    mockQuickPick.placeholder = '';
+    mockQuickPick.matchOnDescription = false;
+    mockQuickPick.matchOnDetail = false;
+
+    // Reset properties via mutable cast
+    const mutable = mockQuickPick as {
+        -readonly [K in keyof vscode.QuickPick<vscode.QuickPickItem>]: vscode.QuickPick<vscode.QuickPickItem>[K];
+    };
+    mutable.items = [];
+    mutable.selectedItems = [];
+    mutable.activeItems = [];
+
+    // Reset the mock functions
+    (mockQuickPick.show as Mock).mockClear();
+    (mockQuickPick.hide as Mock).mockClear();
+    (mockQuickPick.dispose as Mock).mockClear();
+    (mockQuickPick.onDidAccept as Mock).mockClear();
+    (mockQuickPick.onDidHide as Mock).mockClear();
+    (mockQuickPick.onDidChangeValue as Mock).mockClear();
+}
+
+/**
+ * Sets the selectedItems of a mocked QuickPick in a type-safe way.
+ */
+export function setSelectedItems<T extends vscode.QuickPickItem>(quickPick: vscode.QuickPick<T>, items: readonly T[]) {
+    const mutable = quickPick as { -readonly [K in keyof vscode.QuickPick<T>]: vscode.QuickPick<T>[K] };
+    mutable.selectedItems = items;
+}
+
+/**
+ * Sets the activeItems of a mocked QuickPick in a type-safe way.
+ */
+export function setActiveItems<T extends vscode.QuickPickItem>(quickPick: vscode.QuickPick<T>, items: readonly T[]) {
+    const mutable = quickPick as { -readonly [K in keyof vscode.QuickPick<T>]: vscode.QuickPick<T>[K] };
+    mutable.activeItems = items;
+}
+
+export interface MockQuickPick {
+    items: unknown[];
+    placeholder: string;
+    matchOnDescription: boolean;
+    matchOnDetail: boolean;
+    value: string;
+    selectedItems: unknown[];
+    activeItems: unknown[];
+    onDidChangeValue: Mock;
+    onDidAccept: Mock;
+    onDidHide: Mock;
+    show: Mock;
+    hide: Mock;
+    dispose: Mock;
+}
+
+export function createMockQuickPick(): MockQuickPick {
+    return {
+        items: [],
+        placeholder: '',
+        matchOnDescription: false,
+        matchOnDetail: false,
+        value: '',
+        selectedItems: [],
+        activeItems: [],
+        onDidChangeValue: vi.fn(),
+        onDidAccept: vi.fn(),
+        onDidHide: vi.fn(),
+        show: vi.fn(),
+        hide: vi.fn(),
+        dispose: vi.fn(),
+    };
+}
+
+export function asMock(fn: unknown): Mock {
+    return fn as Mock;
+}

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -261,6 +261,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
                 onDidAccept: vi.fn(),
                 onDidHide: vi.fn(),
                 show: vi.fn(),
+                hide: vi.fn(),
                 dispose: vi.fn(),
             }),
             withProgress: vi.fn().mockImplementation(async (_: unknown, task: () => Promise<unknown>) => task()),


### PR DESCRIPTION
…tions

- Added `advanceBookmark` to `JjService` to invoke the `jj bookmark advance` CLI command.
- Created `advanceBookmarkCommand` and `advanceBookmarkAndUploadCommand` to handle context menu selections.
- Contributed context menu items to the JJ Log webview in `package.json`.
- Added unit tests for the service method and the command handlers.
- Created E2E tests for the new context menu actions in `context-menu.spec.ts`.
- Introduced `dragAndDrop` and `waitForBookmark` E2E helpers, and added an E2E test for dragging a bookmark pill to a commit row in `jj-log.spec.ts`.

Fixes #366

## Summary by Sourcery

Add bookmark advancing capabilities and context menu actions, along with shared test utilities and E2E coverage.

New Features:
- Expose an advanceBookmark operation in the JJ service and wire it to new Advance Bookmark and Advance Bookmark & Upload commands and context menu entries.
- Support advancing bookmarks via drag-and-drop of bookmark pills onto commit rows in the JJ log webview.

Enhancements:
- Refine QuickPick mocking by introducing reusable helpers and a central mock factory used across command tests.
- Add a generic dragAndDrop E2E helper and a waitForBookmark helper to simplify interaction and verification logic in Playwright tests.

Tests:
- Extend unit tests for the JJ service and bookmark commands to cover bookmark advancing and upload flows.
- Add E2E tests for the new context menu actions and drag-and-drop bookmark behavior in the JJ log view.