### PR TITLE
cleanup: unify revision prompting

### DIFF
--- a/src/commands/abandon.ts
+++ b/src/commands/abandon.ts
@@ -5,9 +5,16 @@
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
-import { extractRevision, isCurrentWorkingCopyResourceGroup, showJjError, withDelayedProgress } from './command-utils';
+import {
+    extractRevision,
+    isCurrentWorkingCopyResourceGroup,
+    promptForRevision,
+    RevisionQuery,
+    showJjError,
+    withDelayedProgress,
+} from './command-utils';
 
-export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
+export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]): Promise<void> {
     let revisions: string[] = [];
 
     // 1. Check if triggered from Working Copy header (ignore selection)
@@ -28,18 +35,16 @@ export async function abandonCommand(scmProvider: JjScmProvider, jj: JjService, 
                 // Clicked outside selection -> abandon only the clicked one
                 revisions = [clickedRevision];
             }
+        } else if (selectedRevisions.length > 0) {
+            revisions = selectedRevisions;
         } else {
-            // No click arg -> use selection or prompt
-            if (selectedRevisions.length > 0) {
-                revisions = selectedRevisions;
-            } else {
-                const input = await vscode.window.showInputBox({
-                    prompt: 'Enter revision to abandon',
-                    placeHolder: 'Revision ID (e.g. @, commit_id)',
-                });
-                if (input) {
-                    revisions = [input];
-                }
+            const input = await promptForRevision(jj, {
+                placeHolder: 'Select revision to abandon',
+                emptyPrompt: 'Enter revision to abandon',
+                revisionQuery: RevisionQuery.mutable(),
+            });
+            if (input) {
+                revisions = [input];
             }
         }
     }

--- a/src/commands/bookmark-advance.ts
+++ b/src/commands/bookmark-advance.ts
@@ -4,7 +4,7 @@
  */
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
-import { extractRevision, promptForRevision, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevision, promptForRevision, RevisionQuery, showJjError, withDelayedProgress } from './command-utils';
 
 export async function advanceBookmarkCommand(
     scmProvider: JjScmProvider,
@@ -14,7 +14,11 @@ export async function advanceBookmarkCommand(
     let revision = extractRevision(args);
 
     if (!revision) {
-        revision = await promptForRevision(jj, '@', 'Select target revision to advance bookmarks to');
+        revision = await promptForRevision(jj, {
+            placeHolder: 'Select target revision to advance bookmarks to',
+            emptyPrompt: 'Enter revision',
+            revisionQuery: RevisionQuery.ancestorsIncluding('@'),
+        });
     }
 
     if (!revision) {

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -163,8 +163,7 @@ export function extractRevisions(args: unknown[]): string[] {
         }
     }
 
-    const uniqueRevisions = Array.from(new Set(revisions));
-    return uniqueRevisions;
+    return Array.from(new Set(revisions));
 }
 
 /**
@@ -183,22 +182,55 @@ export function getErrorMessage(error: unknown): string {
     return String(error);
 }
 
+export const RevisionQuery = {
+    ancestorsIncluding: (targetRevision = '@'): string => {
+        return `((::${targetRevision} & mutable()) | parents(roots(::${targetRevision} & mutable())))`;
+    },
+    ancestorsExcluding: (targetRevision = '@'): string => {
+        return `((::${targetRevision} & mutable()) | parents(roots(::${targetRevision} & mutable()))) ~ ${targetRevision}`;
+    },
+    mutable: (): string => {
+        return 'visible() & mutable()';
+    },
+    visible: (): string => {
+        return 'visible()';
+    },
+    children: (targetRevision = '@'): string => {
+        return `children(${targetRevision})`;
+    },
+};
+
+export interface PromptForRevisionOptions {
+    placeHolder?: string;
+    emptyPrompt?: string;
+    revisionQuery?: string;
+}
+
+export const DEFAULT_PROMPT_FOR_REVISION_OPTIONS: Required<PromptForRevisionOptions> = {
+    placeHolder: 'Select a revision',
+    emptyPrompt: 'Enter revision',
+    revisionQuery: RevisionQuery.ancestorsExcluding('@'),
+};
+
 /**
  * Prompts the user to select or type a revision.
  * Populates a QuickPick with the mutable ancestors of the target revision.
  */
 export async function promptForRevision(
     jj: JjService,
-    targetRevision: string = '@',
-    placeHolder: string = 'Select a revision',
-    emptyPrompt: string = 'Enter revision',
+    options: PromptForRevisionOptions = {},
 ): Promise<string | undefined> {
+    const { placeHolder, emptyPrompt, revisionQuery } = {
+        ...DEFAULT_PROMPT_FOR_REVISION_OPTIONS,
+        ...options,
+    };
+
     const maxMutableAncestors = vscode.workspace.getConfiguration('jj-view').get<number>('maxMutableAncestors', 10);
     const limit = maxMutableAncestors + 1;
 
     try {
         const commitIds = await jj.getLogIds({
-            revision: `((::${targetRevision} & mutable()) | parents(roots(::${targetRevision} & mutable()))) ~ ${targetRevision}`,
+            revision: revisionQuery,
             limit,
         });
 
@@ -385,51 +417,6 @@ export async function maybeFormatDescriptionOnSave(
         scmProvider.sourceControl.inputBox.value = description;
     }
     return description;
-}
-
-/**
- * Helper to pick a mutable ancestor for a given revision.
- */
-export async function pickAncestor(jj: JjService, revision: string): Promise<string | undefined> {
-    const maxMutableAncestors = vscode.workspace.getConfiguration('jj-view').get<number>('maxMutableAncestors', 10);
-    const limit = maxMutableAncestors + 1;
-
-    const commitIds = await jj.getLogIds({ revision: `(::${revision} & mutable())`, limit });
-
-    if (commitIds.length <= 1) {
-        vscode.window.showInformationMessage('No mutable ancestors available to squash into.');
-        return undefined;
-    }
-
-    const entries = await Promise.all(commitIds.map((id) => jj.getLog({ revision: id })));
-    const linearAncestors = entries.map((e) => e[0]).filter(Boolean);
-
-    const ancestorsToChoose = linearAncestors.slice(1);
-
-    if (ancestorsToChoose.length === 0) {
-        vscode.window.showInformationMessage('No mutable ancestors available to squash into.');
-        return undefined;
-    }
-
-    const options: vscode.QuickPickItem[] = ancestorsToChoose.map((entry) => {
-        const shortId = entry.change_id_shortest || entry.change_id.substring(0, 8);
-        const desc = entry.description?.trim() || '(no description)';
-        const shortDesc = desc.split('\n')[0].substring(0, 50);
-
-        return {
-            label: shortId,
-            description: shortDesc,
-            detail: entry.commit_id,
-        };
-    });
-
-    const selected = await vscode.window.showQuickPick(options, {
-        placeHolder: 'Select which ancestor to squash into',
-        matchOnDescription: true,
-        matchOnDetail: true,
-    });
-
-    return selected?.detail;
 }
 
 /**

--- a/src/commands/compare-all-files-with-revision.ts
+++ b/src/commands/compare-all-files-with-revision.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from '../jj-service';
 import { encodeJjViewQuery } from '../uri-utils';
-import { extractRevision, promptForRevision, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevision, promptForRevision, RevisionQuery, showJjError, withDelayedProgress } from './command-utils';
 
 export async function compareAllFilesWithRevisionCommand(
     jj: JjService,
@@ -16,12 +16,11 @@ export async function compareAllFilesWithRevisionCommand(
     try {
         let revision = extractRevision(args);
         if (!revision) {
-            revision = await promptForRevision(
-                jj,
-                '@',
-                'Select an ancestor to compare with all files',
-                'Enter revision to compare with all files',
-            );
+            revision = await promptForRevision(jj, {
+                placeHolder: 'Select an ancestor to compare with all files',
+                emptyPrompt: 'Enter revision to compare with all files',
+                revisionQuery: RevisionQuery.ancestorsExcluding('@'),
+            });
         }
 
         if (!revision) {

--- a/src/commands/compare-file-with-revision.ts
+++ b/src/commands/compare-file-with-revision.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from '../jj-service';
 import { encodeJjViewQuery } from '../uri-utils';
-import { promptForRevision, showJjError } from './command-utils';
+import { promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
 export async function compareFileWithRevisionCommand(
     jj: JjService,
@@ -33,12 +33,11 @@ export async function compareFileWithRevisionCommand(
             return;
         }
 
-        const revision = await promptForRevision(
-            jj,
-            '@',
-            `Select an ancestor to compare ${path.basename(fileUri.fsPath)} with`,
-            `Compare ${path.basename(fileUri.fsPath)} with revision`,
-        );
+        const revision = await promptForRevision(jj, {
+            placeHolder: `Select an ancestor to compare ${path.basename(fileUri.fsPath)} with`,
+            emptyPrompt: `Compare ${path.basename(fileUri.fsPath)} with revision`,
+            revisionQuery: RevisionQuery.ancestorsExcluding('@'),
+        });
 
         if (!revision) {
             return;

--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -5,7 +5,7 @@
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
-import { showJjError } from './command-utils';
+import { promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
 export interface MergeCommandArg {
     revision: string;
@@ -30,11 +30,19 @@ export async function newMergeChangeCommand(
             revisions.push(...selection);
         } else {
             // Try getting from context or input
-            const rev1 = await vscode.window.showInputBox({ prompt: 'Enter first revision for merge (optional)' });
+            const rev1 = await promptForRevision(jj, {
+                placeHolder: 'Select first revision for merge (optional)',
+                emptyPrompt: 'Enter first revision for merge (optional)',
+                revisionQuery: RevisionQuery.visible(),
+            });
             if (rev1) {
                 revisions.push(rev1);
             }
-            const rev2 = await vscode.window.showInputBox({ prompt: 'Enter second revision for merge (optional)' });
+            const rev2 = await promptForRevision(jj, {
+                placeHolder: 'Select second revision for merge (optional)',
+                emptyPrompt: 'Enter second revision for merge (optional)',
+                revisionQuery: RevisionQuery.visible(),
+            });
             if (rev2) {
                 revisions.push(rev2);
             }

--- a/src/commands/squash-files.ts
+++ b/src/commands/squash-files.ts
@@ -8,7 +8,8 @@ import type { JjService } from '../jj-service';
 import {
     collectResourceStates,
     extractRevision,
-    pickAncestor,
+    promptForRevision,
+    RevisionQuery,
     showJjError,
     withDelayedProgress,
 } from './command-utils';
@@ -51,7 +52,11 @@ export async function squashFilesIntoAncestorCommand(scmProvider: JjScmProvider,
     const revision = extractRevision(args) || '@';
 
     try {
-        const selectedAncestorRev = await pickAncestor(jj, revision);
+        const selectedAncestorRev = await promptForRevision(jj, {
+            placeHolder: 'Select which ancestor to squash into',
+            emptyPrompt: 'Enter ancestor revision',
+            revisionQuery: RevisionQuery.ancestorsExcluding(revision),
+        });
         if (!selectedAncestorRev) {
             return;
         }
@@ -90,8 +95,10 @@ export async function squashFilesIntoChildCommand(scmProvider: JjScmProvider, jj
         } else if (children.length === 1) {
             targetChild = children[0];
         } else {
-            targetChild = await vscode.window.showQuickPick(children, {
+            targetChild = await promptForRevision(jj, {
                 placeHolder: `Select child commit for ${revision}`,
+                emptyPrompt: `Enter child commit for ${revision}`,
+                revisionQuery: RevisionQuery.children(revision),
             });
         }
 

--- a/src/commands/squash-revision.ts
+++ b/src/commands/squash-revision.ts
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
-import { extractRevision, pickAncestor, showJjError, withDelayedProgress } from './command-utils';
+import { extractRevision, promptForRevision, RevisionQuery, showJjError, withDelayedProgress } from './command-utils';
 
 interface SquashMeta {
     revision: string;
@@ -94,7 +94,11 @@ export async function squashRevisionIntoAncestorCommand(scmProvider: JjScmProvid
     const revision = extractRevision(args) || '@';
 
     try {
-        const selectedAncestorRev = await pickAncestor(jj, revision);
+        const selectedAncestorRev = await promptForRevision(jj, {
+            placeHolder: 'Select which ancestor to squash into',
+            emptyPrompt: 'Enter ancestor revision',
+            revisionQuery: RevisionQuery.ancestorsExcluding(revision),
+        });
         if (!selectedAncestorRev) {
             return;
         }

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { promptForRevision, withDelayedProgress } from '../commands/command-utils';
+import { promptForRevision, RevisionQuery, withDelayedProgress } from '../commands/command-utils';
 import { JjService } from '../jj-service';
 import { buildGraph, TestRepo } from './test-repo';
 import { resetMockQuickPick, setActiveItems, setSelectedItems } from './vitest-utils';
@@ -110,7 +110,7 @@ describe('promptForRevision', () => {
         setSelectedItems(mockQuickPick, [{ label: 'any', detail: changeId }]);
         setActiveItems(mockQuickPick, [{ label: 'any', detail: changeId }]);
 
-        const result = await promptForRevision(jj, '@');
+        const result = await promptForRevision(jj, { revisionQuery: RevisionQuery.ancestorsExcluding('@') });
 
         expect(result).toBe(changeId);
     });
@@ -131,7 +131,7 @@ describe('promptForRevision', () => {
         });
         mockQuickPick.value = 'custom-revision';
 
-        const result = await promptForRevision(jj, '@');
+        const result = await promptForRevision(jj, { revisionQuery: RevisionQuery.ancestorsExcluding('@') });
 
         expect(result).toBe('custom-revision');
     });
@@ -139,7 +139,7 @@ describe('promptForRevision', () => {
     it('falls back to input box if no ancestors are found', async () => {
         vi.mocked(vscode.window.showInputBox).mockResolvedValue('manual-rev');
 
-        const result = await promptForRevision(jj, 'root()');
+        const result = await promptForRevision(jj, { revisionQuery: RevisionQuery.ancestorsExcluding('root()') });
 
         expect(result).toBe('manual-rev');
         expect(vscode.window.showInputBox).toHaveBeenCalledWith(
@@ -153,7 +153,7 @@ describe('promptForRevision', () => {
 
         vi.mocked(vscode.window.showInputBox).mockResolvedValue('fallback-rev');
 
-        const result = await promptForRevision(jj, '@');
+        const result = await promptForRevision(jj, { revisionQuery: RevisionQuery.ancestorsExcluding('@') });
 
         expect(result).toBe('fallback-rev');
         expect(vscode.window.showInputBox).toHaveBeenCalledWith(expect.objectContaining({ prompt: 'Enter revision' }));
@@ -174,9 +174,83 @@ describe('promptForRevision', () => {
             acceptCallback();
         });
 
-        await promptForRevision(jj, '@');
+        await promptForRevision(jj, { revisionQuery: RevisionQuery.ancestorsExcluding('@') });
 
         expect(mockQuickPick.matchOnDescription).toBe(true);
         expect(mockQuickPick.matchOnDetail).toBe(true);
+    });
+
+    it('includes target revision with ancestorsIncluding, and excludes it with ancestorsExcluding', async () => {
+        const ids = await buildGraph(repo, [{ label: 'v1', files: { 'file1.txt': 'v1\n' } }]);
+        const targetChangeId = ids.v1.changeId;
+
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+
+        // 1. By default/excluding, target is excluded
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        mockQuickPick.value = 'fallback';
+        await promptForRevision(jj, {
+            placeHolder: 'Select',
+            emptyPrompt: 'Enter',
+            revisionQuery: RevisionQuery.ancestorsExcluding('@'),
+        });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(false);
+
+        // 2. With ancestorsIncluding, target is included
+        resetMockQuickPick(mockQuickPick);
+        mockQuickPick.value = 'fallback';
+        await promptForRevision(jj, {
+            placeHolder: 'Select',
+            emptyPrompt: 'Enter',
+            revisionQuery: RevisionQuery.ancestorsIncluding('@'),
+        });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(true);
+    });
+
+    it('supports RevisionQuery factory methods (mutable, visible, and custom)', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'parent', files: { 'file1.txt': 'parent\n' } },
+            { label: 'child', parents: ['parent'], files: { 'file1.txt': 'child\n' } },
+        ]);
+        const targetChangeId = ids.child.changeId;
+
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+
+        // 1. query: mutable
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        mockQuickPick.value = 'fallback';
+        await promptForRevision(jj, { revisionQuery: RevisionQuery.mutable() });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(true);
+
+        // 2. query: visible
+        resetMockQuickPick(mockQuickPick);
+        await promptForRevision(jj, { revisionQuery: RevisionQuery.visible() });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(true);
+
+        // 3. query: custom string
+        resetMockQuickPick(mockQuickPick);
+        await promptForRevision(jj, { revisionQuery: 'visible()' });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(true);
+
+        // 4. query: children
+        resetMockQuickPick(mockQuickPick);
+        await promptForRevision(jj, { revisionQuery: RevisionQuery.children(ids.parent.changeId) });
+        expect(mockQuickPick.items.some((item) => item.detail === targetChangeId)).toBe(true);
     });
 });

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -10,13 +10,11 @@ import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-import { asMock } from '../vitest-utils';
+import { asMock, resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
-    return createVscodeMock({
-        window: { showInputBox: vi.fn() },
-    });
+    return createVscodeMock();
 });
 
 describe('abandonCommand', () => {
@@ -188,11 +186,22 @@ describe('abandonCommand', () => {
         // Create child
         repo.new();
 
-        asMock(vscode.window.showInputBox).mockResolvedValue(c1);
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        setSelectedItems(mockQuickPick, [{ label: 'any', detail: c1 }]);
+        setActiveItems(mockQuickPick, [{ label: 'any', detail: c1 }]);
 
         await abandonCommand(scmProvider, jj, []);
 
-        expect(vscode.window.showInputBox).toHaveBeenCalled();
+        expect(mockQuickPick.show).toHaveBeenCalled();
 
         // c1 abandoned
         expectChangeAbandoned(c1);

--- a/src/test/commands/merge.test.ts
+++ b/src/test/commands/merge.test.ts
@@ -9,21 +9,18 @@ import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-import { asMock } from '../vitest-utils';
+import { asMock, resetMockQuickPick } from '../vitest-utils';
 
-vi.mock('vscode', () => ({
-    Uri: { file: (path: string) => ({ fsPath: path }) },
-    window: {
-        showErrorMessage: vi.fn(),
-        showWarningMessage: vi.fn(),
-        showInputBox: vi.fn(),
-    },
-}));
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock();
+});
 
 describe('newMergeChangeCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
     let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
 
     beforeEach(() => {
         repo = new TestRepo();
@@ -32,6 +29,17 @@ describe('newMergeChangeCommand', () => {
         scmProvider = createMock<JjScmProvider>({
             refresh: vi.fn(),
             getSelectedCommitIds: vi.fn().mockReturnValue([]),
+        });
+
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
         });
     });
 

--- a/src/test/commands/squash-files.test.ts
+++ b/src/test/commands/squash-files.test.ts
@@ -14,14 +14,13 @@ import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-import { asMock } from '../vitest-utils';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
     return createVscodeMock({
         window: {
-            showQuickPick: vi.fn(),
             showErrorMessage: vi.fn(),
         },
     });
@@ -31,6 +30,7 @@ describe('squash-files commands', () => {
     let jj: JjService;
     let repo: TestRepo;
     let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
 
     beforeEach(() => {
         repo = new TestRepo();
@@ -42,6 +42,17 @@ describe('squash-files commands', () => {
             outputChannel: createMock<vscode.OutputChannel>({
                 appendLine: vi.fn(),
             }),
+        });
+
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
         });
     });
 
@@ -110,22 +121,17 @@ describe('squash-files commands', () => {
                 },
             ]);
 
-            const grandparentCommitId = ids.grandparent.commitId;
-
-            // Mock QuickPick to return grandparent
-            vi.mocked(vscode.window.showQuickPick).mockResolvedValueOnce(
-                createMock<vscode.QuickPickItem>({
-                    detail: grandparentCommitId,
-                    label: 'Ancestor 2',
-                }),
-            );
+            // Mock QuickPick selection to grandparent
+            mockQuickPick.value = ids.grandparent.changeId;
+            setSelectedItems(mockQuickPick, [{ label: 'grandparent', detail: ids.grandparent.changeId }]);
+            setActiveItems(mockQuickPick, [{ label: 'grandparent', detail: ids.grandparent.changeId }]);
 
             const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
             const args = [{ resourceUri: fileUri }];
 
             await squashFilesIntoAncestorCommand(scmProvider, jj, args);
 
-            expect(vscode.window.showQuickPick).toHaveBeenCalled();
+            expect(mockQuickPick.show).toHaveBeenCalled();
 
             // Grandparent should have 'child content'
             const gpContent = repo.getFileContent(ids.grandparent.changeId, fileName);
@@ -176,14 +182,17 @@ describe('squash-files commands', () => {
                 { label: 'child2', parents: ['parent'] },
             ]);
 
-            asMock(vscode.window.showQuickPick).mockResolvedValueOnce(ids.child2.changeId);
+            // Mock QuickPick selection to child2
+            mockQuickPick.value = ids.child2.changeId;
+            setSelectedItems(mockQuickPick, [{ label: 'child2', detail: ids.child2.changeId }]);
+            setActiveItems(mockQuickPick, [{ label: 'child2', detail: ids.child2.changeId }]);
 
             const fileUri = vscode.Uri.file(path.join(repo.path, fileName));
             const args = [{ resourceUri: fileUri }, { revision: ids.parent.changeId }];
 
             await squashFilesIntoChildCommand(scmProvider, jj, args);
 
-            expect(vscode.window.showQuickPick).toHaveBeenCalled();
+            expect(mockQuickPick.show).toHaveBeenCalled();
             expect(repo.getFileContent(ids.child2.changeId, fileName)).toBe('parent modified');
         });
 

--- a/src/test/commands/squash-revision.test.ts
+++ b/src/test/commands/squash-revision.test.ts
@@ -6,7 +6,6 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { pickAncestor } from '../../commands/command-utils';
 import {
     completeSquashRevisionCommand,
     squashRevisionIntoAncestorCommand,
@@ -16,6 +15,7 @@ import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
 
 // Mock VS Code
 vi.mock('vscode', async () => {
@@ -24,6 +24,7 @@ vi.mock('vscode', async () => {
         window: {
             showQuickPick: vi.fn(),
             showTextDocument: vi.fn(),
+            showErrorMessage: vi.fn(),
             tabGroups: {
                 all: [],
                 close: vi.fn(),
@@ -39,18 +40,11 @@ vi.mock('vscode', async () => {
     });
 });
 
-vi.mock('../../commands/command-utils', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('../../commands/command-utils')>();
-    return {
-        ...actual,
-        pickAncestor: vi.fn(),
-    };
-});
-
 describe('squashRevisionIntoParentCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
     let scmProvider: JjScmProvider;
+    let mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>;
 
     beforeEach(() => {
         repo = new TestRepo();
@@ -63,6 +57,17 @@ describe('squashRevisionIntoParentCommand', () => {
             outputChannel: createMock<vscode.OutputChannel>({
                 appendLine: vi.fn(),
             }),
+        });
+
+        mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
         });
     });
 
@@ -315,12 +320,14 @@ describe('squashRevisionIntoParentCommand', () => {
             { label: 'wc', parents: ['child'], isCurrentWorkingCopy: true },
         ]);
 
-        // Mock pickAncestor to select 'base'
-        vi.mocked(pickAncestor).mockResolvedValueOnce(ids.base.commitId);
+        // Mock QuickPick selection to base
+        mockQuickPick.value = ids.base.changeId;
+        setSelectedItems(mockQuickPick, [{ label: 'base', detail: ids.base.changeId }]);
+        setActiveItems(mockQuickPick, [{ label: 'base', detail: ids.base.changeId }]);
 
         await squashRevisionIntoAncestorCommand(scmProvider, jj, [ids.child.changeId]);
 
-        expect(pickAncestor).toHaveBeenCalledWith(expect.anything(), ids.child.changeId);
+        expect(mockQuickPick.show).toHaveBeenCalled();
 
         // base should now have child's content
         expect(repo.getFileContent(ids.base.changeId, 'child.txt')).toBe('child');


### PR DESCRIPTION
- Introduce `RevisionQuery` helpers for constructing revset query strings
- Refactor `promptForRevision` to accept an options object
- Update all revision prompting commands (abandon, merge, advance bookmark, compare, squash ancestor/child) to use unified prompts
- Remove `pickAncestor` helper function
- Refactor SCM unit tests to mock VS Code's QuickPick directly instead of stubbing internal functions

## Summary by Sourcery

Unify revision selection across commands using a configurable revision prompt and shared revset query helpers.

New Features:
- Introduce a RevisionQuery helper object for constructing common revset query strings used in revision prompts.

Enhancements:
- Refactor promptForRevision to take an options object with placeholders and revset queries, and apply it across abandon, merge, bookmark advance, compare, and squash-related commands for consistent revision prompting.
- Remove the bespoke pickAncestor helper in favor of the unified revision prompt with appropriate ancestor queries.
- Simplify extractRevisions to return unique revisions without intermediate variables.

Tests:
- Update and extend unit tests to cover the new RevisionQuery helpers, promptForRevision options, and to mock VS Code QuickPick directly instead of stubbing internal helpers in SCM-related tests.