### PR TITLE
fix: parallelize queries and synchronize dirty indicator state

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -79,7 +79,7 @@ export class ChangeDetectionManager implements vscode.Disposable {
                 if (doc.uri.scheme !== 'file') {
                     return;
                 }
-                const fsPath = doc.uri.fsPath;
+                const { fsPath } = doc.uri;
                 if (/[\\/]\.jj[\\/]/.test(fsPath)) {
                     return;
                 }

--- a/src/commands/describe.ts
+++ b/src/commands/describe.ts
@@ -24,7 +24,7 @@ export async function setDescriptionCommand(scmProvider: JjScmProvider, jj: JjSe
 
     try {
         await withDelayedProgress('Setting description...', jj.describe(description, revision));
-        await scmProvider.refresh({ reason: 'after describe' });
+        scmProvider.refresh({ reason: 'after describe' });
         return description;
     } catch (e: unknown) {
         await showJjError(e, 'Error setting description', jj, scmProvider.outputChannel);

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -60,7 +60,6 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             ? this._repositoryManager.getRepositoryForUri(repoRoot)
             : this._repositoryManager.focusedRepository;
     }
-
     public async refresh(_reason?: string): Promise<void> {
         for (const [changeId, panels] of this._panels.entries()) {
             if (panels.size === 0) {
@@ -84,7 +83,10 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                 const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
                 const formatDescriptionOnSave = config.get<boolean>('commit.formatDescriptionOnSave', false);
 
-                const logs = await repo.jj.getLog({ revision: changeId });
+                const logPromise = repo.jj.getLog({ revision: changeId });
+                const changesPromise = repo.jj.getChanges(changeId).catch(() => null);
+
+                const logs = await logPromise;
                 if (logs.length === 0) {
                     panels.forEach((p) => {
                         p.dispose();
@@ -93,7 +95,8 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                 }
 
                 const log = logs[0];
-                const filesWithStats = await repo.jj.getChanges(changeId).catch(() => log.changes || []);
+                const rawFilesWithStats = await changesPromise;
+                const filesWithStats = rawFilesWithStats || log.changes || [];
 
                 for (const panel of panels) {
                     panel.webview.postMessage({
@@ -258,14 +261,18 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
         }
 
         try {
-            const logs = await repo.jj.getLog({ revision: document.changeId });
+            const logPromise = repo.jj.getLog({ revision: document.changeId });
+            const changesPromise = repo.jj.getChanges(document.changeId).catch(() => null);
+
+            const logs = await logPromise;
             if (logs.length === 0) {
                 panel.dispose();
                 return;
             }
 
             const log = logs[0];
-            const filesWithStats = await repo.jj.getChanges(document.changeId).catch(() => log.changes || []);
+            const rawFilesWithStats = await changesPromise;
+            const filesWithStats = rawFilesWithStats || log.changes || [];
 
             const initialDescription = (log.description || '').trim();
             const initialData = {
@@ -505,6 +512,15 @@ export async function openCommitDetails(
         query: `changeId=${changeId}&repoRoot=${encodeURIComponent(workspaceRoot)}`,
     });
 
+    await closeOtherCommitDetailsTabs(uri, workspaceRoot);
+
+    await vscode.commands.executeCommand('vscode.openWith', uri, JjCommitDetailsEditorProvider.viewType);
+}
+
+export async function closeOtherCommitDetailsTabs(
+    currentUri: vscode.Uri,
+    workspaceRoot: string | undefined,
+): Promise<void> {
     const allTabs = vscode.window.tabGroups.all.flatMap((g) => g.tabs);
     const tabsToClose = allTabs.filter((tab) => {
         if (!(tab.input instanceof vscode.TabInputCustom)) {
@@ -513,14 +529,14 @@ export async function openCommitDetails(
         if (tab.input.viewType !== JjCommitDetailsEditorProvider.viewType) {
             return false;
         }
-        if (tab.input.uri.toString() === uri.toString()) {
+        if (tab.input.uri.toString() === currentUri.toString()) {
             return false;
         }
 
         try {
             const query = new URLSearchParams(tab.input.uri.query);
-            const repoRoot = query.get('repoRoot');
-            return !repoRoot || repoRoot === workspaceRoot;
+            const tabRepoRoot = query.get('repoRoot');
+            return !tabRepoRoot || tabRepoRoot === workspaceRoot;
         } catch {
             return true; // Default to closing if parsing fails
         }
@@ -529,6 +545,4 @@ export async function openCommitDetails(
     if (tabsToClose.length > 0) {
         await vscode.window.tabGroups.close(tabsToClose);
     }
-
-    await vscode.commands.executeCommand('vscode.openWith', uri, JjCommitDetailsEditorProvider.viewType);
 }

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -645,6 +645,12 @@ test.describe('Commit Details E2E', () => {
                 expect(desc).toBe(expectedDesc);
                 expect(desc.split('\n').length).toBeGreaterThan(2);
             }).toPass({ timeout: 15000 });
+
+            // Verify the textarea content has been updated to the formatted description in the UI
+            await expect(textarea).toHaveValue(
+                `Title line\n\nThis is a very long body text that should be wrapped onto multiple lines\nwhen saved because it exceeds the limit of seventy-two characters.`,
+                { timeout: 10000 },
+            );
         });
     });
 });

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -34,6 +34,13 @@ interface SaveFailedMessage {
     type: 'saveFailed';
 }
 
+interface SaveCompleteMessage {
+    type: 'saveComplete';
+    payload: {
+        description: string;
+    };
+}
+
 interface UpdateDescriptionMessage {
     type: 'updateDescription';
     payload: {
@@ -43,15 +50,15 @@ interface UpdateDescriptionMessage {
     };
 }
 
-type WebviewMessage = SaveFailedMessage | UpdateDescriptionMessage;
+type WebviewMessage = SaveFailedMessage | SaveCompleteMessage | UpdateDescriptionMessage;
 
 function isWebviewMessage(data: unknown): data is WebviewMessage {
-    return (
-        typeof data === 'object' &&
-        data !== null &&
-        'type' in data &&
-        typeof (data as Record<string, unknown>).type === 'string'
-    );
+    if (typeof data !== 'object' || data === null) {
+        return false;
+    }
+
+    const { type } = data as { type?: unknown };
+    return typeof type === 'string' && ['saveFailed', 'saveComplete', 'updateDescription'].includes(type);
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
@@ -104,11 +111,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                 textareaRef.current.value = description;
             }
         }
-        setIsSaving(false);
         prevDescriptionRef.current = description;
-        if (saveTimeoutRef.current) {
-            clearTimeout(saveTimeoutRef.current);
-        }
     }, [description]);
 
     React.useEffect(() => {
@@ -123,6 +126,17 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                 if (saveTimeoutRef.current) {
                     clearTimeout(saveTimeoutRef.current);
                 }
+            } else if (data.type === 'saveComplete') {
+                setIsSaving(false);
+                if (saveTimeoutRef.current) {
+                    clearTimeout(saveTimeoutRef.current);
+                }
+                const savedDescription = data.payload.description;
+                setDraftDescription(savedDescription);
+                if (textareaRef.current) {
+                    textareaRef.current.value = savedDescription;
+                }
+                prevDescriptionRef.current = savedDescription;
             } else if (data.type === 'updateDescription') {
                 const { description: newDesc, selectionStart, selectionEnd } = data.payload;
                 isApplyingExtensionEdit.current = true;


### PR DESCRIPTION
Parallelizes `jj.getLog` and `jj.getChanges` calls in the commit details panel to reduce latency.

Introduces a `saveComplete` webview message to correctly coordinate saving and dirty indicator state updates, resolving an issue where the dirty indicator updated later than the saved indicator.