### PR TITLE
cleanup: validate SCM and forge payloads with Zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1033,6 +1033,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "renderdag-ts": "git+https://github.com/brychanrobot/renderdag-ts.git",
-        "ts-pattern": "^5.9.0"
+        "ts-pattern": "^5.9.0",
+        "zod": "^4.4.3"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12
@@ -3385,6 +3388,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -6865,3 +6871,5 @@ snapshots:
   yerror@8.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}

--- a/src/commands/squash-revision.ts
+++ b/src/commands/squash-revision.ts
@@ -5,25 +5,16 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { z } from 'zod';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
 import { extractRevision, promptForRevision, RevisionQuery, showJjError, withDelayedProgress } from './command-utils';
 
-interface SquashMeta {
-    revision: string;
-    parentRev: string;
-}
-
-function isSquashMeta(obj: unknown): obj is SquashMeta {
-    return (
-        !!obj &&
-        typeof obj === 'object' &&
-        'revision' in obj &&
-        'parentRev' in obj &&
-        typeof (obj as Record<string, unknown>).revision === 'string' &&
-        typeof (obj as Record<string, unknown>).parentRev === 'string'
-    );
-}
+const SquashMetaSchema = z.object({
+    revision: z.string(),
+    parentRev: z.string(),
+});
+type SquashMeta = z.infer<typeof SquashMetaSchema>;
 
 /**
  * Command to squash the entire revision into its parent.
@@ -198,11 +189,12 @@ export async function completeSquashRevisionCommand(scmProvider: JjScmProvider, 
 
     try {
         const metaContent = await fs.readFile(metaPath, 'utf-8');
-        const metaRaw: unknown = JSON.parse(metaContent);
-        if (!isSquashMeta(metaRaw)) {
+        const parsed = JSON.parse(metaContent);
+        const validation = SquashMetaSchema.safeParse(parsed);
+        if (!validation.success) {
             throw new Error('Invalid squash metadata.');
         }
-        const { revision, parentRev } = metaRaw;
+        const { revision, parentRev } = validation.data;
 
         // Strip comments
         const finalMessage = message

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -5,6 +5,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import { z } from 'zod';
 import type { ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo } from './jj-types';
@@ -13,38 +14,43 @@ import { fetchWithTimeout } from './utils/fetch-utils';
 import { resolveGerritChangeKey, stripGerritTrailers } from './utils/gerrit-utils';
 import { convertJjChangeIdToHex } from './utils/jj-utils';
 
-export interface GerritFile {
-    status?: string;
-    new_sha?: string;
-}
+export const GerritFileSchema = z.object({
+    status: z.string().optional(),
+    new_sha: z.string().optional(),
+});
+export type GerritFile = z.infer<typeof GerritFileSchema>;
 
-export interface GerritRevision {
-    files?: Record<string, GerritFile>;
-    commit?: {
-        message: string;
-        parents?: { commit: string }[];
-    };
-}
+export const GerritRevisionSchema = z.object({
+    files: z.record(z.string(), GerritFileSchema).optional(),
+    commit: z
+        .object({
+            message: z.string(),
+            parents: z.array(z.object({ commit: z.string() })).optional(),
+        })
+        .optional(),
+});
+export type GerritRevision = z.infer<typeof GerritRevisionSchema>;
 
-export interface GerritChange {
-    change_id: string;
-    _number: number;
-    status: 'NEW' | 'MERGED' | 'ABANDONED';
-    submittable: boolean;
-    unresolved_comment_count?: number;
-    current_revision?: string;
-    revisions?: Record<string, GerritRevision>;
-    project?: string;
-    branch?: string;
-    subject?: string;
-    created?: string;
-    updated?: string;
-    mergeable?: boolean;
-    insertions?: number;
-    deletions?: number;
-    owner?: { _account_id: number };
-    labels?: Record<string, unknown>;
-}
+export const GerritChangeSchema = z.object({
+    change_id: z.string(),
+    _number: z.number(),
+    status: z.enum(['NEW', 'MERGED', 'ABANDONED']),
+    submittable: z.boolean(),
+    unresolved_comment_count: z.number().optional(),
+    current_revision: z.string().optional(),
+    revisions: z.record(z.string(), GerritRevisionSchema).optional(),
+    project: z.string().optional(),
+    branch: z.string().optional(),
+    subject: z.string().optional(),
+    created: z.string().optional(),
+    updated: z.string().optional(),
+    mergeable: z.boolean().optional(),
+    insertions: z.number().optional(),
+    deletions: z.number().optional(),
+    owner: z.object({ _account_id: z.number() }).optional(),
+    labels: z.record(z.string(), z.unknown()).optional(),
+});
+export type GerritChange = z.infer<typeof GerritChangeSchema>;
 
 export class GerritProvider implements CodeForgeProvider {
     public readonly id = 'gerrit';
@@ -343,11 +349,29 @@ export class GerritProvider implements CodeForgeProvider {
 
     private parseBatchResponse(text: string): GerritChange[][] {
         const jsonStr = text.replace(/^\)]}'\n/, '');
-        const data: GerritChange[] | GerritChange[][] = JSON.parse(jsonStr);
-        return this.isBatchResponse(data) ? data : [data];
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(jsonStr);
+        } catch (e) {
+            this.outputChannel?.appendLine(`[GerritProvider] Error parsing batch response: ${e}`);
+            return [];
+        }
+
+        const arraySchema = z.array(z.array(GerritChangeSchema).or(GerritChangeSchema));
+        const validation = arraySchema.safeParse(parsed);
+
+        if (!validation.success) {
+            this.outputChannel?.appendLine(
+                `[GerritProvider] Validation failed for batch response: ${validation.error.message}`,
+            );
+            return [];
+        }
+
+        const data = validation.data;
+        return this.isBatchResponse(data) ? data : [data as GerritChange[]];
     }
 
-    private isBatchResponse(data: GerritChange[] | GerritChange[][]): data is GerritChange[][] {
+    private isBatchResponse(data: (GerritChange | GerritChange[])[]): data is GerritChange[][] {
         return data.length > 0 && Array.isArray(data[0]);
     }
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -3,73 +3,104 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
+import { z } from 'zod';
 import type { AuthResult, CodeForgeAuthManager } from './code-forge-auth';
 import type { AuthManageItem, ChangeStatusRequest, CodeForgeProvider, GitRemote } from './code-forge-provider';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
 
-interface GitHubPrNode {
-    id: string;
-    number: number;
-    state: string;
-    mergeable: string;
-    reviewDecision?: string | null;
-    url: string;
-    headRepository?: {
-        owner: {
-            login: string;
-        };
-    } | null;
-    reviewThreads?: {
-        nodes?: {
-            isResolved: boolean;
-        }[];
-    };
-    commits?: {
-        nodes?: {
-            commit?: {
-                oid: string;
-                message: string;
-                parents?: {
-                    nodes?: {
-                        oid: string;
-                    }[];
-                };
-                statusCheckRollup?: {
-                    state: string;
-                } | null;
-            };
-        }[];
-    };
-}
+export const GitHubPrNodeSchema = z.object({
+    id: z.string(),
+    number: z.number(),
+    state: z.string(),
+    mergeable: z.string(),
+    reviewDecision: z.string().nullable().optional(),
+    url: z.string(),
+    headRepository: z
+        .object({
+            owner: z.object({
+                login: z.string(),
+            }),
+        })
+        .nullable()
+        .optional(),
+    reviewThreads: z
+        .object({
+            nodes: z
+                .array(
+                    z.object({
+                        isResolved: z.boolean(),
+                    }),
+                )
+                .optional(),
+        })
+        .optional(),
+    commits: z
+        .object({
+            nodes: z
+                .array(
+                    z.object({
+                        commit: z
+                            .object({
+                                oid: z.string(),
+                                message: z.string(),
+                                parents: z
+                                    .object({
+                                        nodes: z
+                                            .array(
+                                                z.object({
+                                                    oid: z.string(),
+                                                }),
+                                            )
+                                            .optional(),
+                                    })
+                                    .optional(),
+                                statusCheckRollup: z
+                                    .object({
+                                        state: z.string(),
+                                    })
+                                    .nullable()
+                                    .optional(),
+                            })
+                            .optional(),
+                    }),
+                )
+                .optional(),
+        })
+        .optional(),
+});
+export type GitHubPrNode = z.infer<typeof GitHubPrNodeSchema>;
 
-interface GitHubGqlResponse {
-    errors?: unknown[];
-    data?: {
-        repository?: {
-            parent?: Record<
-                string,
-                {
-                    nodes?: GitHubPrNode[];
-                }
-            > | null;
-        } & Record<
-            string,
-            | {
-                  nodes?: GitHubPrNode[];
-              }
-            | Record<
-                  string,
-                  {
-                      nodes?: GitHubPrNode[];
-                  }
-              >
-            | null
-            | undefined
-        >;
-    };
-}
+export const GitHubGqlResponseSchema = z.object({
+    errors: z.array(z.unknown()).optional(),
+    data: z
+        .object({
+            repository: z
+                .object({
+                    parent: z
+                        .record(
+                            z.string(),
+                            z.object({
+                                nodes: z.array(GitHubPrNodeSchema).optional(),
+                            }),
+                        )
+                        .nullable()
+                        .optional(),
+                })
+                .catchall(z.unknown())
+                .optional(),
+        })
+        .optional(),
+});
+export type GitHubGqlResponse = z.infer<typeof GitHubGqlResponseSchema>;
+
+export const GitHubAliasSchema = z
+    .object({
+        nodes: z.array(GitHubPrNodeSchema).optional(),
+    })
+    .nullable()
+    .optional();
 
 export class GitHubProvider implements CodeForgeProvider {
     public readonly id = 'github';
@@ -337,7 +368,13 @@ export class GitHubProvider implements CodeForgeProvider {
             throw new Error(`GraphQL request failed with status: ${response.statusText}`);
         }
 
-        const json = (await response.json()) as GitHubGqlResponse;
+        const parsedJson = await response.json();
+        const validation = GitHubGqlResponseSchema.safeParse(parsedJson);
+        if (!validation.success) {
+            throw new Error(`Failed to validate GraphQL response: ${validation.error.message}`);
+        }
+
+        const json = validation.data;
         if (json.errors) {
             throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
         }
@@ -360,8 +397,9 @@ export class GitHubProvider implements CodeForgeProvider {
             for (let i = 0; i < bookmarkNames.length; i++) {
                 const alias = `pr_${i}`;
                 const parentPrNodes = repoData.parent?.[alias]?.nodes;
-                const prData = repoData[alias] as { nodes?: GitHubPrNode[] } | undefined;
-                const prNodes = prData?.nodes;
+                const prData = repoData[alias];
+                const parsedAlias = GitHubAliasSchema.safeParse(prData);
+                const prNodes = parsedAlias.success ? parsedAlias.data?.nodes : undefined;
 
                 const localCommitId = bookmarkToCommitId.get(bookmarkNames[i]);
                 const filteredParentNodes = filterPrNodes(parentPrNodes, localCommitId);

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -11,21 +11,35 @@ import { fetchWithTimeout } from './utils/fetch-utils';
 
 const GITLAB_EXTENSION_ID = 'gitlab.gitlab-workflow';
 
-interface GitLabMergeRequest {
-    id: number;
-    iid: number;
-    state: string;
-    draft?: boolean;
-    work_in_progress?: boolean;
-    has_conflicts?: boolean;
-    merge_status?: string;
-    detailed_merge_status?: string;
-    blocking_discussions_resolved?: boolean;
-    user_notes_count?: number;
-    web_url: string;
-    sha: string;
-    source_project_id?: number;
-}
+import { z } from 'zod';
+
+export const GitLabMergeRequestSchema = z.object({
+    id: z.number(),
+    iid: z.number(),
+    state: z.string(),
+    draft: z.boolean().optional(),
+    work_in_progress: z.boolean().optional(),
+    has_conflicts: z.boolean().optional(),
+    merge_status: z.string().optional(),
+    detailed_merge_status: z.string().optional(),
+    blocking_discussions_resolved: z.boolean().optional(),
+    user_notes_count: z.number().optional(),
+    web_url: z.string(),
+    sha: z.string(),
+    source_project_id: z.number().optional(),
+});
+export type GitLabMergeRequest = z.infer<typeof GitLabMergeRequestSchema>;
+
+export const GitLabProjectInfoSchema = z.object({
+    id: z.number().optional(),
+    forked_from_project: z
+        .object({
+            id: z.number().optional(),
+            path_with_namespace: z.string().optional(),
+        })
+        .optional(),
+});
+export type GitLabProjectInfo = z.infer<typeof GitLabProjectInfoSchema>;
 
 interface GitLabRequestContext {
     apiBaseUrl: string;
@@ -365,7 +379,16 @@ export class GitLabProvider implements CodeForgeProvider {
                 return undefined;
             }
 
-            const mrs = (await response.json()) as GitLabMergeRequest[];
+            const parsedJson = await response.json();
+            const validation = GitLabMergeRequestSchema.array().safeParse(parsedJson);
+            if (!validation.success) {
+                this.outputChannel?.appendLine(
+                    `[GitLabProvider] Failed to validate MR array response: ${validation.error.message}`,
+                );
+                return undefined;
+            }
+
+            const mrs = validation.data;
             if (Array.isArray(mrs) && mrs.length > 0) {
                 const filteredMrs = this.filterGitLabMrs(mrs, bookmark, context.bookmarkToCommitId);
                 if (filteredMrs.length > 0) {
@@ -468,7 +491,15 @@ export class GitLabProvider implements CodeForgeProvider {
                 headers: this.getHeaders(token),
             });
             if (response.ok) {
-                return (await response.json()) as GitLabMergeRequest;
+                const parsedJson = await response.json();
+                const validation = GitLabMergeRequestSchema.safeParse(parsedJson);
+                if (validation.success) {
+                    return validation.data;
+                }
+                this.outputChannel?.appendLine(
+                    `[GitLabProvider] Failed to validate single MR detail: ${validation.error.message}`,
+                );
+                return selectedMr;
             }
             this.outputChannel?.appendLine(
                 `[GitLabProvider] Failed to fetch single MR detail with status ${response.status}, falling back to list MR data`,
@@ -566,13 +597,15 @@ export class GitLabProvider implements CodeForgeProvider {
                 headers: this.getHeaders(token),
             });
             if (response.ok) {
-                return (await response.json()) as {
-                    id?: number;
-                    forked_from_project?: {
-                        id?: number;
-                        path_with_namespace?: string;
-                    };
-                };
+                const parsedJson = await response.json();
+                const validation = GitLabProjectInfoSchema.safeParse(parsedJson);
+                if (validation.success) {
+                    return validation.data;
+                }
+                this.outputChannel?.appendLine(
+                    `[GitLabProvider] Failed to validate project info: ${validation.error.message}`,
+                );
+                return undefined;
             }
         } catch (e) {
             this.outputChannel?.appendLine(`[GitLabProvider] Failed to fetch project details for ${path}: ${e}`);

--- a/src/jj-schemas.ts
+++ b/src/jj-schemas.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+
+export const JjBookmarkSchema = z.object({
+    /** The name of the Jujutsu bookmark. */
+    name: z.string(),
+    /** The optional name of the remote tracking branch or null. */
+    remote: z.string().nullable().optional(),
+});
+export type JjBookmark = z.infer<typeof JjBookmarkSchema>;
+
+export const JjWorkspaceSchema = z.object({
+    /** The name of the Jujutsu workspace. */
+    name: z.string(),
+    /** The filesystem path to the workspace root. */
+    path: z.string(),
+});
+export type JjWorkspace = z.infer<typeof JjWorkspaceSchema>;
+
+export const CommitParentSchema = z.object({
+    /** The SHA-1 commit ID of the parent revision. */
+    commit_id: z.string(),
+    /** The jj change ID of the parent revision (e.g. 'qutpskpt'). */
+    change_id: z.string(),
+    /** Whether the parent is an immutable revision (e.g. main@origin). */
+    is_immutable: z.boolean(),
+});
+export type CommitParent = z.infer<typeof CommitParentSchema>;
+
+export const JjStatusEntrySchema = z.object({
+    /** The relative path of the file modified. */
+    path: z.string(),
+    /** The old path if the file was renamed or copied. */
+    oldPath: z.string().optional(),
+    /** The operation type performed on the file. */
+    status: z.enum(['modified', 'added', 'removed', 'renamed', 'copied', 'deleted']),
+    /** The number of added lines. */
+    additions: z.number().optional(),
+    /** The number of deleted lines. */
+    deletions: z.number().optional(),
+    /** Whether the file is currently conflicted. */
+    conflicted: z.boolean().optional(),
+});
+export type JjStatusEntry = z.infer<typeof JjStatusEntrySchema>;
+
+/**
+ * Metadata retrieved from a code forge about a specific Change/PR.
+ */
+export const CodeForgeChangeInfoSchema = z.object({
+    /** Unique identifier for the change (e.g. Gerrit Change-Id or GitHub PR node ID) */
+    id: z.string(),
+    /** User-facing sequential number (e.g. Gerrit change number or GitHub PR number) */
+    number: z.number(),
+    /** The display label (e.g. "CL 123456" or "PR #42") */
+    displayLabel: z.string(),
+    /** Human-readable provider name (e.g. "Gerrit" or "GitHub") */
+    providerName: z.string(),
+    /** Standardized status across forges */
+    status: z.enum(['NEW', 'MERGED', 'ABANDONED']),
+    /** Whether the change is currently submittable/mergeable */
+    submittable: z.boolean(),
+    /** The web URL to the change/PR */
+    url: z.string(),
+    /** Number of unresolved comments/discussions */
+    unresolvedComments: z.number(),
+    /** The commit ID of the current remote revision */
+    currentRevision: z.string().optional(),
+    /** Map of files in the current remote revision and their blob SHAs */
+    files: z
+        .record(
+            z.string(),
+            z.object({
+                newSha: z.string().optional(),
+                status: z.string().optional(),
+            }),
+        )
+        .optional(),
+    /** Aggregate sync status (contentSynced && parentSynced) */
+    synced: z.boolean().optional(),
+    /** Whether the remote parent pointers match the latest patchsets of the local parents */
+    parentSynced: z.boolean().optional(),
+    /** List of commit SHAs for the parents as recorded by the remote */
+    remoteParents: z.array(z.string()).optional(),
+    /** The full commit message of the current remote revision */
+    remoteDescription: z.string().optional(),
+    /** Whether the file contents match exactly between local and remote */
+    contentSynced: z.boolean().optional(),
+});
+export type CodeForgeChangeInfo = z.infer<typeof CodeForgeChangeInfoSchema>;
+
+export const JjLogEntrySchema = z.object({
+    /** The unique SHA-1 identifier for the commit. */
+    commit_id: z.string(),
+    /** The stable change ID (retains value across history rewrites). */
+    change_id: z.string(),
+    /** The shortest unique prefix of the change ID. */
+    change_id_shortest: z.string().optional(),
+    /** The description (commit message). */
+    description: z.string(),
+    /** Details of the revision author. */
+    author: z.object({
+        /** The author's name. */
+        name: z.string(),
+        /** The author's email address. */
+        email: z.string(),
+        /** The creation timestamp. */
+        timestamp: z.string(),
+    }),
+    /** Details of the committer. */
+    committer: z.object({
+        /** The committer's name. */
+        name: z.string(),
+        /** The committer's email address. */
+        email: z.string(),
+        /** The commit timestamp. */
+        timestamp: z.string(),
+    }),
+    /** The parents of the commit revision. */
+    parents: z.array(CommitParentSchema),
+    /** Nearest ancestors that are visible in the graph. */
+    nearest_visible_ancestors: z.array(z.string()).optional(),
+    /** Bookmarks pointing to this revision. */
+    bookmarks: z.array(JjBookmarkSchema).optional(),
+    /** Tags pointing to this revision. */
+    tags: z.array(z.string()).optional(),
+    /** Names of the working copies using this revision. */
+    working_copies: z.array(z.string()).optional(),
+    /** Whether this revision is the current working copy. */
+    is_current_working_copy: z.boolean().optional(),
+    /** Whether this commit revision is immutable. */
+    is_immutable: z.boolean().optional(),
+    /** Whether the revision contains no changes (empty). */
+    is_empty: z.boolean().optional(),
+    /** Whether the change ID is divergent (points to multiple commits). */
+    is_divergent: z.boolean().optional(),
+    /** Offset modifier for divergent change IDs. */
+    change_id_offset: z.number().optional(),
+    /** Whether this revision has merge conflicts. */
+    conflict: z.boolean().optional(),
+    /** Whether this revision is hidden in the jujutsu log. */
+    is_hidden: z.boolean().optional(),
+    /** Modified files within this commit revision. */
+    changes: z.array(JjStatusEntrySchema).optional(),
+    /** Associated Code Forge change metadata. */
+    codeForgeChange: CodeForgeChangeInfoSchema.optional(),
+    /** Whether the local changes need to be uploaded to the code forge. */
+    codeForgeNeedsUpload: z.boolean().optional(),
+});
+export type JjLogEntry = z.infer<typeof JjLogEntrySchema>;

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -6,6 +6,7 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { JjBookmarkSchema, JjLogEntrySchema, JjWorkspaceSchema } from './jj-schemas';
 import {
     BOOKMARK_SCHEMA,
     buildLogTemplate,
@@ -304,7 +305,13 @@ export class JjService {
         }
         try {
             const jsonListString = `[${trimmed.replace(/\r?\n/g, ',')}]`;
-            return JSON.parse(jsonListString) as JjBookmark[];
+            const parsed = JSON.parse(jsonListString);
+            const validation = JjBookmarkSchema.array().safeParse(parsed);
+            if (!validation.success) {
+                this.logger(`Failed to validate bookmarks JSON: ${validation.error.message}. Raw output: ${output}`);
+                return [];
+            }
+            return validation.data;
         } catch (e) {
             this.logger(`Failed to parse bookmarks JSON: ${e}. Raw output: ${output}`);
             return [];
@@ -368,7 +375,13 @@ export class JjService {
             }
             const jsonPart = line.substring(jsonStart);
             try {
-                const entry = JSON.parse(jsonPart) as JjLogEntry;
+                const parsed = JSON.parse(jsonPart);
+                const validation = JjLogEntrySchema.safeParse(parsed);
+                if (!validation.success) {
+                    console.error(`Failed to validate log entry: ${validation.error.message}`, line);
+                    continue;
+                }
+                const entry = validation.data;
                 entries.push(entry);
                 visibleIds.add(entry.change_id);
             } catch (e) {
@@ -904,7 +917,13 @@ export class JjService {
                 continue;
             }
             try {
-                const info = JSON.parse(trimmed) as JjWorkspace;
+                const parsed = JSON.parse(trimmed);
+                const validation = JjWorkspaceSchema.safeParse(parsed);
+                if (!validation.success) {
+                    console.error(`Failed to validate workspace info: ${validation.error.message}`, line);
+                    continue;
+                }
+                const info = validation.data;
                 infos.push(info);
             } catch (e) {
                 console.error('Failed to parse workspace info line:', line, e);

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -3,104 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface JjBookmark {
-    name: string;
-    remote?: string | null;
-}
+import type {
+    CodeForgeChangeInfo,
+    CommitParent,
+    JjBookmark,
+    JjLogEntry,
+    JjStatusEntry,
+    JjWorkspace,
+} from './jj-schemas';
 
-export interface JjWorkspace {
-    name: string;
-    path: string;
-}
-
-/**
- * Metadata retrieved from a code forge about a specific Change/PR.
- */
-export interface CodeForgeChangeInfo {
-    /** Unique identifier for the change (e.g. Gerrit Change-Id or GitHub PR node ID) */
-    id: string;
-    /** User-facing sequential number (e.g. Gerrit change number or GitHub PR number) */
-    number: number;
-    /** The display label (e.g. "CL 123456" or "PR #42") */
-    displayLabel: string;
-    /** Human-readable provider name (e.g. "Gerrit" or "GitHub") */
-    providerName: string;
-    /** Standardized status across forges */
-    status: 'NEW' | 'MERGED' | 'ABANDONED';
-    /** Whether the change is currently submittable/mergeable */
-    submittable: boolean;
-    /** The web URL to the change/PR */
-    url: string;
-    /** Number of unresolved comments/discussions */
-    unresolvedComments: number;
-    /** The commit ID of the current remote revision */
-    currentRevision?: string;
-    /** Map of files in the current remote revision and their blob SHAs */
-    files?: Record<string, { newSha?: string; status?: string }>;
-    /** Aggregate sync status (contentSynced && parentSynced) */
-    synced?: boolean;
-    /** Whether the remote parent pointers match the latest patchsets of the local parents */
-    parentSynced?: boolean;
-    /** List of commit SHAs for the parents as recorded by the remote */
-    remoteParents?: string[];
-    /** The full commit message of the current remote revision */
-    remoteDescription?: string;
-    /** Whether the file contents match exactly between local and remote */
-    contentSynced?: boolean;
-}
-
-/**
- * Metadata about a commit's parent, retrieved from jj.
- */
-export interface CommitParent {
-    /** The SHA-1 commit ID of the parent revision. */
-    commit_id: string;
-    /** The jj change ID of the parent revision (e.g. 'qutpskpt'). */
-    change_id: string;
-    /** Whether the parent is an immutable revision (e.g. main@origin). */
-    is_immutable: boolean;
-}
-
-export interface JjLogEntry {
-    commit_id: string;
-    change_id: string;
-    change_id_shortest?: string;
-    description: string;
-    author: {
-        name: string;
-        email: string;
-        timestamp: string;
-    };
-    committer: {
-        name: string;
-        email: string;
-        timestamp: string;
-    };
-    parents: CommitParent[];
-    nearest_visible_ancestors?: string[];
-    bookmarks?: JjBookmark[];
-    tags?: string[];
-    working_copies?: string[];
-    is_current_working_copy?: boolean;
-    is_immutable?: boolean;
-    is_empty?: boolean;
-    is_divergent?: boolean;
-    change_id_offset?: number;
-    conflict?: boolean;
-    is_hidden?: boolean;
-    changes?: JjStatusEntry[];
-    codeForgeChange?: CodeForgeChangeInfo;
-    codeForgeNeedsUpload?: boolean;
-}
-
-export interface JjStatusEntry {
-    path: string;
-    oldPath?: string;
-    status: 'modified' | 'added' | 'removed' | 'renamed' | 'copied' | 'deleted'; // 'deleted' is sometimes used for removed
-    additions?: number;
-    deletions?: number;
-    conflicted?: boolean;
-}
+export type { CodeForgeChangeInfo, CommitParent, JjBookmark, JjLogEntry, JjStatusEntry, JjWorkspace };
 
 export type CommitAction = 'newChild' | 'edit' | 'squash' | 'abandon' | 'openCodeForge' | 'upload';
 


### PR DESCRIPTION
Declares unified Zod validation schemas with complete JSDoc comments in `src/jj-schemas.ts` and exports inferred types in `src/jj-types.ts`. Integrates schema validation for external data boundaries: Jujutsu CLI outputs, code forge APIs (Gerrit, GitHub GraphQL, GitLab REST), and squash metadata files.