### PR TITLE
test: remove obsolete TestRepo dispose method and unwrap try-finally …

### DIFF
--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -79,7 +79,6 @@ describe('ChangeDetectionManager', () => {
             changeManager = undefined;
         }
 
-        repo.dispose();
         vi.clearAllMocks();
     });
 
@@ -424,7 +423,6 @@ describe('ChangeDetectionManager', () => {
             );
 
             // Clean up the secondary workspace
-            secondRepo.dispose();
         });
     });
 });

--- a/src/test/code-forge-service.test.ts
+++ b/src/test/code-forge-service.test.ts
@@ -103,10 +103,7 @@ describe('CodeForgeService Tests', () => {
         jjService2 = new JjService(repo2.path, NO_OP_LOGGER);
     });
 
-    afterEach(() => {
-        repo1.dispose();
-        repo2.dispose();
-    });
+    afterEach(() => {});
 
     test('Each service gets a distinct provider instance with isolated cache', async () => {
         let provider1: MockProvider | undefined;

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -83,9 +83,7 @@ describe('promptForRevision', () => {
         vi.clearAllMocks();
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     it('returns selected revision from quick pick', async () => {
         const ids = await buildGraph(repo, [

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -34,7 +34,6 @@ describe('abandonCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/absorb.test.ts
+++ b/src/test/commands/absorb.test.ts
@@ -32,7 +32,6 @@ describe('absorbCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/bookmark-advance-upload.test.ts
+++ b/src/test/commands/bookmark-advance-upload.test.ts
@@ -52,8 +52,6 @@ describe('advanceBookmarkAndUploadCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
-        remoteRepo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/bookmark-advance.test.ts
+++ b/src/test/commands/bookmark-advance.test.ts
@@ -37,7 +37,6 @@ describe('advanceBookmarkCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/bookmark.test.ts
+++ b/src/test/commands/bookmark.test.ts
@@ -34,7 +34,6 @@ describe('setBookmarkCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/commit-prompt.test.ts
+++ b/src/test/commands/commit-prompt.test.ts
@@ -40,7 +40,6 @@ describe('commitPromptCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/commit.test.ts
+++ b/src/test/commands/commit.test.ts
@@ -37,7 +37,6 @@ describe('commitCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/compare-all-files-with-revision.test.ts
+++ b/src/test/commands/compare-all-files-with-revision.test.ts
@@ -38,7 +38,6 @@ describe('compareAllFilesWithRevisionCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/compare-file-with-revision.test.ts
+++ b/src/test/commands/compare-file-with-revision.test.ts
@@ -32,7 +32,6 @@ describe('compareFileWithRevisionCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/describe-prompt.test.ts
+++ b/src/test/commands/describe-prompt.test.ts
@@ -40,7 +40,6 @@ describe('describePromptCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -35,7 +35,6 @@ describe('setDescriptionCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/details.test.ts
+++ b/src/test/commands/details.test.ts
@@ -29,7 +29,6 @@ describe('showDetailsCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/discard-change.test.ts
+++ b/src/test/commands/discard-change.test.ts
@@ -111,7 +111,6 @@ describe('discardChangeCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/duplicate.test.ts
+++ b/src/test/commands/duplicate.test.ts
@@ -28,7 +28,6 @@ describe('duplicateCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/edit.test.ts
+++ b/src/test/commands/edit.test.ts
@@ -30,7 +30,6 @@ describe('editCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/index-lock-error.test.ts
+++ b/src/test/commands/index-lock-error.test.ts
@@ -26,7 +26,6 @@ describe('Index Lock Error Handling', () => {
     afterEach(() => {
         vi.clearAllMocks();
         if (repo) {
-            repo.dispose();
         }
     });
 
@@ -105,7 +104,6 @@ describe('Index Lock Error Handling', () => {
 
         afterEach(() => {
             if (testRepo) {
-                testRepo.dispose();
             }
         });
 
@@ -156,11 +154,7 @@ describe('Index Lock Error Handling', () => {
             const showErrorMessage = vscode.window.showErrorMessage as Mock;
             showErrorMessage.mockResolvedValueOnce(undefined);
 
-            try {
-                await showJjError(error, 'Prefix', emptyJjService, mockOutputChannel, []);
-            } finally {
-                emptyDirRepo.dispose();
-            }
+            await showJjError(error, 'Prefix', emptyJjService, mockOutputChannel, []);
 
             expect(showErrorMessage).toHaveBeenCalledWith(
                 'Prefix: Could not acquire lock for index file', // Original simple message

--- a/src/test/commands/merge.test.ts
+++ b/src/test/commands/merge.test.ts
@@ -45,7 +45,6 @@ describe('newMergeChangeCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/multi-diff.test.ts
+++ b/src/test/commands/multi-diff.test.ts
@@ -32,7 +32,6 @@ describe('showMultiFileDiffCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/new-after.test.ts
+++ b/src/test/commands/new-after.test.ts
@@ -37,9 +37,7 @@ describe('newAfterCommand', () => {
         } as unknown as JjScmProvider;
     });
 
-    afterEach(async () => {
-        repo.dispose();
-    });
+    afterEach(async () => {});
 
     it('should create a new commit after the selected commit (between commit and its children)', async () => {
         // Setup repo: root -> A -> B

--- a/src/test/commands/new-before.test.ts
+++ b/src/test/commands/new-before.test.ts
@@ -37,9 +37,7 @@ describe('newBeforeCommand', () => {
         } as unknown as JjScmProvider;
     });
 
-    afterEach(async () => {
-        repo.dispose();
-    });
+    afterEach(async () => {});
 
     it('should create a new commit before the selected commit', async () => {
         // Setup repo: root -> A -> B

--- a/src/test/commands/new.test.ts
+++ b/src/test/commands/new.test.ts
@@ -28,7 +28,6 @@ describe('newCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/rebase.test.ts
+++ b/src/test/commands/rebase.test.ts
@@ -35,7 +35,6 @@ describe('rebaseOntoSelectedCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/restore.test.ts
+++ b/src/test/commands/restore.test.ts
@@ -31,7 +31,6 @@ describe('restoreCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/squash-files.test.ts
+++ b/src/test/commands/squash-files.test.ts
@@ -58,7 +58,6 @@ describe('squash-files commands', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/squash-revision.test.ts
+++ b/src/test/commands/squash-revision.test.ts
@@ -73,7 +73,6 @@ describe('squashRevisionIntoParentCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/squash-selection.test.ts
+++ b/src/test/commands/squash-selection.test.ts
@@ -45,7 +45,6 @@ describe('squash-selection commands', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/undo.test.ts
+++ b/src/test/commands/undo.test.ts
@@ -28,7 +28,6 @@ describe('undoCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -59,7 +59,6 @@ describe('uploadCommand', () => {
     });
 
     afterEach(() => {
-        repo.dispose();
         vi.clearAllMocks();
     });
 
@@ -80,28 +79,25 @@ describe('uploadCommand', () => {
         ]);
 
         const remoteRepo = await setupRemote();
-        try {
-            // Push first to make it tracked
-            repo.gitPush('feature-x');
-            repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            // Setup config to return 'git push' ONLY when queried for 'uploadCommand'
-            mockConfig.get.mockImplementation((key: string) => {
-                if (key === 'uploadCommand') {
-                    return 'git push';
-                }
-                return undefined;
-            });
+        // Push first to make it tracked
+        repo.gitPush('feature-x');
+        repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
+        // Setup config to return 'git push' ONLY when queried for 'uploadCommand'
+        mockConfig.get.mockImplementation((key: string) => {
+            if (key === 'uploadCommand') {
+                return 'git push';
+            }
+            return undefined;
+        });
 
-            // Verify that the push succeeded and remote repository now has the ref
-            expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
-            expect(scmProvider.refresh).toHaveBeenCalled();
-            expect(codeForgeService.requestRefreshWithBackoffs).toHaveBeenCalled();
-        } finally {
-            remoteRepo.dispose();
-        }
+        await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
+
+        // Verify that the push succeeded and remote repository now has the ref
+        expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
+        expect(scmProvider.refresh).toHaveBeenCalled();
+        expect(codeForgeService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
     test('falls back to default when custom command is empty', async () => {
@@ -117,22 +113,19 @@ describe('uploadCommand', () => {
         ]);
 
         const remoteRepo = await setupRemote();
-        try {
-            // Push first to make it tracked
-            repo.gitPush('feature-x');
-            repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            mockConfig.get.mockReturnValue(undefined);
+        // Push first to make it tracked
+        repo.gitPush('feature-x');
+        repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
+        mockConfig.get.mockReturnValue(undefined);
 
-            // Verify that the default push succeeded
-            expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
-            expect(scmProvider.refresh).toHaveBeenCalled();
-            expect(codeForgeService.requestRefreshWithBackoffs).toHaveBeenCalled();
-        } finally {
-            remoteRepo.dispose();
-        }
+        await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
+
+        // Verify that the default push succeeded
+        expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
+        expect(scmProvider.refresh).toHaveBeenCalled();
+        expect(codeForgeService.requestRefreshWithBackoffs).toHaveBeenCalled();
     });
 
     test('extracts revision from object payload (repro for r.substring error)', async () => {
@@ -148,26 +141,17 @@ describe('uploadCommand', () => {
         ]);
 
         const remoteRepo = await setupRemote();
-        try {
-            // Push first to make it tracked
-            repo.gitPush('feature-x');
-            repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            mockConfig.get.mockReturnValue(undefined);
+        // Push first to make it tracked
+        repo.gitPush('feature-x');
+        repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-            // This simulates the webview payload: { changeId: 'feature-x' }
-            await uploadCommand(
-                scmProvider,
-                jjService,
-                codeForgeService,
-                [{ changeId: 'feature-x' }],
-                mockOutputChannel,
-            );
+        mockConfig.get.mockReturnValue(undefined);
 
-            expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
-        } finally {
-            remoteRepo.dispose();
-        }
+        // This simulates the webview payload: { changeId: 'feature-x' }
+        await uploadCommand(scmProvider, jjService, codeForgeService, [{ changeId: 'feature-x' }], mockOutputChannel);
+
+        expect(remoteRepo.hasGitRef('refs/heads/feature-x')).toBe(true);
     });
 
     test('suggests configuration when upload fails and no custom command set', async () => {
@@ -263,83 +247,65 @@ describe('uploadCommand', () => {
         ]);
 
         const remoteRepo = await setupRemote();
-        try {
-            mockConfig.get.mockReturnValue(undefined);
 
-            const mockAuthManager = createMock<CodeForgeAuthManager>({
-                registerProvider: vi.fn(),
-            });
-            const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
-            const githubCodeForgeService = createMock<CodeForgeService>({
-                isEnabled: true,
-                requestRefreshWithBackoffs: vi.fn(),
-                activeProvider: githubProvider,
-            });
+        mockConfig.get.mockReturnValue(undefined);
 
-            // Capture output channel logs
-            const loggedLines: string[] = [];
-            mockOutputChannel.appendLine = vi.fn().mockImplementation((line: string) => {
-                loggedLines.push(line);
-            });
+        const mockAuthManager = createMock<CodeForgeAuthManager>({
+            registerProvider: vi.fn(),
+        });
+        const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
+        const githubCodeForgeService = createMock<CodeForgeService>({
+            isEnabled: true,
+            requestRefreshWithBackoffs: vi.fn(),
+            activeProvider: githubProvider,
+        });
 
-            await uploadCommand(
-                scmProvider,
-                jjService,
-                githubCodeForgeService,
-                [ids.commitA.changeId],
-                mockOutputChannel,
-            );
+        // Capture output channel logs
+        const loggedLines: string[] = [];
+        mockOutputChannel.appendLine = vi.fn().mockImplementation((line: string) => {
+            loggedLines.push(line);
+        });
 
-            // Since there was no local bookmark on commitA, the github provider's getUploadCommand should have returned git push -c <revision>
-            // This should create a new bookmark starting with "push-" in the repo and push it to remote.
-            const pushRefs = remoteRepo.listGitRefs('refs/heads/push-');
-            expect(pushRefs.length).toBe(1);
-        } finally {
-            remoteRepo.dispose();
-        }
+        await uploadCommand(scmProvider, jjService, githubCodeForgeService, [ids.commitA.changeId], mockOutputChannel);
+
+        // Since there was no local bookmark on commitA, the github provider's getUploadCommand should have returned git push -c <revision>
+        // This should create a new bookmark starting with "push-" in the repo and push it to remote.
+        const pushRefs = remoteRepo.listGitRefs('refs/heads/push-');
+        expect(pushRefs.length).toBe(1);
     });
 
     test('GitHub provider: uses -r if revision has local bookmark', async () => {
         const remoteRepo = await setupRemote();
-        try {
-            repo.describe('root commit');
-            await buildGraph(repo, [
-                {
-                    label: 'commitA',
-                    description: 'test github push with bookmark',
-                    bookmarks: ['my-feature-branch'],
-                    isCurrentWorkingCopy: true,
-                },
-            ]);
 
-            mockConfig.get.mockReturnValue(undefined);
+        repo.describe('root commit');
+        await buildGraph(repo, [
+            {
+                label: 'commitA',
+                description: 'test github push with bookmark',
+                bookmarks: ['my-feature-branch'],
+                isCurrentWorkingCopy: true,
+            },
+        ]);
 
-            const mockAuthManager = createMock<CodeForgeAuthManager>({
-                registerProvider: vi.fn(),
-            });
-            const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
-            const githubCodeForgeService = createMock<CodeForgeService>({
-                isEnabled: true,
-                requestRefreshWithBackoffs: vi.fn(),
-                activeProvider: githubProvider,
-            });
+        mockConfig.get.mockReturnValue(undefined);
 
-            await uploadCommand(
-                scmProvider,
-                jjService,
-                githubCodeForgeService,
-                ['my-feature-branch'],
-                mockOutputChannel,
-            );
+        const mockAuthManager = createMock<CodeForgeAuthManager>({
+            registerProvider: vi.fn(),
+        });
+        const githubProvider = new GitHubProvider(mockAuthManager, mockOutputChannel);
+        const githubCodeForgeService = createMock<CodeForgeService>({
+            isEnabled: true,
+            requestRefreshWithBackoffs: vi.fn(),
+            activeProvider: githubProvider,
+        });
 
-            // Since there was a local bookmark, it should use -r, pushing my-feature-branch.
-            expect(remoteRepo.hasGitRef('refs/heads/my-feature-branch')).toBe(true);
+        await uploadCommand(scmProvider, jjService, githubCodeForgeService, ['my-feature-branch'], mockOutputChannel);
 
-            // Also check that no "push-" bookmark was created
-            const pushRefs = remoteRepo.listGitRefs('refs/heads/push-');
-            expect(pushRefs.length).toBe(0);
-        } finally {
-            remoteRepo.dispose();
-        }
+        // Since there was a local bookmark, it should use -r, pushing my-feature-branch.
+        expect(remoteRepo.hasGitRef('refs/heads/my-feature-branch')).toBe(true);
+
+        // Also check that no "push-" bookmark was created
+        const pushRefs = remoteRepo.listGitRefs('refs/heads/push-');
+        expect(pushRefs.length).toBe(0);
     });
 });

--- a/src/test/commit-utils.test.ts
+++ b/src/test/commit-utils.test.ts
@@ -19,9 +19,7 @@ describe('computeCommitActions', () => {
         jj = new JjService(repo.path, NO_OP_LOGGER);
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     async function getCommit(revision: string): Promise<JjLogEntry> {
         const log = await jj.getLog({ revision });

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -52,7 +52,6 @@ describe('Diff Tab Cleaner', () => {
 
     afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/e2e/arbitrary-diff.spec.ts
+++ b/src/test/e2e/arbitrary-diff.spec.ts
@@ -68,7 +68,6 @@ test.describe('Arbitrary Diff E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/e2e/binary-config.spec.ts
+++ b/src/test/e2e/binary-config.spec.ts
@@ -19,32 +19,28 @@ test.describe('JJ Binary Configuration E2E', () => {
         // Open the workspace with default/valid settings first
         const { page } = await vscode.openWorkspace(repo, {}, {}, true);
 
-        try {
-            // Un-hide notifications toast locally
-            await page.addStyleTag({
-                content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
-            });
+        // Un-hide notifications toast locally
+        await page.addStyleTag({
+            content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
+        });
 
-            // Clear any startup notifications (such as the disabled extensions warning)
-            await vscode.executeCommand('notifications.clearAll');
+        // Clear any startup notifications (such as the disabled extensions warning)
+        await vscode.executeCommand('notifications.clearAll');
 
-            // Dynamically set the invalid binary path to trigger the toast configuration change listener
-            await vscode.evaluate(async (vscode, _api, pathVal) => {
-                await vscode.workspace
-                    .getConfiguration('jj-view')
-                    .update('binaryPath', pathVal, vscode.ConfigurationTarget.Global);
-            }, invalidPath);
+        // Dynamically set the invalid binary path to trigger the toast configuration change listener
+        await vscode.evaluate(async (vscode, _api, pathVal) => {
+            await vscode.workspace
+                .getConfiguration('jj-view')
+                .update('binaryPath', pathVal, vscode.ConfigurationTarget.Global);
+        }, invalidPath);
 
-            // Wait for notification to appear and click 'Configure Path'
-            await expectNotificationToast(page, `Invalid 'jj' binary configuration`);
-            await clickNotificationButton(page, 'Configure Path');
+        // Wait for notification to appear and click 'Configure Path'
+        await expectNotificationToast(page, `Invalid 'jj' binary configuration`);
+        await clickNotificationButton(page, 'Configure Path');
 
-            // Verify settings editor is open and find the Binary Path setting
-            const settingItem = await expectSettingsOpen(page, 'Binary Path');
-            await expect(settingItem.locator('input')).toHaveValue(invalidPath);
-        } finally {
-            repo.dispose();
-        }
+        // Verify settings editor is open and find the Binary Path setting
+        const settingItem = await expectSettingsOpen(page, 'Binary Path');
+        await expect(settingItem.locator('input')).toHaveValue(invalidPath);
     });
 
     test('Shows error when jj binary is not found', async ({ vscode }) => {
@@ -69,33 +65,29 @@ test.describe('JJ Binary Configuration E2E', () => {
             true,
         );
 
-        try {
-            // Un-hide notifications toast locally
-            await page.addStyleTag({
-                content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
-            });
+        // Un-hide notifications toast locally
+        await page.addStyleTag({
+            content: '.notifications-toasts { display: block !important; visibility: visible !important; }',
+        });
 
-            // Clear any startup notifications (including the dummy path warning toast)
-            await vscode.executeCommand('notifications.clearAll');
+        // Clear any startup notifications (including the dummy path warning toast)
+        await vscode.executeCommand('notifications.clearAll');
 
-            // Trigger configuration listener by resetting binaryPath to empty string
-            await vscode.evaluate(async (vscode) => {
-                await vscode.workspace
-                    .getConfiguration('jj-view')
-                    .update('binaryPath', '', vscode.ConfigurationTarget.Global);
-            });
+        // Trigger configuration listener by resetting binaryPath to empty string
+        await vscode.evaluate(async (vscode) => {
+            await vscode.workspace
+                .getConfiguration('jj-view')
+                .update('binaryPath', '', vscode.ConfigurationTarget.Global);
+        });
 
-            // Wait for notification and click 'Configure Path'
-            await expectNotificationToast(page, `Could not find 'jj' binary`);
-            await clickNotificationButton(page, 'Configure Path');
+        // Wait for notification and click 'Configure Path'
+        await expectNotificationToast(page, `Could not find 'jj' binary`);
+        await clickNotificationButton(page, 'Configure Path');
 
-            // Verify settings
-            const settingItem = await expectSettingsOpen(page, 'Binary Path');
+        // Verify settings
+        const settingItem = await expectSettingsOpen(page, 'Binary Path');
 
-            // Since we set it to empty string, the UI should show an empty input
-            await expect(settingItem.locator('input')).toHaveValue('');
-        } finally {
-            repo.dispose();
-        }
+        // Since we set it to empty string, the UI should show an empty input
+        await expect(settingItem.locator('input')).toHaveValue('');
     });
 });

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -65,7 +65,6 @@ test.describe('Commit Details E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -56,7 +56,6 @@ test.describe('JJ Log Context Menu E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 
@@ -473,8 +472,6 @@ test.describe('JJ Log Context Menu E2E', () => {
             const pushedCommitId = repo.getCommitId('test-branch');
 
             await waitForBookmark(repo, 'test-branch', pushedCommitId, { remoteRepo, timeout: 20000 });
-
-            remoteRepo.dispose();
         });
 
         test('Advance Bookmark', async () => {
@@ -523,8 +520,6 @@ test.describe('JJ Log Context Menu E2E', () => {
 
             // Remote verification
             await waitForBookmark(repo, 'sync-branch', pushedCommitId, { remoteRepo, timeout: 20000 });
-
-            remoteRepo.dispose();
         });
     });
 });

--- a/src/test/e2e/divergent.spec.ts
+++ b/src/test/e2e/divergent.spec.ts
@@ -42,7 +42,6 @@ test.describe('Divergent Commits E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/e2e/e2e-utils.spec.ts
+++ b/src/test/e2e/e2e-utils.spec.ts
@@ -31,7 +31,6 @@ test.describe('E2E Utilities', () => {
             console.log('----------------------------------------');
             throw err;
         } finally {
-            repo.dispose();
         }
     });
 
@@ -61,7 +60,6 @@ test.describe('E2E Utilities', () => {
             console.log('----------------------------------------');
             throw err;
         } finally {
-            repo.dispose();
         }
     });
 
@@ -84,7 +82,6 @@ test.describe('E2E Utilities', () => {
             console.log('----------------------------------------');
             throw err;
         } finally {
-            repo.dispose();
         }
     });
 });

--- a/src/test/e2e/gerrit.spec.ts
+++ b/src/test/e2e/gerrit.spec.ts
@@ -66,52 +66,48 @@ test.describe('Gerrit Integration E2E', () => {
             'jj-view.uploadCommand': 'describe -m uploaded_successfully',
         });
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // Verify rows show Gerrit status
+        // Verify rows show Gerrit status
 
-            // Explicit Change-Id
-            const row1 = await waitForLogCommitRow(page, 'Explicit Change-Id');
-            await expectBadgeLink(
-                row1,
-                `CL/${clNumbers['explicit-change-id']}`,
-                `${gerrit.url}/c/${clNumbers['explicit-change-id']}`,
-            );
+        // Explicit Change-Id
+        const row1 = await waitForLogCommitRow(page, 'Explicit Change-Id');
+        await expectBadgeLink(
+            row1,
+            `CL/${clNumbers['explicit-change-id']}`,
+            `${gerrit.url}/c/${clNumbers['explicit-change-id']}`,
+        );
 
-            // Fallback (has parent mismatch)
-            const rowFallback = await waitForLogCommitRow(page, 'Fallback Only');
-            await expectBadgeLink(
-                rowFallback,
-                `CL/${clNumbers['fallback-only']}`,
-                `${gerrit.url}/c/${clNumbers['fallback-only']}`,
-            );
+        // Fallback (has parent mismatch)
+        const rowFallback = await waitForLogCommitRow(page, 'Fallback Only');
+        await expectBadgeLink(
+            rowFallback,
+            `CL/${clNumbers['fallback-only']}`,
+            `${gerrit.url}/c/${clNumbers['fallback-only']}`,
+        );
 
-            const uploadButton = rowFallback.getByRole('button', { name: 'Upload changes to Gerrit' });
-            await expect(uploadButton).toBeVisible();
+        const uploadButton = rowFallback.getByRole('button', { name: 'Upload changes to Gerrit' });
+        await expect(uploadButton).toBeVisible();
 
-            // Link Only
-            const rowLink = await waitForLogCommitRow(page, 'Link Only');
-            await expectBadgeLink(rowLink, `CL/${clNumbers['link-only']}`, `${gerrit.url}/c/${clNumbers['link-only']}`);
+        // Link Only
+        const rowLink = await waitForLogCommitRow(page, 'Link Only');
+        await expectBadgeLink(rowLink, `CL/${clNumbers['link-only']}`, `${gerrit.url}/c/${clNumbers['link-only']}`);
 
-            // Mixed
-            const rowMixed = await waitForLogCommitRow(page, 'Mixed trailers');
-            await expectBadgeLink(
-                rowMixed,
-                `CL/${clNumbers['mixed-trailers']}`,
-                `${gerrit.url}/c/${clNumbers['mixed-trailers']}`,
-            );
+        // Mixed
+        const rowMixed = await waitForLogCommitRow(page, 'Mixed trailers');
+        await expectBadgeLink(
+            rowMixed,
+            `CL/${clNumbers['mixed-trailers']}`,
+            `${gerrit.url}/c/${clNumbers['mixed-trailers']}`,
+        );
 
-            // Test upload command
-            await uploadButton.click();
-            const fallbackId = commits['fallback-only'].changeId;
-            await expect(async () => {
-                const desc = repo.getDescription(fallbackId);
-                expect(desc).toContain('uploaded_successfully');
-            }).toPass({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+        // Test upload command
+        await uploadButton.click();
+        const fallbackId = commits['fallback-only'].changeId;
+        await expect(async () => {
+            const desc = repo.getDescription(fallbackId);
+            expect(desc).toContain('uploaded_successfully');
+        }).toPass({ timeout: 15000 });
     });
 
     test("Detects 'Needs Upload' after rebase (rebase hole)", async ({ vscode }) => {
@@ -141,16 +137,12 @@ test.describe('Gerrit Integration E2E', () => {
             'jj-view.gerrit.host': gerrit.url,
         });
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // Row for Child should show upload button because parent mismatch
-            // (locally points to base, Gerrit expects 'sha-1000' which is the old parent)
-            const rowChild = await waitForLogCommitRow(page, 'Child');
-            const uploadButton = rowChild.getByRole('button', { name: 'Upload changes to Gerrit' });
-            await expect(uploadButton).toBeVisible({ timeout: 20000 });
-        } finally {
-            repo.dispose();
-        }
+        // Row for Child should show upload button because parent mismatch
+        // (locally points to base, Gerrit expects 'sha-1000' which is the old parent)
+        const rowChild = await waitForLogCommitRow(page, 'Child');
+        const uploadButton = rowChild.getByRole('button', { name: 'Upload changes to Gerrit' });
+        await expect(uploadButton).toBeVisible({ timeout: 20000 });
     });
 });

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -68,23 +68,19 @@ test.describe('GitHub Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'PR Commit');
+        const row = await waitForLogCommitRow(page, 'PR Commit');
 
-            // Verify PR label is shown with correct number and URL
-            await expectBadgeLink(row, 'PR #42', 'https://github.com/test-owner/test-repo/pull/42');
+        // Verify PR label is shown with correct number and URL
+        await expectBadgeLink(row, 'PR #42', 'https://github.com/test-owner/test-repo/pull/42');
 
-            // Verify unresolved comments bubble is shown
-            await expect(row.getByTitle('3 Unresolved Comments')).toBeVisible();
+        // Verify unresolved comments bubble is shown
+        await expect(row.getByTitle('3 Unresolved Comments')).toBeVisible();
 
-            // Since commit ID matches currentRevision, upload button should NOT be visible
-            const uploadButton = row.getByRole('button', { name: 'Upload changes to GitHub' });
-            await expect(uploadButton).not.toBeVisible();
-        } finally {
-            repo.dispose();
-        }
+        // Since commit ID matches currentRevision, upload button should NOT be visible
+        const uploadButton = row.getByRole('button', { name: 'Upload changes to GitHub' });
+        await expect(uploadButton).not.toBeVisible();
     });
 
     test('Shows Upload button when content is out of sync and performs upload', async ({ vscode }) => {
@@ -126,29 +122,25 @@ test.describe('GitHub Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'Out of Sync Commit');
+        const row = await waitForLogCommitRow(page, 'Out of Sync Commit');
 
-            // Verify PR label and URL
-            await expectBadgeLink(row, 'PR #101', 'https://github.com/test-owner/test-repo/pull/101');
+        // Verify PR label and URL
+        await expectBadgeLink(row, 'PR #101', 'https://github.com/test-owner/test-repo/pull/101');
 
-            // Verify upload button is visible
-            const uploadButton = row.getByRole('button', { name: 'Upload changes to GitHub' });
-            await expect(uploadButton).toBeVisible();
+        // Verify upload button is visible
+        const uploadButton = row.getByRole('button', { name: 'Upload changes to GitHub' });
+        await expect(uploadButton).toBeVisible();
 
-            // Click upload button
-            await uploadButton.click();
+        // Click upload button
+        await uploadButton.click();
 
-            const changeId = commits['out-of-sync-commit'].changeId;
-            await expect(async () => {
-                const desc = repo.getDescription(changeId);
-                expect(desc).toContain('uploaded_successfully');
-            }).toPass({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+        const changeId = commits['out-of-sync-commit'].changeId;
+        await expect(async () => {
+            const desc = repo.getDescription(changeId);
+            expect(desc).toContain('uploaded_successfully');
+        }).toPass({ timeout: 15000 });
     });
 
     test('PR badge is only shown on local bookmark commits, and parent/structure sync indicators are correct', async ({
@@ -220,8 +212,6 @@ test.describe('GitHub Integration E2E', () => {
             await expect(uploadButton).toBeVisible();
             await expect(uploadButton).toHaveAttribute('title', 'Local changes need upload (Click to push)');
         } finally {
-            repo.dispose();
-            remoteRepo.dispose();
         }
     });
 
@@ -240,23 +230,19 @@ test.describe('GitHub Integration E2E', () => {
             },
         );
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // Click the Manage Auth button in the Source Control title bar
-            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
-            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
-            await manageAuthButton.click();
+        // Click the Manage Auth button in the Source Control title bar
+        const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+        await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+        await manageAuthButton.click();
 
-            // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
-            await pickQuickPickItem(page, /Disable Authentication Prompts/);
+        // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
+        await pickQuickPickItem(page, /Disable Authentication Prompts/);
 
-            // Verify confirmation message or state by checking that the quick pick closed
-            const quickPick = locateQuickInputWidget(page);
-            await expect(quickPick).not.toBeVisible();
-        } finally {
-            repo.dispose();
-        }
+        // Verify confirmation message or state by checking that the quick pick closed
+        const quickPick = locateQuickInputWidget(page);
+        await expect(quickPick).not.toBeVisible();
     });
 
     test('Manages GitHub PAT flow via Quick Pick', async ({ vscode }) => {
@@ -275,66 +261,62 @@ test.describe('GitHub Integration E2E', () => {
             true, // showNotifications = true
         );
 
-        try {
+        await focusSCM(page);
+
+        // Click the Manage Auth button in the Source Control title bar
+        const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+        await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+        await manageAuthButton.click();
+
+        // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
+        const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+        await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
+
+        // Click "Enter Personal Access Token (PAT)"
+        await pickQuickPickItem(page, /Enter Personal Access Token/);
+
+        // Wait for the showInputBox input to appear
+        const input = await waitForQuickInput(page);
+        await input.focus();
+        await input.fill('ghp_test-mock-token');
+        await input.press('Enter');
+
+        // Wait for input box to close
+        await expect(quickPick).not.toBeVisible();
+
+        // Re-open the Manage Auth menu
+        await focusSCM(page);
+        await manageAuthButton.click();
+        await expect(quickPick).toBeVisible();
+
+        // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
+        await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
+        await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
+
+        // Click "Clear Personal Access Token (PAT)"
+        await pickQuickPickItem(page, /Clear Personal Access Token/);
+
+        // Wait for menu to close
+        await expect(quickPick).not.toBeVisible();
+
+        // Wait for the success toast to appear, indicating the deletion is complete
+        await expectNotificationToast(page, 'Successfully cleared stored GitHub Personal Access Token');
+
+        // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
+        await expect(async () => {
+            const isVisible = await quickPick.isVisible();
+            if (isVisible) {
+                await page.keyboard.press('Escape');
+                await expect(quickPick).not.toBeVisible();
+            }
             await focusSCM(page);
-
-            // Click the Manage Auth button in the Source Control title bar
-            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
-            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
             await manageAuthButton.click();
+            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
+                timeout: 2000,
+            });
+        }).toPass({ timeout: 15000 });
 
-            // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
-            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
-            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
-
-            // Click "Enter Personal Access Token (PAT)"
-            await pickQuickPickItem(page, /Enter Personal Access Token/);
-
-            // Wait for the showInputBox input to appear
-            const input = await waitForQuickInput(page);
-            await input.focus();
-            await input.fill('ghp_test-mock-token');
-            await input.press('Enter');
-
-            // Wait for input box to close
-            await expect(quickPick).not.toBeVisible();
-
-            // Re-open the Manage Auth menu
-            await focusSCM(page);
-            await manageAuthButton.click();
-            await expect(quickPick).toBeVisible();
-
-            // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
-            await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
-            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
-
-            // Click "Clear Personal Access Token (PAT)"
-            await pickQuickPickItem(page, /Clear Personal Access Token/);
-
-            // Wait for menu to close
-            await expect(quickPick).not.toBeVisible();
-
-            // Wait for the success toast to appear, indicating the deletion is complete
-            await expectNotificationToast(page, 'Successfully cleared stored GitHub Personal Access Token');
-
-            // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
-            await expect(async () => {
-                const isVisible = await quickPick.isVisible();
-                if (isVisible) {
-                    await page.keyboard.press('Escape');
-                    await expect(quickPick).not.toBeVisible();
-                }
-                await focusSCM(page);
-                await manageAuthButton.click();
-                await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
-                    timeout: 2000,
-                });
-            }).toPass({ timeout: 15000 });
-
-            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        } finally {
-            repo.dispose();
-        }
+        await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
     });
 
     test('Detects PR from fork targeting mainline repo', async ({ vscode }) => {
@@ -371,15 +353,11 @@ test.describe('GitHub Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'Fork Commit');
+        const row = await waitForLogCommitRow(page, 'Fork Commit');
 
-            // Verify PR badge is shown with correct number and URL (even though the headOwner is 'fork-owner')
-            await expectBadgeLink(row, 'PR #99', 'https://github.com/mainline-owner/mainline-repo/pull/99');
-        } finally {
-            repo.dispose();
-        }
+        // Verify PR badge is shown with correct number and URL (even though the headOwner is 'fork-owner')
+        await expectBadgeLink(row, 'PR #99', 'https://github.com/mainline-owner/mainline-repo/pull/99');
     });
 });

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -91,7 +91,6 @@ test.describe('GitLab Integration E2E', () => {
             await expect(uploadButton).not.toBeVisible();
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -162,7 +161,6 @@ test.describe('GitLab Integration E2E', () => {
             }).toPass({ timeout: 15000 });
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -221,7 +219,6 @@ test.describe('GitLab Integration E2E', () => {
             await expect(quickPick).not.toBeVisible();
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -301,7 +298,6 @@ test.describe('GitLab Integration E2E', () => {
             await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -360,7 +356,6 @@ test.describe('GitLab Integration E2E', () => {
             await expect(quickPick).not.toBeVisible();
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -405,7 +400,6 @@ test.describe('GitLab Integration E2E', () => {
         } finally {
             gitlab.statusOverride = undefined;
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 
@@ -457,7 +451,6 @@ test.describe('GitLab Integration E2E', () => {
             await expectBadgeLink(row, 'MR !99', 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/99');
         } finally {
             maybePrintExtensionLogs(vscode.userDataDir);
-            repo.dispose();
         }
     });
 });

--- a/src/test/e2e/hidden-commits.spec.ts
+++ b/src/test/e2e/hidden-commits.spec.ts
@@ -15,9 +15,7 @@ test.describe('Hidden Commits', () => {
         repo.init();
     });
 
-    test.afterEach(async () => {
-        repo.dispose();
-    });
+    test.afterEach(async () => {});
 
     test('renders a ghost shape for hidden commit nodes', async ({ vscode }) => {
         // 1. Create a commit that we will hide

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -46,24 +46,20 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
-            const webview = await getLogWebview(page);
+        await focusJJLog(page);
+        const webview = await getLogWebview(page);
 
-            // Assert all commit descriptions are present
-            await expect(await waitForLogCommitRow(page, 'initial setup')).toBeVisible();
-            await expect(await waitForLogCommitRow(page, 'side branch commit')).toBeVisible();
-            await expect(await waitForLogCommitRow(page, 'working tree')).toBeVisible();
+        // Assert all commit descriptions are present
+        await expect(await waitForLogCommitRow(page, 'initial setup')).toBeVisible();
+        await expect(await waitForLogCommitRow(page, 'side branch commit')).toBeVisible();
+        await expect(await waitForLogCommitRow(page, 'working tree')).toBeVisible();
 
-            // Assert Working Copy row is styled bold
-            const wcDesc = webview.locator('.working-copy .commit-desc');
-            await expect(wcDesc).toHaveCSS('font-weight', '700' /* bold */);
+        // Assert Working Copy row is styled bold
+        const wcDesc = webview.locator('.working-copy .commit-desc');
+        await expect(wcDesc).toHaveCSS('font-weight', '700' /* bold */);
 
-            // Assert Bookmark pill is present inside the working copy row
-            await waitForLogPill(page, 'main', 'bookmark');
-        } finally {
-            repo.dispose();
-        }
+        // Assert Bookmark pill is present inside the working copy row
+        await waitForLogPill(page, 'main', 'bookmark');
     });
 
     test('Pane Header Actions: Undo and New Merge Change', async ({ vscode }) => {
@@ -84,58 +80,54 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
-            // 1. New Merge Change (Requires Multi-select)
-            const sideBranchRow = await waitForLogCommitRow(page, { changeId: nodes.side_branch.changeId });
-            const wcRow = await waitForLogCommitRow(page, { changeId: nodes.wc.changeId });
+        await focusJJLog(page);
+        // 1. New Merge Change (Requires Multi-select)
+        const sideBranchRow = await waitForLogCommitRow(page, { changeId: nodes.side_branch.changeId });
+        const wcRow = await waitForLogCommitRow(page, { changeId: nodes.wc.changeId });
 
-            // Click the first one normally, the second with Control
-            await sideBranchRow.click();
-            await expect(sideBranchRow).toHaveAttribute('data-selected', 'true');
+        // Click the first one normally, the second with Control
+        await sideBranchRow.click();
+        await expect(sideBranchRow).toHaveAttribute('data-selected', 'true');
 
-            await wcRow.click({ modifiers: ['Control'] });
-            await expect(wcRow).toHaveAttribute('data-selected', 'true');
+        await wcRow.click({ modifiers: ['Control'] });
+        await expect(wcRow).toHaveAttribute('data-selected', 'true');
 
-            // Click the native 'New Merge Change' header action
-            // name-based locator is more robust for VS Code header actions
-            const mergeAction = page.getByRole('button', { name: 'New Merge Change' }).first();
-            await expect(mergeAction).toBeEnabled();
-            await mergeAction.click();
+        // Click the native 'New Merge Change' header action
+        // name-based locator is more robust for VS Code header actions
+        const mergeAction = page.getByRole('button', { name: 'New Merge Change' }).first();
+        await expect(mergeAction).toBeEnabled();
+        await mergeAction.click();
 
-            // Assert via repo that a new merge commit was created with correct parents
-            await expect(async () => {
-                const parents = repo.getParents('@');
-                expect(parents).toContain(nodes.side_branch.changeId);
-                expect(parents).toContain(nodes.wc.changeId);
-            }).toPass({ timeout: 5000 });
+        // Assert via repo that a new merge commit was created with correct parents
+        await expect(async () => {
+            const parents = repo.getParents('@');
+            expect(parents).toContain(nodes.side_branch.changeId);
+            expect(parents).toContain(nodes.wc.changeId);
+        }).toPass({ timeout: 5000 });
 
-            // Verify full tree: [merge, wc, side_branch, initial, dummy]
-            await expect(async () => {
-                const mergeChangeId = repo.getChangeId('@');
-                await expectTree(repo, [
-                    `@ ${entry(mergeChangeId, '(empty)', [nodes.side_branch.changeId, nodes.wc.changeId])}`,
-                    entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
-                    entry(nodes.side_branch.changeId, 'side branch', nodes.initial.changeId),
-                    entry(nodes.initial.changeId, 'initial setup', dummyId),
-                    entry(dummyId, '(empty)', ROOT_ID),
-                ]);
-            }).toPass();
-
-            // 2. Undo
-            const undoAction = page.getByRole('button', { name: 'Undo' }).first();
-            await undoAction.click();
-
-            // Assert the merge change was undone accurately
+        // Verify full tree: [merge, wc, side_branch, initial, dummy]
+        await expect(async () => {
+            const mergeChangeId = repo.getChangeId('@');
             await expectTree(repo, [
-                `@ ${entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId)}`,
+                `@ ${entry(mergeChangeId, '(empty)', [nodes.side_branch.changeId, nodes.wc.changeId])}`,
+                entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
                 entry(nodes.side_branch.changeId, 'side branch', nodes.initial.changeId),
                 entry(nodes.initial.changeId, 'initial setup', dummyId),
                 entry(dummyId, '(empty)', ROOT_ID),
             ]);
-        } finally {
-            repo.dispose();
-        }
+        }).toPass();
+
+        // 2. Undo
+        const undoAction = page.getByRole('button', { name: 'Undo' }).first();
+        await undoAction.click();
+
+        // Assert the merge change was undone accurately
+        await expectTree(repo, [
+            `@ ${entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId)}`,
+            entry(nodes.side_branch.changeId, 'side branch', nodes.initial.changeId),
+            entry(nodes.initial.changeId, 'initial setup', dummyId),
+            entry(dummyId, '(empty)', ROOT_ID),
+        ]);
     });
 
     test('Hover Actions: New Child, Squash, Abandon', async ({ vscode }) => {
@@ -156,79 +148,75 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // 1. New Child
-            const branchId = nodes.branch.changeId;
-            await clickLogAction(page, { changeId: branchId }, 'New Child');
+        // 1. New Child
+        const branchId = nodes.branch.changeId;
+        await clickLogAction(page, { changeId: branchId }, 'New Child');
 
-            let childId = '';
-            await expect(async () => {
-                const currentId = repo.getChangeId('@');
-                // Ensure @ has actually moved away from wc
-                expect(currentId).not.toBe(nodes.wc.changeId);
-                childId = currentId;
-            }).toPass({ timeout: 10000 });
+        let childId = '';
+        await expect(async () => {
+            const currentId = repo.getChangeId('@');
+            // Ensure @ has actually moved away from wc
+            expect(currentId).not.toBe(nodes.wc.changeId);
+            childId = currentId;
+        }).toPass({ timeout: 10000 });
 
-            // Make a file change in the child so it's not abandoned by 'jj edit'
-            // but keep description empty so 'jj squash' stays silent
-            repo.writeFile('child.txt', 'child content');
+        // Make a file change in the child so it's not abandoned by 'jj edit'
+        // but keep description empty so 'jj squash' stays silent
+        repo.writeFile('child.txt', 'child content');
 
-            // Tree: [new_child(@), wc, branch, initial, dummy]
-            // Order: child is newest head, wc is other head.
-            await expect(async () => {
-                const childId = repo.getChangeId('@');
-                await expectTree(repo, [
-                    `@ ${entry(childId, '(empty)', nodes.branch.changeId)}`,
-                    entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
-                    entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-                    entry(nodes.initial.changeId, 'initial setup', dummyId),
-                    entry(dummyId, '(empty)', ROOT_ID),
-                ]);
-            }).toPass();
-            await waitForWebviewWorkingCopy(page, childId);
-
-            // 2. Prepare for squash: move working copy away from the new child
-            const initialId = nodes.initial.changeId;
-            await clickLogAction(page, { changeId: initialId }, 'Edit Commit');
-
-            // Tree is the same commits, just @ moved. Order: [child, wc, branch, initial, dummy]
+        // Tree: [new_child(@), wc, branch, initial, dummy]
+        // Order: child is newest head, wc is other head.
+        await expect(async () => {
+            const childId = repo.getChangeId('@');
             await expectTree(repo, [
-                entry(childId, '(empty)', nodes.branch.changeId),
+                `@ ${entry(childId, '(empty)', nodes.branch.changeId)}`,
                 entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
                 entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-                `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
+                entry(nodes.initial.changeId, 'initial setup', dummyId),
                 entry(dummyId, '(empty)', ROOT_ID),
             ]);
-            await waitForWebviewWorkingCopy(page, initialId);
+        }).toPass();
+        await waitForWebviewWorkingCopy(page, childId);
 
-            // 3. Squash the child into branch
-            await clickLogAction(page, { changeId: childId }, 'Squash');
+        // 2. Prepare for squash: move working copy away from the new child
+        const initialId = nodes.initial.changeId;
+        await clickLogAction(page, { changeId: initialId }, 'Edit Commit');
 
-            // After squash: child is gone. branch has its changes.
-            await expectTree(repo, [
-                entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
-                entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-                `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
-                entry(dummyId, '(empty)', ROOT_ID),
-            ]);
-            await waitForWebviewCommitRemoved(page, childId);
+        // Tree is the same commits, just @ moved. Order: [child, wc, branch, initial, dummy]
+        await expectTree(repo, [
+            entry(childId, '(empty)', nodes.branch.changeId),
+            entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
+            entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
+            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
+            entry(dummyId, '(empty)', ROOT_ID),
+        ]);
+        await waitForWebviewWorkingCopy(page, initialId);
 
-            // 4. Abandon the branch commit
-            await clickLogAction(page, { changeId: branchId }, 'Abandon');
+        // 3. Squash the child into branch
+        await clickLogAction(page, { changeId: childId }, 'Squash');
 
-            // After abandon branch: branch is gone. wc (child of branch) becomes child of initial.
-            // Tree: [wc, initial(@)]
-            await expectTree(repo, [
-                entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
-                `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
-                entry(dummyId, '(empty)', ROOT_ID),
-            ]);
-            await waitForWebviewCommitRemoved(page, branchId);
-        } finally {
-            repo.dispose();
-        }
+        // After squash: child is gone. branch has its changes.
+        await expectTree(repo, [
+            entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
+            entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
+            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
+            entry(dummyId, '(empty)', ROOT_ID),
+        ]);
+        await waitForWebviewCommitRemoved(page, childId);
+
+        // 4. Abandon the branch commit
+        await clickLogAction(page, { changeId: branchId }, 'Abandon');
+
+        // After abandon branch: branch is gone. wc (child of branch) becomes child of initial.
+        // Tree: [wc, initial(@)]
+        await expectTree(repo, [
+            entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
+            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
+            entry(dummyId, '(empty)', ROOT_ID),
+        ]);
+        await waitForWebviewCommitRemoved(page, branchId);
     });
 
     test('Multi-select and Drag & Drop (Rebase)', async ({ vscode }) => {
@@ -252,27 +240,23 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const sourceRow = await waitForLogCommitRow(page, { changeId: nodes.source.changeId });
-            const targetRow = await waitForLogCommitRow(page, { changeId: nodes.target.changeId });
+        const sourceRow = await waitForLogCommitRow(page, { changeId: nodes.source.changeId });
+        const targetRow = await waitForLogCommitRow(page, { changeId: nodes.target.changeId });
 
-            await sourceRow.scrollIntoViewIfNeeded();
-            await targetRow.scrollIntoViewIfNeeded();
+        await sourceRow.scrollIntoViewIfNeeded();
+        await targetRow.scrollIntoViewIfNeeded();
 
-            // Drag source onto target to rebase
-            await dragAndDrop(page, { source: sourceRow, target: targetRow });
+        // Drag source onto target to rebase
+        await dragAndDrop(page, { source: sourceRow, target: targetRow });
 
-            // Verify rebase via repo
-            await expect(async () => {
-                // Check 'source' parent is now 'target'
-                const parents = repo.getParents(nodes.source.changeId);
-                expect(parents).toContain(nodes.target.changeId);
-            }).toPass({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+        // Verify rebase via repo
+        await expect(async () => {
+            // Check 'source' parent is now 'target'
+            const parents = repo.getParents(nodes.source.changeId);
+            expect(parents).toContain(nodes.target.changeId);
+        }).toPass({ timeout: 10000 });
     });
 
     test('Delete Bookmark (Command Palette/Quick Pick Flow)', async ({ vscode }) => {
@@ -294,25 +278,21 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
-            await triggerRefresh(page);
+        await focusJJLog(page);
+        await triggerRefresh(page);
 
-            // 2. Verify bookmark pill is visible
-            const bookmarkPill = await waitForLogPill(page, 'local-to-delete', 'bookmark');
-            await expect(bookmarkPill).toBeVisible();
+        // 2. Verify bookmark pill is visible
+        const bookmarkPill = await waitForLogPill(page, 'local-to-delete', 'bookmark');
+        await expect(bookmarkPill).toBeVisible();
 
-            // 3. Trigger Delete Bookmark via keyboard shortcut
-            await page.keyboard.press('Control+Alt+D');
+        // 3. Trigger Delete Bookmark via keyboard shortcut
+        await page.keyboard.press('Control+Alt+D');
 
-            // 4. Select the bookmark to delete in the Quick Pick
-            await pickQuickPickItem(page, 'local-to-delete');
+        // 4. Select the bookmark to delete in the Quick Pick
+        await pickQuickPickItem(page, 'local-to-delete');
 
-            // 5. Verify the bookmark pill disappears from the webview
-            await expect(bookmarkPill).toBeHidden({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+        // 5. Verify the bookmark pill disappears from the webview
+        await expect(bookmarkPill).toBeHidden({ timeout: 10000 });
     });
 
     test('Drag & Drop Bookmark (Advance/Move)', async ({ vscode }) => {
@@ -334,35 +314,31 @@ test.describe('JJ Log Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // 2. Locate the draggable bookmark pill and target commit row (move forward)
-            const bookmarkPill = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
-            const wcRow = await waitForLogCommitRow(page, { changeId: nodes.wc.changeId });
+        // 2. Locate the draggable bookmark pill and target commit row (move forward)
+        const bookmarkPill = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
+        const wcRow = await waitForLogCommitRow(page, { changeId: nodes.wc.changeId });
 
-            // 3. Drag the bookmark pill onto the wc commit row (move forward)
-            await dragAndDrop(page, { source: bookmarkPill, target: wcRow });
+        // 3. Drag the bookmark pill onto the wc commit row (move forward)
+        await dragAndDrop(page, { source: bookmarkPill, target: wcRow });
 
-            // 4. Verify bookmark moved to wc in local repository
-            const wcCommitId = repo.getCommitId(nodes.wc.changeId);
-            await expect(async () => {
-                expect(repo.getCommitId('drag-bookmark')).toBe(wcCommitId);
-            }).toPass({ timeout: 10000 });
+        // 4. Verify bookmark moved to wc in local repository
+        const wcCommitId = repo.getCommitId(nodes.wc.changeId);
+        await expect(async () => {
+            expect(repo.getCommitId('drag-bookmark')).toBe(wcCommitId);
+        }).toPass({ timeout: 10000 });
 
-            // 5. Drag it backward (from wc back onto initial commit)
-            const initialRow = await waitForLogCommitRow(page, { changeId: nodes.initial.changeId });
-            // Re-fetch the bookmark pill since the webview refreshes after the move command
-            const bookmarkPillAfterMove = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
-            await dragAndDrop(page, { source: bookmarkPillAfterMove, target: initialRow });
+        // 5. Drag it backward (from wc back onto initial commit)
+        const initialRow = await waitForLogCommitRow(page, { changeId: nodes.initial.changeId });
+        // Re-fetch the bookmark pill since the webview refreshes after the move command
+        const bookmarkPillAfterMove = await waitForLogPill(page, 'drag-bookmark', 'bookmark');
+        await dragAndDrop(page, { source: bookmarkPillAfterMove, target: initialRow });
 
-            // 6. Verify bookmark moved back to initial commit in local repository
-            const initialCommitId = repo.getCommitId(nodes.initial.changeId);
-            await expect(async () => {
-                expect(repo.getCommitId('drag-bookmark')).toBe(initialCommitId);
-            }).toPass({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+        // 6. Verify bookmark moved back to initial commit in local repository
+        const initialCommitId = repo.getCommitId(nodes.initial.changeId);
+        await expect(async () => {
+            expect(repo.getCommitId('drag-bookmark')).toBe(initialCommitId);
+        }).toPass({ timeout: 10000 });
     });
 });

--- a/src/test/e2e/multi-repo.spec.ts
+++ b/src/test/e2e/multi-repo.spec.ts
@@ -82,10 +82,8 @@ test.describe('Multi-Repo Switching E2E', () => {
 
     test.afterEach(async () => {
         if (secondRepo) {
-            secondRepo.dispose();
         }
         if (mainRepo) {
-            mainRepo.dispose();
         }
     });
 

--- a/src/test/e2e/quick-diff.spec.ts
+++ b/src/test/e2e/quick-diff.spec.ts
@@ -14,7 +14,6 @@ test.describe('Quick Diff E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
         repo = undefined;
     });

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -53,25 +53,21 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // Verify groups
-            const mergeConflictsHeader = page.getByRole('treeitem', { name: 'Merge Conflicts' });
-            const workingCopyHeader = page.getByRole('treeitem', { name: /Working Copy/ });
+        // Verify groups
+        const mergeConflictsHeader = page.getByRole('treeitem', { name: 'Merge Conflicts' });
+        const workingCopyHeader = page.getByRole('treeitem', { name: /Working Copy/ });
 
-            await expect(mergeConflictsHeader).toBeVisible();
-            await expect(workingCopyHeader).toBeVisible();
+        await expect(mergeConflictsHeader).toBeVisible();
+        await expect(workingCopyHeader).toBeVisible();
 
-            // Verify ancestor groups (merge commit is empty, showing parents @-2^1 and @-2^2)
-            await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({ timeout: 5000 });
-            await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible();
+        // Verify ancestor groups (merge commit is empty, showing parents @-2^1 and @-2^2)
+        await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible();
 
-            // Verify SCM input is populated with working copy description
-            await expectScmDescription(page, 'my working copy');
-        } finally {
-            repo.dispose();
-        }
+        // Verify SCM input is populated with working copy description
+        await expectScmDescription(page, 'my working copy');
     });
 
     test('Top-Level Commands: Commit and New Change', async ({ vscode }) => {
@@ -85,44 +81,40 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            const scmInput = page.getByRole('treeitem', { name: 'Source Control Input' });
+        const scmInput = page.getByRole('treeitem', { name: 'Source Control Input' });
 
-            // Set Description and Commit with robust helper inside a single retry-safe block
+        // Set Description and Commit with robust helper inside a single retry-safe block
+        await expect(async () => {
+            await setScmDescription(page, 'Updated description explicitly', vscode);
+
+            // Commit using button inside the Source Control view title bar
+            const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
+            await commitButton.click();
+
             await expect(async () => {
-                await setScmDescription(page, 'Updated description explicitly', vscode);
+                expect(repo.log()).toContain('Updated description explicitly');
+            }).toPass({ timeout: 5000 });
+        }).toPass({ timeout: 15000 });
 
-                // Commit using button inside the Source Control view title bar
-                const commitButton = page.getByRole('button', { name: 'Commit (Ctrl+Enter)' }).first();
-                await commitButton.click();
+        // Ensure wait for SCM refresh before next action
+        await expect(scmInput).not.toContainText('Updated description explicitly', { timeout: 10000 });
 
-                await expect(async () => {
-                    expect(repo.log()).toContain('Updated description explicitly');
-                }).toPass({ timeout: 5000 });
-            }).toPass({ timeout: 15000 });
+        const prevWcId = repo.getWorkingCopyId();
 
-            // Ensure wait for SCM refresh before next action
-            await expect(scmInput).not.toContainText('Updated description explicitly', { timeout: 10000 });
+        // Click New Change (+)
+        const newButton = page.getByRole('button', { name: 'New', exact: true }).first();
+        await expect(newButton).toBeVisible();
+        await newButton.click();
 
-            const prevWcId = repo.getWorkingCopyId();
-
-            // Click New Change (+)
-            const newButton = page.getByRole('button', { name: 'New', exact: true }).first();
-            await expect(newButton).toBeVisible();
-            await newButton.click();
-
-            // Wait for UI to reflect empty input box and tree to update
-            await expectTree(repo, [
-                expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[${prevWcId}\\] \\(empty\\)$`)),
-                entry(prevWcId, '(empty)', initialId),
-                entry(initialId, 'Updated description explicitly', workspaceRootId),
-                entry(workspaceRootId, '(empty)', ROOT_ID),
-            ]);
-        } finally {
-            repo.dispose();
-        }
+        // Wait for UI to reflect empty input box and tree to update
+        await expectTree(repo, [
+            expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[${prevWcId}\\] \\(empty\\)$`)),
+            entry(prevWcId, '(empty)', initialId),
+            entry(initialId, 'Updated description explicitly', workspaceRootId),
+            entry(workspaceRootId, '(empty)', ROOT_ID),
+        ]);
     });
 
     test('Keyboard Shortcuts: Ctrl+S and Ctrl+Enter', async ({ vscode }) => {
@@ -135,36 +127,32 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
-            let scmInput: Locator | undefined;
+        await focusSCM(page);
+        let scmInput: Locator | undefined;
 
-            // Set Description and Save with Control+S
-            await expect(async () => {
-                scmInput = await setScmDescription(page, 'Using keyboard shortcuts', vscode);
-                await page.keyboard.press('Control+S');
+        // Set Description and Save with Control+S
+        await expect(async () => {
+            scmInput = await setScmDescription(page, 'Using keyboard shortcuts', vscode);
+            await page.keyboard.press('Control+S');
 
-                // Wait for input to be stable (picked up by the backend)
-                expect(repo.getDescription('@').trim()).toBe('Using keyboard shortcuts');
-            }).toPass({ timeout: 15000 });
+            // Wait for input to be stable (picked up by the backend)
+            expect(repo.getDescription('@').trim()).toBe('Using keyboard shortcuts');
+        }).toPass({ timeout: 15000 });
 
-            // Set Description and Commit with Control+Enter
-            await expect(async () => {
-                scmInput = await setScmDescription(page, 'Commit via keyboard', vscode);
-                await page.keyboard.press('Control+Enter');
+        // Set Description and Commit with Control+Enter
+        await expect(async () => {
+            scmInput = await setScmDescription(page, 'Commit via keyboard', vscode);
+            await page.keyboard.press('Control+Enter');
 
-                // Wait for it to be committed and appear in log
-                const log = repo.log();
-                expect(log).toContain('Commit via keyboard');
-            }).toPass({ timeout: 15000 });
+            // Wait for it to be committed and appear in log
+            const log = repo.log();
+            expect(log).toContain('Commit via keyboard');
+        }).toPass({ timeout: 15000 });
 
-            if (!scmInput) {
-                throw new Error('scmInput not initialized');
-            }
-            await expect(scmInput).not.toContainText('Commit via keyboard', { timeout: 10000 });
-        } finally {
-            repo.dispose();
+        if (!scmInput) {
+            throw new Error('scmInput not initialized');
         }
+        await expect(scmInput).not.toContainText('Commit via keyboard', { timeout: 10000 });
     });
 
     test('Format on Save for SCM Set Description and Commit', async ({ vscode }) => {
@@ -179,53 +167,49 @@ test.describe('SCM Pane E2E', () => {
             'jj-view.commit.formatDescriptionOnSave': true,
         });
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            const longBody =
-                'This is a very long body text that should be wrapped onto multiple lines when saved because it exceeds the limit of seventy-two characters.';
-            const messageToFormat = `Title line\n\n${longBody}`;
+        const longBody =
+            'This is a very long body text that should be wrapped onto multiple lines when saved because it exceeds the limit of seventy-two characters.';
+        const messageToFormat = `Title line\n\n${longBody}`;
 
-            // 1. Test Set Description (Ctrl+S)
-            // Use a toPass block for the entire operation to handle synchronization delays
-            // between the renderer and extension host.
-            await expect(async () => {
-                await setScmDescription(page, messageToFormat, vscode);
-                await page.keyboard.press('Control+S');
+        // 1. Test Set Description (Ctrl+S)
+        // Use a toPass block for the entire operation to handle synchronization delays
+        // between the renderer and extension host.
+        await expect(async () => {
+            await setScmDescription(page, messageToFormat, vscode);
+            await page.keyboard.press('Control+S');
 
-                const desc = repo.getDescription('@');
-                const expectedDesc =
-                    'Title line\n\nThis is a very long body text that should be wrapped onto multiple lines\nwhen saved because it exceeds the limit of seventy-two characters.';
-                expect(desc).toBe(expectedDesc);
-                expect(desc.split('\n').length).toBeGreaterThan(2);
+            const desc = repo.getDescription('@');
+            const expectedDesc =
+                'Title line\n\nThis is a very long body text that should be wrapped onto multiple lines\nwhen saved because it exceeds the limit of seventy-two characters.';
+            expect(desc).toBe(expectedDesc);
+            expect(desc.split('\n').length).toBeGreaterThan(2);
 
-                // Wait for the UI input box to reflect the formatted text
-                await expectScmDescription(page, expectedDesc);
-            }).toPass({ timeout: 20000 });
+            // Wait for the UI input box to reflect the formatted text
+            await expectScmDescription(page, expectedDesc);
+        }).toPass({ timeout: 20000 });
 
-            // 2. Test Commit (Ctrl+Enter)
-            const longBody2 =
-                'Another very long body text that should be wrapped onto multiple lines when committed from the SCM input box.';
-            const messageToFormat2 = `Commit Title\n\n${longBody2}`;
+        // 2. Test Commit (Ctrl+Enter)
+        const longBody2 =
+            'Another very long body text that should be wrapped onto multiple lines when committed from the SCM input box.';
+        const messageToFormat2 = `Commit Title\n\n${longBody2}`;
 
-            await expect(async () => {
-                const scmInput2 = await setScmDescription(page, messageToFormat2, vscode);
+        await expect(async () => {
+            const scmInput2 = await setScmDescription(page, messageToFormat2, vscode);
 
-                await page.keyboard.press('Control+Enter');
-                await expect(scmInput2).not.toContainText('Commit Title', { timeout: 5000 });
+            await page.keyboard.press('Control+Enter');
+            await expect(scmInput2).not.toContainText('Commit Title', { timeout: 5000 });
 
-                // Wait for it to be committed, formatted, and appear in log
-                const log = repo.log();
-                expect(log).toContain('Commit Title');
-                // Find latest commit description (working copy is parent of the new commit)
-                const desc = repo.getDescription('@-');
-                const expectedDesc = `Commit Title\n\nAnother very long body text that should be wrapped onto multiple lines\nwhen committed from the SCM input box.`;
-                expect(desc).toBe(expectedDesc);
-                expect(desc.split('\n').length).toBeGreaterThan(2);
-            }).toPass({ timeout: 20000 });
-        } finally {
-            repo.dispose();
-        }
+            // Wait for it to be committed, formatted, and appear in log
+            const log = repo.log();
+            expect(log).toContain('Commit Title');
+            // Find latest commit description (working copy is parent of the new commit)
+            const desc = repo.getDescription('@-');
+            const expectedDesc = `Commit Title\n\nAnother very long body text that should be wrapped onto multiple lines\nwhen committed from the SCM input box.`;
+            expect(desc).toBe(expectedDesc);
+            expect(desc.split('\n').length).toBeGreaterThan(2);
+        }).toPass({ timeout: 20000 });
     });
 
     test('Group-Level Actions: Abandon Working Copy and Squash Ancestor', async ({ vscode }) => {
@@ -252,40 +236,36 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Abandon Working Copy
-            await clickScmAction(page, /Working Copy/, SCM_ACTIONS.Abandon);
+        // 1. Abandon Working Copy
+        await clickScmAction(page, /Working Copy/, SCM_ACTIONS.Abandon);
 
-            // Assert via repo that wc change is abandoned. Poll until true.
-            await expect(async () => {
-                const isWcChangeStillPresent = repo.log().includes(commits.wc.changeId);
-                expect(isWcChangeStillPresent).toBe(false);
-            }).toPass({ timeout: 5000 });
+        // Assert via repo that wc change is abandoned. Poll until true.
+        await expect(async () => {
+            const isWcChangeStillPresent = repo.log().includes(commits.wc.changeId);
+            expect(isWcChangeStillPresent).toBe(false);
+        }).toPass({ timeout: 5000 });
 
-            // 2. Squash Ancestor into Initial
-            // ancestor change is @-2 now because middle is still there.
-            await clickScmAction(page, /ancestor change/, SCM_ACTIONS.SquashRevisionIntoParent);
+        // 2. Squash Ancestor into Initial
+        // ancestor change is @-2 now because middle is still there.
+        await clickScmAction(page, /ancestor change/, SCM_ACTIONS.SquashRevisionIntoParent);
 
-            // Assert via repo that the ancestor was squashed into its parent (initial). Poll until true.
-            await expect(async () => {
-                const logAfterSquash = repo.log();
-                // The ancestor's change ID should be gone
-                expect(logAfterSquash).not.toContain(commits.ancestor.changeId);
-                // The middle change should still be there
-                expect(logAfterSquash).toContain('middle change');
+        // Assert via repo that the ancestor was squashed into its parent (initial). Poll until true.
+        await expect(async () => {
+            const logAfterSquash = repo.log();
+            // The ancestor's change ID should be gone
+            expect(logAfterSquash).not.toContain(commits.ancestor.changeId);
+            // The middle change should still be there
+            expect(logAfterSquash).toContain('middle change');
 
-                // Verify files in initial (it should have its own files + ancestor's files)
-                const filesInInitial = repo.getFiles(commits.initial.changeId);
-                expect(filesInInitial).toContain('i.txt');
-                expect(filesInInitial).toContain('a.txt');
-                expect(filesInInitial).toContain('a2.txt');
-                expect(filesInInitial).toContain('base.txt'); // inherited from base
-            }).toPass({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+            // Verify files in initial (it should have its own files + ancestor's files)
+            const filesInInitial = repo.getFiles(commits.initial.changeId);
+            expect(filesInInitial).toContain('i.txt');
+            expect(filesInInitial).toContain('a.txt');
+            expect(filesInInitial).toContain('a2.txt');
+            expect(filesInInitial).toContain('base.txt'); // inherited from base
+        }).toPass({ timeout: 10000 });
     });
 
     test('Squash into Ancestor (Revision and Files)', async ({ vscode }) => {
@@ -306,41 +286,37 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Squash Revision into Ancestor
-            // We'll squash 'middle' into 'target'
-            await clickScmAction(page, /middle message/, SCM_ACTIONS.SquashRevisionIntoAncestor);
-            // Pick 'target' from quickpick. Since it has no description, it will show '(no description)'
-            await pickQuickPickItem(page, '(no description)');
+        // 1. Squash Revision into Ancestor
+        // We'll squash 'middle' into 'target'
+        await clickScmAction(page, /middle message/, SCM_ACTIONS.SquashRevisionIntoAncestor);
+        // Pick 'target' from quickpick. Since it has no description, it will show '(no description)'
+        await pickQuickPickItem(page, '(no description)');
 
-            await expect(async () => {
-                const log = repo.log();
-                expect(log).not.toContain(commits.middle.changeId);
-                const targetFiles = repo.getFiles(commits.target.changeId);
-                expect(targetFiles).toContain('t.txt');
-                expect(targetFiles).toContain('m.txt');
-            }).toPass({ timeout: 10000 });
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).not.toContain(commits.middle.changeId);
+            const targetFiles = repo.getFiles(commits.target.changeId);
+            expect(targetFiles).toContain('t.txt');
+            expect(targetFiles).toContain('m.txt');
+        }).toPass({ timeout: 10000 });
 
-            // 2. Squash Files into Ancestor
-            // We'll squash s.txt from 'source' (WC) into 'base'
-            // Hover over s.txt row and click squash into ancestor
-            await clickScmAction(page, /s\.txt/, SCM_ACTIONS.SquashFilesIntoAncestor);
-            // Pick 'base' from quickpick.
-            await pickQuickPickItem(page, '(no description)');
+        // 2. Squash Files into Ancestor
+        // We'll squash s.txt from 'source' (WC) into 'base'
+        // Hover over s.txt row and click squash into ancestor
+        await clickScmAction(page, /s\.txt/, SCM_ACTIONS.SquashFilesIntoAncestor);
+        // Pick 'base' from quickpick.
+        await pickQuickPickItem(page, '(no description)');
 
-            await expect(async () => {
-                const baseFiles = repo.getFiles(commits.base.changeId);
-                expect(baseFiles).toContain('s.txt');
+        await expect(async () => {
+            const baseFiles = repo.getFiles(commits.base.changeId);
+            expect(baseFiles).toContain('s.txt');
 
-                // Verify s.txt is no longer modified in the working copy
-                const wcDiff = repo.getDiffSummary('@');
-                expect(wcDiff).not.toContain('s.txt');
-            }).toPass({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+            // Verify s.txt is no longer modified in the working copy
+            const wcDiff = repo.getDiffSummary('@');
+            expect(wcDiff).not.toContain('s.txt');
+        }).toPass({ timeout: 10000 });
     });
 
     test('File-Level Actions: Discard Changes and Diff Editing (Right Side)', async ({ vscode }) => {
@@ -363,123 +339,119 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
-            // Discard Changes (file3.txt)
-            const wcFile3Row = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
-            const discardIcon = wcFile3Row.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
-            await hoverAndClick(wcFile3Row, discardIcon);
+        await focusSCM(page);
+        // Discard Changes (file3.txt)
+        const wcFile3Row = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
+        const discardIcon = wcFile3Row.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
+        await hoverAndClick(wcFile3Row, discardIcon);
 
-            // Assert the file was restored by polling
-            await expect(async () => {
-                expect(repo.getFileContent('@', 'file3.txt').trim()).toBe('base3');
-            }).toPass({ timeout: 5000 });
+        // Assert the file was restored by polling
+        await expect(async () => {
+            expect(repo.getFileContent('@', 'file3.txt').trim()).toBe('base3');
+        }).toPass({ timeout: 5000 });
 
-            // File-Level Squash (file.txt)
-            // Hover over file.txt in Working Copy and click Squash
-            // file.txt and the group squash action share the same codicon-arrow-down icon
-            const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
-            const squashFileIcon = wcFileRow
-                .getByRole('button', { name: 'Squash File(s) into Parent', exact: true })
-                .first();
-            await hoverAndClick(wcFileRow, squashFileIcon);
+        // File-Level Squash (file.txt)
+        // Hover over file.txt in Working Copy and click Squash
+        // file.txt and the group squash action share the same codicon-arrow-down icon
+        const wcFileRow = page.getByRole('treeitem', { name: /file\.txt, modified/ });
+        const squashFileIcon = wcFileRow
+            .getByRole('button', { name: 'Squash File(s) into Parent', exact: true })
+            .first();
+        await hoverAndClick(wcFileRow, squashFileIcon);
 
-            // Assert via repo that file.txt changes were squashed into the parent commit
-            await expect(async () => {
-                const parentChanges = repo.getDiffSummary('@-');
-                expect(parentChanges).toContain('A file.txt');
-                const wcChanges = repo.getDiffSummary('@');
-                expect(wcChanges).not.toContain('A file.txt');
-            }).toPass({ timeout: 5000 });
+        // Assert via repo that file.txt changes were squashed into the parent commit
+        await expect(async () => {
+            const parentChanges = repo.getDiffSummary('@-');
+            expect(parentChanges).toContain('A file.txt');
+            const wcChanges = repo.getDiffSummary('@');
+            expect(wcChanges).not.toContain('A file.txt');
+        }).toPass({ timeout: 5000 });
 
-            // Open Single File Diff (file2.txt)
-            await openScmDiff(page, /file2\.txt/);
+        // Open Single File Diff (file2.txt)
+        await openScmDiff(page, /file2\.txt/);
 
-            // Edit the right side of the diff editor (the working copy)
-            const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+        // Edit the right side of the diff editor (the working copy)
+        const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+        await rightEditor.click();
+
+        // Selecting all text and typing
+        // Use toPass to retry the entire typing sequence since Monaco can be finicky
+        await expect(async () => {
             await rightEditor.click();
+            await page.keyboard.press('Control+A');
+            await page.keyboard.press('Backspace');
+            await page.keyboard.insertText('edited from diff');
+            await expect(rightEditor).toContainText('edited from diff', { timeout: 1000 });
+        }).toPass({ timeout: 5000 });
 
-            // Selecting all text and typing
-            // Use toPass to retry the entire typing sequence since Monaco can be finicky
-            await expect(async () => {
-                await rightEditor.click();
-                await page.keyboard.press('Control+A');
-                await page.keyboard.press('Backspace');
-                await page.keyboard.insertText('edited from diff');
-                await expect(rightEditor).toContainText('edited from diff', { timeout: 1000 });
-            }).toPass({ timeout: 5000 });
+        // Save and ensure JJ picks it up.
+        // Ensure focus before save
+        await rightEditor.click();
+        await page.keyboard.press('Control+s');
 
-            // Save and ensure JJ picks it up.
-            // Ensure focus before save
-            await rightEditor.click();
-            await page.keyboard.press('Control+s');
+        // Verify file content on disk and in jj using toPass polling
+        await expect(async () => {
+            const diskContent = fs.readFileSync(path.join(repo.path, 'file2.txt'), 'utf8').trim();
+            expect(diskContent).toBe('edited from diff');
 
-            // Verify file content on disk and in jj using toPass polling
-            await expect(async () => {
-                const diskContent = fs.readFileSync(path.join(repo.path, 'file2.txt'), 'utf8').trim();
-                expect(diskContent).toBe('edited from diff');
+            const content = repo.getFileContent('@', 'file2.txt').trim();
+            expect(content).toBe('edited from diff');
+        }).toPass({ timeout: 10000, intervals: [50, 100, 250, 500] });
 
-                const content = repo.getFileContent('@', 'file2.txt').trim();
-                expect(content).toBe('edited from diff');
-            }).toPass({ timeout: 10000, intervals: [50, 100, 250, 500] });
+        // Create a chain (initial -> wc_commit -> new_wc) to verify squash into a non-immediate ancestor
+        await focusSCM(page);
+        const scmInputSquash = await setScmDescription(page, 'commit wc', vscode);
+        await page.keyboard.press('Control+Enter');
+        await expect(scmInputSquash).not.toContainText('commit wc', { timeout: 10000 });
 
-            // Create a chain (initial -> wc_commit -> new_wc) to verify squash into a non-immediate ancestor
-            await focusSCM(page);
-            const scmInputSquash = await setScmDescription(page, 'commit wc', vscode);
-            await page.keyboard.press('Control+Enter');
-            await expect(scmInputSquash).not.toContainText('commit wc', { timeout: 10000 });
+        await expect(async () => {
+            expect(repo.getParents('@').length).toBe(1);
+        }).toPass({ timeout: 5000 });
+        // Now we have initial -> wc_commit -> new_wc
+        // Modify file3.txt in the new working copy
+        repo.writeFile('file3.txt', 'new mod3');
 
-            await expect(async () => {
-                expect(repo.getParents('@').length).toBe(1);
-            }).toPass({ timeout: 5000 });
-            // Now we have initial -> wc_commit -> new_wc
-            // Modify file3.txt in the new working copy
-            repo.writeFile('file3.txt', 'new mod3');
+        // Click the SCM refresh button
+        const refreshButton = page.getByRole('button', { name: 'Refresh' }).first();
+        await refreshButton.click();
 
-            // Click the SCM refresh button
-            const refreshButton = page.getByRole('button', { name: 'Refresh' }).first();
-            await refreshButton.click();
+        // Wait for file3.txt to appear in SCM Working Copy
+        const newWcFileRow = page.getByRole('treeitem', { name: /file3\.txt, modified/ }).first();
+        await expect(newWcFileRow).toBeVisible({ timeout: 5000 });
 
-            // Wait for file3.txt to appear in SCM Working Copy
-            const newWcFileRow = page.getByRole('treeitem', { name: /file3\.txt, modified/ }).first();
-            await expect(newWcFileRow).toBeVisible({ timeout: 5000 });
+        // Hover to reveal inline actions
+        await newWcFileRow.hover();
+        const squashIcon = newWcFileRow
+            .getByRole('button', { name: 'Squash File(s) into Parent', exact: true })
+            .first();
+        await expect(squashIcon).toBeVisible();
 
-            // Hover to reveal inline actions
-            await newWcFileRow.hover();
-            const squashIcon = newWcFileRow
-                .getByRole('button', { name: 'Squash File(s) into Parent', exact: true })
-                .first();
-            await expect(squashIcon).toBeVisible();
+        // The squashInto action should be visible since there are two mutable ancestors
+        const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash File\(s\) into Ancestor/ }).first();
+        await hoverAndClick(newWcFileRow, squashIntoIcon);
 
-            // The squashInto action should be visible since there are two mutable ancestors
-            const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash File\(s\) into Ancestor/ }).first();
-            await hoverAndClick(newWcFileRow, squashIntoIcon);
+        // SCM QuickPick should appear for Ancestor selection
+        const quickPickInput = page.getByRole('listbox');
+        await expect(quickPickInput).toBeVisible({ timeout: 5000 });
 
-            // SCM QuickPick should appear for Ancestor selection
-            const quickPickInput = page.getByRole('listbox');
-            await expect(quickPickInput).toBeVisible({ timeout: 5000 });
+        const ancestor2Option = page.getByRole('option', { name: /initial/i });
+        await ancestor2Option.click();
+        await expect(quickPickInput).not.toBeVisible({ timeout: 5000 });
 
-            const ancestor2Option = page.getByRole('option', { name: /initial/i });
-            await ancestor2Option.click();
-            await expect(quickPickInput).not.toBeVisible({ timeout: 5000 });
+        // Verify the squash happened by waiting for there to be only ONE file3.txt row (the ancestor one)
+        await expect(async () => {
+            const rows = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
+            const count = await rows.count();
+            expect(count).toBe(1);
+        }).toPass({ timeout: 10000 });
 
-            // Verify the squash happened by waiting for there to be only ONE file3.txt row (the ancestor one)
-            await expect(async () => {
-                const rows = page.getByRole('treeitem', { name: /file3\.txt, modified/ });
-                const count = await rows.count();
-                expect(count).toBe(1);
-            }).toPass({ timeout: 10000 });
+        await expect(async () => {
+            const wcChanges = repo.getDiffSummary('@');
+            expect(wcChanges).not.toContain('file3.txt');
 
-            await expect(async () => {
-                const wcChanges = repo.getDiffSummary('@');
-                expect(wcChanges).not.toContain('file3.txt');
-
-                // The ancestor should now have the change.
-                expect(repo.getFileContent('@--', 'file3.txt').trim()).toBe('new mod3');
-            }).toPass({ timeout: 5000 });
-        } finally {
-            repo.dispose();
-        }
+            // The ancestor should now have the change.
+            expect(repo.getFileContent('@--', 'file3.txt').trim()).toBe('new mod3');
+        }).toPass({ timeout: 5000 });
     });
 
     test('Additional Actions: Absorb, Edit, Show Details, Squash File to Child', async ({ vscode }) => {
@@ -505,52 +477,48 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Absorb
-            await clickScmAction(page, /Working Copy/, SCM_ACTIONS.Absorb);
+        // 1. Absorb
+        await clickScmAction(page, /Working Copy/, SCM_ACTIONS.Absorb);
 
-            // Wait for SCM refresh to confirm absorb (the wc change for f1.txt is consumed into ancestor)
-            await expect(async () => {
-                expect(repo.getFileContent(commits.ancestor.changeId, 'f1.txt').trim()).toBe('2');
-            }).toPass({ timeout: 5000 });
+        // Wait for SCM refresh to confirm absorb (the wc change for f1.txt is consumed into ancestor)
+        await expect(async () => {
+            expect(repo.getFileContent(commits.ancestor.changeId, 'f1.txt').trim()).toBe('2');
+        }).toPass({ timeout: 5000 });
 
-            // 2. Show Details
-            await expect(async () => {
-                await clickScmAction(page, /ancestor change/, SCM_ACTIONS.ShowDetails);
-                await waitForTab(page, /^Commit: /);
-            }).toPass({ timeout: 20000 });
+        // 2. Show Details
+        await expect(async () => {
+            await clickScmAction(page, /ancestor change/, SCM_ACTIONS.ShowDetails);
+            await waitForTab(page, /^Commit: /);
+        }).toPass({ timeout: 20000 });
 
-            // Return focus to SCM View
-            await focusSCM(page);
+        // Return focus to SCM View
+        await focusSCM(page);
 
-            // 3. Squash File to Child (Pull from Ancestor)
-            // Groups are expanded by default, so f2.txt is already visible.
-            await clickScmAction(page, /f2\.txt/, SCM_ACTIONS.SquashFilesIntoChild);
+        // 3. Squash File to Child (Pull from Ancestor)
+        // Groups are expanded by default, so f2.txt is already visible.
+        await clickScmAction(page, /f2\.txt/, SCM_ACTIONS.SquashFilesIntoChild);
 
-            // Assert via repo that f2.txt from ancestor was moved to working copy
-            // and the UI SCM tree has refreshed to reflect the new state.
-            await expect(async () => {
-                const wcChanges = repo.getDiffSummary('@');
-                expect(wcChanges).toContain('A f2.txt');
+        // Assert via repo that f2.txt from ancestor was moved to working copy
+        // and the UI SCM tree has refreshed to reflect the new state.
+        await expect(async () => {
+            const wcChanges = repo.getDiffSummary('@');
+            expect(wcChanges).toContain('A f2.txt');
 
-                // Also wait for the UI SCM tree to refresh.
-                // In SCM tree under Working Copy group, there should be f2.txt
-                await expectFileInScmGroup(page, /Working Copy/i, /f2\.txt/i);
-            }).toPass({ timeout: 10000 });
+            // Also wait for the UI SCM tree to refresh.
+            // In SCM tree under Working Copy group, there should be f2.txt
+            await expectFileInScmGroup(page, /Working Copy/i, /f2\.txt/i);
+        }).toPass({ timeout: 10000 });
 
-            // 4. Edit (Make ancestor the working copy)
-            await clickScmAction(page, /ancestor change/, SCM_ACTIONS.Edit);
+        // 4. Edit (Make ancestor the working copy)
+        await clickScmAction(page, /ancestor change/, SCM_ACTIONS.Edit);
 
-            // Assert via repo that the working copy is now the ancestor
-            await expect(async () => {
-                const changeId = repo.getWorkingCopyId();
-                expect(changeId).toBe(commits.ancestor.changeId);
-            }).toPass({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+        // Assert via repo that the working copy is now the ancestor
+        await expect(async () => {
+            const changeId = repo.getWorkingCopyId();
+            expect(changeId).toBe(commits.ancestor.changeId);
+        }).toPass({ timeout: 15000 });
     });
 
     test('Multi-File Diff and Diff Editing', async ({ vscode }) => {
@@ -569,34 +537,30 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
-            // 1. Multi-File Diff
-            await clickScmAction(page, /ancestor change/, SCM_ACTIONS.MultiFileDiff);
+        await focusSCM(page);
+        // 1. Multi-File Diff
+        await clickScmAction(page, /ancestor change/, SCM_ACTIONS.MultiFileDiff);
 
-            // Wait for Multi-File Diff View to appear
-            await waitForTab(page, /ancestor change/);
+        // Wait for Multi-File Diff View to appear
+        await waitForTab(page, /ancestor change/);
 
-            // Wait for the diff editor inside the view
-            await page.waitForSelector('.monaco-diff-editor');
+        // Wait for the diff editor inside the view
+        await page.waitForSelector('.monaco-diff-editor');
 
-            // Find the editor for f1.txt's right side
-            const firstRightEditor = page.locator('.monaco-diff-editor .editor.modified').first();
-            await firstRightEditor.click();
+        // Find the editor for f1.txt's right side
+        const firstRightEditor = page.locator('.monaco-diff-editor .editor.modified').first();
+        await firstRightEditor.click();
 
-            // Navigate out of readonly and type new text
-            await page.keyboard.press('Control+A');
-            await page.keyboard.insertText('edited from multi-diff');
-            await page.keyboard.press('Control+S');
+        // Navigate out of readonly and type new text
+        await page.keyboard.press('Control+A');
+        await page.keyboard.insertText('edited from multi-diff');
+        await page.keyboard.press('Control+S');
 
-            // Ensure the ancestor commit was mutated with the diff edits
-            await expect(async () => {
-                const f1Content = repo.getFileContent(commits.ancestor.changeId, 'f1.txt');
-                expect(f1Content.trim()).toBe('edited from multi-diff');
-            }).toPass({ timeout: 5000 });
-        } finally {
-            repo.dispose();
-        }
+        // Ensure the ancestor commit was mutated with the diff edits
+        await expect(async () => {
+            const f1Content = repo.getFileContent(commits.ancestor.changeId, 'f1.txt');
+            expect(f1Content.trim()).toBe('edited from multi-diff');
+        }).toPass({ timeout: 5000 });
     });
 
     test('File Watcher automatically updates SCM decorations', async ({ vscode }) => {
@@ -609,41 +573,37 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // Wait for initial load
-            const initialWcGroup = page.getByRole('treeitem', { name: /Working Copy/ });
-            await expect(initialWcGroup).toBeVisible();
+        // Wait for initial load
+        const initialWcGroup = page.getByRole('treeitem', { name: /Working Copy/ });
+        await expect(initialWcGroup).toBeVisible();
 
-            // The vscode fixture already awaits change detection watchers to be ready,
-            // so we don't need a long blind wait here.
+        // The vscode fixture already awaits change detection watchers to be ready,
+        // so we don't need a long blind wait here.
 
-            // 1. Modify tracked.txt via filesystem (File Watcher picks it up)
-            repo.writeFile('tracked.txt', 'modified');
+        // 1. Modify tracked.txt via filesystem (File Watcher picks it up)
+        repo.writeFile('tracked.txt', 'modified');
 
-            // 2. Wait for it to appear with "Modified" decoration
-            const trackedRow = page.getByRole('treeitem', { name: /tracked\.txt.*modified/i });
-            await expect(trackedRow).toBeVisible({ timeout: 15000 });
+        // 2. Wait for it to appear with "Modified" decoration
+        const trackedRow = page.getByRole('treeitem', { name: /tracked\.txt.*modified/i });
+        await expect(trackedRow).toBeVisible({ timeout: 15000 });
 
-            // 3. Create a completely untracked file and add it to .gitignore
-            repo.writeFile('.gitignore', 'totally-untracked.txt\n');
-            repo.writeFile('totally-untracked.txt', 'ignored content');
+        // 3. Create a completely untracked file and add it to .gitignore
+        repo.writeFile('.gitignore', 'totally-untracked.txt\n');
+        repo.writeFile('totally-untracked.txt', 'ignored content');
 
-            // 4. Focus the File Explorer pane to see the ignored decoration
-            await page.keyboard.press('Control+Shift+E');
+        // 4. Focus the File Explorer pane to see the ignored decoration
+        await page.keyboard.press('Control+Shift+E');
 
-            // 5. Wait for the File Explorer to show the ignored file decoration
-            // Force a refresh first because VS Code file watchers can sometimes miss fast external writes in tests
-            await page.keyboard.press('Control+Alt+E');
+        // 5. Wait for the File Explorer to show the ignored file decoration
+        // Force a refresh first because VS Code file watchers can sometimes miss fast external writes in tests
+        await page.keyboard.press('Control+Alt+E');
 
-            // VS Code's explorer treeitem has its own aria-label of the filename, but its child element contains the decoration
-            const treeItem = page.getByRole('treeitem', { name: 'totally-untracked.txt', exact: true });
-            const ignoredLabel = treeItem.locator('.monaco-icon-label[aria-label*="Ignored"]');
-            await expect(ignoredLabel).toBeVisible({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+        // VS Code's explorer treeitem has its own aria-label of the filename, but its child element contains the decoration
+        const treeItem = page.getByRole('treeitem', { name: 'totally-untracked.txt', exact: true });
+        const ignoredLabel = treeItem.locator('.monaco-icon-label[aria-label*="Ignored"]');
+        await expect(ignoredLabel).toBeVisible({ timeout: 15000 });
     });
 
     test('Squash File to Child on Grandparent Commits', async ({ vscode }) => {
@@ -674,25 +634,21 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 3. Squash File to Child (Pull from Ancestor)
-            await clickScmAction(page, /gp\.txt/, SCM_ACTIONS.SquashFilesIntoChild);
+        // 3. Squash File to Child (Pull from Ancestor)
+        await clickScmAction(page, /gp\.txt/, SCM_ACTIONS.SquashFilesIntoChild);
 
-            // Assert via repo that gp.txt from grandparent was moved to parent, NOT the working copy
-            await expect(async () => {
-                const parentChanges = repo.getDiffSummary('@-');
-                expect(parentChanges).toContain('A gp.txt');
-                expect(parentChanges).toContain('A p.txt');
+        // Assert via repo that gp.txt from grandparent was moved to parent, NOT the working copy
+        await expect(async () => {
+            const parentChanges = repo.getDiffSummary('@-');
+            expect(parentChanges).toContain('A gp.txt');
+            expect(parentChanges).toContain('A p.txt');
 
-                const wcChanges = repo.getDiffSummary('@');
-                expect(wcChanges).not.toContain('A gp.txt');
-                expect(wcChanges).toContain('A wc.txt');
-            }).toPass({ timeout: 5000 });
-        } finally {
-            repo.dispose();
-        }
+            const wcChanges = repo.getDiffSummary('@');
+            expect(wcChanges).not.toContain('A gp.txt');
+            expect(wcChanges).toContain('A wc.txt');
+        }).toPass({ timeout: 5000 });
     });
 
     test('File-Level Actions: Discard Changes on Ancestor Commits', async ({ vscode }) => {
@@ -720,23 +676,17 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            const ancestorFileRow = page.getByRole('treeitem', { name: /file_ancestor\.txt.*modified/i });
-            await expect(ancestorFileRow).toBeVisible();
+        const ancestorFileRow = page.getByRole('treeitem', { name: /file_ancestor\.txt.*modified/i });
+        await expect(ancestorFileRow).toBeVisible();
 
-            const discardIcon = ancestorFileRow
-                .locator('.action-item', { has: page.locator('.codicon-discard') })
-                .first();
-            await hoverAndClick(ancestorFileRow, discardIcon);
+        const discardIcon = ancestorFileRow.locator('.action-item', { has: page.locator('.codicon-discard') }).first();
+        await hoverAndClick(ancestorFileRow, discardIcon);
 
-            await expect(async () => {
-                expect(repo.getFileContent(commits.ancestor.changeId, 'file_ancestor.txt').trim()).toBe('base');
-            }).toPass({ timeout: 5000 });
-        } finally {
-            repo.dispose();
-        }
+        await expect(async () => {
+            expect(repo.getFileContent(commits.ancestor.changeId, 'file_ancestor.txt').trim()).toBe('base');
+        }).toPass({ timeout: 5000 });
     });
 
     test('File Click Behavior: openDiffOnClick = true (Default)', async ({ vscode }) => {
@@ -771,26 +721,22 @@ test.describe('SCM Pane E2E', () => {
             'jj-view.openDiffOnClick': true,
         });
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Click modified.txt -> should open diff editor
-            const modifiedRow = await openScmDiff(page, /modified\.txt/i);
+        // 1. Click modified.txt -> should open diff editor
+        const modifiedRow = await openScmDiff(page, /modified\.txt/i);
 
-            // 2. Click deleted.txt -> should open diff editor
-            await openScmDiff(page, /deleted\.txt/i);
+        // 2. Click deleted.txt -> should open diff editor
+        await openScmDiff(page, /deleted\.txt/i);
 
-            // 3. Click conflict.txt -> should open merge editor
-            await openScmMerge(page, /conflict\.txt/i);
+        // 3. Click conflict.txt -> should open merge editor
+        await openScmMerge(page, /conflict\.txt/i);
 
-            // 4. Open File via inline button -> should open regular editor
-            const openFileIcon = modifiedRow.getByRole('button', { name: 'Open File', exact: true }).first();
-            await hoverAndClick(modifiedRow, openFileIcon);
-            await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
-            await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
-        } finally {
-            repo.dispose();
-        }
+        // 4. Open File via inline button -> should open regular editor
+        const openFileIcon = modifiedRow.getByRole('button', { name: 'Open File', exact: true }).first();
+        await hoverAndClick(modifiedRow, openFileIcon);
+        await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
+        await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
     });
 
     test('File Click Behavior: openDiffOnClick = false', async ({ vscode }) => {
@@ -825,26 +771,22 @@ test.describe('SCM Pane E2E', () => {
             'jj-view.openDiffOnClick': false,
         });
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Click modified.txt -> should open regular editor
-            const modifiedRow = await openScmFile(page, /modified\.txt/i);
-            await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
+        // 1. Click modified.txt -> should open regular editor
+        const modifiedRow = await openScmFile(page, /modified\.txt/i);
+        await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();
 
-            // 2. Click deleted.txt -> should still open diff editor
-            await openScmDiff(page, /deleted\.txt/i);
+        // 2. Click deleted.txt -> should still open diff editor
+        await openScmDiff(page, /deleted\.txt/i);
 
-            // 3. Click conflict.txt -> should open merge editor
-            await openScmMerge(page, /conflict\.txt/i);
+        // 3. Click conflict.txt -> should open merge editor
+        await openScmMerge(page, /conflict\.txt/i);
 
-            // 4. Open Changes via inline button (for modified file) -> should open diff editor
-            const openChangesIcon = modifiedRow.getByRole('button', { name: 'Open Changes', exact: true }).first();
-            await hoverAndClick(modifiedRow, openChangesIcon);
-            await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
-        } finally {
-            repo.dispose();
-        }
+        // 4. Open Changes via inline button (for modified file) -> should open diff editor
+        const openChangesIcon = modifiedRow.getByRole('button', { name: 'Open Changes', exact: true }).first();
+        await hoverAndClick(modifiedRow, openChangesIcon);
+        await expect(page.locator('.monaco-diff-editor')).toBeVisible({ timeout: 5000 });
     });
 
     test('Squash selection into parent via diff editor context menu', async ({ vscode }) => {
@@ -887,38 +829,34 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Open Diff Editor
-            await openScmDiff(page, fileName, /Working Copy/);
+        // 1. Open Diff Editor
+        await openScmDiff(page, fileName, /Working Copy/);
 
-            // 2. Select the FIRST modified line in the right side (line 2)
-            const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
-            const line2 = await selectLine(page, rightEditor, 'line 2 modified');
+        // 2. Select the FIRST modified line in the right side (line 2)
+        const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+        const line2 = await selectLine(page, rightEditor, 'line 2 modified');
 
-            // 3. Open Context Menu on the selected line and click "Squash Selection into Parent"
-            await line2.click({ button: 'right' });
-            await clickContextMenuItem(page, /Squash Selection into Parent/i);
+        // 3. Open Context Menu on the selected line and click "Squash Selection into Parent"
+        await line2.click({ button: 'right' });
+        await clickContextMenuItem(page, /Squash Selection into Parent/i);
 
-            // 4. Verify the change is moved to the parent in JJ
-            await expect(async () => {
-                const parentContent = repo.getFileContent('@-', fileName);
-                const wcContent = repo.getFileContent('@', fileName);
-                const wcDiffSummary = repo.getDiffSummary('@');
+        // 4. Verify the change is moved to the parent in JJ
+        await expect(async () => {
+            const parentContent = repo.getFileContent('@-', fileName);
+            const wcContent = repo.getFileContent('@', fileName);
+            const wcDiffSummary = repo.getDiffSummary('@');
 
-                // Parent should have the first modification
-                expect(parentContent).toBe(fileContentPartiallyModified);
+            // Parent should have the first modification
+            expect(parentContent).toBe(fileContentPartiallyModified);
 
-                // Working copy should still have BOTH modifications (because it's the head)
-                expect(wcContent).toBe(fileContentFullyModified);
+            // Working copy should still have BOTH modifications (because it's the head)
+            expect(wcContent).toBe(fileContentFullyModified);
 
-                // other.txt should still be modified
-                expect(wcDiffSummary).toContain('other.txt');
-            }).toPass({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+            // other.txt should still be modified
+            expect(wcDiffSummary).toContain('other.txt');
+        }).toPass({ timeout: 15000 });
     });
 
     test('Squash selection into parent via non-working copy diff editor context menu', async ({ vscode }) => {
@@ -955,41 +893,37 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Open Diff Editor for the 'child' commit
-            // The group name in SCM for 'child' will be its description 'child commit'
-            await openScmDiff(page, fileName, /child commit/);
+        // 1. Open Diff Editor for the 'child' commit
+        // The group name in SCM for 'child' will be its description 'child commit'
+        await openScmDiff(page, fileName, /child commit/);
 
-            // 2. Select the FIRST modified line in the right side (line 2)
-            // In a non-WC diff, the right side is the 'child' commit
-            const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
-            const line2 = await selectLine(page, rightEditor, 'line 2 modified');
+        // 2. Select the FIRST modified line in the right side (line 2)
+        // In a non-WC diff, the right side is the 'child' commit
+        const rightEditor = page.locator('.monaco-diff-editor .editor.modified');
+        const line2 = await selectLine(page, rightEditor, 'line 2 modified');
 
-            // 3. Open Context Menu on the selected line and click "Squash Selection into Parent"
-            await line2.click({ button: 'right' });
-            await clickContextMenuItem(page, /Squash Selection into Parent/i);
+        // 3. Open Context Menu on the selected line and click "Squash Selection into Parent"
+        await line2.click({ button: 'right' });
+        await clickContextMenuItem(page, /Squash Selection into Parent/i);
 
-            // 4. Verify the change is moved to the parent in JJ
-            await expect(async () => {
-                const parentContent = repo.getFileContent(ids.parent.changeId, fileName);
-                const childContent = repo.getFileContent(ids.child.changeId, fileName);
+        // 4. Verify the change is moved to the parent in JJ
+        await expect(async () => {
+            const parentContent = repo.getFileContent(ids.parent.changeId, fileName);
+            const childContent = repo.getFileContent(ids.child.changeId, fileName);
 
-                // Parent should now have the squashed modification
-                expect(parentContent).toBe(fileContentPartiallyModified);
+            // Parent should now have the squashed modification
+            expect(parentContent).toBe(fileContentPartiallyModified);
 
-                // Child should still have its original content (but only line 4 is now "new" relative to parent)
-                expect(childContent).toBe(fileContentFullyModified);
+            // Child should still have its original content (but only line 4 is now "new" relative to parent)
+            expect(childContent).toBe(fileContentFullyModified);
 
-                // Check diff of child to be sure
-                const childDiff = repo.getDiff(ids.child.changeId, { git: true });
-                expect(childDiff).toContain('+line 4 modified');
-                expect(childDiff).not.toContain('+line 2 modified');
-            }).toPass({ timeout: 15000 });
-        } finally {
-            repo.dispose();
-        }
+            // Check diff of child to be sure
+            const childDiff = repo.getDiff(ids.child.changeId, { git: true });
+            expect(childDiff).toContain('+line 4 modified');
+            expect(childDiff).not.toContain('+line 2 modified');
+        }).toPass({ timeout: 15000 });
     });
 
     test('Closes diff editor automatically when the revision is squashed', async ({ vscode }) => {
@@ -1017,29 +951,25 @@ test.describe('SCM Pane E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // 1. Open Diff Editor for the target commit
-            await openScmDiff(page, fileName, /target commit message/);
+        // 1. Open Diff Editor for the target commit
+        await openScmDiff(page, fileName, /target commit message/);
 
-            // 2. Verify tab is open
-            const tab = page.getByRole('tab', { name: fileName });
-            await expect(tab).toBeVisible();
+        // 2. Verify tab is open
+        const tab = page.getByRole('tab', { name: fileName });
+        await expect(tab).toBeVisible();
 
-            // 3. Squash target commit into parent using SCM action
-            await clickScmAction(page, /target commit message/, SCM_ACTIONS.SquashRevisionIntoParent);
+        // 3. Squash target commit into parent using SCM action
+        await clickScmAction(page, /target commit message/, SCM_ACTIONS.SquashRevisionIntoParent);
 
-            // 4. Verify that the tab gets closed automatically
-            await expect(tab).not.toBeVisible({ timeout: 15000 });
+        // 4. Verify that the tab gets closed automatically
+        await expect(tab).not.toBeVisible({ timeout: 15000 });
 
-            // 5. Verify target is actually squashed (changeId no longer exists) in jj
-            await expect(async () => {
-                const log = repo.log();
-                expect(log).not.toContain(commits.target.changeId);
-            }).toPass({ timeout: 10000 });
-        } finally {
-            repo.dispose();
-        }
+        // 5. Verify target is actually squashed (changeId no longer exists) in jj
+        await expect(async () => {
+            const log = repo.log();
+            expect(log).not.toContain(commits.target.changeId);
+        }).toPass({ timeout: 10000 });
     });
 });

--- a/src/test/e2e/squash.spec.ts
+++ b/src/test/e2e/squash.spec.ts
@@ -27,7 +27,6 @@ test.describe('Squash E2E', () => {
 
     test.afterEach(async () => {
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/e2e/workspace.spec.ts
+++ b/src/test/e2e/workspace.spec.ts
@@ -37,26 +37,22 @@ test.describe('Workspace Management E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo);
 
-        try {
-            await focusJJLog(page);
-            const webview = await getLogWebview(page);
+        await focusJJLog(page);
+        const webview = await getLogWebview(page);
 
-            // The default workspace label is 'default@'
-            await waitForLogPill(page, 'default@', 'workspace');
+        // The default workspace label is 'default@'
+        await waitForLogPill(page, 'default@', 'workspace');
 
-            // The secondary workspace label should match our workspace name
-            await waitForLogPill(page, workspaceName, 'workspace');
+        // The secondary workspace label should match our workspace name
+        await waitForLogPill(page, workspaceName, 'workspace');
 
-            // 'default@' should be on the 'other' commit
-            const otherRow = webview.locator(`[data-change-id="${otherId}"]`);
-            await expect(otherRow.locator('.bookmark-pill', { hasText: 'default@' })).toBeVisible();
+        // 'default@' should be on the 'other' commit
+        const otherRow = webview.locator(`[data-change-id="${otherId}"]`);
+        await expect(otherRow.locator('.bookmark-pill', { hasText: 'default@' })).toBeVisible();
 
-            // 'repo2@' should be on its own working copy (created by workspace add)
-            const repo2Pill = webview.locator('.bookmark-pill', { hasText: new RegExp(`${workspaceName}.*@`) });
-            await expect(repo2Pill).toBeVisible();
-        } finally {
-            repo.dispose();
-        }
+        // 'repo2@' should be on its own working copy (created by workspace add)
+        const repo2Pill = webview.locator('.bookmark-pill', { hasText: new RegExp(`${workspaceName}.*@`) });
+        await expect(repo2Pill).toBeVisible();
     });
 
     test('Add Workspace via title bar action', async ({ vscode }) => {
@@ -69,51 +65,47 @@ test.describe('Workspace Management E2E', () => {
         // Enable notifications for this test so we can click "Open Workspace"
         const { app, page } = await vscode.openWorkspace(repo, {}, {}, true);
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // 1. Click Add Workspace and input name
+        // 1. Click Add Workspace and input name
+        await expect(async () => {
+            await clickLogTitleButton(page, 'Add Workspace');
+            const input = await waitForQuickInput(page, 2000);
+            await input.fill(workspaceName, { timeout: 2000 });
+            await page.keyboard.press('Enter');
+        }, 'Failed to add workspace via title bar').toPass({ timeout: 20000 });
+
+        // 3. Verify workspace pill appears in webview
+        await waitForLogPill(page, workspaceName, 'workspace');
+
+        // 4. Click "Open Workspace" in the notification and verify a new window opens
+        const openWorkspace = async (): Promise<Page> => {
+            let newPage: Page | undefined;
             await expect(async () => {
-                await clickLogTitleButton(page, 'Add Workspace');
-                const input = await waitForQuickInput(page, 2000);
-                await input.fill(workspaceName, { timeout: 2000 });
-                await page.keyboard.press('Enter');
-            }, 'Failed to add workspace via title bar').toPass({ timeout: 20000 });
+                const [window] = await Promise.all([
+                    app.waitForEvent('window', { timeout: 8000 }),
+                    clickNotificationButton(page, 'Open Workspace'),
+                ]);
+                newPage = window;
+            }, 'Failed to open new workspace window').toPass({ timeout: 25000 });
 
-            // 3. Verify workspace pill appears in webview
-            await waitForLogPill(page, workspaceName, 'workspace');
+            if (!newPage) {
+                throw new Error('New workspace window was not captured');
+            }
+            return newPage;
+        };
 
-            // 4. Click "Open Workspace" in the notification and verify a new window opens
-            const openWorkspace = async (): Promise<Page> => {
-                let newPage: Page | undefined;
-                await expect(async () => {
-                    const [window] = await Promise.all([
-                        app.waitForEvent('window', { timeout: 8000 }),
-                        clickNotificationButton(page, 'Open Workspace'),
-                    ]);
-                    newPage = window;
-                }, 'Failed to open new workspace window').toPass({ timeout: 25000 });
+        const newPage = await openWorkspace();
 
-                if (!newPage) {
-                    throw new Error('New workspace window was not captured');
-                }
-                return newPage;
-            };
+        // Wait for workbench to load in new window
+        await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
 
-            const newPage = await openWorkspace();
+        // On Linux, the window title should contain the folder name
+        await expect.poll(async () => await newPage.title(), { timeout: 10000 }).toContain(workspaceName);
 
-            // Wait for workbench to load in new window
-            await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
-
-            // On Linux, the window title should contain the folder name
-            await expect.poll(async () => await newPage.title(), { timeout: 10000 }).toContain(workspaceName);
-
-            // 5. Verify in jj
-            const workspaces = repo.getLog('all()', 'working_copies.map(|w| w.name()).join("\\n")');
-            expect(workspaces).toContain(workspaceName);
-        } finally {
-            repo.dispose();
-        }
+        // 5. Verify in jj
+        const workspaces = repo.getLog('all()', 'working_copies.map(|w| w.name()).join("\\n")');
+        expect(workspaces).toContain(workspaceName);
     });
 
     test('Forget and Delete Workspace via context menu', async ({ vscode }) => {
@@ -133,50 +125,46 @@ test.describe('Workspace Management E2E', () => {
 
         const { page } = await vscode.openWorkspace(repo, {}, {}, true);
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // 1. Forget Workspace
-            const forgetPill = await waitForLogPill(page, forgetWs, 'workspace');
+        // 1. Forget Workspace
+        const forgetPill = await waitForLogPill(page, forgetWs, 'workspace');
 
-            await rightClickAndSelect(page, forgetPill, 'Forget Workspace');
+        await rightClickAndSelect(page, forgetPill, 'Forget Workspace');
 
-            // Confirm warning dialog
-            const forgetBtn = page.getByRole('button', { name: 'Yes, Forget Workspace' });
-            await expect(forgetBtn, 'Forget confirmation button should be visible').toBeVisible({ timeout: 5000 });
-            await forgetBtn.click();
+        // Confirm warning dialog
+        const forgetBtn = page.getByRole('button', { name: 'Yes, Forget Workspace' });
+        await expect(forgetBtn, 'Forget confirmation button should be visible').toBeVisible({ timeout: 5000 });
+        await forgetBtn.click();
 
-            await expect(async () => {
-                const webview = await getLogWebview(page, 300);
-                await expect(webview.locator('.bookmark-pill', { hasText: forgetWs })).not.toBeVisible({
-                    timeout: 500,
-                });
-            }).toPass({ timeout: 15000 });
+        await expect(async () => {
+            const webview = await getLogWebview(page, 300);
+            await expect(webview.locator('.bookmark-pill', { hasText: forgetWs })).not.toBeVisible({
+                timeout: 500,
+            });
+        }).toPass({ timeout: 15000 });
 
-            const stillExists = fs.existsSync(forgetWsPath);
-            expect(stillExists, `Directory ${forgetWsPath} should still exist after forget`).toBe(true);
+        const stillExists = fs.existsSync(forgetWsPath);
+        expect(stillExists, `Directory ${forgetWsPath} should still exist after forget`).toBe(true);
 
-            // 2. Delete Workspace
-            const deletePill = await waitForLogPill(page, deleteWs, 'workspace');
+        // 2. Delete Workspace
+        const deletePill = await waitForLogPill(page, deleteWs, 'workspace');
 
-            await rightClickAndSelect(page, deletePill, 'Delete Workspace Directory');
+        await rightClickAndSelect(page, deletePill, 'Delete Workspace Directory');
 
-            // Confirm warning dialog
-            const deleteBtn = page.getByRole('button', { name: 'Yes, Delete Workspace' });
-            await expect(deleteBtn, 'Delete confirmation button should be visible').toBeVisible({ timeout: 5000 });
-            await deleteBtn.click();
+        // Confirm warning dialog
+        const deleteBtn = page.getByRole('button', { name: 'Yes, Delete Workspace' });
+        await expect(deleteBtn, 'Delete confirmation button should be visible').toBeVisible({ timeout: 5000 });
+        await deleteBtn.click();
 
-            await expect(async () => {
-                const webview = await getLogWebview(page, 300);
-                await expect(webview.locator('.bookmark-pill', { hasText: deleteWs })).not.toBeVisible({
-                    timeout: 500,
-                });
-            }).toPass({ timeout: 15000 });
+        await expect(async () => {
+            const webview = await getLogWebview(page, 300);
+            await expect(webview.locator('.bookmark-pill', { hasText: deleteWs })).not.toBeVisible({
+                timeout: 500,
+            });
+        }).toPass({ timeout: 15000 });
 
-            const gone = !fs.existsSync(deleteWsPath);
-            expect(gone, `Directory ${deleteWsPath} should be removed after delete`).toBe(true);
-        } finally {
-            repo.dispose();
-        }
+        const gone = !fs.existsSync(deleteWsPath);
+        expect(gone, `Directory ${deleteWsPath} should be removed after delete`).toBe(true);
     });
 });

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -93,7 +93,6 @@ describe('GerritService Detection', () => {
         if (fakeGerritServer) {
             await fakeGerritServer.stop();
         }
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -76,7 +76,6 @@ describe('Gerrit Sync Verification', () => {
     afterEach(async () => {
         service?.dispose();
         await fakeGerritServer?.stop();
-        repo.dispose();
         vi.clearAllMocks();
     });
 

--- a/src/test/git-colocation.integration.test.ts
+++ b/src/test/git-colocation.integration.test.ts
@@ -23,9 +23,7 @@ suite('Git Colocation Integration Test Suite', () => {
         jjService = new JjService(repo.path, NO_OP_LOGGER);
     });
 
-    suiteTeardown(() => {
-        repo.dispose();
-    });
+    suiteTeardown(() => {});
 
     setup(() => {
         sandbox = sinon.createSandbox();

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -314,19 +314,16 @@ describe('GitHubProvider', () => {
         }
 
         const testRepo = new TestRepo();
-        try {
-            testRepo.init();
-            const jj = new JjService(testRepo.path, {
-                info: () => {},
-                warn: () => {},
-                error: () => {},
-                debug: () => {},
-            });
-            const result = await provider.fetchStatuses(changes, jj);
-            expect(result).toBe(true);
-        } finally {
-            testRepo.dispose();
-        }
+
+        testRepo.init();
+        const jj = new JjService(testRepo.path, {
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+            debug: () => {},
+        });
+        const result = await provider.fetchStatuses(changes, jj);
+        expect(result).toBe(true);
 
         expect(fetchBatchSpy).toHaveBeenCalledTimes(3);
         expect(fetchBatchSpy.mock.calls[0][0].length).toBe(20);
@@ -367,19 +364,16 @@ describe('GitHubProvider', () => {
         ];
 
         const testRepo = new TestRepo();
-        try {
-            testRepo.init();
-            const jj = new JjService(testRepo.path, {
-                info: () => {},
-                warn: () => {},
-                error: () => {},
-                debug: () => {},
-            });
-            const result = await provider.fetchStatuses(changes, jj);
-            expect(result).toBe(false); // No cache changes were registered
-        } finally {
-            testRepo.dispose();
-        }
+
+        testRepo.init();
+        const jj = new JjService(testRepo.path, {
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+            debug: () => {},
+        });
+        const result = await provider.fetchStatuses(changes, jj);
+        expect(result).toBe(false); // No cache changes were registered
 
         // Verify cache was preserved (not deleted)
         expect(cache.get('bm-1')).toBeDefined();
@@ -582,18 +576,15 @@ describe('GitHubProvider', () => {
 
         const changes: ChangeStatusRequest[] = [{ commitId: 'sha-local-differs', bookmarks: ['my-feature-merged'] }];
         const testRepo = new TestRepo();
-        try {
-            testRepo.init();
-            const jj = new JjService(testRepo.path, {
-                info: () => {},
-                warn: () => {},
-                error: () => {},
-                debug: () => {},
-            });
-            await provider.fetchStatuses(changes, jj);
-        } finally {
-            testRepo.dispose();
-        }
+
+        testRepo.init();
+        const jj = new JjService(testRepo.path, {
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+            debug: () => {},
+        });
+        await provider.fetchStatuses(changes, jj);
 
         // my-feature-merged SHOULD be cached even though local commit ID doesn't match
         expect(cache.get('my-feature-merged')).toBeDefined();

--- a/src/test/graph-compute.test.ts
+++ b/src/test/graph-compute.test.ts
@@ -421,9 +421,7 @@ describe('Graph Layout Integration Tests (Real jj output)', () => {
         jjService = new JjService(repo.path, NO_OP_LOGGER);
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     /*
      * Linear History Layout

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -65,7 +65,6 @@ describe('JjEditFileSystemProvider', () => {
 
     afterEach(async () => {
         await repoManager.dispose();
-        repo.dispose();
     });
 
     it('stat returns a default file stat', async () => {

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -110,9 +110,6 @@ suite('JjRepositoryManager Integration Test', () => {
         await manager.dispose();
         registry.dispose();
 
-        for (const repo of extraRepos) {
-            repo.dispose();
-        }
         for (const dir of extraDirs) {
             try {
                 fs.rmSync(dir, { recursive: true, force: true });
@@ -122,7 +119,6 @@ suite('JjRepositoryManager Integration Test', () => {
         }
 
         if (mainRepo.path !== resolvedWorkspaceRoot) {
-            mainRepo.dispose();
         } else {
             try {
                 if (resolvedWorkspaceRoot) {

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -61,7 +61,6 @@ suite('JJ SCM Provider Integration Test', () => {
             await contextHelper.dispose();
         }
         if (repo) {
-            repo.dispose();
         }
     });
 

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -19,9 +19,7 @@ describe('JjService Diff Tests', () => {
         jjService = new JjService(repo.path, NO_OP_LOGGER);
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     test('getChanges with from/to revisions correctly identifies arbitrary changes', async () => {
         const ids = await buildGraph(repo, [

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -21,9 +21,7 @@ describe('JjService Unit Tests', () => {
         jjService = new JjService(repo.path, NO_OP_LOGGER);
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     test('getLog returns valid log entry', async () => {
         const [log] = await jjService.getLog({ revision: '@' });
@@ -1477,75 +1475,69 @@ log = "none()"
         // Setup a remote repo and push a bookmark to it to simulate a remote bookmark
         const remoteRepo = new TestRepo();
         remoteRepo.init();
-        try {
-            repo.addRemote('origin', remoteRepo.path);
-            repo.config('remotes.origin.auto-track-bookmarks', '"*"');
 
-            // Push feature-a to remote
-            repo.gitPush('feature-a');
+        repo.addRemote('origin', remoteRepo.path);
+        repo.config('remotes.origin.auto-track-bookmarks', '"*"');
 
-            // Move feature-a locally so it points to a different commit than the remote
-            repo.bookmarkMove('feature-a', ids.commitB.changeId);
+        // Push feature-a to remote
+        repo.gitPush('feature-a');
 
-            // After move, feature-a@origin points to the parent, while local feature-a points to the child.
-            // Since their targets differ, feature-a@origin will be returned by getBookmarks().
-            const bookmarks = await jjService.getBookmarks();
+        // Move feature-a locally so it points to a different commit than the remote
+        repo.bookmarkMove('feature-a', ids.commitB.changeId);
 
-            expect(bookmarks).toEqual([
-                { name: 'feature-a', remote: null },
-                { name: 'feature-a', remote: 'origin' },
-                { name: 'feature-b', remote: null },
-            ]);
-        } finally {
-            remoteRepo.dispose();
-        }
+        // After move, feature-a@origin points to the parent, while local feature-a points to the child.
+        // Since their targets differ, feature-a@origin will be returned by getBookmarks().
+        const bookmarks = await jjService.getBookmarks();
+
+        expect(bookmarks).toEqual([
+            { name: 'feature-a', remote: null },
+            { name: 'feature-a', remote: 'origin' },
+            { name: 'feature-b', remote: null },
+        ]);
     });
 
     test('getBookmarks with revision filters bookmarks by revision', async () => {
         const remoteRepo = new TestRepo();
         remoteRepo.init();
-        try {
-            repo.addRemote('origin', remoteRepo.path);
-            repo.config('remotes.origin.auto-track-bookmarks', '"*"');
 
-            repo.describe('root commit');
-            const ids = await buildGraph(repo, [
-                { label: 'commitA', description: 'commit A', bookmarks: ['feature-b'] },
-                { label: 'commitB', parents: ['commitA'], description: 'commit B', bookmarks: ['feature-c'] },
-                { label: 'commitC', parents: ['commitB'], description: 'commit C', bookmarks: ['feature-a'] },
-                { label: 'commitD', parents: ['commitC'], description: 'commit D', isCurrentWorkingCopy: true },
-            ]);
+        repo.addRemote('origin', remoteRepo.path);
+        repo.config('remotes.origin.auto-track-bookmarks', '"*"');
 
-            // Push feature-b (which is at commitA) to remote
-            repo.gitPush('feature-b');
+        repo.describe('root commit');
+        const ids = await buildGraph(repo, [
+            { label: 'commitA', description: 'commit A', bookmarks: ['feature-b'] },
+            { label: 'commitB', parents: ['commitA'], description: 'commit B', bookmarks: ['feature-c'] },
+            { label: 'commitC', parents: ['commitB'], description: 'commit C', bookmarks: ['feature-a'] },
+            { label: 'commitD', parents: ['commitC'], description: 'commit D', isCurrentWorkingCopy: true },
+        ]);
 
-            // Move feature-b locally to commit B
-            repo.bookmarkMove('feature-b', ids.commitB.changeId);
+        // Push feature-b (which is at commitA) to remote
+        repo.gitPush('feature-b');
 
-            // Push feature-a (which is at commitC) to remote
-            repo.gitPush('feature-a');
+        // Move feature-b locally to commit B
+        repo.bookmarkMove('feature-b', ids.commitB.changeId);
 
-            // Move feature-a locally to commit D
-            repo.bookmarkMove('feature-a', ids.commitD.changeId);
+        // Push feature-a (which is at commitC) to remote
+        repo.gitPush('feature-a');
 
-            // Query bookmarks on Commit B (@--)
-            const parentBookmarks = await jjService.getBookmarks({ revision: '@--' });
-            expect(parentBookmarks).toEqual([
-                { name: 'feature-b', remote: null },
-                { name: 'feature-b', remote: 'origin' },
-                { name: 'feature-c', remote: null },
-                { name: 'feature-c', remote: 'origin' },
-            ]);
+        // Move feature-a locally to commit D
+        repo.bookmarkMove('feature-a', ids.commitD.changeId);
 
-            // Query bookmarks on Commit D (@)
-            const childBookmarks = await jjService.getBookmarks({ revision: '@' });
-            expect(childBookmarks).toEqual([
-                { name: 'feature-a', remote: null },
-                { name: 'feature-a', remote: 'origin' },
-            ]);
-        } finally {
-            remoteRepo.dispose();
-        }
+        // Query bookmarks on Commit B (@--)
+        const parentBookmarks = await jjService.getBookmarks({ revision: '@--' });
+        expect(parentBookmarks).toEqual([
+            { name: 'feature-b', remote: null },
+            { name: 'feature-b', remote: 'origin' },
+            { name: 'feature-c', remote: null },
+            { name: 'feature-c', remote: 'origin' },
+        ]);
+
+        // Query bookmarks on Commit D (@)
+        const childBookmarks = await jjService.getBookmarks({ revision: '@' });
+        expect(childBookmarks).toEqual([
+            { name: 'feature-a', remote: null },
+            { name: 'feature-a', remote: 'origin' },
+        ]);
     });
 
     describe('checkTrackedPaths', () => {

--- a/src/test/jj-view-fs-provider.test.ts
+++ b/src/test/jj-view-fs-provider.test.ts
@@ -45,7 +45,6 @@ describe('JjViewFileSystemProvider', () => {
 
     afterEach(async () => {
         await repoManager.dispose();
-        repo.dispose();
     });
 
     it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -61,7 +61,6 @@ describe('resolveRepository', () => {
 
     afterEach(async () => {
         await repoManager.dispose();
-        repo.dispose();
     });
 
     it('resolves repository from SourceControlResourceState argument', () => {

--- a/src/test/subdirectory-mapping.test.ts
+++ b/src/test/subdirectory-mapping.test.ts
@@ -16,9 +16,7 @@ describe('JjService Subdirectory Mapping', () => {
         repo.init();
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     test('getRepoRoot returns the true repo root from a subdirectory', async () => {
         const workspacePath = path.join(repo.path, 'subdirectory');

--- a/src/test/test-repo.test.ts
+++ b/src/test/test-repo.test.ts
@@ -14,9 +14,7 @@ describe('TestRepo', () => {
         repo.init();
     });
 
-    afterEach(() => {
-        repo.dispose();
-    });
+    afterEach(() => {});
 
     it('basic operations', () => {
         repo.writeFile('file.txt', 'hello');

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -52,10 +52,6 @@ export class TestRepo {
         tempDirs.add(this.path);
     }
 
-    dispose() {
-        // Defer actual directory deletion to process exit to avoid blocking file watchers
-    }
-
     // POLICY: This method is intentionally private. Do not expose it publicly.
     // Instead, create specific methods for each operation to ensure strictly typed usage
     // and prevent arbitrary command execution in tests.

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -146,7 +146,6 @@ suite('Webview Commands End-to-End Integration Test', () => {
             await contextHelper.dispose();
         }
         if (repo) {
-            repo.dispose();
         }
         if (outputChannel) {
             outputChannel.dispose();

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -79,7 +79,6 @@ suite('Webview Initialization Integration Test', () => {
         }
         disposables = [];
         if (repo) {
-            repo.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -93,7 +93,6 @@ suite('Webview Visibility Integration Test', () => {
             await contextHelper.dispose();
         }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
-        repo.dispose();
     });
 
     test('webview re-renders when becoming visible', async () => {


### PR DESCRIPTION
…blocks

Remove the empty `dispose()` method from `TestRepo` as its filesystem cleanup has been deferred to process exit via process 'exit' event listeners. Clean up all obsolete `repo.dispose()`, `remoteRepo.dispose()`, `testRepo.dispose()`, and `emptyDirRepo.dispose()` calls across the entire test codebase, unwrapping the try-finally blocks that became empty to keep the test suites simple and syntactically clean.