### PR TITLE
test: modernize resource cleanup and stubbing via ERM and Sinon wrappers

### DIFF
--- a/src/test/code-forge-auth.test.ts
+++ b/src/test/code-forge-auth.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { type AuthResult, CodeForgeAuthManager } from '../code-forge-auth';
 import { createMock, createMockLogOutputChannel } from './test-utils';
@@ -74,6 +74,10 @@ describe('CodeForgeAuthManager', () => {
         vi.mocked(vscode.commands.executeCommand).mockReset();
     });
 
+    afterEach(() => {
+        delete process.env.TEST_GITHUB_ENV_KEY;
+    });
+
     test('isAuthSkipped and setAuthSkipped persistent states', async () => {
         expect(authManager.isAuthSkipped('github')).toBe(false);
         await authManager.setAuthSkipped('github', true);
@@ -100,17 +104,13 @@ describe('CodeForgeAuthManager', () => {
 
     test('getSessionToken checks environment variables first', async () => {
         process.env.TEST_GITHUB_ENV_KEY = 'env-token-123';
-        try {
-            const token = await authManager.getSessionToken('github', {
-                scopes: ['repo'],
-                envTokenKey: 'TEST_GITHUB_ENV_KEY',
-                promptMessage: 'test',
-                prompt: false,
-            });
-            expect(token).toBe('env-token-123');
-        } finally {
-            delete process.env.TEST_GITHUB_ENV_KEY;
-        }
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'TEST_GITHUB_ENV_KEY',
+            promptMessage: 'test',
+            prompt: false,
+        });
+        expect(token).toBe('env-token-123');
     });
 
     test('getSessionToken checks stored token in secrets', async () => {

--- a/src/test/e2e/binary-config.spec.ts
+++ b/src/test/e2e/binary-config.spec.ts
@@ -7,12 +7,12 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { expect } from '@playwright/test';
-import { TestRepo } from '../test-repo';
+import { ScopedTestRepo } from '../test-repo';
 import { clickNotificationButton, expectNotificationToast, expectSettingsOpen, test } from './e2e-helpers';
 
 test.describe('JJ Binary Configuration E2E', () => {
     test('Shows error and opens settings for invalid binary path', async ({ vscode }) => {
-        const repo = new TestRepo();
+        using repo = new ScopedTestRepo();
         repo.init();
 
         const invalidPath = path.join(os.tmpdir(), 'non-existent-jj-binary');
@@ -44,7 +44,7 @@ test.describe('JJ Binary Configuration E2E', () => {
     });
 
     test('Shows error when jj binary is not found', async ({ vscode }) => {
-        const repo = new TestRepo();
+        using repo = new ScopedTestRepo();
         repo.init();
 
         // Filter PATH to exclude directories containing 'jj' so we don't crash the extension host

--- a/src/test/e2e/e2e-utils.spec.ts
+++ b/src/test/e2e/e2e-utils.spec.ts
@@ -30,7 +30,6 @@ test.describe('E2E Utilities', () => {
             console.log(await vscode.getOutputChannelLogs('JJ View'));
             console.log('----------------------------------------');
             throw err;
-        } finally {
         }
     });
 
@@ -59,7 +58,6 @@ test.describe('E2E Utilities', () => {
             console.log(await vscode.getOutputChannelLogs('JJ View'));
             console.log('----------------------------------------');
             throw err;
-        } finally {
         }
     });
 
@@ -81,7 +79,6 @@ test.describe('E2E Utilities', () => {
             console.log(await vscode.getOutputChannelLogs('JJ View'));
             console.log('----------------------------------------');
             throw err;
-        } finally {
         }
     });
 });

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -194,25 +194,22 @@ test.describe('GitHub Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const childRow = await waitForLogCommitRow(page, 'Child Commit');
-            const parentRow = await waitForLogCommitRow(page, 'Parent Commit');
+        const childRow = await waitForLogCommitRow(page, 'Child Commit');
+        const parentRow = await waitForLogCommitRow(page, 'Parent Commit');
 
-            // 1. Child row should show the PR #42 badge and URL (since it has local bookmark)
-            await expectBadgeLink(childRow, 'PR #42', 'https://github.com/test-owner/test-repo/pull/42');
+        // 1. Child row should show the PR #42 badge and URL (since it has local bookmark)
+        await expectBadgeLink(childRow, 'PR #42', 'https://github.com/test-owner/test-repo/pull/42');
 
-            // 2. Parent row should NOT show the PR #42 badge (since it only has remote bookmark)
-            await expect(parentRow.locator('a', { hasText: 'PR #42' })).not.toBeVisible();
+        // 2. Parent row should NOT show the PR #42 badge (since it only has remote bookmark)
+        await expect(parentRow.locator('a', { hasText: 'PR #42' })).not.toBeVisible();
 
-            // 3. Child row has local changes that need upload, and parent has correct structure (no parent mismatch).
-            // So the child row upload button should NOT show the parent mismatch title.
-            const uploadButton = childRow.getByRole('button', { name: 'Upload changes to GitHub' });
-            await expect(uploadButton).toBeVisible();
-            await expect(uploadButton).toHaveAttribute('title', 'Local changes need upload (Click to push)');
-        } finally {
-        }
+        // 3. Child row has local changes that need upload, and parent has correct structure (no parent mismatch).
+        // So the child row upload button should NOT show the parent mismatch title.
+        const uploadButton = childRow.getByRole('button', { name: 'Upload changes to GitHub' });
+        await expect(uploadButton).toBeVisible();
+        await expect(uploadButton).toHaveAttribute('title', 'Local changes need upload (Click to push)');
     });
 
     test('Manages GitHub auth choices via Quick Pick', async ({ vscode }) => {

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -36,6 +36,11 @@ test.describe('GitLab Integration E2E', () => {
         gitlab.clearRequests();
     });
 
+    test.afterEach(async ({ vscode }) => {
+        gitlab.statusOverride = undefined;
+        maybePrintExtensionLogs(vscode.userDataDir);
+    });
+
     test('Detects GitLab MR status via bookmark', async ({ vscode }) => {
         const repo = new TestRepo();
         repo.init();
@@ -75,23 +80,19 @@ test.describe('GitLab Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'MR Commit');
+        const row = await waitForLogCommitRow(page, 'MR Commit');
 
-            // Verify MR label is shown with correct number and URL
-            await expectBadgeLink(row, 'MR !42', 'https://gitlab.com/test-owner/test-repo/-/merge_requests/42');
+        // Verify MR label is shown with correct number and URL
+        await expectBadgeLink(row, 'MR !42', 'https://gitlab.com/test-owner/test-repo/-/merge_requests/42');
 
-            // Verify unresolved comments bubble is shown (value: 3)
-            await expect(row.getByTitle('3 Unresolved Comments')).toBeVisible();
+        // Verify unresolved comments bubble is shown (value: 3)
+        await expect(row.getByTitle('3 Unresolved Comments')).toBeVisible();
 
-            // Since commit ID matches currentRevision, upload button should NOT be visible
-            const uploadButton = row.getByRole('button', { name: 'Upload changes to GitLab' });
-            await expect(uploadButton).not.toBeVisible();
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        // Since commit ID matches currentRevision, upload button should NOT be visible
+        const uploadButton = row.getByRole('button', { name: 'Upload changes to GitLab' });
+        await expect(uploadButton).not.toBeVisible();
     });
 
     test('Shows Upload button when content is out of sync and performs upload', async ({ vscode }) => {
@@ -139,29 +140,25 @@ test.describe('GitLab Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'Out of Sync Commit');
+        const row = await waitForLogCommitRow(page, 'Out of Sync Commit');
 
-            // Verify MR label and URL
-            await expectBadgeLink(row, 'MR !101', 'https://gitlab.com/test-owner/test-repo/-/merge_requests/101');
+        // Verify MR label and URL
+        await expectBadgeLink(row, 'MR !101', 'https://gitlab.com/test-owner/test-repo/-/merge_requests/101');
 
-            // Verify upload button is visible
-            const uploadButton = row.getByRole('button', { name: 'Upload changes to GitLab' });
-            await expect(uploadButton).toBeVisible();
+        // Verify upload button is visible
+        const uploadButton = row.getByRole('button', { name: 'Upload changes to GitLab' });
+        await expect(uploadButton).toBeVisible();
 
-            // Click upload button
-            await uploadButton.click();
+        // Click upload button
+        await uploadButton.click();
 
-            const changeId = commits['out-of-sync-commit'].changeId;
-            await expect(async () => {
-                const desc = repo.getDescription(changeId);
-                expect(desc).toContain('uploaded_successfully');
-            }).toPass({ timeout: 15000 });
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        const changeId = commits['out-of-sync-commit'].changeId;
+        await expect(async () => {
+            const desc = repo.getDescription(changeId);
+            expect(desc).toContain('uploaded_successfully');
+        }).toPass({ timeout: 15000 });
     });
 
     test('Manages GitLab auth choices via Quick Pick', async ({ vscode }) => {
@@ -200,26 +197,22 @@ test.describe('GitLab Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
-            await waitForLogCommitRow(page, 'MR Commit');
+        await focusJJLog(page);
+        await waitForLogCommitRow(page, 'MR Commit');
 
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // Click the Manage Auth button in the Source Control title bar
-            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
-            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
-            await manageAuthButton.click();
+        // Click the Manage Auth button in the Source Control title bar
+        const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+        await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+        await manageAuthButton.click();
 
-            // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
-            await pickQuickPickItem(page, /Disable Authentication Prompts/);
+        // Now the custom Quick Pick should be visible. Let's select "Disable Authentication Prompts"
+        await pickQuickPickItem(page, /Disable Authentication Prompts/);
 
-            // Verify confirmation message or state by checking that the quick pick closed
-            const quickPick = locateQuickInputWidget(page);
-            await expect(quickPick).not.toBeVisible();
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        // Verify confirmation message or state by checking that the quick pick closed
+        const quickPick = locateQuickInputWidget(page);
+        await expect(quickPick).not.toBeVisible();
     });
 
     test('Manages GitLab PAT flow via Quick Pick', async ({ vscode }) => {
@@ -239,66 +232,62 @@ test.describe('GitLab Integration E2E', () => {
             true, // showNotifications = true
         );
 
-        try {
+        await focusSCM(page);
+
+        // Click the Manage Auth button in the Source Control title bar
+        const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+        await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+        await manageAuthButton.click();
+
+        // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
+        const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+        await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
+
+        // Click "Enter Personal Access Token (PAT)"
+        await pickQuickPickItem(page, /Enter Personal Access Token/);
+
+        // Wait for the showInputBox input to appear
+        const input = await waitForQuickInput(page);
+        await input.focus();
+        await input.fill('glpat-test-mock-token');
+        await input.press('Enter');
+
+        // Wait for input box to close
+        await expect(quickPick).not.toBeVisible();
+
+        // Re-open the Manage Auth menu
+        await focusSCM(page);
+        await manageAuthButton.click();
+        await expect(quickPick).toBeVisible();
+
+        // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
+        await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
+        await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
+
+        // Click "Clear Personal Access Token (PAT)"
+        await pickQuickPickItem(page, /Clear Personal Access Token/);
+
+        // Wait for menu to close
+        await expect(quickPick).not.toBeVisible();
+
+        // Wait for the success toast to appear, indicating the deletion is complete
+        await expectNotificationToast(page, 'Successfully cleared stored GitLab Personal Access Token');
+
+        // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
+        await expect(async () => {
+            const isVisible = await quickPick.isVisible();
+            if (isVisible) {
+                await page.keyboard.press('Escape');
+                await expect(quickPick).not.toBeVisible();
+            }
             await focusSCM(page);
-
-            // Click the Manage Auth button in the Source Control title bar
-            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
-            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
             await manageAuthButton.click();
+            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
+                timeout: 2000,
+            });
+        }).toPass({ timeout: 15000 });
 
-            // Check that the items "Sign In (OAuth)" and "Enter Personal Access Token (PAT)" are present
-            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
-            await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible();
-
-            // Click "Enter Personal Access Token (PAT)"
-            await pickQuickPickItem(page, /Enter Personal Access Token/);
-
-            // Wait for the showInputBox input to appear
-            const input = await waitForQuickInput(page);
-            await input.focus();
-            await input.fill('glpat-test-mock-token');
-            await input.press('Enter');
-
-            // Wait for input box to close
-            await expect(quickPick).not.toBeVisible();
-
-            // Re-open the Manage Auth menu
-            await focusSCM(page);
-            await manageAuthButton.click();
-            await expect(quickPick).toBeVisible();
-
-            // Verify "Update Personal Access Token (PAT)" and "Clear Personal Access Token (PAT)" are now visible
-            await expect(locateQuickInputItem(page, 'Update Personal Access Token (PAT)')).toBeVisible();
-            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).toBeVisible();
-
-            // Click "Clear Personal Access Token (PAT)"
-            await pickQuickPickItem(page, /Clear Personal Access Token/);
-
-            // Wait for menu to close
-            await expect(quickPick).not.toBeVisible();
-
-            // Wait for the success toast to appear, indicating the deletion is complete
-            await expectNotificationToast(page, 'Successfully cleared stored GitLab Personal Access Token');
-
-            // Re-open again to confirm it reverted back to "Enter Personal Access Token (PAT)"
-            await expect(async () => {
-                const isVisible = await quickPick.isVisible();
-                if (isVisible) {
-                    await page.keyboard.press('Escape');
-                    await expect(quickPick).not.toBeVisible();
-                }
-                await focusSCM(page);
-                await manageAuthButton.click();
-                await expect(locateQuickInputItem(page, 'Enter Personal Access Token (PAT)')).toBeVisible({
-                    timeout: 2000,
-                });
-            }).toPass({ timeout: 15000 });
-
-            await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
     });
 
     test('Shows extension-not-found interstitial when signing in via OAuth without GitLab extension', async ({
@@ -321,42 +310,38 @@ test.describe('GitLab Integration E2E', () => {
             true, // showNotifications = true
         );
 
-        try {
-            await focusSCM(page);
+        await focusSCM(page);
 
-            // Click the Manage Auth button in the Source Control title bar
-            const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
-            await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
-            await manageAuthButton.click();
+        // Click the Manage Auth button in the Source Control title bar
+        const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();
+        await expect(manageAuthButton).toBeVisible({ timeout: 15000 });
+        await manageAuthButton.click();
 
-            // The Quick Pick should be visible. Select "Sign In (OAuth)"
-            await pickQuickPickItem(page, /Sign In.*OAuth/);
+        // The Quick Pick should be visible. Select "Sign In (OAuth)"
+        await pickQuickPickItem(page, /Sign In.*OAuth/);
 
-            // Since the GitLab Workflow extension is not installed in the E2E environment
-            // (VS Code runs with --disable-extensions), we expect an error notification
-            // explaining the extension is missing, with options to install or use a PAT.
-            const notificationToast = page.locator('.notifications-toasts .notification-toast', {
-                hasText: 'authentication provider is not available',
-            });
-            await expect(notificationToast).toBeVisible({ timeout: 10000 });
+        // Since the GitLab Workflow extension is not installed in the E2E environment
+        // (VS Code runs with --disable-extensions), we expect an error notification
+        // explaining the extension is missing, with options to install or use a PAT.
+        const notificationToast = page.locator('.notifications-toasts .notification-toast', {
+            hasText: 'authentication provider is not available',
+        });
+        await expect(notificationToast).toBeVisible({ timeout: 10000 });
 
-            // The toast should offer "Enter PAT" as an alternative
-            const enterPatButton = notificationToast.getByRole('button', { name: 'Enter PAT' });
-            await expect(enterPatButton).toBeVisible();
-            await enterPatButton.click();
+        // The toast should offer "Enter PAT" as an alternative
+        const enterPatButton = notificationToast.getByRole('button', { name: 'Enter PAT' });
+        await expect(enterPatButton).toBeVisible();
+        await enterPatButton.click();
 
-            // Wait for the showInputBox input to appear for PAT entry
-            const input = await waitForQuickInput(page);
-            await input.focus();
-            await input.fill('glpat-extension-not-found-test');
-            await input.press('Enter');
+        // Wait for the showInputBox input to appear for PAT entry
+        const input = await waitForQuickInput(page);
+        await input.focus();
+        await input.fill('glpat-extension-not-found-test');
+        await input.press('Enter');
 
-            // Verify the quick input is gone — PAT was accepted
-            const quickPick = locateQuickInputWidget(page).filter({ visible: true });
-            await expect(quickPick).not.toBeVisible();
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        // Verify the quick input is gone — PAT was accepted
+        const quickPick = locateQuickInputWidget(page).filter({ visible: true });
+        await expect(quickPick).not.toBeVisible();
     });
 
     test('Shows warning notification toast on 403 Forbidden scope errors', async ({ vscode }) => {
@@ -392,15 +377,10 @@ test.describe('GitLab Integration E2E', () => {
             true, // showNotifications = true
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            // Wait for the warning notification toast to appear
-            await expectNotificationToast(page, "requires 'Merge Request' read/write permissions or 'api' scope");
-        } finally {
-            gitlab.statusOverride = undefined;
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        // Wait for the warning notification toast to appear
+        await expectNotificationToast(page, "requires 'Merge Request' read/write permissions or 'api' scope");
     });
 
     test('Detects MR from fork targeting mainline repo', async ({ vscode }) => {
@@ -442,15 +422,11 @@ test.describe('GitLab Integration E2E', () => {
             },
         );
 
-        try {
-            await focusJJLog(page);
+        await focusJJLog(page);
 
-            const row = await waitForLogCommitRow(page, 'Fork Commit');
+        const row = await waitForLogCommitRow(page, 'Fork Commit');
 
-            // Verify MR badge is shown with correct ID (even though it's submitted from project ID 200, which is the fork)
-            await expectBadgeLink(row, 'MR !99', 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/99');
-        } finally {
-            maybePrintExtensionLogs(vscode.userDataDir);
-        }
+        // Verify MR badge is shown with correct ID (even though it's submitted from project ID 200, which is the fork)
+        await expectBadgeLink(row, 'MR !99', 'https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/99');
     });
 });

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import type { CodeForgeAuthManager } from '../code-forge-auth';
 import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
@@ -44,8 +44,12 @@ describe('GitHubProvider', () => {
     let provider: GitHubProvider;
     let mockOutputChannel: vscode.LogOutputChannel;
     let mockAuthManager: CodeForgeAuthManager;
+    let originalEnv: string | undefined;
+    let originalFetch: typeof global.fetch;
 
     beforeEach(() => {
+        originalEnv = process.env.JJ_VIEW_GITHUB_TOKEN;
+        originalFetch = global.fetch;
         mockOutputChannel = createMockLogOutputChannel({ appendLine: vi.fn() });
         mockAuthManager = createMock<CodeForgeAuthManager>({
             isAuthSkipped: vi.fn().mockReturnValue(false),
@@ -66,6 +70,11 @@ describe('GitHubProvider', () => {
         });
         provider = new GitHubProvider(mockAuthManager, mockOutputChannel);
         vi.mocked(vscode.window.showWarningMessage).mockReset();
+    });
+
+    afterEach(() => {
+        process.env.JJ_VIEW_GITHUB_TOKEN = originalEnv;
+        global.fetch = originalFetch;
     });
 
     test('parseGitHubUrl correctly parses standard and dotted repo URLs', () => {
@@ -400,37 +409,27 @@ describe('GitHubProvider', () => {
     });
 
     test('hasAuth returns true if environment variable JJ_VIEW_GITHUB_TOKEN is set', async () => {
-        const originalEnv = process.env.JJ_VIEW_GITHUB_TOKEN;
-        try {
-            process.env.JJ_VIEW_GITHUB_TOKEN = 'test-token';
-            const hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-        } finally {
-            process.env.JJ_VIEW_GITHUB_TOKEN = originalEnv;
-        }
+        process.env.JJ_VIEW_GITHUB_TOKEN = 'test-token';
+        const hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
     });
 
     test('hasAuth returns true if stored token is found, false otherwise', async () => {
-        const originalEnv = process.env.JJ_VIEW_GITHUB_TOKEN;
         delete process.env.JJ_VIEW_GITHUB_TOKEN;
-        try {
-            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
-            let hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-            expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('github_token');
+        vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
+        let hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
+        expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('github_token');
 
-            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
-            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
-            hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-            expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('github', ['repo']);
+        vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
+        vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
+        hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
+        expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('github', ['repo']);
 
-            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
-            hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(false);
-        } finally {
-            process.env.JJ_VIEW_GITHUB_TOKEN = originalEnv;
-        }
+        vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
+        hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(false);
     });
 
     test('getAuthManageItems delegates to authManager.getAuthManageItems', async () => {
@@ -475,7 +474,6 @@ describe('GitHubProvider', () => {
         setPrivate(provider, 'owner', 'fork-owner');
         setPrivate(provider, 'repo', 'fork-repo');
 
-        const originalFetch = global.fetch;
         const fetchMock = vi.fn().mockResolvedValue({
             ok: true,
             status: 200,
@@ -514,28 +512,24 @@ describe('GitHubProvider', () => {
         });
         global.fetch = fetchMock;
 
-        try {
-            const fetchBatch = exposePrivate<{
-                fetchBatchFromNetwork(
-                    bookmarkNames: string[],
-                    bookmarkToCommitId: Map<string, string>,
-                ): Promise<Map<string, CodeForgeChangeInfo>>;
-            }>(provider).fetchBatchFromNetwork.bind(provider);
+        const fetchBatch = exposePrivate<{
+            fetchBatchFromNetwork(
+                bookmarkNames: string[],
+                bookmarkToCommitId: Map<string, string>,
+            ): Promise<Map<string, CodeForgeChangeInfo>>;
+        }>(provider).fetchBatchFromNetwork.bind(provider);
 
-            const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
-            expect(results.size).toBe(1);
-            const pr = results.get('my-feature-branch');
-            expect(pr).toBeDefined();
-            expect(pr?.id).toBe('parent-pr-id');
-            expect(pr?.number).toBe(42);
-            expect(pr?.url).toBe('https://github.com/parent-owner/parent-repo/pull/42');
+        const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
+        expect(results.size).toBe(1);
+        const pr = results.get('my-feature-branch');
+        expect(pr).toBeDefined();
+        expect(pr?.id).toBe('parent-pr-id');
+        expect(pr?.number).toBe(42);
+        expect(pr?.url).toBe('https://github.com/parent-owner/parent-repo/pull/42');
 
-            expect(fetchMock).toHaveBeenCalledTimes(1);
-            const requestBody = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
-            expect(requestBody.query).toContain('parent {');
-        } finally {
-            global.fetch = originalFetch;
-        }
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const requestBody = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+        expect(requestBody.query).toContain('parent {');
     });
 
     test('fetchStatuses matches closed/merged PRs even if local commit ID differs', async () => {

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import type { CodeForgeAuthManager } from '../code-forge-auth';
 import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider';
@@ -44,8 +44,12 @@ describe('GitLabProvider', () => {
     let provider: GitLabProvider;
     let mockOutputChannel: vscode.LogOutputChannel;
     let mockAuthManager: CodeForgeAuthManager;
+    let originalEnv: string | undefined;
+    let originalFetch: typeof global.fetch;
 
     beforeEach(() => {
+        originalEnv = process.env.JJ_VIEW_GITLAB_TOKEN;
+        originalFetch = global.fetch;
         mockOutputChannel = createMockLogOutputChannel({ appendLine: vi.fn() });
         mockAuthManager = createMock<CodeForgeAuthManager>({
             isAuthSkipped: vi.fn().mockReturnValue(false),
@@ -68,6 +72,11 @@ describe('GitLabProvider', () => {
         });
         provider = new GitLabProvider(mockAuthManager, mockOutputChannel);
         vi.mocked(vscode.window.showWarningMessage).mockReset();
+    });
+
+    afterEach(() => {
+        process.env.JJ_VIEW_GITLAB_TOKEN = originalEnv;
+        global.fetch = originalFetch;
     });
 
     test('parseGitLabUrl correctly parses standard, subgroup, and configured host URLs', () => {
@@ -396,37 +405,27 @@ describe('GitLabProvider', () => {
     });
 
     test('hasAuth returns true if environment variable JJ_VIEW_GITLAB_TOKEN is set', async () => {
-        const originalEnv = process.env.JJ_VIEW_GITLAB_TOKEN;
-        try {
-            process.env.JJ_VIEW_GITLAB_TOKEN = 'test-token';
-            const hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-        } finally {
-            process.env.JJ_VIEW_GITLAB_TOKEN = originalEnv;
-        }
+        process.env.JJ_VIEW_GITLAB_TOKEN = 'test-token';
+        const hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
     });
 
     test('hasAuth returns true if stored token is found, false otherwise', async () => {
-        const originalEnv = process.env.JJ_VIEW_GITLAB_TOKEN;
         delete process.env.JJ_VIEW_GITLAB_TOKEN;
-        try {
-            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
-            let hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-            expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('gitlab_token');
+        vi.mocked(mockAuthManager.secrets.get).mockResolvedValue('stored-pat');
+        let hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
+        expect(mockAuthManager.secrets.get).toHaveBeenCalledWith('gitlab_token');
 
-            vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
-            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
-            hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(true);
-            expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('gitlab', ['api']);
+        vi.mocked(mockAuthManager.secrets.get).mockResolvedValue(undefined);
+        vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(true);
+        hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(true);
+        expect(mockAuthManager.hasOAuthSession).toHaveBeenCalledWith('gitlab', ['api']);
 
-            vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
-            hasAuth = await provider.hasAuth();
-            expect(hasAuth).toBe(false);
-        } finally {
-            process.env.JJ_VIEW_GITLAB_TOKEN = originalEnv;
-        }
+        vi.mocked(mockAuthManager.hasOAuthSession).mockResolvedValue(false);
+        hasAuth = await provider.hasAuth();
+        expect(hasAuth).toBe(false);
     });
 
     test('getAuthManageItems delegates to authManager.getAuthManageItems', async () => {
@@ -476,7 +475,6 @@ describe('GitLabProvider', () => {
         setPrivate(provider, 'gitlabHost', 'https://gitlab.com');
         setPrivate(provider, 'projectPath', 'fork-owner/fork-repo');
 
-        const originalFetch = global.fetch;
         const fetchMock = vi.fn().mockImplementation(async (url: string) => {
             if (url.includes('/projects/fork-owner%2Ffork-repo')) {
                 return createMock<Response>({
@@ -536,25 +534,21 @@ describe('GitLabProvider', () => {
         });
         global.fetch = fetchMock;
 
-        try {
-            const fetchBatch = exposePrivate<{
-                fetchBatchFromNetwork(
-                    bookmarkNames: string[],
-                    bookmarkToCommitId: Map<string, string>,
-                ): Promise<Map<string, CodeForgeChangeInfo>>;
-            }>(provider).fetchBatchFromNetwork.bind(provider);
+        const fetchBatch = exposePrivate<{
+            fetchBatchFromNetwork(
+                bookmarkNames: string[],
+                bookmarkToCommitId: Map<string, string>,
+            ): Promise<Map<string, CodeForgeChangeInfo>>;
+        }>(provider).fetchBatchFromNetwork.bind(provider);
 
-            const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
-            expect(results.size).toBe(1);
-            const mr = results.get('my-feature-branch');
-            expect(mr).toBeDefined();
-            expect(mr?.id).toBe('101');
-            expect(mr?.number).toBe(42);
-            expect(mr?.url).toBe('https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/42');
+        const results = await fetchBatch(['my-feature-branch'], new Map([['my-feature-branch', 'sha-parent']]));
+        expect(results.size).toBe(1);
+        const mr = results.get('my-feature-branch');
+        expect(mr).toBeDefined();
+        expect(mr?.id).toBe('101');
+        expect(mr?.number).toBe(42);
+        expect(mr?.url).toBe('https://gitlab.com/mainline-owner/mainline-repo/-/merge_requests/42');
 
-            expect(accessPrivate(provider, 'resolvedProjectPath')).toBe('mainline-owner/mainline-repo');
-        } finally {
-            global.fetch = originalFetch;
-        }
+        expect(accessPrivate(provider, 'resolvedProjectPath')).toBe('mainline-owner/mainline-repo');
     });
 });

--- a/src/test/integration-test-utils.ts
+++ b/src/test/integration-test-utils.ts
@@ -5,12 +5,14 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import type * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import type { CodeForgeRegistry } from '../code-forge-registry';
 import type { Api } from '../extension';
 import type { JjRepository } from '../jj-repository';
 import type { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjScmProvider } from '../jj-scm-provider';
+import { createMock } from './test-utils';
 
 export interface TestRepositoryContext {
     codeForgeRegistry: CodeForgeRegistry;
@@ -182,4 +184,64 @@ export async function waitUntil(
         await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
     return await condition();
+}
+
+/**
+ * Stubs specific configuration keys on the vscode.workspace.getConfiguration API.
+ * Delegates all other configuration queries to the original implementation.
+ */
+export function stubConfig(sandbox: sinon.SinonSandbox, configs: Record<string, unknown>): sinon.SinonStub {
+    const original = vscode.workspace.getConfiguration;
+    const configMock = createMock<vscode.WorkspaceConfiguration>({
+        get: (key: string, defaultValue?: unknown) => {
+            if (key in configs) {
+                return configs[key];
+            }
+            const originalConfig = original('jj-view');
+            return originalConfig.get(key, defaultValue);
+        },
+        has: (key: string) => {
+            if (key in configs) {
+                return true;
+            }
+            const originalConfig = original('jj-view');
+            return originalConfig.has(key);
+        },
+        inspect: (key: string) => {
+            const originalConfig = original('jj-view');
+            return originalConfig.inspect(key);
+        },
+        update: (key: string, value: unknown, target?: vscode.ConfigurationTarget | boolean | null) => {
+            const originalConfig = original('jj-view');
+            return originalConfig.update(key, value, target);
+        },
+    });
+
+    return sandbox.stub(vscode.workspace, 'getConfiguration').callsFake((section?, scope?) => {
+        if (section === 'jj-view') {
+            return configMock;
+        }
+        return original(section, scope);
+    });
+}
+
+/**
+ * Stubs a specific VS Code command execution handler, automatically delegating all
+ * other command executions to the original vscode.commands.executeCommand.
+ */
+export function stubCommand(
+    sandbox: sinon.SinonSandbox,
+    commandId: string,
+    handler: (...args: unknown[]) => unknown,
+): sinon.SinonStub {
+    const original = vscode.commands.executeCommand;
+    return sandbox
+        .stub(vscode.commands, 'executeCommand')
+        .callsFake(<T>(command: string, ...args: unknown[]): Thenable<T> => {
+            if (command === commandId) {
+                const result = handler(...args);
+                return Promise.resolve(result as never);
+            }
+            return original(command, ...args);
+        });
 }

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -9,7 +9,9 @@ import * as path from 'node:path';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { CodeForgeRegistry } from '../code-forge-registry';
+import type { Api } from '../extension';
 import { JjRepositoryManager } from '../jj-repository-manager';
+import { autoCleanup, ScopedSymlink, ScopedTempDir, ScopedTestRepo } from './scoped-helpers';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel, exposePrivate } from './test-utils';
 
@@ -22,15 +24,13 @@ suite('JjRepositoryManager Integration Test', () => {
     let sandbox: sinon.SinonSandbox;
     let initialFolders: vscode.Uri[] = [];
     let resolvedWorkspaceRoot: string | undefined;
-    let extraRepos: TestRepo[] = [];
-    let extraDirs: string[] = [];
 
     suiteSetup(() => {
         process.env.VSCODE_TEST = '1';
         initialFolders = (vscode.workspace.workspaceFolders || []).map((f) => f.uri);
     });
 
-    async function setWorkspaceFolders(folders: vscode.Uri[]): Promise<void> {
+    async function setWorkspaceFoldersInternal(folders: vscode.Uri[]): Promise<void> {
         const currentFolders = vscode.workspace.workspaceFolders || [];
         const currentCount = currentFolders.length;
 
@@ -64,9 +64,23 @@ suite('JjRepositoryManager Integration Test', () => {
         });
     }
 
+    async function setWorkspaceFolders(folders: vscode.Uri[]): Promise<AsyncDisposable> {
+        await setWorkspaceFoldersInternal(folders);
+
+        return {
+            async [Symbol.asyncDispose]() {
+                const extension = vscode.extensions.getExtension<Api>('jj-view.jj-view');
+                if (extension) {
+                    const api = await extension.activate();
+                    await api.repositoryManager.clear();
+                }
+                await manager.clear();
+                await setWorkspaceFoldersInternal(initialFolders);
+            },
+        };
+    }
+
     setup(async () => {
-        extraRepos = [];
-        extraDirs = [];
         sandbox = sinon.createSandbox();
         registry = new CodeForgeRegistry();
         outputChannel = createMockLogOutputChannel({
@@ -83,7 +97,7 @@ suite('JjRepositoryManager Integration Test', () => {
         });
 
         // Ensure we are working with the clean, initial workspace folder
-        await setWorkspaceFolders(initialFolders);
+        await setWorkspaceFoldersInternal(initialFolders);
 
         resolvedWorkspaceRoot = initialFolders[0] ? fs.realpathSync(initialFolders[0].fsPath) : undefined;
         if (resolvedWorkspaceRoot && fs.existsSync(resolvedWorkspaceRoot)) {
@@ -101,7 +115,7 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     teardown(async () => {
-        const extension = vscode.extensions.getExtension<import('../extension').Api>('jj-view.jj-view');
+        const extension = vscode.extensions.getExtension<Api>('jj-view.jj-view');
         if (extension) {
             const api = await extension.activate();
             await api.repositoryManager.clear();
@@ -109,14 +123,6 @@ suite('JjRepositoryManager Integration Test', () => {
 
         await manager.dispose();
         registry.dispose();
-
-        for (const dir of extraDirs) {
-            try {
-                fs.rmSync(dir, { recursive: true, force: true });
-            } catch {
-                // Ignore
-            }
-        }
 
         if (mainRepo.path !== resolvedWorkspaceRoot) {
         } else {
@@ -131,7 +137,7 @@ suite('JjRepositoryManager Integration Test', () => {
             }
         }
 
-        await setWorkspaceFolders(initialFolders);
+        await setWorkspaceFoldersInternal(initialFolders);
 
         sandbox.restore();
     });
@@ -146,21 +152,17 @@ suite('JjRepositoryManager Integration Test', () => {
         await manager.dispose();
 
         // 2. Create a new manager with the same workspaceState to simulate restart
-        const restartManager = new JjRepositoryManager(registry, outputChannel, workspaceState);
-        try {
-            // 3. Initialize from cache - should restore immediately
-            await restartManager.restoreCachedRepositories();
-            assert.strictEqual(restartManager.repositories.length, 1, 'Should load repo from cache');
-            assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
-            assert.strictEqual(restartManager.focusedRepository?.rootUri.fsPath, mainRepo.path);
+        await using restartManager = autoCleanup(new JjRepositoryManager(registry, outputChannel, workspaceState));
+        // 3. Initialize from cache - should restore immediately
+        await restartManager.restoreCachedRepositories();
+        assert.strictEqual(restartManager.repositories.length, 1, 'Should load repo from cache');
+        assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
+        assert.strictEqual(restartManager.focusedRepository?.rootUri.fsPath, mainRepo.path);
 
-            // 4. Run scan on restartManager to verify reconciliation
-            await restartManager.scanForRepositories();
-            assert.strictEqual(restartManager.repositories.length, 1, 'Reconciliation should keep the repository');
-            assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
-        } finally {
-            await restartManager.dispose();
-        }
+        // 4. Run scan on restartManager to verify reconciliation
+        await restartManager.scanForRepositories();
+        assert.strictEqual(restartManager.repositories.length, 1, 'Reconciliation should keep the repository');
+        assert.strictEqual(restartManager.repositories[0].rootUri.fsPath, mainRepo.path);
     });
 
     test('reconciliation disposes of invalid/missing cached repositories', async () => {
@@ -172,25 +174,17 @@ suite('JjRepositoryManager Integration Test', () => {
         await manager.dispose();
 
         // 2. Create restartManager
-        const restartManager = new JjRepositoryManager(registry, outputChannel, workspaceState);
-        try {
-            // 3. Initialize from cache
-            await restartManager.restoreCachedRepositories();
-            assert.strictEqual(restartManager.repositories.length, 1);
+        await using restartManager = autoCleanup(new JjRepositoryManager(registry, outputChannel, workspaceState));
+        // 3. Initialize from cache
+        await restartManager.restoreCachedRepositories();
+        assert.strictEqual(restartManager.repositories.length, 1);
 
-            // 4. Delete the .jj/working_copy/type file to make the cached repo invalid/missing
-            fs.rmSync(path.join(mainRepo.path, '.jj', 'working_copy', 'type'), { force: true });
+        // 4. Delete the .jj/working_copy/type file to make the cached repo invalid/missing
+        fs.rmSync(path.join(mainRepo.path, '.jj', 'working_copy', 'type'), { force: true });
 
-            // 5. Run scan - should reconcile and dispose of the now-missing repository
-            await restartManager.scanForRepositories();
-            assert.strictEqual(
-                restartManager.repositories.length,
-                0,
-                'Should remove repo that is no longer valid on disk',
-            );
-        } finally {
-            await restartManager.dispose();
-        }
+        // 5. Run scan - should reconcile and dispose of the now-missing repository
+        await restartManager.scanForRepositories();
+        assert.strictEqual(restartManager.repositories.length, 0, 'Should remove repo that is no longer valid on disk');
     });
 
     test('getRepositoryForUri works for repo and subfolders', async () => {
@@ -215,7 +209,6 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('scan filters out secondary workspaces when main is present', async () => {
         const secondaryRepo = mainRepo.workspaceAdd('second_ws');
-        extraRepos.push(secondaryRepo);
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(secondaryRepo.path)]);
 
         await manager.scanForRepositories();
@@ -233,7 +226,6 @@ suite('JjRepositoryManager Integration Test', () => {
 
         // Try to dynamically register secondary workspace path
         const secondaryRepo = mainRepo.workspaceAdd('second_ws');
-        extraRepos.push(secondaryRepo);
 
         const fileUri = vscode.Uri.file(path.join(secondaryRepo.path, 'file.txt'));
         const repo = await manager.maybeRegisterRepositoryContainingUri(fileUri);
@@ -245,7 +237,6 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('scan includes secondary workspace if main is NOT present', async () => {
         const secondaryRepo = mainRepo.workspaceAdd('second_ws');
-        extraRepos.push(secondaryRepo);
         await setWorkspaceFolders([vscode.Uri.file(secondaryRepo.path)]);
 
         await manager.scanForRepositories();
@@ -258,7 +249,6 @@ suite('JjRepositoryManager Integration Test', () => {
         const subRepoPath = path.join(mainRepo.path, 'subproject');
         fs.mkdirSync(subRepoPath, { recursive: true });
         const subRepo = new TestRepo(subRepoPath);
-        extraRepos.push(subRepo);
         subRepo.init();
 
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(subRepo.path)]);
@@ -280,9 +270,8 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     test('scan discovers multiple sibling repositories in a non-repo root', async () => {
-        // Create a non-repo parent directory outside mainRepo
-        const tmpParent = fs.realpathSync(fs.mkdtempSync(path.join(path.dirname(mainRepo.path), 'jj-view-siblings-')));
-        extraDirs.push(tmpParent);
+        using tmpParentDir = new ScopedTempDir(path.join(path.dirname(mainRepo.path), 'jj-view-siblings-'));
+        const tmpParent = tmpParentDir.path;
         const parentPath = path.join(tmpParent, 'siblings');
         const repo1Path = path.join(parentPath, 'project1');
         const repo2Path = path.join(parentPath, 'project2');
@@ -290,13 +279,12 @@ suite('JjRepositoryManager Integration Test', () => {
         fs.mkdirSync(repo1Path, { recursive: true });
         fs.mkdirSync(repo2Path, { recursive: true });
 
-        const repo1 = new TestRepo(repo1Path);
-        const repo2 = new TestRepo(repo2Path);
-        extraRepos.push(repo1, repo2);
+        using repo1 = new ScopedTestRepo(repo1Path);
+        using repo2 = new ScopedTestRepo(repo2Path);
         repo1.init();
         repo2.init();
 
-        await setWorkspaceFolders([vscode.Uri.file(parentPath)]);
+        await using _workspace = await setWorkspaceFolders([vscode.Uri.file(parentPath)]);
 
         await manager.scanForRepositories();
 
@@ -306,11 +294,13 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     test('tryAutoSwitch changes focused repository', async () => {
-        const otherRepo = new TestRepo();
-        extraRepos.push(otherRepo);
+        using otherRepo = new ScopedTestRepo();
         otherRepo.init();
 
-        await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(otherRepo.path)]);
+        await using _workspace = await setWorkspaceFolders([
+            vscode.Uri.file(mainRepo.path),
+            vscode.Uri.file(otherRepo.path),
+        ]);
 
         await manager.scanForRepositories();
         const initialFocus = manager.focusedRepository?.rootUri.fsPath;
@@ -331,23 +321,15 @@ suite('JjRepositoryManager Integration Test', () => {
         // Create a symlink to the main repository
         const symlinkPath = `${mainRepo.path}-symlink`;
 
-        try {
-            fs.symlinkSync(mainRepo.path, symlinkPath, 'dir');
+        using _symlink = new ScopedSymlink(symlinkPath, mainRepo.path, 'dir');
 
-            await manager.scanForRepositories();
+        await manager.scanForRepositories();
 
-            // A file URI inside the symlink path should match the repository
-            const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
-            const matched = manager.getRepositoryForUri(symlinkFileUri);
-            assert.ok(matched, 'Should match repository through symbolic link path');
-            assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
-        } finally {
-            try {
-                fs.unlinkSync(symlinkPath);
-            } catch {
-                // Ignore
-            }
-        }
+        // A file URI inside the symlink path should match the repository
+        const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
+        const matched = manager.getRepositoryForUri(symlinkFileUri);
+        assert.ok(matched, 'Should match repository through symbolic link path');
+        assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
     });
 
     test('getRepositoryForUri matches files in nested symlinked directory layout (issue 348)', async () => {
@@ -359,55 +341,40 @@ suite('JjRepositoryManager Integration Test', () => {
         //     └── .jj -> mainRepo.path/.jj (symlink to directory)
 
         // Create a target directory inside the repository
-        const targetDir = fs.realpathSync(fs.mkdtempSync(path.join(mainRepo.path, 'jj-view-nested-')));
+        using nestedDir = new ScopedTempDir(path.join(mainRepo.path, 'jj-view-nested-'));
+        const targetDir = nestedDir.path;
 
         const symlinkPath = path.join(mainRepo.path, 'bazel-core');
         const jjSymlinkPath = path.join(targetDir, '.jj');
 
-        try {
-            // Create symlink: bazel-core -> targetDir
-            fs.symlinkSync(targetDir, symlinkPath, 'dir');
+        // Create symlink: bazel-core -> targetDir
+        using _link1 = new ScopedSymlink(symlinkPath, targetDir, 'dir');
 
-            // Create symlink: targetDir/.jj -> mainRepo.path/.jj
-            fs.symlinkSync(path.join(mainRepo.path, '.jj'), jjSymlinkPath, 'dir');
+        // Create symlink: targetDir/.jj -> mainRepo.path/.jj
+        using _link2 = new ScopedSymlink(jjSymlinkPath, path.join(mainRepo.path, '.jj'), 'dir');
 
-            // Scan to discover repositories
-            await manager.scanForRepositories();
+        // Scan to discover repositories
+        await manager.scanForRepositories();
 
-            // Verify that we only have the main repository registered, not the nested one
-            assert.strictEqual(manager.repositories.length, 1);
-            assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
+        // Verify that we only have the main repository registered, not the nested one
+        assert.strictEqual(manager.repositories.length, 1);
+        assert.strictEqual(manager.repositories[0].rootUri.fsPath, mainRepo.path);
 
-            // A file URI inside the symlink path should match the repository
-            const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
-            const matched = manager.getRepositoryForUri(symlinkFileUri);
-            assert.ok(matched, 'Should match repository through nested symlink path');
-            assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
-        } finally {
-            try {
-                fs.unlinkSync(symlinkPath);
-            } catch {
-                // Ignore
-            }
-            try {
-                fs.unlinkSync(jjSymlinkPath);
-            } catch {
-                // Ignore
-            }
-            try {
-                fs.rmdirSync(targetDir);
-            } catch {
-                // Ignore
-            }
-        }
+        // A file URI inside the symlink path should match the repository
+        const symlinkFileUri = vscode.Uri.file(path.join(symlinkPath, 'file.txt'));
+        const matched = manager.getRepositoryForUri(symlinkFileUri);
+        assert.ok(matched, 'Should match repository through nested symlink path');
+        assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
     });
 
     test('scan ignores repositories listed in ignoredRepositories config', async () => {
-        const otherRepo = new TestRepo();
-        extraRepos.push(otherRepo);
+        using otherRepo = new ScopedTestRepo();
         otherRepo.init();
 
-        await setWorkspaceFolders([vscode.Uri.file(mainRepo.path), vscode.Uri.file(otherRepo.path)]);
+        await using _workspace = await setWorkspaceFolders([
+            vscode.Uri.file(mainRepo.path),
+            vscode.Uri.file(otherRepo.path),
+        ]);
 
         // Stub configuration
         const getStub = sandbox.stub();
@@ -432,8 +399,7 @@ suite('JjRepositoryManager Integration Test', () => {
 
     test('scan registers repositories in scanRepositories config even if autoDetect is false', async () => {
         const otherRepoPath = path.join(mainRepo.path, 'other-project');
-        const otherRepo = new TestRepo(otherRepoPath);
-        extraRepos.push(otherRepo);
+        using otherRepo = new ScopedTestRepo(otherRepoPath);
         otherRepo.init();
 
         await setWorkspaceFolders([vscode.Uri.file(mainRepo.path)]);
@@ -487,13 +453,11 @@ suite('JjRepositoryManager Integration Test', () => {
         const sub1 = path.join(mainRepo.path, 'subproject1');
         const sub2 = path.join(mainRepo.path, 'nested', 'subproject2');
 
-        const sub1Repo = new TestRepo(sub1);
+        using sub1Repo = new ScopedTestRepo(sub1);
         sub1Repo.init();
-        extraRepos.push(sub1Repo);
 
-        const sub2Repo = new TestRepo(sub2);
+        using sub2Repo = new ScopedTestRepo(sub2);
         sub2Repo.init();
-        extraRepos.push(sub2Repo);
 
         await manager.scanForRepositories();
 
@@ -513,13 +477,11 @@ suite('JjRepositoryManager Integration Test', () => {
         const sub1 = path.join(mainRepo.path, 'subproject1');
         const sub2 = path.join(mainRepo.path, 'nested', 'subproject2');
 
-        const sub1Repo = new TestRepo(sub1);
+        using sub1Repo = new ScopedTestRepo(sub1);
         sub1Repo.init();
-        extraRepos.push(sub1Repo);
 
-        const sub2Repo = new TestRepo(sub2);
+        using sub2Repo = new ScopedTestRepo(sub2);
         sub2Repo.init();
-        extraRepos.push(sub2Repo);
 
         const getStub = sandbox.stub();
         getStub.withArgs('autoRepositoryDetection', true).returns('subFolders');
@@ -589,11 +551,10 @@ suite('JjRepositoryManager Integration Test', () => {
     });
 
     test('isPathInOrAncestorOfWorkspace rejects repositories in unrelated directories', async () => {
-        const tempParent = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-unrelated-'));
-        extraDirs.push(tempParent);
+        using tempParentDir = new ScopedTempDir(path.join(os.tmpdir(), 'jj-unrelated-'));
+        const tempParent = tempParentDir.path;
 
-        const unrelatedRepo = new TestRepo(tempParent);
-        extraRepos.push(unrelatedRepo);
+        using unrelatedRepo = new ScopedTestRepo(tempParent);
         unrelatedRepo.init();
 
         const registered = await manager.maybeRegisterRepositoryContainingUri(vscode.Uri.file(unrelatedRepo.path));

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
+import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import { compareAllFilesWithRevisionCommand } from '../commands/compare-all-files-with-revision';
 import { squashFilesIntoParentCommand } from '../commands/squash-files';
@@ -16,14 +17,21 @@ import { ScmContextValue } from '../jj-context-keys';
 import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
-import { createTestRepositoryContext, waitUntil } from './integration-test-utils';
+import {
+    createTestRepositoryContext,
+    stubCommand,
+    stubConfig,
+    type TestRepositoryContext,
+    waitUntil,
+} from './integration-test-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { accessPrivate, createMockLogOutputChannel } from './test-utils';
 
 suite('JJ SCM Provider Integration Test', () => {
     let jj: JjService;
     let scmProvider: JjScmProvider;
-    let contextHelper: import('./integration-test-utils').TestRepositoryContext;
+    let contextHelper: TestRepositoryContext;
+    let sandbox: sinon.SinonSandbox;
 
     let repo: TestRepo;
 
@@ -33,6 +41,7 @@ suite('JJ SCM Provider Integration Test', () => {
     }
 
     setup(async () => {
+        sandbox = sinon.createSandbox();
         // Initialize TestRepo (creates temp dir)
         repo = new TestRepo();
         repo.init();
@@ -57,10 +66,10 @@ suite('JJ SCM Provider Integration Test', () => {
         // Allow VS Code to settle before disposing repository
         await new Promise((resolve) => setTimeout(resolve, 500));
 
+        sandbox.restore();
+
         if (contextHelper) {
             await contextHelper.dispose();
-        }
-        if (repo) {
         }
     });
 
@@ -113,7 +122,7 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok(resourceState, 'Should find resource state for modified file');
         assert.strictEqual(workingCopyGroup.resourceStates[0].decorations?.tooltip, 'modified');
 
-        const command = workingCopyGroup.resourceStates[0].command;
+        const { command } = workingCopyGroup.resourceStates[0];
         assert.ok(command, 'Resource state should have a command');
         assert.strictEqual(command.command, 'vscode.diff', 'Command should be vscode.diff');
         assert.strictEqual(command.arguments?.length, 3, 'Diff command should have 3 arguments');
@@ -148,69 +157,47 @@ suite('JJ SCM Provider Integration Test', () => {
         ]);
         await fsp.unlink(deletedFilePath);
 
-        const originalGetConfiguration = vscode.workspace.getConfiguration;
-        const configStub = {
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'openDiffOnClick') {
-                    return false;
-                }
-                return defaultValue;
-            },
-        };
-        (vscode.workspace as { getConfiguration: unknown }).getConfiguration = (section: string) => {
-            if (section === 'jj-view') {
-                return configStub;
-            }
-            return originalGetConfiguration(section);
-        };
+        stubConfig(sandbox, { openDiffOnClick: false });
 
-        try {
-            await scmProvider.refresh({ forceSnapshot: true });
+        await scmProvider.refresh({ forceSnapshot: true });
 
-            const workingCopyGroup = accessPrivate(
-                scmProvider,
-                '_workingCopyGroup',
-            ) as vscode.SourceControlResourceGroup;
-            const resourceState = workingCopyGroup.resourceStates.find(
-                (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
-            );
-            assert.ok(resourceState, 'Should find resource state for modified file');
+        const workingCopyGroup = accessPrivate(scmProvider, '_workingCopyGroup') as vscode.SourceControlResourceGroup;
+        const resourceState = workingCopyGroup.resourceStates.find(
+            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+        );
+        assert.ok(resourceState, 'Should find resource state for modified file');
 
-            const { command } = resourceState;
-            assert.ok(command, 'Resource state should have a command');
-            assert.strictEqual(
-                command.command,
-                'vscode.open',
-                'Command should be vscode.open when openDiffOnClick is false',
-            );
-            assert.strictEqual(command.arguments?.length, 1, 'Open command should have 1 argument');
-            const openUri = command.arguments?.[0] as vscode.Uri;
-            assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
-            assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
+        const { command } = resourceState;
+        assert.ok(command, 'Resource state should have a command');
+        assert.strictEqual(
+            command.command,
+            'vscode.open',
+            'Command should be vscode.open when openDiffOnClick is false',
+        );
+        assert.strictEqual(command.arguments?.length, 1, 'Open command should have 1 argument');
+        const openUri = command.arguments?.[0] as vscode.Uri;
+        assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
+        assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
 
-            const { diffTitle } = resourceState as JjResourceState;
-            assert.ok(diffTitle, 'diffTitle should be set');
+        const { diffTitle } = resourceState as JjResourceState;
+        assert.ok(diffTitle, 'diffTitle should be set');
 
-            const { leftUri } = resourceState as JjResourceState;
-            const { rightUri } = resourceState as JjResourceState;
-            assert.ok(leftUri && rightUri, 'leftUri and rightUri should be set');
+        const { leftUri, rightUri } = resourceState as JjResourceState;
+        assert.ok(leftUri && rightUri, 'leftUri and rightUri should be set');
 
-            assert.strictEqual(leftUri.scheme, 'jj-view', 'left URI scheme should be jj-view');
-            assert.strictEqual(normalize(rightUri.fsPath), normalize(filePath), 'right URI should be the file path');
+        assert.strictEqual(leftUri.scheme, 'jj-view', 'left URI scheme should be jj-view');
+        assert.strictEqual(normalize(rightUri.fsPath), normalize(filePath), 'right URI should be the file path');
 
-            // Deleted files should still open the diff editor even when openDiffOnClick is false
-            const deletedState = workingCopyGroup.resourceStates.find(
-                (r) => normalize(r.resourceUri.fsPath) === normalize(deletedFilePath),
-            );
-            assert.ok(deletedState, 'Should find resource state for deleted file');
-            assert.strictEqual(
-                deletedState.command?.command,
-                'vscode.diff',
-                'Deleted file should use vscode.diff regardless of openDiffOnClick',
-            );
-        } finally {
-            (vscode.workspace as { getConfiguration: unknown }).getConfiguration = originalGetConfiguration;
-        }
+        // Deleted files should still open the diff editor even when openDiffOnClick is false
+        const deletedState = workingCopyGroup.resourceStates.find(
+            (r) => normalize(r.resourceUri.fsPath) === normalize(deletedFilePath),
+        );
+        assert.ok(deletedState, 'Should find resource state for deleted file');
+        assert.strictEqual(
+            deletedState.command?.command,
+            'vscode.diff',
+            'Deleted file should use vscode.diff regardless of openDiffOnClick',
+        );
     });
 
     test('Shows parent commit changes in separate group', async () => {
@@ -241,7 +228,7 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
         assert.ok(parentGroup.label.startsWith('@-1'), `Label '${parentGroup.label}' should start with '@-1'`);
 
-        const command = resourceState.command;
+        const { command } = resourceState;
         assert.ok(command);
         const [leftUri, rightUri] = command.arguments as vscode.Uri[];
 
@@ -316,47 +303,28 @@ suite('JJ SCM Provider Integration Test', () => {
             },
         ]);
 
-        // Mock config getter
-        const originalGetConfiguration = vscode.workspace.getConfiguration;
-        const configStub = {
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'maxMutableAncestors') {
-                    return 3;
-                }
-                return defaultValue;
-            },
-        };
-        (vscode.workspace as { getConfiguration: unknown }).getConfiguration = (section: string) => {
-            if (section === 'jj-view') {
-                return configStub;
-            }
-            return originalGetConfiguration(section);
-        };
+        stubConfig(sandbox, { maxMutableAncestors: 3 });
 
-        try {
-            await scmProvider.refresh({ forceSnapshot: true });
+        await scmProvider.refresh({ forceSnapshot: true });
 
-            const parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
-            assert.ok(
-                parentGroups.length >= 2,
-                `Should have at least 2 ancestor groups (parent and grandparent), got ${parentGroups.length}`,
-            );
+        const parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
+        assert.ok(
+            parentGroups.length >= 2,
+            `Should have at least 2 ancestor groups (parent and grandparent), got ${parentGroups.length}`,
+        );
 
-            // Parent group (@-1) - This parent has a mutable parent (grandparent), so it should be squashable
-            assert.ok(parentGroups[0].label.startsWith('@-1'), `First group label should start with '@-1'`);
-            assert.ok((parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowSquash));
-            assert.ok(
-                (parentGroups[0].resourceStates[0].contextValue as string).includes(
-                    ScmContextValue.ResourceAllowSquashIntoAncestor,
-                ),
-            );
+        // Parent group (@-1) - This parent has a mutable parent (grandparent), so it should be squashable
+        assert.ok(parentGroups[0].label.startsWith('@-1'), `First group label should start with '@-1'`);
+        assert.ok((parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowSquash));
+        assert.ok(
+            (parentGroups[0].resourceStates[0].contextValue as string).includes(
+                ScmContextValue.ResourceAllowSquashIntoAncestor,
+            ),
+        );
 
-            // Grandparent group (@-2) - Its parent might be the implicit root/initial commit, so we don't strictly assert its squashability here
-            assert.ok(parentGroups[1].label.startsWith('@-2'), `Second group label should start with '@-2'`);
-            assert.ok(parentGroups[1].resourceStates.length > 0, 'Grandparent group should have resources');
-        } finally {
-            (vscode.workspace as { getConfiguration: unknown }).getConfiguration = originalGetConfiguration;
-        }
+        // Grandparent group (@-2) - Its parent might be the implicit root/initial commit, so we don't strictly assert its squashability here
+        assert.ok(parentGroups[1].label.startsWith('@-2'), `Second group label should start with '@-2'`);
+        assert.ok(parentGroups[1].resourceStates.length > 0, 'Grandparent group should have resources');
     });
 
     test('Partial Move to Parent moves selected changes', async () => {
@@ -444,65 +412,35 @@ suite('JJ SCM Provider Integration Test', () => {
         const conflictGroup = accessPrivate(scmProvider, '_conflictGroup') as vscode.SourceControlResourceGroup;
         assert.ok(conflictGroup.resourceStates.length > 0, 'Should have conflicted file');
 
-        let capturedArgs: {
+        const executeStub = stubCommand(sandbox, '_open.mergeEditor', () => null);
+
+        // Call openMergeEditor
+        await scmProvider.openMergeEditor(conflictGroup.resourceStates);
+
+        // Verify the argument format
+        assert.ok(executeStub.calledOnce, 'Should have called _open.mergeEditor');
+        const args = executeStub.firstCall.args[1] as {
             base: vscode.Uri;
             input1: { uri: vscode.Uri };
             input2: { uri: vscode.Uri };
             output: vscode.Uri;
-        } | null = null;
-        const originalExecuteCommand = vscode.commands.executeCommand;
-        const stub = async (command: string, ...args: unknown[]) => {
-            if (command === '_open.mergeEditor') {
-                capturedArgs = args[0] as {
-                    base: vscode.Uri;
-                    input1: { uri: vscode.Uri };
-                    input2: { uri: vscode.Uri };
-                    output: vscode.Uri;
-                };
-                // Don't actually open the editor in tests
-                return;
-            }
-            return originalExecuteCommand.call(vscode.commands, command, ...args);
         };
-        type WritableCommands = { executeCommand: (command: string, ...args: unknown[]) => Thenable<unknown> };
-        (vscode.commands as WritableCommands).executeCommand = stub;
 
-        try {
-            // Call openMergeEditor
-            await scmProvider.openMergeEditor(conflictGroup.resourceStates);
+        // CRITICAL: base must be a plain URI, not an object
+        assert.ok(args.base instanceof vscode.Uri, 'base should be a plain Uri, not an object');
 
-            // Verify the argument format
-            assert.ok(capturedArgs, 'Should have captured _open.mergeEditor arguments');
-            const args = capturedArgs as {
-                base: vscode.Uri;
-                input1: { uri: vscode.Uri };
-                input2: { uri: vscode.Uri };
-                output: vscode.Uri;
-            };
+        // input1 and input2 should be objects with uri property
+        assert.ok(typeof args.input1 === 'object', 'input1 should be an object');
+        assert.ok(args.input1.uri instanceof vscode.Uri, 'input1.uri should be a Uri');
+        assert.ok(typeof args.input2 === 'object', 'input2 should be an object');
+        assert.ok(args.input2.uri instanceof vscode.Uri, 'input2.uri should be a Uri');
 
-            // CRITICAL: base must be a plain URI, not an object
-            assert.ok(args.base instanceof vscode.Uri, 'base should be a plain Uri, not an object');
+        // output should be a URI
+        assert.ok(args.output instanceof vscode.Uri, 'output should be a Uri');
 
-            // input1 and input2 should be objects with uri property
-            assert.ok(typeof args.input1 === 'object', 'input1 should be an object');
-            assert.ok(args.input1.uri instanceof vscode.Uri, 'input1.uri should be a Uri');
-            assert.ok(typeof args.input2 === 'object', 'input2 should be an object');
-            assert.ok(args.input2.uri instanceof vscode.Uri, 'input2.uri should be a Uri');
-
-            // output should be a URI
-            assert.ok(args.output instanceof vscode.Uri, 'output should be a Uri');
-
-            // Verify URI scheme
-            assert.strictEqual(args.base.scheme, 'jj-merge-output', 'base scheme should be jj-merge-output');
-            assert.strictEqual(
-                args.input1.uri.scheme,
-                'jj-merge-output',
-                'input1.uri scheme should be jj-merge-output',
-            );
-        } finally {
-            // Restore original executeCommand
-            (vscode.commands as WritableCommands).executeCommand = originalExecuteCommand;
-        }
+        // Verify URI scheme
+        assert.strictEqual(args.base.scheme, 'jj-merge-output', 'base scheme should be jj-merge-output');
+        assert.strictEqual(args.input1.uri.scheme, 'jj-merge-output', 'input1.uri scheme should be jj-merge-output');
     });
     test('Squash button squashes changes into parent', async () => {
         const filePath = path.join(repo.path, 'squash-test.txt');
@@ -737,55 +675,36 @@ suite('JJ SCM Provider Integration Test', () => {
     });
 
     test('Parent group context value updates when switching between immutable and mutable parents', async () => {
-        // Mock config to only show 1 ancestor for this test
-        const originalGetConfiguration = vscode.workspace.getConfiguration;
-        const configStub = {
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'maxMutableAncestors') {
-                    return 1;
-                }
-                return defaultValue;
-            },
-        };
-        (vscode.workspace as { getConfiguration: unknown }).getConfiguration = (section: string) => {
-            if (section === 'jj-view') {
-                return configStub;
-            }
-            return originalGetConfiguration(section);
-        };
+        stubConfig(sandbox, { maxMutableAncestors: 1 });
 
-        try {
-            // Scenario:
-            // 1. Edit C1 (Parent is Root). Root is Immutable. Group should be 'jjAncestorGroup'.
-            // 2. Edit C2 (Parent is C1). C1 is Mutable. Group should be 'jjAncestorGroup:mutable'.
+        // Scenario:
+        // 1. Edit C1 (Parent is Root). Root is Immutable. Group should be 'jjAncestorGroup'.
+        // 2. Edit C2 (Parent is C1). C1 is Mutable. Group should be 'jjAncestorGroup:mutable'.
 
-            // 1. Create C1 on top of root
-            repo.new(['root()'], 'C1');
-            // Current working copy (@) is C1. Parent is Root.
+        // 1. Create C1 on top of root
+        repo.new(['root()'], 'C1');
+        // Current working copy (@) is C1. Parent is Root.
 
-            await scmProvider.refresh();
-            let parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
-            // Root is immutable, so no parent group should be created
-            assert.strictEqual(parentGroups.length, 0, 'Should have 0 parent groups when parent is immutable');
+        await scmProvider.refresh();
+        let parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
+        // Root is immutable, so no parent group should be created
+        assert.strictEqual(parentGroups.length, 0, 'Should have 0 parent groups when parent is immutable');
 
-            // 2. Create C2 on top of C1
-            repo.new([], 'C2');
-            // Current working copy (@) is C2. Parent is C1.
-            // C1 is a normal commit, so it is mutable.
+        // 2. Create C2 on top of C1
+        repo.new([], 'C2');
+        // Current working copy (@) is C2. Parent is C1.
+        // C1 is a normal commit, so it is mutable.
 
-            await scmProvider.refresh();
-            parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
-            assert.strictEqual(parentGroups.length, 1, 'Should show 1 ancestor group (direct parent)');
+        await scmProvider.refresh();
+        parentGroups = accessPrivate(scmProvider, '_parentGroups') as vscode.SourceControlResourceGroup[];
+        assert.strictEqual(parentGroups.length, 1, 'Should show 1 ancestor group (direct parent)');
 
-            // This is the key assertion: Did the group get the correct context value?
-            assert.ok(
-                (parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowEdit),
-                'Parent (C1) should allow edit',
-            );
-            assert.ok(parentGroups[0].label.includes('C1'), 'Group should be C1');
-        } finally {
-            (vscode.workspace as { getConfiguration: unknown }).getConfiguration = originalGetConfiguration;
-        }
+        // This is the key assertion: Did the group get the correct context value?
+        assert.ok(
+            (parentGroups[0].contextValue as string).includes(ScmContextValue.GroupAllowEdit),
+            'Parent (C1) should allow edit',
+        );
+        assert.ok(parentGroups[0].label.includes('C1'), 'Group should be C1');
     });
 
     test('Verifies comprehensive SCM context values (WorkingCopy, Conflict)', async () => {

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService, NO_OP_LOGGER } from '../jj-service';
-import { buildGraph, TestRepo } from './test-repo';
+import { buildGraph, ScopedTestRepo, TestRepo } from './test-repo';
 
 describe('JjService Unit Tests', () => {
     let jjService: JjService;
@@ -1473,7 +1473,7 @@ log = "none()"
         ]);
 
         // Setup a remote repo and push a bookmark to it to simulate a remote bookmark
-        const remoteRepo = new TestRepo();
+        using remoteRepo = new ScopedTestRepo();
         remoteRepo.init();
 
         repo.addRemote('origin', remoteRepo.path);
@@ -1497,7 +1497,7 @@ log = "none()"
     });
 
     test('getBookmarks with revision filters bookmarks by revision', async () => {
-        const remoteRepo = new TestRepo();
+        using remoteRepo = new ScopedTestRepo();
         remoteRepo.init();
 
         repo.addRemote('origin', remoteRepo.path);

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -13,12 +13,12 @@ vi.mock('vscode', async () => {
 });
 
 // Import after mock
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { CodeForgeRegistry } from '../code-forge-registry';
 import type { JjRepository } from '../jj-repository';
 import { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjScmProvider } from '../jj-scm-provider';
+import { ScopedSymlink, ScopedTempDir } from './scoped-helpers';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
 
@@ -174,35 +174,25 @@ describe('resolveRepository', () => {
         //     └── .jj -> repo.path/.jj (symlink to directory)
 
         // Create a target directory inside the repository
-        const targetDir = fs.realpathSync(fs.mkdtempSync(path.join(repo.path, 'jj-view-nested-')));
+        using nestedDir = new ScopedTempDir(path.join(repo.path, 'jj-view-nested-'));
+        const targetDir = nestedDir.path;
+
         const symlinkPath = path.join(repo.path, 'bazel-core');
         const jjSymlinkPath = path.join(targetDir, '.jj');
 
-        try {
-            // Create symlink: bazel-core -> targetDir
-            fs.symlinkSync(targetDir, symlinkPath, 'dir');
+        // Create symlink: bazel-core -> targetDir
+        using _link1 = new ScopedSymlink(symlinkPath, targetDir, 'dir');
 
-            // Create symlink: targetDir/.jj -> repo.path/.jj
-            fs.symlinkSync(path.join(repo.path, '.jj'), jjSymlinkPath, 'dir');
+        // Create symlink: targetDir/.jj -> repo.path/.jj
+        using _link2 = new ScopedSymlink(jjSymlinkPath, path.join(repo.path, '.jj'), 'dir');
 
-            // Resource URI is inside the symlink path
-            const mockState = { resourceUri: vscode.Uri.file(path.join(symlinkPath, 'file.txt')) };
+        // Resource URI is inside the symlink path
+        const mockState = { resourceUri: vscode.Uri.file(path.join(symlinkPath, 'file.txt')) };
 
-            const result = resolveRepository([mockState], repoManager, scmProviders);
+        const result = resolveRepository([mockState], repoManager, scmProviders);
 
-            expect(result).toBeDefined();
-            expect(result?.repo).toBe(resolvedRepo);
-            expect(result?.scm).toBe(mockScm);
-        } finally {
-            try {
-                fs.unlinkSync(symlinkPath);
-            } catch {}
-            try {
-                fs.unlinkSync(jjSymlinkPath);
-            } catch {}
-            try {
-                fs.rmdirSync(targetDir);
-            } catch {}
-        }
+        expect(result).toBeDefined();
+        expect(result?.repo).toBe(resolvedRepo);
+        expect(result?.scm).toBe(mockScm);
     });
 });

--- a/src/test/scoped-helpers.ts
+++ b/src/test/scoped-helpers.ts
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+
+export class ScopedStub<T extends object, K extends keyof T> implements Disposable {
+    private readonly originalValue: T[K];
+
+    constructor(
+        private readonly target: T,
+        private readonly key: K,
+        stubValue: T[K],
+    ) {
+        this.originalValue = target[key];
+        Reflect.set(target, key, stubValue);
+    }
+
+    [Symbol.dispose]() {
+        Reflect.set(this.target, this.key, this.originalValue);
+    }
+}
+
+export class ScopedSymlink implements Disposable {
+    constructor(
+        public readonly linkPath: string,
+        target: string,
+        type?: fs.symlink.Type,
+    ) {
+        fs.symlinkSync(target, linkPath, type);
+    }
+
+    [Symbol.dispose]() {
+        try {
+            fs.unlinkSync(this.linkPath);
+        } catch {}
+    }
+}
+
+export class ScopedTempDir implements Disposable {
+    public readonly path: string;
+
+    constructor(prefix: string) {
+        this.path = fs.realpathSync(fs.mkdtempSync(prefix));
+    }
+
+    [Symbol.dispose]() {
+        try {
+            fs.rmSync(this.path, { recursive: true, force: true });
+        } catch {}
+    }
+}
+
+export { ScopedTestRepo } from './test-repo';
+
+/**
+ * An async RAII callback wrapper to execute a deferred cleanup action on scope exit.
+ */
+export class ScopedAsyncCallback implements AsyncDisposable {
+    constructor(private readonly callback: () => Promise<void>) {}
+
+    async [Symbol.asyncDispose]() {
+        await this.callback();
+    }
+}
+
+/**
+ * Wraps any object that has a `.dispose()` method in a Proxy implementing the
+ * Explicit Resource Management (ERM) protocol (`Disposable` and `AsyncDisposable`).
+ *
+ * This allows using the resource with native `using` or `await using` declarations
+ * for scoped RAII lifecycle management in tests:
+ *
+ * @example
+ * ```ts
+ * // Synchronous RAII cleanup
+ * using repo = autoCleanup(new TestRepo());
+ *
+ * // Asynchronous RAII cleanup
+ * await using manager = autoCleanup(new JjRepositoryManager(...));
+ * ```
+ *
+ * @param obj The target object containing a `.dispose()` method (sync or async).
+ * @returns A Proxy wrapping the target object that intercepts the ERM symbols
+ * (`Symbol.dispose` / `Symbol.asyncDispose`) to invoke the target's `.dispose()`,
+ * while forwarding all other property accesses and correctly binding methods.
+ */
+export function autoCleanup<T extends { dispose: () => void | Promise<void> }>(
+    obj: T,
+): T & AsyncDisposable & Disposable {
+    return new Proxy(obj, {
+        get(target, prop, receiver) {
+            if (prop === Symbol.dispose) {
+                return () => {
+                    const res = target.dispose();
+                    if (res instanceof Promise) {
+                        res.catch(() => {});
+                    }
+                };
+            }
+            if (prop === Symbol.asyncDispose) {
+                return async () => {
+                    await target.dispose();
+                };
+            }
+            const value = Reflect.get(target, prop, receiver);
+            if (typeof value === 'function') {
+                return value.bind(target);
+            }
+            return value;
+        },
+        set(target, prop, val, receiver) {
+            return Reflect.set(target, prop, val, receiver);
+        },
+        has(target, prop) {
+            return Reflect.has(target, prop);
+        },
+        ownKeys(target) {
+            return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+            return Reflect.getOwnPropertyDescriptor(target, prop);
+        },
+    }) as T & AsyncDisposable & Disposable;
+}

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -32,12 +32,23 @@ merge-editor = "builtin"
 
 writeDefaultConfig(testXdgConfigHome);
 
-process.on('exit', () => {
+function cleanup() {
     for (const dir of tempDirs) {
         try {
             fs.rmSync(dir, { recursive: true, force: true });
         } catch {}
     }
+    tempDirs.clear();
+}
+
+process.on('exit', cleanup);
+process.once('SIGINT', () => {
+    cleanup();
+    process.kill(process.pid, 'SIGINT');
+});
+process.once('SIGTERM', () => {
+    cleanup();
+    process.kill(process.pid, 'SIGTERM');
 });
 
 export class TestRepo {
@@ -50,6 +61,13 @@ export class TestRepo {
         }
         this.path = fs.realpathSync.native ? fs.realpathSync.native(rawPath) : fs.realpathSync(rawPath);
         tempDirs.add(this.path);
+    }
+
+    dispose() {
+        try {
+            fs.rmSync(this.path, { recursive: true, force: true });
+        } catch {}
+        tempDirs.delete(this.path);
     }
 
     // POLICY: This method is intentionally private. Do not expose it publicly.
@@ -601,4 +619,10 @@ export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): P
 
     // Return map
     return labelToId;
+}
+
+export class ScopedTestRepo extends TestRepo implements Disposable {
+    [Symbol.dispose]() {
+        this.dispose();
+    }
 }


### PR DESCRIPTION
- **ERM Cleanup**:
  - Add `ScopedTestRepo` implementing `Disposable` for clean block-scoped repository lifecycles in tests.
  - Update `setWorkspaceFolders` to return an `AsyncDisposable` handle that automatically restores the original workspace state.
  - Transition temporary test repositories and directories to `using` / `await using` blocks across unit and end-to-end suites.
- **Sinon Stub Wrappers**:
  - Add type-safe `stubConfig` and `stubCommand` wrappers in `integration-test-utils` to handle Sinon configurations and commands.
  - Simplify `jj-scm.integration.test.ts` by removing manual suite-level backup state, custom setup/teardown code, and try-finally blocks.
  - Use Sinon's built-in argument recording in `openMergeEditor` to verify executed command arguments instead of capturing to local variables.