### PR TITLE
fix(comments): resolve relative SCM targets by change_id

### DIFF
--- a/src/comments-manager.ts
+++ b/src/comments-manager.ts
@@ -97,7 +97,7 @@ export class CommentsManager implements vscode.Disposable {
             }
             const bookmarks =
                 logEntry.bookmarks?.filter((b: JjBookmark) => !b.remote).map((b: JjBookmark) => b.name) || [];
-            return activeProvider.getCachedChangeInfo(revision, logEntry.description, bookmarks);
+            return activeProvider.getCachedChangeInfo(logEntry.change_id, logEntry.description, bookmarks);
         } catch {
             // Ignore error
         }

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -241,11 +241,15 @@ export class GerritProvider implements CodeForgeProvider {
         }
 
         if (changeId) {
-            try {
-                const hexId = convertJjChangeIdToHex(changeId);
-                return `I${hexId}`;
-            } catch (e) {
-                this.outputChannel?.error(`[GerritProvider] Failed to convert JJ Change-Id: ${e}`);
+            const baseId = changeId.split('/')[0];
+            const isJjChangeId = /^[k-z]+$/.test(baseId);
+            if (isJjChangeId) {
+                try {
+                    const hexId = convertJjChangeIdToHex(changeId);
+                    return `I${hexId}`;
+                } catch (e) {
+                    this.outputChannel?.error(`[GerritProvider] Failed to convert JJ Change-Id: ${e}`);
+                }
             }
         }
         return undefined;

--- a/src/test/comments-manager.test.ts
+++ b/src/test/comments-manager.test.ts
@@ -301,7 +301,10 @@ describe('CommentsManager Tests', () => {
 
         // Construct the manager (triggers initial pull targeting '@')
         commentsManager = new CommentsManager(repositoryManager);
-        expect(await pullWaiter.waitNext()).toBe('@');
+
+        const workingCopyLog1 = await repositoryManager.focusedRepository?.jj.getLog({ revision: '@' });
+        const workingCopyChangeId1 = workingCopyLog1?.[0]?.change_id;
+        expect(await pullWaiter.waitNext()).toBe(workingCopyChangeId1);
 
         // Explicitly target c1 (parent)
         await commentsManager.showCommentsForChange(c1ChangeId);
@@ -319,7 +322,9 @@ describe('CommentsManager Tests', () => {
         testRepo.new();
 
         // Wait for the automatic background pull to happen and target the new working copy
-        expect(await pullWaiter.waitNext()).toBe('@');
+        const workingCopyLog2 = await repositoryManager.focusedRepository?.jj.getLog({ revision: '@' });
+        const workingCopyChangeId2 = workingCopyLog2?.[0]?.change_id;
+        expect(await pullWaiter.waitNext()).toBe(workingCopyChangeId2);
 
         // explicitChangeId should be cleared to undefined
         expect(accessPrivate<string | undefined>(commentsManager, 'explicitChangeId')).toBeUndefined();
@@ -330,7 +335,7 @@ describe('CommentsManager Tests', () => {
         commentsManager.dispose();
 
         // Build c1 (parent, normal commit) and c2 (working copy, with 'no-change' in description)
-        await buildGraph(testRepo, [
+        const ids = await buildGraph(testRepo, [
             { label: 'c1', description: 'Normal parent commit with comments' },
             { label: 'c2', parents: ['c1'], description: 'Working copy with no-change' },
         ]);
@@ -339,8 +344,8 @@ describe('CommentsManager Tests', () => {
         const pullWaiter = provider.createCommentThreadsWaiter();
         commentsManager = new CommentsManager(repositoryManager);
 
-        // Wait for the automatic background pull to happen and target the parent
-        expect(await pullWaiter.waitNext()).toBe('@-');
+        // Wait for the automatic background pull to happen and target the parent c1
+        expect(await pullWaiter.waitNext()).toBe(ids.c1.changeId);
     });
 
     test('should safely handle malformed avatar URLs', async () => {

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -83,6 +83,31 @@ describe('GerritProvider', () => {
         expect(accessPrivate(provider, 'gerritHost')).toBeUndefined();
     });
 
+    test('resolveCacheKey returns undefined for non-JJ values without conversion', () => {
+        const resolveKey = exposePrivate<{
+            resolveCacheKey(changeId?: string, description?: string): string | undefined;
+        }>(provider).resolveCacheKey.bind(provider);
+
+        expect(resolveKey('@')).toBeUndefined();
+        expect(resolveKey('@-')).toBeUndefined();
+        expect(resolveKey('d239d787')).toBeUndefined();
+        expect(resolveKey(undefined)).toBeUndefined();
+        expect(resolveKey('')).toBeUndefined();
+    });
+
+    test('resolveCacheKey converts valid JJ Change-Ids (including suffixes) as expected', () => {
+        const resolveKey = exposePrivate<{
+            resolveCacheKey(changeId?: string, description?: string): string | undefined;
+        }>(provider).resolveCacheKey.bind(provider);
+
+        // JJ Change-Ids (k-z letters) without suffix should convert successfully
+        expect(resolveKey('zzzz')).toBe('I0000');
+        expect(resolveKey('yyyy')).toBe('I1111');
+
+        // JJ Change-Ids with suffixes should be split on "/" before conversion
+        expect(resolveKey('zzzz/123')).toBe('I0000');
+    });
+
     test('fetchStatuses preserves cache on transient fetchBatchFromNetwork error', async () => {
         setPrivate(provider, 'gerritHost', 'https://my-gerrit-host.com');
 


### PR DESCRIPTION
- Pass `logEntry.change_id` instead of the raw `revision` name to `getCachedChangeInfo` in `CommentsManager.resolveChangeInfo`. This ensures that relative targets like `@` and `@-` correctly resolve their change info without relying on explicit `Change-Id` trailers in local descriptions.
- Guard the Gerrit provider's `resolveCacheKey` by validating that the `changeId` matches the Jujutsu Change-Id character range (`k-z`) before executing hex conversion. This prevents conversion errors for relative revision names and commit SHAs.
- Update `comments-manager.test.ts` to assert that the manager retrieves comments using resolved Jujutsu change IDs instead of the raw `@` and `@-` revision strings.
- Add unit test coverage in `gerrit-provider.test.ts` to verify `resolveCacheKey` gracefully ignores `@`, `@-`, and hexadecimal commit SHAs.