### PR TITLE
ci: upload packaged VSIX as a uniquely named workflow artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,28 @@ jobs:
             - name: Verify VSIX Contents
               run: node tooling/verify-vsix.ts jj-view.vsix
 
+            - name: Generate Unique VSIX Name
+              id: vsix_info
+              run: |
+                  SAFE_REF=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9.-]/-/g')
+                  SUFFIX="run${{ github.run_number }}-${{ github.run_attempt }}"
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    BASE_NAME="jj-view-pr${{ github.event.number }}-${SUFFIX}"
+                  else
+                    BASE_NAME="jj-view-${SAFE_REF}-${SUFFIX}"
+                  fi
+                  echo "vsix_name=${BASE_NAME}.vsix" >> $GITHUB_OUTPUT
+                  cp jj-view.vsix "${BASE_NAME}.vsix"
+
+            - name: Upload VSIX Artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  path: ${{ steps.vsix_info.outputs.vsix_name }}
+                  archive: false
+                  retention-days: 7
+
             - name: Upload Build Artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: build-outputs
                   path: |
@@ -123,7 +143,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Download Build Artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
@@ -172,7 +192,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Download Build Artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
@@ -225,7 +245,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Download Build Artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
@@ -240,7 +260,7 @@ jobs:
 
             - name: Upload Playwright Report
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report
                   path: playwright-report/
@@ -248,7 +268,7 @@ jobs:
 
             - name: Upload E2E Test Results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: e2e-test-results
                   path: test-results/
@@ -267,7 +287,7 @@ jobs:
                   fetch-depth: 0
 
             - name: Download Build Artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
@@ -307,7 +327,7 @@ jobs:
                   echo "EOF" >> $GITHUB_OUTPUT
 
             - name: Upload Persistent Artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: jj-view-extension-packaged
                   path: ${{ steps.release_info.outputs.vsix_name }}


### PR DESCRIPTION
This adds steps in the CI build process (`prepare` job) to copy the compiled extension to a uniquely named VSIX file (incorporating either the PR number or the sanitized branch name and a timestamp) and upload it as a standalone artifact. The artifact is retained for 7 days to allow easy testing from PR builds without cluttering GitHub Actions storage indefinitely.