### PR TITLE
feat(gerrit): support authenticated API calls

### DIFF
--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -32,7 +32,7 @@ export class CodeForgeService implements vscode.Disposable {
     private activeProviderInstance: CodeForgeProvider | undefined;
 
     constructor(
-        private workspaceRoot: string,
+        public readonly workspaceRoot: string,
         private jjService: JjService,
         private registry: CodeForgeRegistry,
         private outputChannel?: JjLoggerChannel,
@@ -181,20 +181,21 @@ export class CodeForgeService implements vscode.Disposable {
     private async doDetectActiveProvider(): Promise<void> {
         try {
             const remotes = await this.jjService.getGitRemotes();
+            const repoRoot = await this.jjService.getRepoRoot();
             const preferredId = vscode.workspace.getConfiguration('jj-view').get<string>('codeForge.provider');
 
             let detectedProvider: CodeForgeProvider | undefined;
 
             if (preferredId) {
                 const provider = this.providers.get(preferredId);
-                if (provider && (await provider.detect(this.workspaceRoot, remotes))) {
+                if (provider && (await provider.detect(repoRoot, remotes))) {
                     detectedProvider = provider;
                 }
             }
 
             if (!detectedProvider) {
                 for (const provider of this.providers.values()) {
-                    if (await provider.detect(this.workspaceRoot, remotes)) {
+                    if (await provider.detect(repoRoot, remotes)) {
                         detectedProvider = provider;
                         break;
                     }

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -2,8 +2,6 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import * as fs from 'node:fs';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { z } from 'zod';
 import type {
@@ -17,6 +15,8 @@ import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
+import { getGerritAuthHeader, resolveGitRoot } from './utils/gerrit-credential-utils';
+import { detectGerritHost } from './utils/gerrit-host-detection';
 import { resolveGerritChangeKey, stripGerritTrailers } from './utils/gerrit-utils';
 import { convertJjChangeIdToHex } from './utils/jj-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
@@ -75,6 +75,10 @@ interface GerritCommentGql {
     in_reply_to?: string;
 }
 
+interface FetchGerritOptions extends RequestInit {
+    timeoutMs?: number;
+}
+
 export class GerritProvider implements CodeForgeProvider {
     public readonly id = 'gerrit';
     public readonly displayName = 'Gerrit';
@@ -82,118 +86,45 @@ export class GerritProvider implements CodeForgeProvider {
 
     private cache = new Map<string, CodeForgeChangeInfo>();
     private gerritHost: string | undefined;
+    private repoRoot: string | undefined;
+    private gitRoot: string | null = null;
+    private authHeader: { name: string; value: string } | undefined;
+    private authChecked = false;
 
     private _onDidUpdate = new vscode.EventEmitter<void>();
     public readonly onDidUpdate = this._onDidUpdate.event;
 
     constructor(private outputChannel?: JjLoggerChannel) {}
 
-    public async detect(workspaceRoot: string, remotes: GitRemote[]): Promise<boolean> {
-        const detectedHost = vscode.workspace.getConfiguration('jj-view').get<string>('gerrit.host')?.trim();
-        if (detectedHost) {
-            const host = detectedHost.replace(/\/$/, '');
+    public async detect(repoRoot: string, remotes: GitRemote[]): Promise<boolean> {
+        const binaryPath = vscode.workspace.getConfiguration('jj-view').get<string>('binaryPath') || 'jj';
+        const gitRoot = await resolveGitRoot(repoRoot, binaryPath);
+
+        if (this.repoRoot !== repoRoot) {
+            this.clearCache();
+            this.repoRoot = repoRoot;
+            this.gitRoot = gitRoot;
+        } else if (gitRoot !== null) {
+            if (this.gitRoot !== gitRoot) {
+                this.clearCache();
+            }
+            this.gitRoot = gitRoot;
+        }
+
+        const host = await detectGerritHost(
+            repoRoot,
+            this.gitRoot,
+            remotes,
+            (h: string) => this.probeGerritHost(h),
+            this.outputChannel,
+        );
+
+        if (host) {
             if (this.gerritHost !== host) {
                 this.clearCache();
             }
             this.gerritHost = host;
             return true;
-        }
-
-        // Check .gitreview file
-        try {
-            const gitreviewPath = path.join(workspaceRoot, '.gitreview');
-            if (fs.existsSync(gitreviewPath)) {
-                const content = await fs.promises.readFile(gitreviewPath, 'utf8');
-                const match = content.match(/host=(.+)/);
-                if (match?.[1]) {
-                    let host = match[1].trim();
-                    if (!host.startsWith('http')) {
-                        host = `https://${host}`;
-                    }
-                    const cleanHost = host.replace(/\/$/, '');
-                    if (this.gerritHost !== cleanHost) {
-                        this.clearCache();
-                    }
-                    this.gerritHost = cleanHost;
-                    return true;
-                }
-            }
-        } catch (e) {
-            this.outputChannel?.error(`[GerritProvider] Failed to parse .gitreview: ${e}`);
-        }
-
-        // Check git remotes via jj
-        // Prioritize 'origin', then 'gerrit', then others
-        const origin = remotes.find((r) => r.name === 'origin');
-        const gerrit = remotes.find((r) => r.name === 'gerrit');
-
-        const sortedRemotes = [];
-        if (origin) {
-            sortedRemotes.push(origin);
-        }
-        if (gerrit) {
-            sortedRemotes.push(gerrit);
-        }
-        remotes.forEach((r) => {
-            if (r.name !== 'origin' && r.name !== 'gerrit') {
-                sortedRemotes.push(r);
-            }
-        });
-
-        for (const { name, url } of sortedRemotes) {
-            this.outputChannel?.info(`[GerritProvider] Checking remote '${name}' URL: '${url}'`);
-
-            let host: string | undefined;
-
-            if (url.includes('googlesource.com') || url.includes('/gerrit/')) {
-                host = url;
-            } else if (url.startsWith('sso://')) {
-                const match = url.match(/sso:\/\/([^/]+)\/(.+)/);
-                if (match) {
-                    host = `https://${match[1]}.googlesource.com/${match[2]}`;
-                }
-            }
-
-            if (host) {
-                if (host.startsWith('ssh://')) {
-                    const match = host.match(/ssh:\/\/([^@]+@)?([^:/]+)(:\d+)?\/(.+)/);
-                    if (match) {
-                        host = `https://${match[2]}`;
-                    }
-                }
-
-                if (host.endsWith('.git')) {
-                    host = host.slice(0, -4);
-                }
-
-                if (host.includes('googlesource.com')) {
-                    try {
-                        const urlObj = new URL(host);
-                        host = urlObj.origin;
-                    } catch {
-                        if (!host.startsWith('http')) {
-                            const match = host.match(/([a-zA-Z0-9-]+\.googlesource\.com)/);
-                            if (match) {
-                                host = `https://${match[1]}`;
-                            }
-                        }
-                    }
-                }
-
-                if (host.includes('googlesource.com') && !host.includes('-review')) {
-                    host = host.replace('.googlesource.com', '-review.googlesource.com');
-                }
-
-                if (await this.probeGerritHost(host)) {
-                    if (this.gerritHost !== host) {
-                        this.clearCache();
-                    }
-                    this.gerritHost = host;
-                    return true;
-                } else {
-                    this.outputChannel?.error(`[GerritProvider] Probe failed for host: ${host}`);
-                }
-            }
         }
 
         this.gerritHost = undefined;
@@ -208,6 +139,45 @@ export class GerritProvider implements CodeForgeProvider {
             this.outputChannel?.error(`[GerritProvider] Probe error for host ${host}: ${e}`);
             return false;
         }
+    }
+
+    private async getAuthHeader(): Promise<{ name: string; value: string } | undefined> {
+        if (!this.gerritHost || !this.repoRoot) {
+            return undefined;
+        }
+        if (this.authChecked) {
+            return this.authHeader;
+        }
+        this.authChecked = true;
+        this.authHeader = await getGerritAuthHeader(this.gerritHost, this.gitRoot, this.outputChannel);
+        return this.authHeader;
+    }
+
+    private async fetchGerrit(url: string, options?: FetchGerritOptions): Promise<Response> {
+        const auth = await this.getAuthHeader();
+        let finalUrl = url;
+        const headers = new Headers(options?.headers);
+
+        if (auth) {
+            headers.set(auth.name, auth.value);
+            // Rewrite /changes/ to /a/changes/ to force Gerrit to authenticate
+            try {
+                const parsedUrl = new URL(url);
+                if (parsedUrl.pathname.startsWith('/changes/') && !parsedUrl.pathname.startsWith('/a/')) {
+                    parsedUrl.pathname = `/a${parsedUrl.pathname}`;
+                    finalUrl = parsedUrl.toString();
+                }
+            } catch {
+                // Handle relative URL (e.g. '/changes/...')
+                if (url.startsWith('/changes/') && !url.startsWith('/a/')) {
+                    finalUrl = `/a${url}`;
+                }
+            }
+        }
+
+        const timeout = options?.timeoutMs ?? 15000;
+        this.outputChannel?.debug(`[GerritProvider] fetchGerrit: ${finalUrl} (auth: ${!!auth})`);
+        return fetchWithTimeout(finalUrl, timeout, { ...options, headers });
     }
 
     public getCachedChangeInfo(
@@ -354,7 +324,7 @@ export class GerritProvider implements CodeForgeProvider {
 
         const urlStr = `${baseUrl}?${params.toString()}`;
         this.outputChannel?.info(`[GerritProvider] GET ${urlStr}`);
-        const response = await fetchWithTimeout(urlStr, 15000);
+        const response = await this.fetchGerrit(urlStr);
         if (!response.ok) {
             throw new Error(`Batch request failed with status: ${response.status}`);
         }
@@ -394,7 +364,7 @@ export class GerritProvider implements CodeForgeProvider {
             return [];
         }
 
-        const data = validation.data;
+        const { data } = validation;
         return this.isBatchResponse(data) ? data : [data as GerritChange[]];
     }
 
@@ -455,10 +425,12 @@ export class GerritProvider implements CodeForgeProvider {
             return;
         }
 
-        if (info.remoteDescription && description) {
-            if (stripGerritTrailers(description) !== stripGerritTrailers(info.remoteDescription)) {
-                return;
-            }
+        if (
+            info.remoteDescription &&
+            description &&
+            stripGerritTrailers(description) !== stripGerritTrailers(info.remoteDescription)
+        ) {
+            return;
         }
 
         const gerritFiles = info.files;
@@ -509,7 +481,7 @@ export class GerritProvider implements CodeForgeProvider {
         }
 
         const url = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const response = await fetchWithTimeout(url, 15000, { signal });
+        const response = await this.fetchGerrit(url, { signal });
         if (!response.ok) {
             throw new Error(`Failed to fetch Gerrit comments: ${response.statusText}`);
         }
@@ -581,7 +553,7 @@ export class GerritProvider implements CodeForgeProvider {
 
         // Fetch comments to locate parent file path and line
         const commentsUrl = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const commentsResponse = await fetchWithTimeout(commentsUrl, 15000);
+        const commentsResponse = await this.fetchGerrit(commentsUrl);
         if (!commentsResponse.ok) {
             throw new Error(`Failed to fetch comments to locate parent: ${commentsResponse.statusText}`);
         }
@@ -605,7 +577,7 @@ export class GerritProvider implements CodeForgeProvider {
 
         // Post review with comment reply
         const reviewUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/review`;
-        const response = await fetchWithTimeout(reviewUrl, 15000, {
+        const response = await this.fetchGerrit(reviewUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -631,7 +603,7 @@ export class GerritProvider implements CodeForgeProvider {
         }
 
         // Re-fetch to retrieve the newly posted comment
-        const updatedCommentsResponse = await fetchWithTimeout(commentsUrl, 15000);
+        const updatedCommentsResponse = await this.fetchGerrit(commentsUrl);
         if (!updatedCommentsResponse.ok) {
             throw new Error('Failed to retrieve updated comments');
         }
@@ -672,7 +644,7 @@ export class GerritProvider implements CodeForgeProvider {
 
         // Fetch comments to locate parent file path and line
         const commentsUrl = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const commentsResponse = await fetchWithTimeout(commentsUrl, 15000);
+        const commentsResponse = await this.fetchGerrit(commentsUrl);
         if (!commentsResponse.ok) {
             throw new Error(`Failed to fetch comments to locate parent: ${commentsResponse.statusText}`);
         }
@@ -696,7 +668,7 @@ export class GerritProvider implements CodeForgeProvider {
 
         // Post review with a resolution reply comment
         const reviewUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/review`;
-        const response = await fetchWithTimeout(reviewUrl, 15000, {
+        const response = await this.fetchGerrit(reviewUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -724,6 +696,8 @@ export class GerritProvider implements CodeForgeProvider {
 
     public clearCache(): void {
         this.cache.clear();
+        this.authHeader = undefined;
+        this.authChecked = false;
         this._onDidUpdate.fire();
     }
 

--- a/src/test/gerrit-credential-utils.test.ts
+++ b/src/test/gerrit-credential-utils.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import {
+    getGerritAuthHeader,
+    getGitCookies,
+    getGitCredential,
+    matchCookieDomain,
+    resolveGitRoot,
+} from '../utils/gerrit-credential-utils';
+import { TestRepo } from './test-repo';
+
+describe('Credential Utils', () => {
+    let tempDir: string;
+    let repo: TestRepo | undefined;
+
+    beforeEach(async () => {
+        repo = undefined;
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jj-view-cred-test-'));
+    });
+
+    afterEach(async () => {
+        if (repo) {
+            repo.dispose();
+        }
+        try {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // Ignore
+        }
+    });
+
+    describe('resolveGitRoot', () => {
+        test('resolves git directory of a real jj repo', async () => {
+            repo = new TestRepo();
+            repo.init();
+
+            const gitRoot = await resolveGitRoot(repo.path);
+            expect(gitRoot).not.toBeNull();
+            expect(gitRoot).toBe(path.join(repo.path, '.git'));
+        });
+
+        test('returns null when not in a jj repo', async () => {
+            const result = await resolveGitRoot(tempDir);
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('matchCookieDomain', () => {
+        test('matches exact hostnames case insensitively', () => {
+            expect(matchCookieDomain('gerrit.example.com', 'gerrit.example.com')).toBe(true);
+            expect(matchCookieDomain('GERRIT.example.com', 'gerrit.EXAMPLE.com')).toBe(true);
+            expect(matchCookieDomain('gerrit.example.com', 'other.com')).toBe(false);
+        });
+
+        test('matches subdomains for wildcard cookie domains', () => {
+            expect(matchCookieDomain('gerrit.example.com', '.example.com')).toBe(true);
+            expect(matchCookieDomain('example.com', '.example.com')).toBe(true);
+            expect(matchCookieDomain('sub.gerrit.example.com', '.example.com')).toBe(true);
+            expect(matchCookieDomain('other.com', '.example.com')).toBe(false);
+        });
+    });
+
+    describe('getGitCookies', () => {
+        test('reads cookies from configured git cookiefile', async () => {
+            const gitDir = path.join(tempDir, 'git-repo.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const cookieFile = path.join(tempDir, 'cookies.txt');
+            await fs.writeFile(
+                cookieFile,
+                '# Netscape HTTP Cookie File\n' +
+                    'gerrit.example.com\tFALSE\t/\tTRUE\t0\to\tusername=password\n' +
+                    '.other.com\tTRUE\t/\tTRUE\t0\tauth\ttoken_val\n',
+            );
+
+            cp.execSync(`git --git-dir="${gitDir}" config http.cookiefile "${cookieFile}"`);
+
+            const cookies = await getGitCookies(gitDir, 'gerrit.example.com');
+            expect(cookies).toBe('o=username=password');
+        });
+
+        test('returns null if no cookies file exists', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-empty.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const cookies = await getGitCookies(gitDir, 'gerrit.example.com');
+            expect(cookies).toBeNull();
+        });
+    });
+
+    describe('getGitCredential', () => {
+        test('invokes git credential fill and parses output', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-cred.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            cp.execSync(
+                `git --git-dir="${gitDir}" config credential.helper "!f() { echo username=testuser; echo password=testpassword; }; f"`,
+            );
+
+            const creds = await getGitCredential(gitDir, 'gerrit.example.com');
+            expect(creds).toEqual({ username: 'testuser', password: 'testpassword' });
+        });
+
+        test('returns null when credential helper returns no password', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-cred-nopw.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            cp.execSync(`git --git-dir="${gitDir}" config credential.helper "!f() { echo username=testuser; }; f"`);
+
+            const creds = await getGitCredential(gitDir, 'gerrit.example.com');
+            expect(creds).toBeNull();
+        });
+
+        test('returns null when git credential helper invocation fails', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-cred-fail.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            cp.execSync(`git --git-dir="${gitDir}" config credential.helper "!f() { exit 1; }; f"`);
+
+            const creds = await getGitCredential(gitDir, 'gerrit.example.com');
+            expect(creds).toBeNull();
+        });
+    });
+
+    describe('getGerritAuthHeader', () => {
+        test('prioritizes LUCI token if present', async () => {
+            const isWindows = process.platform === 'win32';
+            const scriptName = isWindows ? 'luci-auth.cmd' : 'luci-auth';
+            const scriptPath = path.join(tempDir, scriptName);
+
+            if (isWindows) {
+                await fs.writeFile(
+                    scriptPath,
+                    '@echo off\r\n' +
+                        'if "%1"=="token" if "%2"=="-scopes" (\r\n' +
+                        '  echo fake_luci_token_123\r\n' +
+                        '  exit /b 0\r\n' +
+                        ')\r\n' +
+                        'exit /b 1\r\n',
+                );
+            } else {
+                await fs.writeFile(
+                    scriptPath,
+                    '#!/bin/sh\n' +
+                        'if [ "$1" = "token" ] && [ "$2" = "-scopes" ]; then\n' +
+                        '  echo "fake_luci_token_123"\n' +
+                        '  exit 0\n' +
+                        'fi\n' +
+                        'exit 1\n',
+                );
+                await fs.chmod(scriptPath, 0o755);
+            }
+
+            const originalPath = process.env.PATH;
+            const originalLuciContext = process.env.LUCI_CONTEXT;
+
+            process.env.PATH = `${tempDir}${path.delimiter}${originalPath}`;
+            process.env.LUCI_CONTEXT = '{"some":"context"}';
+
+            try {
+                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                expect(header).toEqual({ name: 'Authorization', value: 'Bearer fake_luci_token_123' });
+            } finally {
+                process.env.PATH = originalPath;
+                process.env.LUCI_CONTEXT = originalLuciContext;
+            }
+        });
+
+        test('uses Google SSO helper if available', async () => {
+            const isWindows = process.platform === 'win32';
+            const scriptName = isWindows ? 'git-remote-sso.cmd' : 'git-remote-sso';
+            const scriptPath = path.join(tempDir, scriptName);
+
+            const extraConfig = path.join(tempDir, 'extra_headers.config');
+            await fs.writeFile(extraConfig, 'extraHeader = Authorization: Basic c3NvX3VzZXI6c3NvX3Bhc3M=\n');
+
+            if (isWindows) {
+                await fs.writeFile(
+                    scriptPath,
+                    '@echo off\r\n' +
+                        'if "%1"=="-print_config" (\r\n' +
+                        `  echo include.path=${extraConfig}\r\n` +
+                        '  exit /b 0\r\n' +
+                        ')\r\n' +
+                        'exit /b 1\r\n',
+                );
+            } else {
+                await fs.writeFile(
+                    scriptPath,
+                    '#!/bin/sh\n' +
+                        'if [ "$1" = "-print_config" ]; then\n' +
+                        `  echo "include.path=${extraConfig}"\n` +
+                        '  exit 0\n' +
+                        'fi\n' +
+                        'exit 1\n',
+                );
+                await fs.chmod(scriptPath, 0o755);
+            }
+
+            const originalPath = process.env.PATH;
+            process.env.PATH = `${tempDir}${path.delimiter}${originalPath}`;
+
+            try {
+                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                expect(header).toEqual({ name: 'Authorization', value: 'Basic c3NvX3VzZXI6c3NvX3Bhc3M=' });
+            } finally {
+                process.env.PATH = originalPath;
+            }
+        });
+
+        test('uses GCE Metadata if available', async () => {
+            const server = http.createServer((req, res) => {
+                if (req.url === '/') {
+                    res.writeHead(200, { 'Metadata-Flavor': 'Google', 'Content-Type': 'text/plain' });
+                    res.end('OK');
+                } else if (req.url === '/computeMetadata/v1/instance/service-accounts/default/token') {
+                    res.writeHead(200, { 'Metadata-Flavor': 'Google', 'Content-Type': 'application/json' });
+                    res.end(JSON.stringify({ token_type: 'Bearer', access_token: 'fake_gce_token_789' }));
+                } else {
+                    res.writeHead(404);
+                    res.end();
+                }
+            });
+
+            const port = await new Promise<number>((resolve) => {
+                server.listen(0, '127.0.0.1', () => {
+                    const address = server.address();
+                    if (address && typeof address !== 'string') {
+                        resolve(address.port);
+                    }
+                });
+            });
+
+            const originalGceHost = process.env.GCE_METADATA_HOST;
+            process.env.GCE_METADATA_HOST = `http://127.0.0.1:${port}`;
+
+            try {
+                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                expect(header).toEqual({ name: 'Authorization', value: 'Bearer fake_gce_token_789' });
+            } finally {
+                process.env.GCE_METADATA_HOST = originalGceHost;
+                server.close();
+            }
+        });
+
+        test('prioritizes git cookies (Bearer format)', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-header-cookie.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const cookieFile = path.join(tempDir, 'cookies.txt');
+            await fs.writeFile(cookieFile, 'gerrit.example.com\tFALSE\t/\tTRUE\t0\to\tcookieval\n');
+            cp.execSync(`git --git-dir="${gitDir}" config http.cookiefile "${cookieFile}"`);
+
+            const header = await getGerritAuthHeader('https://gerrit.example.com', gitDir);
+            expect(header).toEqual({ name: 'Authorization', value: 'Bearer cookieval' });
+        });
+
+        test('prioritizes git cookies (Basic format with git- prefix)', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-header-cookie-basic.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const cookieFile = path.join(tempDir, 'cookies.txt');
+            await fs.writeFile(cookieFile, 'gerrit.example.com\tFALSE\t/\tTRUE\t0\to\tgit-user=pass123\n');
+            cp.execSync(`git --git-dir="${gitDir}" config http.cookiefile "${cookieFile}"`);
+
+            const header = await getGerritAuthHeader('https://gerrit.example.com', gitDir);
+            const expectedAuth = Buffer.from('git-user:pass123').toString('base64');
+            expect(header).toEqual({ name: 'Authorization', value: `Basic ${expectedAuth}` });
+        });
+
+        test('falls back to credential helper basic auth', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-header-helper.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            cp.execSync(
+                `git --git-dir="${gitDir}" config credential.helper "!f() { echo username=git-luci; echo password=token123; }; f"`,
+            );
+
+            const header = await getGerritAuthHeader('https://gerrit.example.com', gitDir);
+            const expectedAuth = Buffer.from('git-luci:token123').toString('base64');
+            expect(header).toEqual({ name: 'Authorization', value: `Basic ${expectedAuth}` });
+        });
+
+        test('supports non-URL host strings', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-header-non-url.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const cookieFile = path.join(tempDir, 'cookies.txt');
+            await fs.writeFile(cookieFile, 'gerrit.example.com\tFALSE\t/\tTRUE\t0\to\tcookieval\n');
+            cp.execSync(`git --git-dir="${gitDir}" config http.cookiefile "${cookieFile}"`);
+
+            const header = await getGerritAuthHeader('gerrit.example.com', gitDir);
+            expect(header).toEqual({ name: 'Authorization', value: 'Bearer cookieval' });
+        });
+
+        test('returns undefined when no auth is available', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-header-noauth.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const header = await getGerritAuthHeader('https://gerrit.example.com', gitDir);
+            expect(header).toBeUndefined();
+        });
+    });
+});

--- a/src/test/gerrit-host-detection.test.ts
+++ b/src/test/gerrit-host-detection.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { detectGerritHost, normalizeHostUrl, parseRemoteUrl } from '../utils/gerrit-host-detection';
+import { createMock } from './test-utils';
+
+vi.mock('vscode', () => ({
+    workspace: {
+        getConfiguration: vi.fn(() => ({
+            get: vi.fn(),
+        })),
+    },
+}));
+
+function mockGerritHostSetting(value: string | undefined): void {
+    vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
+        createMock<vscode.WorkspaceConfiguration>({
+            get: (key: string) => {
+                if (key === 'gerrit.host') {
+                    return value;
+                }
+                return undefined;
+            },
+        }),
+    );
+}
+
+describe('Gerrit Host Detection Utilities', () => {
+    describe('normalizeHostUrl', () => {
+        test('prepends protocol, trims trailing slashes', () => {
+            expect(normalizeHostUrl('gerrit.example.com/')).toBe('https://gerrit.example.com');
+            expect(normalizeHostUrl('http://gerrit.example.com//')).toBe('http://gerrit.example.com');
+        });
+
+        test('extracts origin for googlesource.com hosts', () => {
+            expect(normalizeHostUrl('https://chromium.googlesource.com/chromium/src')).toBe(
+                'https://chromium.googlesource.com',
+            );
+        });
+
+        test('preserves paths for non-googlesource.com hosts', () => {
+            expect(normalizeHostUrl('https://git.eclipse.org/gerrit/p/platform')).toBe(
+                'https://git.eclipse.org/gerrit/p/platform',
+            );
+        });
+    });
+
+    describe('parseRemoteUrl', () => {
+        test('handles googlesource.com and /gerrit/ URLs', () => {
+            expect(parseRemoteUrl('https://chromium.googlesource.com/chromium/src.git')).toBe(
+                'https://chromium-review.googlesource.com',
+            );
+            expect(parseRemoteUrl('https://git.eclipse.org/gerrit/p/platform.git')).toBe(
+                'https://git.eclipse.org/gerrit/p/platform',
+            );
+        });
+
+        test('handles sso:// URLs', () => {
+            expect(parseRemoteUrl('sso://chromium/chromium/src.git')).toBe('https://chromium-review.googlesource.com');
+        });
+
+        test('handles ssh:// URLs', () => {
+            expect(parseRemoteUrl('ssh://user@gerrit.example.com:29418/gerrit/project')).toBe(
+                'https://gerrit.example.com',
+            );
+        });
+
+        test('handles persistent-https:// and rpc:// URLs', () => {
+            expect(parseRemoteUrl('persistent-https://chromium.googlesource.com/chromium/src')).toBe(
+                'https://chromium-review.googlesource.com',
+            );
+            expect(parseRemoteUrl('rpc://chromium.googlesource.com/chromium/src')).toBe(
+                'https://chromium-review.googlesource.com',
+            );
+        });
+
+        test('handles SCP-like ssh URLs', () => {
+            expect(parseRemoteUrl('user@gerrit.example.com:gerrit/project.git')).toBe('https://gerrit.example.com');
+        });
+
+        test('returns undefined for non-Gerrit remote URLs', () => {
+            expect(parseRemoteUrl('https://github.com/owner/repo.git')).toBeUndefined();
+        });
+    });
+
+    describe('detectGerritHost', () => {
+        let tempDir: string;
+        let gitRoot: string;
+        let mockProbe: Mock<(host: string) => Promise<boolean>>;
+
+        beforeEach(async () => {
+            tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-host-detection-test-'));
+            gitRoot = path.join(tempDir, '.git');
+            mockProbe = vi.fn().mockResolvedValue(true);
+        });
+
+        afterEach(async () => {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        });
+
+        test('detects from workspace configuration setting first', async () => {
+            mockGerritHostSetting('setting.example.com');
+
+            const host = await detectGerritHost(tempDir, null, [], mockProbe);
+            expect(host).toBe('https://setting.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://setting.example.com');
+        });
+
+        test('detects from git configuration as fallback', async () => {
+            // Setup Git repo with config
+            cp.execSync(`git init --bare "${gitRoot}"`);
+            cp.execSync(`git --git-dir="${gitRoot}" config gerrit.host "git-config-host.example.com"`);
+
+            mockGerritHostSetting(undefined);
+
+            const host = await detectGerritHost(tempDir, gitRoot, [], mockProbe);
+            expect(host).toBe('https://git-config-host.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://git-config-host.example.com');
+        });
+
+        test('detects from .gitreview file as fallback', async () => {
+            mockGerritHostSetting(undefined);
+
+            await fs.writeFile(path.join(tempDir, '.gitreview'), '[gerrit]\nhost=review.example.com\n');
+
+            const host = await detectGerritHost(tempDir, null, [], mockProbe);
+            expect(host).toBe('https://review.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://review.example.com');
+        });
+
+        test('detects and sorts git remotes as fallback', async () => {
+            mockGerritHostSetting(undefined);
+
+            const remotes = [
+                { name: 'other', url: 'https://github.com/owner/repo.git' },
+                { name: 'origin', url: 'https://chromium.googlesource.com/chromium/src.git' },
+            ];
+
+            const host = await detectGerritHost(tempDir, null, remotes, mockProbe);
+            expect(host).toBe('https://chromium-review.googlesource.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://chromium-review.googlesource.com');
+        });
+
+        test('falls back to next source when probe fails', async () => {
+            // Setting host fails probing, but git config host succeeds probing
+            mockGerritHostSetting('stale-setting.example.com');
+
+            cp.execSync(`git init --bare "${gitRoot}"`);
+            cp.execSync(`git --git-dir="${gitRoot}" config gerrit.host "valid-git-host.example.com"`);
+
+            mockProbe.mockImplementation(async (h: string) => {
+                return h === 'https://valid-git-host.example.com';
+            });
+
+            const host = await detectGerritHost(tempDir, gitRoot, [], mockProbe);
+            expect(host).toBe('https://valid-git-host.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://stale-setting.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://valid-git-host.example.com');
+        });
+
+        test('git config host fails probing -> falls back to .gitreview', async () => {
+            mockGerritHostSetting(undefined);
+
+            cp.execSync(`git init --bare "${gitRoot}"`);
+            cp.execSync(`git --git-dir="${gitRoot}" config gerrit.host "stale-git.example.com"`);
+
+            await fs.writeFile(path.join(tempDir, '.gitreview'), '[gerrit]\nhost=valid-review.example.com\n');
+
+            mockProbe.mockImplementation(async (h: string) => {
+                return h === 'https://valid-review.example.com';
+            });
+
+            const host = await detectGerritHost(tempDir, gitRoot, [], mockProbe);
+            expect(host).toBe('https://valid-review.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://stale-git.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://valid-review.example.com');
+        });
+
+        test('.gitreview host fails probing -> falls back to remotes', async () => {
+            mockGerritHostSetting(undefined);
+
+            await fs.writeFile(path.join(tempDir, '.gitreview'), '[gerrit]\nhost=stale-review.example.com\n');
+
+            const remotes = [{ name: 'origin', url: 'https://chromium.googlesource.com/chromium/src.git' }];
+
+            mockProbe.mockImplementation(async (h: string) => {
+                return h === 'https://chromium-review.googlesource.com';
+            });
+
+            const host = await detectGerritHost(tempDir, null, remotes, mockProbe);
+            expect(host).toBe('https://chromium-review.googlesource.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://stale-review.example.com');
+            expect(mockProbe).toHaveBeenCalledWith('https://chromium-review.googlesource.com');
+        });
+
+        test('returns undefined if all candidates fail probing', async () => {
+            mockGerritHostSetting('broken-setting.example.com');
+            mockProbe.mockResolvedValue(false);
+
+            const host = await detectGerritHost(tempDir, null, [], mockProbe);
+            expect(host).toBeUndefined();
+            expect(mockProbe).toHaveBeenCalledWith('https://broken-setting.example.com');
+        });
+    });
+});

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -2,6 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import type { ChangeStatusRequest } from '../code-forge-provider';
@@ -81,6 +86,40 @@ describe('GerritProvider', () => {
         const result = await provider.detect('/root', []);
         expect(result).toBe(false);
         expect(accessPrivate(provider, 'gerritHost')).toBeUndefined();
+    });
+
+    test('detect reads gerrit.host from git configuration as fallback', async () => {
+        const tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-provider-detect-gitconfig-'));
+        const gitRoot = path.join(tempRepoDir, '.git');
+        cp.execSync(`git init --bare "${gitRoot}"`);
+        cp.execSync(`git --git-dir="${gitRoot}" config gerrit.host "git-config-host.example.com"`);
+
+        // Mock workspace config to return undefined for gerrit.host
+        vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+            get: (key: string) => {
+                if (key === 'binaryPath') {
+                    return 'jj';
+                }
+                return undefined;
+            },
+            has: vi.fn(),
+            update: vi.fn(),
+            inspect: vi.fn(),
+        } as unknown as vscode.WorkspaceConfiguration);
+
+        setPrivate(provider, 'repoRoot', tempRepoDir);
+        setPrivate(provider, 'gitRoot', gitRoot);
+
+        vi.spyOn(
+            exposePrivate<{ probeGerritHost(host: string): Promise<boolean> }>(provider),
+            'probeGerritHost',
+        ).mockResolvedValue(true);
+
+        const result = await provider.detect(tempRepoDir, []);
+        expect(result).toBe(true);
+        expect(accessPrivate(provider, 'gerritHost')).toBe('https://git-config-host.example.com');
+
+        await fs.rm(tempRepoDir, { recursive: true, force: true });
     });
 
     test('resolveCacheKey returns undefined for non-JJ values without conversion', () => {
@@ -310,6 +349,129 @@ describe('GerritProvider', () => {
             await provider.resolveCommentThread('I12345', 'comment-1', false);
             threads = await provider.getCommentThreads('I12345');
             expect(threads[0].isResolved).toBe(false);
+        });
+
+        test('attaches authentication headers and rewrites URL when auth is available', async () => {
+            const tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-auth-test-'));
+            const gitRoot = path.join(tempRepoDir, '.git');
+            cp.execSync(`git init --bare "${gitRoot}"`);
+            cp.execSync(
+                `git --git-dir="${gitRoot}" config credential.helper "!f() { echo username=testuser; echo password=testpass; }; f"`,
+            );
+
+            setPrivate(provider, 'repoRoot', tempRepoDir);
+            setPrivate(provider, 'gitRoot', gitRoot);
+
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            await provider.getCommentThreads('I12345');
+
+            expect(server.requests).toContain('/a/changes/123/comments');
+            expect(server.requests).not.toContain('/changes/123/comments');
+
+            expect(server.lastHeaders).toBeDefined();
+            const expectedAuth = Buffer.from('testuser:testpass').toString('base64');
+            expect(server.lastHeaders?.authorization).toBe(`Basic ${expectedAuth}`);
+
+            await fs.rm(tempRepoDir, { recursive: true, force: true });
+        });
+
+        test('does not rewrite URL or send auth headers when auth is unavailable', async () => {
+            const tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-auth-test-unauth-'));
+            const gitRoot = path.join(tempRepoDir, '.git');
+            cp.execSync(`git init --bare "${gitRoot}"`);
+
+            // No credential.helper is configured and no cookies are present.
+            setPrivate(provider, 'repoRoot', tempRepoDir);
+            setPrivate(provider, 'gitRoot', gitRoot);
+
+            server.clearRequests();
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            await provider.getCommentThreads('I12345');
+
+            expect(server.requests).toContain('/changes/123/comments');
+            expect(server.requests).not.toContain('/a/changes/123/comments');
+
+            expect(server.lastHeaders).toBeDefined();
+            expect(server.lastHeaders?.authorization).toBeUndefined();
+            expect(server.lastHeaders?.cookie).toBeUndefined();
+
+            await fs.rm(tempRepoDir, { recursive: true, force: true });
+        });
+
+        test('reuses cached authentication header and clearCache forces recomputation', async () => {
+            const tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-auth-cache-test-'));
+            const gitRoot = path.join(tempRepoDir, '.git');
+            cp.execSync(`git init --bare "${gitRoot}"`);
+
+            const logFile = path.join(tempRepoDir, 'call_log.txt');
+            cp.execSync(
+                `git --git-dir="${gitRoot}" config credential.helper "!f() { echo username=testuser; echo password=testpass; echo invoked >> \\"${logFile}\\"; }; f"`,
+            );
+
+            setPrivate(provider, 'repoRoot', tempRepoDir);
+            setPrivate(provider, 'gitRoot', gitRoot);
+
+            server.clearRequests();
+            server.registerComments(123, {});
+
+            // First call - should trigger credential helper
+            await provider.getCommentThreads('I12345');
+
+            // Second call - should use cached credentials
+            await provider.getCommentThreads('I12345');
+
+            let logContent = await fs.readFile(logFile, 'utf8');
+            let lines = logContent.trim().split('\n').filter(Boolean);
+            expect(lines).toHaveLength(1);
+
+            // Clear cache - should force helper invocation on next request
+            provider.clearCache();
+
+            // Repopulate cache for this changeId so getCommentThreads doesn't exit early
+            const cache = accessPrivate<Map<string, CodeForgeChangeInfo>>(provider, 'cache');
+            cache.set('I12345', {
+                id: 'I12345',
+                number: 123,
+                displayLabel: 'CL/123',
+                providerName: 'Gerrit',
+                status: 'NEW',
+                submittable: true,
+                unresolvedComments: 0,
+                url: `${server.url}/c/test-project/+/123`,
+                currentRevision: 'sha-1',
+            });
+
+            await provider.getCommentThreads('I12345');
+
+            logContent = await fs.readFile(logFile, 'utf8');
+            lines = logContent.trim().split('\n').filter(Boolean);
+            expect(lines).toHaveLength(2);
+
+            await fs.rm(tempRepoDir, { recursive: true, force: true });
         });
     });
 });

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -187,6 +187,7 @@ describe('GerritService Detection', () => {
 
     test('detect clears cache on gerritHost change, but preserves it if unchanged', async () => {
         service = initService();
+        await service.awaitReady();
 
         // 1. Initial detection sets gerritHost to chromium-review
         repo.addRemote('origin', 'https://chromium.googlesource.com/chromium/src.git');
@@ -909,7 +910,9 @@ describe('GerritService Detection', () => {
 
     test('detectActiveProvider fires onDidUpdate only when host status changes', async () => {
         // Start disabled
-        mockConfig.get.mockReturnValue(undefined);
+        mockConfig.get.mockImplementation(() => {
+            return undefined;
+        });
         service = initService();
         await service.awaitReady();
         expect(service.isEnabled).toBe(false);
@@ -924,7 +927,12 @@ describe('GerritService Detection', () => {
         expect(updateCount).toBe(0);
 
         // Set config so it succeeds
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        mockConfig.get.mockImplementation((key: string) => {
+            if (key === 'gerrit.host') {
+                return fakeGerritServer.url;
+            }
+            return undefined;
+        });
         await service.detectActiveProvider(true);
         expect(service.isEnabled).toBe(true);
         expect(updateCount).toBe(1);
@@ -934,7 +942,9 @@ describe('GerritService Detection', () => {
         expect(updateCount).toBe(1);
 
         // Change config back to undefined, should fire when disabled
-        mockConfig.get.mockReturnValue(undefined);
+        mockConfig.get.mockImplementation(() => {
+            return undefined;
+        });
         await service.detectActiveProvider(true);
         expect(service.isEnabled).toBe(false);
         expect(updateCount).toBe(2);

--- a/src/test/helpers/fake-gerrit-server.ts
+++ b/src/test/helpers/fake-gerrit-server.ts
@@ -24,6 +24,7 @@ export class FakeGerritServer {
     private server: http.Server | undefined;
     public url = '';
     public requests: string[] = [];
+    public lastHeaders: http.IncomingHttpHeaders | undefined;
 
     private nextChangeNumber = 1000;
 
@@ -134,12 +135,14 @@ export class FakeGerritServer {
 
     public clearRequests() {
         this.requests = [];
+        this.lastHeaders = undefined;
     }
 
     public async start(): Promise<string> {
         this.server = http.createServer((req, res) => {
             const urlStr = req.url || '';
             this.requests.push(urlStr);
+            this.lastHeaders = req.headers;
 
             if (urlStr.includes('/config/server/version')) {
                 res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/src/utils/gerrit-credential-utils.ts
+++ b/src/utils/gerrit-credential-utils.ts
@@ -1,0 +1,470 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as cp from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { JjLoggerChannel } from './output-channel';
+
+/**
+ * A helper to wrap cp.execFile in a Promise to prevent deep nesting of callbacks.
+ */
+function execFilePromise(
+    file: string,
+    args: string[],
+    options?: cp.ExecFileOptions,
+    input?: string,
+): Promise<{ err: Error | null; stdout: string }> {
+    return new Promise((resolve) => {
+        const child = cp.execFile(file, args, options ?? {}, (err, stdout) => {
+            const outStr =
+                typeof stdout === 'string' ? stdout : ((stdout as Buffer | undefined)?.toString('utf8') ?? '');
+            resolve({ err, stdout: outStr });
+        });
+        if (child.stdin) {
+            if (input) {
+                child.stdin.write(input);
+            }
+            child.stdin.end();
+        }
+    });
+}
+
+/**
+ * Resolves the backing git directory of a jj repository using `jj git root`.
+ */
+export async function resolveGitRoot(repoRoot: string, binaryPath = 'jj'): Promise<string | null> {
+    const { err, stdout } = await execFilePromise(binaryPath, ['git', 'root'], { cwd: repoRoot, timeout: 10000 });
+    if (err || !stdout) {
+        return null;
+    }
+    return stdout.trim();
+}
+
+/**
+ * Checks if a host matches a Netscape cookie domain.
+ */
+export function matchCookieDomain(host: string, cookieDomain: string): boolean {
+    const h = host.toLowerCase();
+    const cd = cookieDomain.toLowerCase();
+    if (cd.startsWith('.')) {
+        const domainWithoutDot = cd.slice(1);
+        return h === domainWithoutDot || h.endsWith(cd);
+    }
+    return h === cd;
+}
+
+/**
+ * Queries a configuration value from git config.
+ */
+export async function getGitConfig(gitDir: string | null, key: string, isPath = false): Promise<string | null> {
+    if (!gitDir) {
+        return null;
+    }
+    const args = isPath
+        ? [`--git-dir=${gitDir}`, 'config', '--path', '--get', key]
+        : [`--git-dir=${gitDir}`, 'config', '--get', key];
+    const { err, stdout } = await execFilePromise('git', args, { timeout: 10000 });
+    if (err || !stdout) {
+        return null;
+    }
+    return stdout.trim();
+}
+
+/**
+ * Resolves the path to the git cookies file.
+ */
+export async function getGitCookiesPath(gitDir: string | null): Promise<string | null> {
+    let cookiefilePath = await getGitConfig(gitDir, 'http.cookiefile', true);
+
+    if (!cookiefilePath && process.env.GIT_COOKIES_PATH) {
+        cookiefilePath = process.env.GIT_COOKIES_PATH;
+    }
+
+    if (!cookiefilePath) {
+        const defaultCookies = path.join(os.homedir(), '.gitcookies');
+        try {
+            await fs.access(defaultCookies);
+            cookiefilePath = defaultCookies;
+        } catch {
+            return null;
+        }
+    }
+
+    return cookiefilePath;
+}
+
+/**
+ * Reads and parses cookies for a specific host from the configured git cookiefile.
+ */
+export async function getGitCookies(gitDir: string | null, host: string): Promise<string | null> {
+    const cookiefilePath = await getGitCookiesPath(gitDir);
+    if (!cookiefilePath) {
+        return null;
+    }
+
+    try {
+        const content = await fs.readFile(cookiefilePath, 'utf8');
+        const matchingCookies: string[] = [];
+
+        for (const line of content.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (trimmed.length === 0 || trimmed.startsWith('#')) {
+                continue;
+            }
+
+            const parts = trimmed.split('\t');
+            if (parts.length < 7) {
+                continue;
+            }
+
+            const domain = parts[0];
+            const name = parts[5];
+            const value = parts[6];
+
+            if (!matchCookieDomain(host, domain)) {
+                continue;
+            }
+            matchingCookies.push(`${name}=${value}`);
+        }
+
+        if (matchingCookies.length > 0) {
+            return matchingCookies.join('; ');
+        }
+    } catch {
+        // Ignore read/parse errors
+    }
+
+    return null;
+}
+
+/**
+ * Extracts and formats key 'o' cookie from gitcookie file to Authorization header format.
+ */
+export async function parseCookieFile(
+    filePath: string,
+    host: string,
+    outputChannel?: JjLoggerChannel,
+): Promise<{ name: string; value: string } | null> {
+    try {
+        const content = await fs.readFile(filePath, 'utf8');
+        for (const line of content.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (trimmed.length === 0 || trimmed.startsWith('#')) {
+                continue;
+            }
+            const fields = trimmed.split('\t');
+            if (fields.length < 7) {
+                continue;
+            }
+            const domain = fields[0];
+            const xpath = fields[2];
+            const name = fields[5];
+            const val = fields[6];
+
+            if (xpath !== '/' || name !== 'o' || !matchCookieDomain(host, domain)) {
+                continue;
+            }
+
+            outputChannel?.debug(`[GerritAuth] Found matching cookie for domain ${domain} (key=o)`);
+            if (!val.startsWith('git-')) {
+                return { name: 'Authorization', value: `Bearer ${val}` };
+            }
+
+            const idx = val.indexOf('=');
+            if (idx === -1) {
+                continue;
+            }
+            const login = val.slice(0, idx);
+            const secret = val.slice(idx + 1);
+            const auth = Buffer.from(`${login}:${secret}`).toString('base64');
+            return { name: 'Authorization', value: `Basic ${auth}` };
+        }
+    } catch (e) {
+        outputChannel?.debug(`[GerritAuth] Failed reading or parsing cookie file ${filePath}: ${e}`);
+    }
+    return null;
+}
+
+/**
+ * LUCI Context Authenticator.
+ */
+export async function getLuciToken(outputChannel?: JjLoggerChannel): Promise<string | null> {
+    if (!process.env.LUCI_CONTEXT) {
+        outputChannel?.debug('[GerritAuth] LUCI_CONTEXT environment variable not set');
+        return null;
+    }
+    outputChannel?.debug('[GerritAuth] Running luci-auth token...');
+    const { err, stdout } = await execFilePromise(
+        'luci-auth',
+        ['token', '-scopes', 'email https://www.googleapis.com/auth/gerritcodereview'],
+        { timeout: 5000, shell: process.platform === 'win32' },
+    );
+    if (err) {
+        outputChannel?.debug(`[GerritAuth] luci-auth execution failed: ${err.message}`);
+        return null;
+    }
+    if (!stdout) {
+        outputChannel?.debug('[GerritAuth] luci-auth returned empty stdout');
+        return null;
+    }
+    return stdout.trim();
+}
+
+/**
+ * Helper to parse extra header configuration files used by git-remote-sso.
+ */
+async function parseExtraHeaderFile(filePath: string): Promise<{ name: string; value: string } | null> {
+    try {
+        const content = await fs.readFile(filePath, 'utf8');
+        for (const line of content.split(/\r?\n/)) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('extraHeader')) {
+                continue;
+            }
+            const idx = trimmed.indexOf('=');
+            if (idx === -1) {
+                continue;
+            }
+            const headerVal = trimmed.slice(idx + 1).trim();
+            const colonIdx = headerVal.indexOf(':');
+            if (colonIdx === -1) {
+                continue;
+            }
+            return {
+                name: headerVal.slice(0, colonIdx).trim(),
+                value: headerVal.slice(colonIdx + 1).trim(),
+            };
+        }
+    } catch {
+        // Ignore read errors
+    }
+    return null;
+}
+
+/**
+ * Google SSO Helper Authenticator (`git-remote-sso`).
+ */
+export async function getSsoAuth(
+    host: string,
+    outputChannel?: JjLoggerChannel,
+): Promise<{ name: string; value: string } | null> {
+    const checkCmd = process.platform === 'win32' ? 'where' : 'which';
+    outputChannel?.debug(`[GerritAuth] Checking if git-remote-sso helper exists using ${checkCmd}...`);
+    const { err: checkErr, stdout: checkStdout } = await execFilePromise(checkCmd, ['git-remote-sso'], {
+        shell: process.platform === 'win32',
+    });
+    if (checkErr || !checkStdout) {
+        outputChannel?.debug('[GerritAuth] git-remote-sso helper not found in PATH');
+        return null;
+    }
+
+    const ssoBin = checkStdout.trim().split(/\r?\n/)[0];
+    outputChannel?.debug(`[GerritAuth] Found git-remote-sso helper: ${ssoBin}. Printing config...`);
+    const { err: ssoErr, stdout: ssoStdout } = await execFilePromise(
+        ssoBin,
+        ['-print_config', 'sso://*.git.corp.google.com'],
+        { timeout: 5000, shell: process.platform === 'win32' },
+    );
+    if (ssoErr || !ssoStdout) {
+        outputChannel?.debug(`[GerritAuth] git-remote-sso print_config failed: ${ssoErr?.message}`);
+        return null;
+    }
+
+    const config: Record<string, string> = {};
+    for (const line of ssoStdout.split(/\r?\n/)) {
+        const idx = line.indexOf('=');
+        if (idx !== -1) {
+            config[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+        }
+    }
+
+    const includePath = config['include.path'];
+    if (includePath) {
+        outputChannel?.debug(`[GerritAuth] Parsing git-remote-sso extraHeader config file: ${includePath}`);
+        const extraHeader = await parseExtraHeaderFile(includePath);
+        if (extraHeader) {
+            return extraHeader;
+        }
+    }
+
+    const cookiefile = config['http.cookiefile'];
+    if (cookiefile) {
+        outputChannel?.debug(`[GerritAuth] Parsing git-remote-sso cookiefile: ${cookiefile}`);
+        try {
+            const cookies = await parseCookieFile(cookiefile, host, outputChannel);
+            if (cookies) {
+                return cookies;
+            }
+        } catch (e) {
+            outputChannel?.debug(`[GerritAuth] Failed parsing git-remote-sso cookies: ${e}`);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * GCE Metadata Authenticator.
+ */
+export async function getGceAuth(outputChannel?: JjLoggerChannel): Promise<{ name: string; value: string } | null> {
+    try {
+        const metadataHost = process.env.GCE_METADATA_HOST || 'http://metadata.google.internal';
+        outputChannel?.debug(`[GerritAuth] Probing GCE Metadata server at ${metadataHost}...`);
+        const probeResponse = await fetch(metadataHost, {
+            headers: { 'Metadata-Flavor': 'Google' },
+            signal: AbortSignal.timeout(2000),
+        });
+        if (!probeResponse.ok || probeResponse.headers.get('Metadata-Flavor') !== 'Google') {
+            outputChannel?.debug('[GerritAuth] GCE Metadata probe failed or invalid flavor');
+            return null;
+        }
+
+        outputChannel?.debug('[GerritAuth] Fetching GCE service account token...');
+        const tokenResponse = await fetch(
+            `${metadataHost}/computeMetadata/v1/instance/service-accounts/default/token`,
+            {
+                headers: { 'Metadata-Flavor': 'Google' },
+                signal: AbortSignal.timeout(3000),
+            },
+        );
+        if (!tokenResponse.ok) {
+            outputChannel?.debug(
+                `[GerritAuth] GCE service account token request failed: status ${tokenResponse.status}`,
+            );
+            return null;
+        }
+        const data = (await tokenResponse.json()) as { token_type?: string; access_token?: string };
+        if (data.token_type && data.access_token) {
+            return {
+                name: 'Authorization',
+                value: `${data.token_type} ${data.access_token}`,
+            };
+        }
+    } catch (e) {
+        outputChannel?.debug(`[GerritAuth] GCE Metadata request failed: ${e}`);
+    }
+    return null;
+}
+
+/**
+ * Queries the git credential helper for the given host.
+ */
+export async function getGitCredential(
+    gitDir: string | null,
+    host: string,
+    outputChannel?: JjLoggerChannel,
+): Promise<{ username?: string; password?: string } | null> {
+    const args = gitDir ? [`--git-dir=${gitDir}`, 'credential', 'fill'] : ['credential', 'fill'];
+    const options = {
+        cwd: os.homedir(),
+        timeout: 15000,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    };
+    const input = `protocol=https\nhost=${host}\n\n`;
+
+    outputChannel?.debug(`[GerritAuth] Running git credential helper with args: ${args.join(' ')}`);
+    const { err, stdout } = await execFilePromise('git', args, options, input);
+    if (err) {
+        outputChannel?.debug(`[GerritAuth] git credential helper failed: ${err.message}`);
+        return null;
+    }
+    if (!stdout) {
+        outputChannel?.debug('[GerritAuth] git credential helper returned empty output');
+        return null;
+    }
+
+    let username: string | undefined;
+    let password: string | undefined;
+
+    for (const line of stdout.split(/\r?\n/)) {
+        if (line.startsWith('username=')) {
+            username = line.substring('username='.length);
+        } else if (line.startsWith('password=')) {
+            password = line.substring('password='.length);
+        }
+    }
+
+    if (!password) {
+        outputChannel?.debug('[GerritAuth] git credential helper did not return a password');
+        return null;
+    }
+
+    return { username, password };
+}
+
+/**
+ * Combines cookies and credential helper checks to return authentication headers for Gerrit.
+ */
+export async function getGerritAuthHeader(
+    gerritHost: string,
+    gitDir: string | null,
+    outputChannel?: JjLoggerChannel,
+): Promise<{ name: string; value: string } | undefined> {
+    let hostname = gerritHost;
+    try {
+        hostname = new URL(gerritHost).hostname;
+    } catch {
+        // Fallback to raw host string if it's not a valid URL
+    }
+
+    outputChannel?.debug(`[GerritAuth] Getting auth header for ${hostname} (gitDir=${gitDir})`);
+
+    // 1. LUCI Context
+    outputChannel?.debug('[GerritAuth] Checking LUCI Context...');
+    const luciToken = await getLuciToken(outputChannel);
+    if (luciToken) {
+        outputChannel?.debug('[GerritAuth] Successfully authenticated using LUCI Context token');
+        return { name: 'Authorization', value: `Bearer ${luciToken}` };
+    }
+
+    // 2. Google SSO
+    outputChannel?.debug('[GerritAuth] Checking Google SSO helper...');
+    const ssoAuth = await getSsoAuth(hostname, outputChannel);
+    if (ssoAuth) {
+        outputChannel?.debug('[GerritAuth] Successfully authenticated using Google SSO helper');
+        return ssoAuth;
+    }
+
+    // 3. GCE Metadata
+    outputChannel?.debug('[GerritAuth] Checking GCE Metadata...');
+    const gceAuth = await getGceAuth(outputChannel);
+    if (gceAuth) {
+        outputChannel?.debug('[GerritAuth] Successfully authenticated using GCE Metadata');
+        return gceAuth;
+    }
+
+    // 4. Git Cookies (parsed as Basic/Bearer matching gerrit_util.py)
+    outputChannel?.debug('[GerritAuth] Checking Git Cookies...');
+    const cookiefilePath = await getGitCookiesPath(gitDir);
+    if (cookiefilePath) {
+        outputChannel?.debug(`[GerritAuth] Reading cookies from ${cookiefilePath}`);
+        const cookieAuth = await parseCookieFile(cookiefilePath, hostname, outputChannel);
+        if (cookieAuth) {
+            outputChannel?.debug('[GerritAuth] Successfully authenticated using Git Cookies');
+            return cookieAuth;
+        }
+    }
+
+    // 5. Git Credential Helper (parsed as Basic/Bearer matching gerrit_util.py)
+    outputChannel?.debug('[GerritAuth] Checking Git Credential Helper...');
+    const credential = await getGitCredential(gitDir, hostname, outputChannel);
+    if (credential?.password) {
+        outputChannel?.debug('[GerritAuth] Successfully retrieved credentials from Git Credential Helper');
+        const { username, password } = credential;
+        if (username?.startsWith('git-')) {
+            const auth = Buffer.from(`${username}:${password}`).toString('base64');
+            return { name: 'Authorization', value: `Basic ${auth}` };
+        }
+        if (!username || username === 'Host') {
+            return { name: 'Authorization', value: `Bearer ${password}` };
+        }
+        const auth = Buffer.from(`${username}:${password}`).toString('base64');
+        return { name: 'Authorization', value: `Basic ${auth}` };
+    }
+
+    outputChannel?.debug('[GerritAuth] No credentials resolved');
+    return undefined;
+}

--- a/src/utils/gerrit-host-detection.ts
+++ b/src/utils/gerrit-host-detection.ts
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { GitRemote } from '../code-forge-provider';
+import { getGitConfig } from './gerrit-credential-utils';
+import type { JjLoggerChannel } from './output-channel';
+
+/**
+ * Normalizes a Gerrit host URL by cleaning trailing slashes, prepending protocol,
+ * and extracting the origin for googlesource.com hosts.
+ */
+export function normalizeHostUrl(hostUrl: string): string {
+    let host = hostUrl.replace(/\/+$/, '');
+    if (!host.startsWith('http')) {
+        host = `https://${host}`;
+    }
+    if (host.includes('googlesource.com')) {
+        try {
+            const urlObj = new URL(host);
+            host = urlObj.origin;
+        } catch {
+            // Fallback to raw host if URL parsing fails
+        }
+    }
+    return host;
+}
+
+/**
+ * Resolves the Gerrit host from the configured VS Code setting.
+ */
+function getHostFromSettings(outputChannel?: JjLoggerChannel): string | undefined {
+    outputChannel?.debug('[GerritDetector] Checking VS Code settings for jj-view.gerrit.host...');
+    const settingHost = vscode.workspace.getConfiguration('jj-view').get<string>('gerrit.host')?.trim();
+    if (settingHost) {
+        if (settingHost.toLowerCase() === 'true' || settingHost.toLowerCase() === 'false') {
+            outputChannel?.debug(
+                `[GerritDetector] Skipping settings gerrit.host: '${settingHost}' (interpreted as boolean flag)`,
+            );
+            return undefined;
+        }
+        return normalizeHostUrl(settingHost);
+    }
+    return undefined;
+}
+
+/**
+ * Resolves the Gerrit host from the git configuration.
+ */
+async function getHostFromGitConfig(
+    gitRoot: string | null,
+    outputChannel?: JjLoggerChannel,
+): Promise<string | undefined> {
+    if (!gitRoot) {
+        outputChannel?.debug('[GerritDetector] Git root is null, skipping git config check');
+        return undefined;
+    }
+
+    outputChannel?.debug('[GerritDetector] Checking git config for gerrit.gerritserver...');
+    const gerritServer = await getGitConfig(gitRoot, 'gerrit.gerritserver');
+    if (gerritServer) {
+        if (gerritServer.toLowerCase() === 'true' || gerritServer.toLowerCase() === 'false') {
+            outputChannel?.debug(
+                `[GerritDetector] Skipping git config gerrit.gerritserver: '${gerritServer}' (interpreted as boolean flag)`,
+            );
+        } else {
+            return normalizeHostUrl(gerritServer);
+        }
+    }
+
+    outputChannel?.debug('[GerritDetector] Checking git config for gerrit.host...');
+    const configHost = await getGitConfig(gitRoot, 'gerrit.host');
+    if (configHost) {
+        if (configHost.toLowerCase() === 'true' || configHost.toLowerCase() === 'false') {
+            outputChannel?.debug(
+                `[GerritDetector] Skipping git config gerrit.host: '${configHost}' (interpreted as boolean flag)`,
+            );
+        } else {
+            return normalizeHostUrl(configHost);
+        }
+    }
+    return undefined;
+}
+
+async function getHostFromGitReview(repoRoot: string, outputChannel?: JjLoggerChannel): Promise<string | undefined> {
+    const gitreviewPath = path.join(repoRoot, '.gitreview');
+    outputChannel?.debug(`[GerritDetector] Checking .gitreview file at: ${gitreviewPath}`);
+    try {
+        const content = await fs.readFile(gitreviewPath, 'utf8');
+        const match = content.match(/host=(.+)/);
+        if (match?.[1]) {
+            const host = normalizeHostUrl(match[1].trim());
+            outputChannel?.debug(`[GerritDetector] Found host in .gitreview: ${host}`);
+            return host;
+        }
+        outputChannel?.debug('[GerritDetector] No host entry found in .gitreview');
+    } catch (e) {
+        if ((e as { code?: string }).code !== 'ENOENT') {
+            outputChannel?.error(`[GerritDetector] Failed to parse .gitreview: ${e}`);
+        } else {
+            outputChannel?.debug('[GerritDetector] .gitreview file not found');
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Extracts and maps a remote URL to a candidate Gerrit host.
+ */
+export function parseRemoteUrl(url: string): string | undefined {
+    // 1. Identify SSH URLs (both standard ssh:// and SCP-like host:path syntax)
+    let isSsh = false;
+    let sshHost: string | undefined;
+
+    if (url.startsWith('ssh://')) {
+        isSsh = true;
+        const match = url.match(/ssh:\/\/([^@]+@)?([^:/]+)(:\d+)?\/(.+)/);
+        if (match) {
+            sshHost = match[2];
+        }
+    } else if (!url.includes('://') && url.includes(':')) {
+        isSsh = true;
+        const colonIdx = url.indexOf(':');
+        const hostPart = url.slice(0, colonIdx);
+        const atIdx = hostPart.indexOf('@');
+        sshHost = atIdx !== -1 ? hostPart.slice(atIdx + 1) : hostPart;
+    }
+
+    if (isSsh) {
+        if (!sshHost) {
+            return undefined;
+        }
+        // For SSH, we only map if it's a googlesource domain, contains 'gerrit' in host, or contains '/gerrit/' / ':gerrit/' in original URL
+        const isGooglesource = sshHost.endsWith('googlesource.com');
+        const isGerritHost = sshHost.includes('gerrit');
+        const isGerritPath = url.includes('/gerrit/') || url.includes(':gerrit/');
+        if (!isGooglesource && !isGerritHost && !isGerritPath) {
+            return undefined;
+        }
+        let host = `https://${sshHost}`;
+        if (isGooglesource && !sshHost.includes('-review')) {
+            host = host.replace('.googlesource.com', '-review.googlesource.com');
+        }
+        return normalizeHostUrl(host);
+    }
+
+    // 2. HTTP/HTTPS or custom protocols (sso://, persistent-https://, rpc://)
+    let parsedUrl: URL;
+    try {
+        parsedUrl = new URL(url);
+    } catch {
+        return undefined;
+    }
+
+    let { protocol, hostname, pathname } = parsedUrl;
+
+    // Handle sso:// protocol (e.g. sso://chromium/chromium/src)
+    if (protocol === 'sso:') {
+        hostname = `${hostname}.googlesource.com`;
+        protocol = 'https:';
+    }
+
+    // Force protocol to https for custom Git helper schemes (like rpc:// or persistent-https://)
+    if (protocol !== 'https:' && protocol !== 'http:') {
+        protocol = 'https:';
+    }
+
+    const isGooglesource = hostname.endsWith('googlesource.com');
+    const isGerritPath = pathname.includes('/gerrit/');
+    if (!isGooglesource && !isGerritPath) {
+        return undefined;
+    }
+
+    if (isGooglesource) {
+        let host = `${protocol}//${hostname}`;
+        if (!hostname.includes('-review')) {
+            host = host.replace('.googlesource.com', '-review.googlesource.com');
+        }
+        return normalizeHostUrl(host);
+    }
+
+    // Non-googlesource Gerrit path (preserve host + path, but strip .git)
+    let host = `${protocol}//${hostname}${pathname}`;
+    if (host.endsWith('.git')) {
+        host = host.slice(0, -4);
+    }
+    return normalizeHostUrl(host);
+}
+
+/**
+ * Searches for a valid Gerrit host from the list of Git remotes.
+ */
+async function getHostFromRemotes(
+    remotes: GitRemote[],
+    probeFn: (host: string) => Promise<boolean>,
+    outputChannel?: JjLoggerChannel,
+): Promise<string | undefined> {
+    outputChannel?.debug(`[GerritDetector] Scanning ${remotes.length} remotes for Gerrit host candidates`);
+    const origin = remotes.find((r) => r.name === 'origin');
+    const gerrit = remotes.find((r) => r.name === 'gerrit');
+
+    const sortedRemotes = [];
+    if (origin) {
+        sortedRemotes.push(origin);
+    }
+    if (gerrit) {
+        sortedRemotes.push(gerrit);
+    }
+    for (const r of remotes) {
+        if (r.name !== 'origin' && r.name !== 'gerrit') {
+            sortedRemotes.push(r);
+        }
+    }
+
+    for (const { name, url } of sortedRemotes) {
+        outputChannel?.debug(`[GerritDetector] Parsing remote '${name}' URL: '${url}'`);
+        const candidate = parseRemoteUrl(url);
+        if (!candidate) {
+            outputChannel?.debug(
+                `[GerritDetector] Remote '${name}' URL '${url}' was not parsed into a Gerrit candidate`,
+            );
+            continue;
+        }
+
+        outputChannel?.debug(`[GerritDetector] Probing candidate host: ${candidate} (from remote '${name}')`);
+        if (await probeFn(candidate)) {
+            outputChannel?.debug(`[GerritDetector] Candidate host ${candidate} succeeded probe`);
+            return candidate;
+        }
+        outputChannel?.error(`[GerritDetector] Probe failed for host: ${candidate} (from remote '${name}')`);
+    }
+
+    outputChannel?.debug('[GerritDetector] No remote candidates matched or succeeded probe');
+    return undefined;
+}
+
+export async function detectGerritHost(
+    repoRoot: string,
+    gitRoot: string | null,
+    remotes: GitRemote[],
+    probeFn: (host: string) => Promise<boolean>,
+    outputChannel?: JjLoggerChannel,
+): Promise<string | undefined> {
+    outputChannel?.debug(`[GerritDetector] Starting host detection for repoRoot=${repoRoot}, gitRoot=${gitRoot}`);
+
+    // 1. Check settings
+    const settingHost = getHostFromSettings(outputChannel);
+    if (settingHost) {
+        outputChannel?.debug(`[GerritDetector] Found setting host candidate: ${settingHost}`);
+        if (await probeFn(settingHost)) {
+            outputChannel?.debug(`[GerritDetector] Setting host candidate succeeded probe: ${settingHost}`);
+            return settingHost;
+        }
+        outputChannel?.debug(`[GerritDetector] Setting host candidate failed probe: ${settingHost}`);
+    }
+
+    // 2. Check git config
+    const gitConfigHost = await getHostFromGitConfig(gitRoot, outputChannel);
+    if (gitConfigHost) {
+        outputChannel?.debug(`[GerritDetector] Found git config host candidate: ${gitConfigHost}`);
+        if (await probeFn(gitConfigHost)) {
+            outputChannel?.debug(`[GerritDetector] Git config host candidate succeeded probe: ${gitConfigHost}`);
+            return gitConfigHost;
+        }
+        outputChannel?.debug(`[GerritDetector] Git config host candidate failed probe: ${gitConfigHost}`);
+    }
+
+    // 3. Check .gitreview
+    const gitreviewHost = await getHostFromGitReview(repoRoot, outputChannel);
+    if (gitreviewHost) {
+        outputChannel?.debug(`[GerritDetector] Found .gitreview host candidate: ${gitreviewHost}`);
+        if (await probeFn(gitreviewHost)) {
+            outputChannel?.debug(`[GerritDetector] .gitreview host candidate succeeded probe: ${gitreviewHost}`);
+            return gitreviewHost;
+        }
+        outputChannel?.debug(`[GerritDetector] .gitreview host candidate failed probe: ${gitreviewHost}`);
+    }
+
+    // 4. Check remotes
+    outputChannel?.debug('[GerritDetector] Falling back to remote URL candidates detection');
+    const remoteHost = await getHostFromRemotes(remotes, probeFn, outputChannel);
+    if (remoteHost) {
+        outputChannel?.debug(`[GerritDetector] Remote host candidate succeeded probe: ${remoteHost}`);
+        return remoteHost;
+    }
+
+    outputChannel?.debug('[GerritDetector] No valid Gerrit host detected');
+    return undefined;
+}


### PR DESCRIPTION
Add support for querying gitcookies and Git credential helpers to authorize Gerrit API requests.

- Resolve backing Git directory paths to load credential configurations.
- Retrieve cookie file paths or credential helpers to parse authentication tokens.
- Add fetch wrapper that automatically routes calls through Gerrit's authenticated endpoints.