### PR TITLE
fix(test): resolve intermittent integration test flake in openMergeEd…

### DIFF
--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -418,8 +418,9 @@ suite('JJ SCM Provider Integration Test', () => {
         await scmProvider.openMergeEditor(conflictGroup.resourceStates);
 
         // Verify the argument format
-        assert.ok(executeStub.calledOnce, 'Should have called _open.mergeEditor');
-        const args = executeStub.firstCall.args[1] as {
+        const mergeEditorCall = executeStub.getCalls().find((call) => call.args[0] === '_open.mergeEditor');
+        assert.ok(mergeEditorCall, 'Should have called _open.mergeEditor');
+        const args = mergeEditorCall.args[1] as {
             base: vscode.Uri;
             input1: { uri: vscode.Uri };
             input2: { uri: vscode.Uri };


### PR DESCRIPTION
…itor

Instead of asserting executeStub.calledOnce on the global executeCommand stub (which can be called by concurrent tasks like setContext updates, causing false assertion failures), filter calls by the specific '_open.mergeEditor' command ID.