### PR TITLE
feat(comments): add command to copy unresolved code review comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -550,6 +550,12 @@
                 "title": "Unresolve Thread",
                 "category": "JJ View",
                 "icon": "$(reply)"
+            },
+            {
+                "command": "jj-view.copyUnresolvedComments",
+                "title": "Copy Unresolved Comments",
+                "category": "JJ View",
+                "icon": "$(copy)"
             }
         ],
         "keybindings": [
@@ -588,6 +594,10 @@
                 },
                 {
                     "command": "jj-view.unresolveCommentThread",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.copyUnresolvedComments",
                     "when": "false"
                 },
                 {
@@ -693,6 +703,11 @@
                     "command": "jj-view.workspaceAdd",
                     "group": "navigation@10",
                     "when": "view == jj-view.logView"
+                },
+                {
+                    "command": "jj-view.copyUnresolvedComments",
+                    "group": "navigation",
+                    "when": "view == workbench.panel.comments && jj.codeForgeActive"
                 }
             ],
             "webview/context": [

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -40,3 +40,7 @@ export async function unresolveCommentThreadCommand(
     const thread = 'thread' in arg ? arg.thread : arg;
     await commentsManager.toggleResolveThread(thread, false);
 }
+
+export async function copyUnresolvedCommentsCommand(commentsManager: CommentsManager) {
+    await commentsManager.copyUnresolvedComments();
+}

--- a/src/comments-manager.ts
+++ b/src/comments-manager.ts
@@ -13,6 +13,7 @@ export class CommentsManager implements vscode.Disposable {
     private commentController: vscode.CommentController;
     private threads = new Map<string, vscode.CommentThread>(); // threadId -> vscode.CommentThread
     private activeChangeId: string | undefined;
+    private activeChangeInfo: CodeForgeChangeInfo | undefined;
     private activeRepoPath: string | undefined;
     private disposables: vscode.Disposable[] = [];
     private repoDisposables: vscode.Disposable[] = [];
@@ -38,6 +39,7 @@ export class CommentsManager implements vscode.Disposable {
             this.repositoryManager.onDidChangeFocusedRepository(() => {
                 this.clearThreads();
                 this.activeChangeId = undefined;
+                this.activeChangeInfo = undefined;
                 this.activeRepoPath = undefined;
                 this.explicitChangeId = undefined;
                 this.lastWorkingCopyId = undefined;
@@ -175,6 +177,7 @@ export class CommentsManager implements vscode.Disposable {
             if (!repo) {
                 this.clearThreads();
                 this.activeChangeId = undefined;
+                this.activeChangeInfo = undefined;
                 this.activeRepoPath = undefined;
                 return;
             }
@@ -186,6 +189,7 @@ export class CommentsManager implements vscode.Disposable {
             if (!activeProvider?.getCommentThreads) {
                 this.clearThreads();
                 this.activeChangeId = undefined;
+                this.activeChangeInfo = undefined;
                 this.activeRepoPath = undefined;
                 return;
             }
@@ -226,6 +230,7 @@ export class CommentsManager implements vscode.Disposable {
             } else {
                 this.clearThreads();
                 this.activeChangeId = undefined;
+                this.activeChangeInfo = undefined;
                 this.activeRepoPath = undefined;
             }
         } catch {
@@ -256,6 +261,7 @@ export class CommentsManager implements vscode.Disposable {
         if (this.activeChangeId !== providerChangeId) {
             this.clearThreads();
             this.activeChangeId = undefined;
+            this.activeChangeInfo = undefined;
             this.activeRepoPath = undefined;
         }
 
@@ -267,6 +273,7 @@ export class CommentsManager implements vscode.Disposable {
                 return;
             }
             this.activeChangeId = providerChangeId;
+            this.activeChangeInfo = changeInfo;
             this.activeRepoPath = repo.rootUri.fsPath;
             this.updateCommentThreads(threadsList);
         } catch {
@@ -297,6 +304,7 @@ export class CommentsManager implements vscode.Disposable {
         } else {
             this.clearThreads();
             this.activeChangeId = undefined;
+            this.activeChangeInfo = undefined;
             this.activeRepoPath = undefined;
         }
         // Focus the native comments panel
@@ -315,7 +323,7 @@ export class CommentsManager implements vscode.Disposable {
      */
     private mapToVscodeComment(c: CodeForgeComment): vscode.Comment {
         let avatarUri: vscode.Uri | undefined;
-        if (c.author.avatarUrl) {
+        if (c.author?.avatarUrl) {
             try {
                 avatarUri = vscode.Uri.parse(c.author.avatarUrl);
             } catch {
@@ -325,7 +333,7 @@ export class CommentsManager implements vscode.Disposable {
         return {
             body: new vscode.MarkdownString(c.body),
             author: {
-                name: c.author.name,
+                name: c.author?.name || 'Unknown',
                 iconPath: avatarUri,
             },
             mode: vscode.CommentMode.Preview,
@@ -496,6 +504,66 @@ export class CommentsManager implements vscode.Disposable {
             );
         } catch (err) {
             vscode.window.showErrorMessage(`Failed to toggle resolve: ${err}`);
+        }
+    }
+
+    public async copyUnresolvedComments(): Promise<void> {
+        const unresolvedThreads = Array.from(this.threads.values()).filter(
+            (thread) => thread.state === vscode.CommentThreadState.Unresolved,
+        );
+
+        if (unresolvedThreads.length === 0) {
+            vscode.window.showInformationMessage('No unresolved comments for the active change.');
+            return;
+        }
+
+        unresolvedThreads.sort((a, b) => {
+            const pathA = a.uri.fsPath;
+            const pathB = b.uri.fsPath;
+            if (pathA !== pathB) {
+                return pathA.localeCompare(pathB);
+            }
+            const lineA = a.range?.start.line ?? 0;
+            const lineB = b.range?.start.line ?? 0;
+            return lineA - lineB;
+        });
+
+        const info = this.activeChangeInfo;
+        let changeLabel = '';
+        if (info) {
+            changeLabel = ` for ${info.displayLabel}`;
+        }
+
+        let result = `### Unresolved Comments${changeLabel}\n\n`;
+
+        for (const thread of unresolvedThreads) {
+            const relativePath = vscode.workspace.asRelativePath(thread.uri);
+            if (thread.range) {
+                const lineNum = thread.range.start.line + 1;
+                result += `- **${relativePath}:${lineNum}**\n`;
+            } else {
+                result += `- **${relativePath}**\n`;
+            }
+            for (const comment of thread.comments) {
+                const author = comment.author?.name || 'Unknown';
+                const body = typeof comment.body === 'string' ? comment.body : comment.body.value;
+                const indentedBody = body
+                    .split(/\r?\n/)
+                    .map((line) => `    > ${line}`)
+                    .join('\n');
+                result += `  - **${author}**:\n${indentedBody}\n`;
+            }
+        }
+
+        try {
+            await vscode.env.clipboard.writeText(`${result.trim()}\n`);
+            vscode.window.showInformationMessage(
+                `Copied ${unresolvedThreads.length} unresolved comment(s) to clipboard.`,
+            );
+        } catch (error) {
+            vscode.window.showErrorMessage(
+                `Failed to copy comments to clipboard: ${error instanceof Error ? error.message : String(error)}`,
+            );
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { advanceBookmarkAndUploadCommand } from './commands/bookmark-advance-upl
 import { deleteBookmarkCommand } from './commands/bookmark-delete';
 import { resolveRepository } from './commands/command-utils';
 import {
+    copyUnresolvedCommentsCommand,
     replyCommentCommand,
     resolveCommentThreadCommand,
     showCommentsCommand,
@@ -489,6 +490,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 await unresolveCommentThreadCommand(commentsManager, arg);
             },
         ),
+        vscode.commands.registerCommand('jj-view.copyUnresolvedComments', async () => {
+            await copyUnresolvedCommentsCommand(commentsManager);
+        }),
     );
 
     context.subscriptions.push(

--- a/src/test/comments-manager.test.ts
+++ b/src/test/comments-manager.test.ts
@@ -389,4 +389,245 @@ describe('CommentsManager Tests', () => {
 
         expect(accessPrivate<string | undefined>(commentsManager, 'explicitChangeId')).toBe('some-change-id');
     });
+
+    test('copyUnresolvedComments should filter, format, and copy unresolved comments to the clipboard', async () => {
+        const threads: CodeForgeCommentThread[] = [
+            {
+                id: 'thread-1',
+                filePath: 'file.txt',
+                line: 10,
+                isResolved: false,
+                comments: [
+                    {
+                        id: 'comment-1',
+                        author: { name: 'Author A' },
+                        body: 'This is unresolved',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                    {
+                        id: 'comment-2',
+                        author: { name: 'Author B' },
+                        body: 'Replying to unresolved',
+                        createdAt: '2026-06-30T12:05:00Z',
+                    },
+                ],
+            },
+            {
+                id: 'thread-2',
+                filePath: 'other.txt',
+                line: 5,
+                isResolved: true,
+                comments: [
+                    {
+                        id: 'comment-3',
+                        author: { name: 'Author C' },
+                        body: 'This is resolved',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+        ];
+        provider.setThreads(threads);
+
+        // Fetch comments so they are loaded into commentsManager
+        await commentsManager.showCommentsForChange('@');
+
+        // Let's call copyUnresolvedComments
+        await commentsManager.copyUnresolvedComments();
+
+        // Check that writeText was called
+        const writeTextMock = vscode.env.clipboard.writeText as import('vitest').Mock;
+        expect(writeTextMock).toHaveBeenCalled();
+        const copiedText = writeTextMock.mock.calls[0][0];
+
+        expect(copiedText).toContain('### Unresolved Comments for PR #123');
+        expect(copiedText).toContain('- **file.txt:10**');
+        expect(copiedText).toContain('  - **Author A**:');
+        expect(copiedText).toContain('    > This is unresolved');
+        expect(copiedText).toContain('  - **Author B**:');
+        expect(copiedText).toContain('    > Replying to unresolved');
+
+        // It should NOT contain the resolved comment from thread-2
+        expect(copiedText).not.toContain('other.txt:5');
+        expect(copiedText).not.toContain('This is resolved');
+    });
+
+    test('copyUnresolvedComments should show message and not copy if there are no unresolved comments', async () => {
+        const threads: CodeForgeCommentThread[] = [
+            {
+                id: 'thread-1',
+                filePath: 'file.txt',
+                line: 10,
+                isResolved: true,
+                comments: [
+                    {
+                        id: 'comment-1',
+                        author: { name: 'Author A' },
+                        body: 'This is resolved',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+        ];
+        provider.setThreads(threads);
+
+        await commentsManager.showCommentsForChange('@');
+
+        // Reset the clipboard mock
+        const writeTextMock = vscode.env.clipboard.writeText as import('vitest').Mock;
+        writeTextMock.mockClear();
+
+        await commentsManager.copyUnresolvedComments();
+
+        expect(writeTextMock).not.toHaveBeenCalled();
+        expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+            'No unresolved comments for the active change.',
+        );
+    });
+
+    test('copyUnresolvedComments should handle range-less threads correctly', async () => {
+        const threads: CodeForgeCommentThread[] = [
+            {
+                id: 'thread-1',
+                filePath: 'file.txt',
+                line: 10,
+                isResolved: false,
+                comments: [
+                    {
+                        id: 'comment-1',
+                        author: { name: 'Author A' },
+                        body: 'File-level comment',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+        ];
+        provider.setThreads(threads);
+
+        await commentsManager.showCommentsForChange('@');
+
+        // Force the mock range to be undefined to simulate range-less thread
+        for (const thread of commentsManager.getThreads().values()) {
+            Object.defineProperty(thread, 'range', { value: undefined });
+        }
+
+        const writeTextMock = vscode.env.clipboard.writeText as import('vitest').Mock;
+        writeTextMock.mockClear();
+
+        await commentsManager.copyUnresolvedComments();
+
+        expect(writeTextMock).toHaveBeenCalled();
+        const copiedText = writeTextMock.mock.calls[0][0];
+        expect(copiedText).toContain('### Unresolved Comments for PR #123');
+        expect(copiedText).toContain('- **file.txt**');
+        expect(copiedText).not.toContain('file.txt:');
+        expect(copiedText).toContain('  - **Author A**:');
+        expect(copiedText).toContain('    > File-level comment');
+    });
+
+    test('copyUnresolvedComments should handle clipboard write failure and show error message', async () => {
+        const threads: CodeForgeCommentThread[] = [
+            {
+                id: 'thread-1',
+                filePath: 'file.txt',
+                line: 10,
+                isResolved: false,
+                comments: [
+                    {
+                        id: 'comment-1',
+                        author: { name: 'Author A' },
+                        body: 'This is unresolved',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+        ];
+        provider.setThreads(threads);
+
+        await commentsManager.showCommentsForChange('@');
+
+        const writeTextMock = vscode.env.clipboard.writeText as import('vitest').Mock;
+        writeTextMock.mockClear();
+        writeTextMock.mockRejectedValueOnce(new Error('Clipboard write error'));
+
+        const showErrorMessageMock = vscode.window.showErrorMessage as import('vitest').Mock;
+        showErrorMessageMock.mockClear();
+
+        await commentsManager.copyUnresolvedComments();
+
+        expect(writeTextMock).toHaveBeenCalled();
+        expect(showErrorMessageMock).toHaveBeenCalledWith(
+            'Failed to copy comments to clipboard: Clipboard write error',
+        );
+    });
+
+    test('copyUnresolvedComments should sort threads by file path and line number, and handle missing author name', async () => {
+        const threads: CodeForgeCommentThread[] = [
+            {
+                id: 'thread-line-15',
+                filePath: 'file.txt',
+                line: 15,
+                isResolved: false,
+                comments: [
+                    {
+                        id: 'comment-1',
+                        author: { name: '' },
+                        body: 'Second comment in file.txt',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+            {
+                id: 'thread-file-b',
+                filePath: 'another.txt',
+                line: 5,
+                isResolved: false,
+                comments: [
+                    {
+                        id: 'comment-2',
+                        author: { name: 'Author B' },
+                        body: 'Comment in another.txt',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    },
+                ],
+            },
+            {
+                id: 'thread-line-10',
+                filePath: 'file.txt',
+                line: 10,
+                isResolved: false,
+                comments: [
+                    createMock<CodeForgeComment>({
+                        id: 'comment-3',
+                        // simulated missing author object or name
+                        body: 'First comment in file.txt',
+                        createdAt: '2026-06-30T12:00:00Z',
+                    }),
+                ],
+            },
+        ];
+        provider.setThreads(threads);
+
+        await commentsManager.showCommentsForChange('@');
+
+        const writeTextMock = vscode.env.clipboard.writeText as import('vitest').Mock;
+        writeTextMock.mockClear();
+
+        await commentsManager.copyUnresolvedComments();
+
+        expect(writeTextMock).toHaveBeenCalled();
+        const copiedText = writeTextMock.mock.calls[0][0];
+
+        // Verify order: another.txt:5 -> file.txt:10 -> file.txt:15
+        const indexAnother = copiedText.indexOf('another.txt:5');
+        const indexFile10 = copiedText.indexOf('file.txt:10');
+        const indexFile15 = copiedText.indexOf('file.txt:15');
+
+        expect(indexAnother).toBeLessThan(indexFile10);
+        expect(indexFile10).toBeLessThan(indexFile15);
+
+        // Verify author fallbacks
+        expect(copiedText).toContain('  - **Unknown**:\n    > First comment in file.txt');
+        expect(copiedText).toContain('  - **Unknown**:\n    > Second comment in file.txt');
+    });
 });

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -500,4 +500,111 @@ test.describe('GitHub Integration E2E', () => {
         } finally {
         }
     });
+
+    test('Can copy unresolved comments to clipboard', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://github.com/test-owner/test-repo.git');
+
+        const graph: CommitDefinition[] = [
+            {
+                label: 'base',
+                parents: ['root()'],
+                description: 'base',
+            },
+            {
+                label: 'pr-commit',
+                parents: ['base'],
+                description: 'PR Commit',
+                bookmarks: ['my-feature-branch'],
+                files: {
+                    'file.txt': 'line 1\nline 2\nline 3\nline 4\nline 5\n',
+                },
+            },
+        ];
+
+        const commits = await buildGraph(repo, graph);
+
+        github.registerPR('my-feature-branch', {
+            id: 'pr_node_id_123',
+            number: 42,
+            state: 'OPEN',
+            mergeable: 'MERGEABLE',
+            url: 'https://github.com/test-owner/test-repo/pull/42',
+            currentRevision: commits['pr-commit'].commitId,
+            unresolvedComments: 1,
+        });
+
+        github.registerReviewThreads('pr_node_id_123', [
+            {
+                id: 'thread-1',
+                isResolved: false,
+                path: 'file.txt',
+                line: 3,
+                comments: [
+                    {
+                        id: 'c-1',
+                        body: 'Review comment body',
+                        createdAt: '2026-06-30T12:00:00Z',
+                        author: { login: 'reviewer' },
+                    },
+                ],
+            },
+        ]);
+
+        const { page } = await vscode.openWorkspace(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'github',
+            },
+            {
+                JJ_VIEW_GITHUB_API_URL: github.url,
+                JJ_VIEW_GITHUB_TOKEN: 'test-token',
+            },
+        );
+
+        await focusJJLog(page);
+
+        const row = await waitForLogCommitRow(page, 'PR Commit');
+        const bubble = row.getByTitle('1 Unresolved Comments');
+        await expect(bubble).toBeVisible();
+
+        // Click unresolved comments bubble to focus and fetch comments
+        await bubble.click();
+
+        // Wait until the fake server receives a request for the review threads
+        await expect
+            .poll(() => {
+                return github.requests.some((req) => req.body.includes('reviewThreads('));
+            })
+            .toBe(true);
+
+        // Wait for CommentsManager to parse and populate the threads
+        await waitForCommentThreadsCount(vscode);
+
+        // Clear clipboard first
+        await vscode.evaluate(async (vscode) => {
+            await vscode.env.clipboard.writeText('');
+        });
+
+        // Trigger the copy command
+        await vscode.executeCommand('jj-view.copyUnresolvedComments');
+
+        // Verify clipboard content
+        await expect
+            .poll(async () => {
+                return await vscode.evaluate(async (vscode) => {
+                    return await vscode.env.clipboard.readText();
+                });
+            })
+            .toContain('### Unresolved Comments for PR #42');
+
+        await expect
+            .poll(async () => {
+                return await vscode.evaluate(async (vscode) => {
+                    return await vscode.env.clipboard.readText();
+                });
+            })
+            .toContain('Review comment body');
+    });
 });

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -307,6 +307,10 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         },
         env: {
             openExternal: vi.fn(),
+            clipboard: {
+                writeText: vi.fn().mockResolvedValue(undefined),
+                readText: vi.fn().mockResolvedValue(''),
+            },
         },
         window: {
             showErrorMessage: vi.fn(),
@@ -410,6 +414,16 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             onDidSaveTextDocument: onDidSaveTextDocumentEmitter.event,
 
             findFiles: vi.fn().mockResolvedValue([]),
+            asRelativePath: vi.fn().mockImplementation((pathOrUri: string | { fsPath: string }) => {
+                const fsPath = typeof pathOrUri === 'string' ? pathOrUri : pathOrUri.fsPath;
+                for (const folder of mockWorkspaceFolders) {
+                    const folderPath = folder.uri.fsPath;
+                    if (fsPath.startsWith(folderPath)) {
+                        return fsPath.substring(folderPath.length).replace(/^[/\\]/, '');
+                    }
+                }
+                return fsPath.split(/[/\\]/).pop() || fsPath;
+            }),
         },
         commands: {
             executeCommand: vi.fn(),


### PR DESCRIPTION
Implement a command to format and copy all unresolved comments for the active change to the clipboard as Markdown, and add a navigation button for it in the built-in VS Code Comments view title bar. Also includes unit tests and an E2E test.