### PR TITLE
feat(comments): add direct reply actions to SCM comment threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ The extension automatically refreshes the view when:
 - Supports uploading changes directly via SCM actions.
 - Auto-detected from Git remote URLs (including self-hosted instances). Set `jj-view.gitlab.host` if you use a custom self-hosted instance.
 
+### 💬 Review Discussions & Comments
+- **Unresolved Comments Bubble**: Displays a counter pill on each revision with pending unresolved comments. Clicking it focuses and fetches review comments.
+- **Inline Comment Threads**: Displays code review comments inline directly in the VS Code diff editors.
+- **Direct Reply & Resolution Actions**:
+  - **Ack**: Submits a default reply of `"Acknowledged"` and resolves the comment thread.
+  - **Done**: Submits a default reply of `"Done"` and resolves the comment thread.
+  - **Reply & Resolve**: Submits your typed response and resolves the comment thread.
+  - **Reply**: Submits your typed response and leaves the comment thread unresolved.
+- **Copy Unresolved Comments**: Copies a formatted markdown summary of all unresolved comments for the active revision to your clipboard using the copy action in the Comments panel title bar.
+
 ### 🔑 Authentication
 
 Configuring credentials (such as OAuth tokens or Personal Access Tokens) for GitHub and GitLab is seamless:

--- a/package.json
+++ b/package.json
@@ -535,6 +535,21 @@
                 "category": "JJ View"
             },
             {
+                "command": "jj-view.ackComment",
+                "title": "Ack",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.doneComment",
+                "title": "Done",
+                "category": "JJ View"
+            },
+            {
+                "command": "jj-view.replyAndResolveComment",
+                "title": "Reply & Resolve",
+                "category": "JJ View"
+            },
+            {
                 "command": "jj-view.replyComment",
                 "title": "Reply",
                 "category": "JJ View"
@@ -582,6 +597,18 @@
             "commandPalette": [
                 {
                     "command": "jj-view.showComments",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.ackComment",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.doneComment",
+                    "when": "false"
+                },
+                {
+                    "command": "jj-view.replyAndResolveComment",
                     "when": "false"
                 },
                 {
@@ -1006,18 +1033,33 @@
             ],
             "comments/commentThread/context": [
                 {
-                    "command": "jj-view.replyComment",
+                    "command": "jj-view.replyAndResolveComment",
                     "group": "inline@1",
                     "when": "commentController =~ /jj-view/"
                 },
                 {
-                    "command": "jj-view.resolveCommentThread",
+                    "command": "jj-view.doneComment",
                     "group": "inline@2",
+                    "when": "commentController =~ /jj-view/"
+                },
+                {
+                    "command": "jj-view.ackComment",
+                    "group": "inline@3",
+                    "when": "commentController =~ /jj-view/"
+                },
+                {
+                    "command": "jj-view.replyComment",
+                    "group": "inline@4",
+                    "when": "commentController =~ /jj-view/"
+                },
+                {
+                    "command": "jj-view.resolveCommentThread",
+                    "group": "inline@5",
                     "when": "commentController =~ /jj-view/ && commentThread == unresolved"
                 },
                 {
                     "command": "jj-view.unresolveCommentThread",
-                    "group": "inline@2",
+                    "group": "inline@5",
                     "when": "commentController =~ /jj-view/ && commentThread == resolved"
                 }
             ]

--- a/src/code-forge-provider.ts
+++ b/src/code-forge-provider.ts
@@ -59,7 +59,12 @@ export interface CodeForgeProvider {
     /** Fetch all comment threads for a given change */
     getCommentThreads?(changeId: string, signal?: AbortSignal): Promise<CodeForgeCommentThread[]>;
     /** Reply to a comment thread */
-    replyToCommentThread?(changeId: string, threadId: string, body: string): Promise<CodeForgeComment>;
+    replyToCommentThread?(
+        changeId: string,
+        threadId: string,
+        body: string,
+        resolved?: boolean,
+    ): Promise<CodeForgeComment>;
     /** Resolve/unresolve a comment thread */
     resolveCommentThread?(changeId: string, threadId: string, resolved: boolean): Promise<void>;
 }

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type * as vscode from 'vscode';
+import { ACK_REPLY_TEXT, DONE_REPLY_TEXT } from '../comments-constants';
 import type { CommentsManager } from '../comments-manager';
 
 export async function showCommentsCommand(commentsManager: CommentsManager, changeId?: string) {
@@ -19,6 +20,39 @@ export async function replyCommentCommand(commentsManager: CommentsManager, repl
     await commentsManager.replyToThread(reply);
 }
 
+export async function ackCommentCommand(commentsManager: CommentsManager, reply?: vscode.CommentReply) {
+    if (!reply) {
+        return;
+    }
+    await commentsManager.replyToThread(
+        {
+            thread: reply.thread,
+            text: ACK_REPLY_TEXT,
+        },
+        /* resolved */ true,
+    );
+}
+
+export async function doneCommentCommand(commentsManager: CommentsManager, reply?: vscode.CommentReply) {
+    if (!reply) {
+        return;
+    }
+    await commentsManager.replyToThread(
+        {
+            thread: reply.thread,
+            text: DONE_REPLY_TEXT,
+        },
+        /* resolved */ true,
+    );
+}
+
+export async function replyAndResolveCommentCommand(commentsManager: CommentsManager, reply?: vscode.CommentReply) {
+    if (!reply) {
+        return;
+    }
+    await commentsManager.replyToThread(reply, /* resolved */ true);
+}
+
 export async function resolveCommentThreadCommand(
     commentsManager: CommentsManager,
     arg?: vscode.CommentThread | vscode.CommentReply,
@@ -27,7 +61,7 @@ export async function resolveCommentThreadCommand(
         return;
     }
     const thread = 'thread' in arg ? arg.thread : arg;
-    await commentsManager.toggleResolveThread(thread, true);
+    await commentsManager.toggleResolveThread(thread, /* resolved */ true);
 }
 
 export async function unresolveCommentThreadCommand(
@@ -38,7 +72,7 @@ export async function unresolveCommentThreadCommand(
         return;
     }
     const thread = 'thread' in arg ? arg.thread : arg;
-    await commentsManager.toggleResolveThread(thread, false);
+    await commentsManager.toggleResolveThread(thread, /* resolved */ false);
 }
 
 export async function copyUnresolvedCommentsCommand(commentsManager: CommentsManager) {

--- a/src/comments-constants.ts
+++ b/src/comments-constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ACK_REPLY_TEXT = 'Acknowledged';
+export const DONE_REPLY_TEXT = 'Done';

--- a/src/comments-manager.ts
+++ b/src/comments-manager.ts
@@ -74,7 +74,7 @@ export class CommentsManager implements vscode.Disposable {
         // Listen for remote updates from CodeForgeService
         this.repoDisposables.push(
             repo.codeForge.onDidUpdate(async () => {
-                await this.pullCommentsAutomatically().catch(() => {});
+                await this.refreshActiveChangeComments().catch(() => {});
             }),
         );
     }
@@ -236,6 +236,19 @@ export class CommentsManager implements vscode.Disposable {
         } catch {
             // Ignore
         }
+    }
+
+    /**
+     * Lightweight method to pull comments for the active target change directly.
+     * Avoids running any slow jj CLI queries.
+     */
+    public async refreshActiveChangeComments(): Promise<void> {
+        const repo = this.repositoryManager.focusedRepository;
+        if (!repo || !this.activeChangeInfo) {
+            return;
+        }
+        const signal = this.startNewLoad();
+        await this.loadCommentsForChange(this.activeChangeInfo, signal);
     }
 
     /**
@@ -410,7 +423,7 @@ export class CommentsManager implements vscode.Disposable {
         }
     }
 
-    public async replyToThread(reply: vscode.CommentReply): Promise<void> {
+    public async replyToThread(reply: vscode.CommentReply, resolved?: boolean): Promise<void> {
         const repo = this.repositoryManager.focusedRepository;
         const changeId = this.activeChangeId;
         if (!repo || !changeId) {
@@ -449,8 +462,8 @@ export class CommentsManager implements vscode.Disposable {
                     cancellable: false,
                 },
                 async () => {
-                    await provider.replyToCommentThread(changeId, threadId, reply.text);
-                    await this.pullCommentsAutomatically();
+                    await provider.replyToCommentThread(changeId, threadId, reply.text, resolved);
+                    await this.refreshActiveChangeComments();
                     repo.codeForge.requestRefreshWithBackoffs();
                 },
             );
@@ -498,7 +511,7 @@ export class CommentsManager implements vscode.Disposable {
                 },
                 async () => {
                     await provider.resolveCommentThread(changeId, threadId, resolved);
-                    await this.pullCommentsAutomatically();
+                    await this.refreshActiveChangeComments();
                     repo.codeForge.requestRefreshWithBackoffs();
                 },
             );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,10 @@ import { advanceBookmarkAndUploadCommand } from './commands/bookmark-advance-upl
 import { deleteBookmarkCommand } from './commands/bookmark-delete';
 import { resolveRepository } from './commands/command-utils';
 import {
+    ackCommentCommand,
     copyUnresolvedCommentsCommand,
+    doneCommentCommand,
+    replyAndResolveCommentCommand,
     replyCommentCommand,
     resolveCommentThreadCommand,
     showCommentsCommand,
@@ -474,6 +477,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     context.subscriptions.push(
         vscode.commands.registerCommand('jj-view.showComments', async (changeId?: string) => {
             await showCommentsCommand(commentsManager, changeId);
+        }),
+        vscode.commands.registerCommand('jj-view.ackComment', async (reply?: vscode.CommentReply) => {
+            await ackCommentCommand(commentsManager, reply);
+        }),
+        vscode.commands.registerCommand('jj-view.doneComment', async (reply?: vscode.CommentReply) => {
+            await doneCommentCommand(commentsManager, reply);
+        }),
+        vscode.commands.registerCommand('jj-view.replyAndResolveComment', async (reply?: vscode.CommentReply) => {
+            await replyAndResolveCommentCommand(commentsManager, reply);
         }),
         vscode.commands.registerCommand('jj-view.replyComment', async (reply?: vscode.CommentReply) => {
             await replyCommentCommand(commentsManager, reply);

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -542,7 +542,12 @@ export class GerritProvider implements CodeForgeProvider {
         return threads;
     }
 
-    public async replyToCommentThread(changeId: string, threadId: string, body: string): Promise<CodeForgeComment> {
+    public async replyToCommentThread(
+        changeId: string,
+        threadId: string,
+        body: string,
+        resolved?: boolean,
+    ): Promise<CodeForgeComment> {
         const changeInfo = Array.from(this.cache.values()).find((info) => info.id === changeId);
         if (!changeInfo) {
             throw new Error('Change not found in cache');
@@ -584,14 +589,14 @@ export class GerritProvider implements CodeForgeProvider {
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                drafts: 'PUBLISH',
+                drafts: 'KEEP',
                 comments: {
                     [parentFilePath]: [
                         {
                             in_reply_to: threadId,
                             line: parentComment.line,
                             message: body,
-                            unresolved: parentComment.unresolved ?? true,
+                            unresolved: resolved !== undefined ? !resolved : (parentComment.unresolved ?? true),
                         },
                     ],
                 },
@@ -675,7 +680,7 @@ export class GerritProvider implements CodeForgeProvider {
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                drafts: 'PUBLISH',
+                drafts: 'KEEP',
                 comments: {
                     [parentFilePath]: [
                         {

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -623,27 +623,55 @@ export class GitHubProvider implements CodeForgeProvider {
         return threads;
     }
 
-    public async replyToCommentThread(_changeId: string, threadId: string, body: string): Promise<CodeForgeComment> {
+    public async replyToCommentThread(
+        _changeId: string,
+        threadId: string,
+        body: string,
+        resolved?: boolean,
+    ): Promise<CodeForgeComment> {
         const token = await this.getSessionToken();
         if (!token) {
             throw new Error('Not authenticated');
         }
 
-        const query = `
-        mutation($threadId: ID!, $body: String!) {
-            addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
-                comment {
-                    id
-                    body
-                    createdAt
-                    author {
-                        login
-                        avatarUrl
+        const query =
+            resolved !== undefined
+                ? `
+            mutation($threadId: ID!, $body: String!) {
+                addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+                    comment {
+                        id
+                        body
+                        createdAt
+                        author {
+                            login
+                            avatarUrl
+                        }
+                    }
+                }
+                resolve: ${resolved ? 'resolveReviewThread' : 'unresolveReviewThread'}(input: {threadId: $threadId}) {
+                    thread {
+                        id
+                        isResolved
                     }
                 }
             }
-        }
-        `;
+            `
+                : `
+            mutation($threadId: ID!, $body: String!) {
+                addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+                    comment {
+                        id
+                        body
+                        createdAt
+                        author {
+                            login
+                            avatarUrl
+                        }
+                    }
+                }
+            }
+            `;
 
         const apiUrl = process.env.JJ_VIEW_GITHUB_API_URL || 'https://api.github.com/graphql';
         const response = await fetchWithTimeout(apiUrl, 15000, {

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -781,7 +781,12 @@ export class GitLabProvider implements CodeForgeProvider {
         return threads;
     }
 
-    public async replyToCommentThread(changeId: string, threadId: string, body: string): Promise<CodeForgeComment> {
+    public async replyToCommentThread(
+        changeId: string,
+        threadId: string,
+        body: string,
+        resolved?: boolean,
+    ): Promise<CodeForgeComment> {
         const changeInfo = Array.from(this.cache.values()).find((info) => info.id === changeId);
         if (!changeInfo) {
             throw new Error('Change not found in cache');
@@ -810,6 +815,11 @@ export class GitLabProvider implements CodeForgeProvider {
         }
 
         const note = (await response.json()) as GitLabNoteGql;
+
+        if (resolved !== undefined) {
+            await this.resolveCommentThread(changeId, threadId, resolved);
+        }
+
         return {
             id: note.id.toString(),
             author: {

--- a/src/test/comments-command.test.ts
+++ b/src/test/comments-command.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// sort-imports-ignore
+
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import type * as vscode from 'vscode';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    return createVscodeMock();
+});
+
+import {
+    ackCommentCommand,
+    doneCommentCommand,
+    replyAndResolveCommentCommand,
+    replyCommentCommand,
+} from '../commands/comments';
+import type { CommentsManager } from '../comments-manager';
+import { createMock } from './test-utils';
+
+describe('Comment Command Handlers', () => {
+    let mockCommentsManager: CommentsManager;
+    let replyToThreadSpy: Mock;
+    let toggleResolveThreadSpy: Mock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Create spies
+        replyToThreadSpy = vi.fn().mockResolvedValue(undefined);
+        toggleResolveThreadSpy = vi.fn().mockResolvedValue(undefined);
+
+        mockCommentsManager = createMock<CommentsManager>({
+            replyToThread: replyToThreadSpy,
+            toggleResolveThread: toggleResolveThreadSpy,
+        });
+    });
+
+    test('replyCommentCommand delegates to replyToThread without resolving', async () => {
+        const mockThread = createMock<vscode.CommentThread>();
+        const reply = createMock<vscode.CommentReply>({
+            thread: mockThread,
+            text: 'my response',
+        });
+
+        await replyCommentCommand(mockCommentsManager, reply);
+
+        expect(replyToThreadSpy).toHaveBeenCalledWith(reply);
+        expect(toggleResolveThreadSpy).not.toHaveBeenCalled();
+    });
+
+    test('ackCommentCommand sends Acknowledged comment and resolves the thread', async () => {
+        const mockThread = createMock<vscode.CommentThread>();
+        const reply = createMock<vscode.CommentReply>({
+            thread: mockThread,
+            text: 'some random typed text',
+        });
+
+        await ackCommentCommand(mockCommentsManager, reply);
+
+        expect(replyToThreadSpy).toHaveBeenCalledWith(
+            {
+                thread: mockThread,
+                text: 'Acknowledged',
+            },
+            true,
+        );
+        expect(toggleResolveThreadSpy).not.toHaveBeenCalled();
+    });
+
+    test('doneCommentCommand sends Done comment and resolves the thread', async () => {
+        const mockThread = createMock<vscode.CommentThread>();
+        const reply = createMock<vscode.CommentReply>({
+            thread: mockThread,
+            text: 'some random typed text',
+        });
+
+        await doneCommentCommand(mockCommentsManager, reply);
+
+        expect(replyToThreadSpy).toHaveBeenCalledWith(
+            {
+                thread: mockThread,
+                text: 'Done',
+            },
+            true,
+        );
+        expect(toggleResolveThreadSpy).not.toHaveBeenCalled();
+    });
+
+    test('replyAndResolveCommentCommand sends typed text and resolves the thread', async () => {
+        const mockThread = createMock<vscode.CommentThread>();
+        const reply = createMock<vscode.CommentReply>({
+            thread: mockThread,
+            text: 'my typed response',
+        });
+
+        await replyAndResolveCommentCommand(mockCommentsManager, reply);
+
+        expect(replyToThreadSpy).toHaveBeenCalledWith(reply, true);
+        expect(toggleResolveThreadSpy).not.toHaveBeenCalled();
+    });
+
+    test('command handlers return early if reply is falsy', async () => {
+        await replyCommentCommand(mockCommentsManager, undefined);
+        await ackCommentCommand(mockCommentsManager, undefined);
+        await doneCommentCommand(mockCommentsManager, undefined);
+        await replyAndResolveCommentCommand(mockCommentsManager, undefined);
+
+        expect(replyToThreadSpy).not.toHaveBeenCalled();
+        expect(toggleResolveThreadSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/test/comments-manager.test.ts
+++ b/src/test/comments-manager.test.ts
@@ -70,7 +70,12 @@ class MockCommentsProvider implements CodeForgeProvider {
         return this.threads;
     }
 
-    async replyToCommentThread(_changeId: string, threadId: string, body: string): Promise<CodeForgeComment> {
+    async replyToCommentThread(
+        _changeId: string,
+        threadId: string,
+        body: string,
+        resolved?: boolean,
+    ): Promise<CodeForgeComment> {
         const reply: CodeForgeComment = {
             id: 'new-reply',
             author: { name: 'Replier' },
@@ -80,6 +85,9 @@ class MockCommentsProvider implements CodeForgeProvider {
         const thread = this.threads.find((t) => t.id === threadId);
         if (thread) {
             thread.comments.push(reply);
+            if (resolved !== undefined) {
+                thread.isResolved = resolved;
+            }
         }
         return reply;
     }

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -1400,69 +1400,77 @@ export async function getReviewWidget(page: Page, expectedText?: string): Promis
 }
 
 /**
- * Types and submits a reply on the given comment thread review widget.
+ * Expands the comment reply input form if it is not already visible.
  */
-export async function replyToCommentThread(page: Page, reviewWidget: Locator, text: string) {
-    const start = Date.now();
-    // Click the "Reply..." placeholder button to expand the comment form
+async function expandReplyFormIfNeeded(reviewWidget: Locator) {
     const replyPlaceholderBtn = reviewWidget.locator('.review-thread-reply-button');
-    await expect(replyPlaceholderBtn).toBeVisible();
-    await replyPlaceholderBtn.click();
+    if (await replyPlaceholderBtn.isVisible()) {
+        await replyPlaceholderBtn.click();
+    }
+}
 
-    // Type into the reply input in the DOM (Monaco Editor instance inside comment-form)
+/**
+ * Clicks a button in the form actions of a comment thread review widget.
+ */
+async function clickCommentButton(reviewWidget: Locator, buttonLabel: string | RegExp, perfLabel: string) {
+    const start = Date.now();
+    await expandReplyFormIfNeeded(reviewWidget);
+
+    const button = reviewWidget
+        .locator('.form-actions button, .form-actions [role="button"]')
+        .filter({ hasText: buttonLabel })
+        .first();
+    await expect(button).toBeVisible();
+    await button.click();
+    logPerf(perfLabel, start);
+}
+
+/**
+ * Types text into the reply input and clicks a button in the form actions.
+ */
+async function submitTypedCommentReply(
+    page: Page,
+    reviewWidget: Locator,
+    text: string,
+    buttonLabel: string | RegExp,
+    perfLabel: string,
+) {
+    const start = Date.now();
+    await expandReplyFormIfNeeded(reviewWidget);
+
     const editor = reviewWidget.locator('.comment-form .monaco-editor');
     await expect(editor).toBeVisible();
     await editor.click();
     await page.keyboard.type(text);
 
-    // Find and click the "Reply" button in the form actions
-    const replyBtn = reviewWidget
+    const button = reviewWidget
         .locator('.form-actions button, .form-actions [role="button"]')
-        .filter({ hasText: 'Reply' })
+        .filter({ hasText: buttonLabel })
         .first();
-    await expect(replyBtn).toBeVisible();
-    await replyBtn.click();
-    logPerf('replyToCommentThread', start);
+    await expect(button).toBeVisible();
+    await button.click();
+    logPerf(perfLabel, start);
+}
+
+/**
+ * Types and submits a reply on the given comment thread review widget.
+ */
+export async function replyToCommentThread(page: Page, reviewWidget: Locator, text: string) {
+    await submitTypedCommentReply(page, reviewWidget, text, /^Reply$/, 'replyToCommentThread');
 }
 
 /**
  * Resolves the given comment thread review widget by clicking the resolve button next to Reply.
  */
 export async function resolveCommentThread(reviewWidget: Locator) {
-    const start = Date.now();
-    // If the reply form is not already expanded, click the "Reply..." placeholder to show the action buttons.
-    const replyPlaceholderBtn = reviewWidget.locator('.review-thread-reply-button');
-    await expect(replyPlaceholderBtn).toBeVisible();
-    await replyPlaceholderBtn.click();
-
-    // Find and click the "Resolve Thread" button in the form actions
-    const resolveBtn = reviewWidget
-        .locator('.form-actions button, .form-actions [role="button"]')
-        .filter({ hasText: 'Resolve Thread' })
-        .first();
-    await expect(resolveBtn).toBeVisible();
-    await resolveBtn.click();
-    logPerf('resolveCommentThread', start);
+    await clickCommentButton(reviewWidget, 'Resolve Thread', 'resolveCommentThread');
 }
 
 /**
  * Unresolves the given comment thread review widget by clicking the unresolve button next to Reply.
  */
 export async function unresolveCommentThread(reviewWidget: Locator) {
-    const start = Date.now();
-    // If the reply form is not already expanded, click the "Reply..." placeholder to show the action buttons.
-    const replyPlaceholderBtn = reviewWidget.locator('.review-thread-reply-button');
-    await expect(replyPlaceholderBtn).toBeVisible();
-    await replyPlaceholderBtn.click();
-
-    // Find and click the "Unresolve Thread" button in the form actions
-    const unresolveBtn = reviewWidget
-        .locator('.form-actions button, .form-actions [role="button"]')
-        .filter({ hasText: 'Unresolve Thread' })
-        .first();
-    await expect(unresolveBtn).toBeVisible();
-    await unresolveBtn.click();
-    logPerf('unresolveCommentThread', start);
+    await clickCommentButton(reviewWidget, 'Unresolve Thread', 'unresolveCommentThread');
 }
 
 /**
@@ -1500,4 +1508,25 @@ export async function waitForThreadState(
             contextValue: expectedContextValue,
             collapsibleState: expectedCollapsibleState,
         });
+}
+
+/**
+ * Clicks the "Ack" button on the given comment thread review widget.
+ */
+export async function replyWithAck(reviewWidget: Locator) {
+    await clickCommentButton(reviewWidget, 'Ack', 'replyWithAck');
+}
+
+/**
+ * Clicks the "Done" button on the given comment thread review widget.
+ */
+export async function replyWithDone(reviewWidget: Locator) {
+    await clickCommentButton(reviewWidget, 'Done', 'replyWithDone');
+}
+
+/**
+ * Types text and clicks the "Reply & Resolve" button on the given comment thread review widget.
+ */
+export async function replyAndResolve(page: Page, reviewWidget: Locator, text: string) {
+    await submitTypedCommentReply(page, reviewWidget, text, 'Reply & Resolve', 'replyAndResolve');
 }

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -4,6 +4,7 @@
  */
 
 import { expect } from '@playwright/test';
+import { ACK_REPLY_TEXT, DONE_REPLY_TEXT } from '../../comments-constants';
 import { FakeGitHubServer } from '../helpers/fake-github-server';
 import { buildGraph, type CommitDefinition, TestRepo } from '../test-repo';
 import {
@@ -16,7 +17,10 @@ import {
     locateQuickInputWidget,
     openFileInEditor,
     pickQuickPickItem,
+    replyAndResolve,
     replyToCommentThread,
+    replyWithAck,
+    replyWithDone,
     resolveCommentThread,
     test,
     unresolveCommentThread,
@@ -606,5 +610,142 @@ test.describe('GitHub Integration E2E', () => {
                 });
             })
             .toContain('Review comment body');
+    });
+
+    test('Can reply with Ack, Done, and Reply & Resolve buttons', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        repo.addRemote('origin', 'https://github.com/test-owner/test-repo.git');
+
+        const graph: CommitDefinition[] = [
+            { label: 'base', description: 'base' },
+            {
+                label: 'pr-commit',
+                parents: ['base'],
+                description: 'PR Commit',
+                bookmarks: ['my-feature-branch'],
+                files: {
+                    'file.txt': 'line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\nline 8\nline 9\nline 10\n',
+                },
+            },
+        ];
+
+        const commits = await buildGraph(repo, graph);
+
+        github.registerPR('my-feature-branch', {
+            id: 'pr_node_id_123',
+            number: 42,
+            state: 'OPEN',
+            mergeable: 'MERGEABLE',
+            url: 'https://github.com/test-owner/test-repo/pull/42',
+            currentRevision: commits['pr-commit'].commitId,
+            unresolvedComments: 1,
+        });
+
+        github.registerReviewThreads('pr_node_id_123', [
+            {
+                id: 'thread-1',
+                isResolved: false,
+                path: 'file.txt',
+                line: 10,
+                comments: [
+                    {
+                        id: 'c-1',
+                        body: 'Review comment body',
+                        createdAt: '2026-06-30T12:00:00Z',
+                        author: { login: 'reviewer' },
+                    },
+                ],
+            },
+        ]);
+
+        const { page } = await vscode.openWorkspace(
+            repo,
+            {
+                'jj-view.codeForge.provider': 'github',
+            },
+            {
+                JJ_VIEW_GITHUB_API_URL: github.url,
+                JJ_VIEW_GITHUB_TOKEN: 'test-token',
+            },
+        );
+
+        await focusJJLog(page);
+
+        const row = await waitForLogCommitRow(page, 'PR Commit');
+        const bubble = row.getByTitle('1 Unresolved Comments');
+        await expect(bubble).toBeVisible();
+
+        // Focus and fetch comments
+        await bubble.click();
+
+        // Wait for CommentsManager to parse and populate the threads
+        await waitForCommentThreadsCount(vscode);
+
+        // Open the file in the editor
+        await openFileInEditor(vscode, page, 'file.txt', repo);
+
+        // 1. Test "Ack" button
+        let reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await replyWithAck(reviewWidget);
+
+        // Wait for thread to be resolved & collapsed
+        await waitForThreadState(vscode, 'resolved', 0);
+        await expect(page.locator('.review-widget')).toBeHidden();
+
+        // Scroll editor to top using keyboard
+        await page.locator('.editor-instance .monaco-editor').first().click();
+        await page.keyboard.press('Control+Home');
+
+        // Expand thread to verify UI contains the reply
+        await page.locator('.comment-range-glyph').first().click();
+        reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await expect(reviewWidget).toContainText(ACK_REPLY_TEXT);
+
+        // Unresolve the thread to test the next button
+        await unresolveCommentThread(reviewWidget);
+
+        // Wait for thread to be unresolved
+        await waitForThreadState(vscode, 'unresolved', 1);
+
+        // 2. Test "Done" button
+        reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await replyWithDone(reviewWidget);
+
+        // Wait for thread to be resolved & collapsed
+        await waitForThreadState(vscode, 'resolved', 0);
+        await expect(page.locator('.review-widget')).toBeHidden();
+
+        // Scroll editor to top using keyboard
+        await page.locator('.editor-instance .monaco-editor').first().click();
+        await page.keyboard.press('Control+Home');
+
+        // Expand thread to verify UI contains the reply
+        await page.locator('.comment-range-glyph').first().click();
+        reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await expect(reviewWidget).toContainText(DONE_REPLY_TEXT);
+
+        // Unresolve the thread to test the next button
+        await unresolveCommentThread(reviewWidget);
+
+        // Wait for thread to be unresolved
+        await waitForThreadState(vscode, 'unresolved', 1);
+
+        // 3. Test "Reply & Resolve" button
+        reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await replyAndResolve(page, reviewWidget, 'My custom reply and resolve');
+
+        // Wait for thread to be resolved & collapsed
+        await waitForThreadState(vscode, 'resolved', 0);
+        await expect(page.locator('.review-widget')).toBeHidden();
+
+        // Scroll editor to top using keyboard
+        await page.locator('.editor-instance .monaco-editor').first().click();
+        await page.keyboard.press('Control+Home');
+
+        // Expand thread to verify UI contains the reply
+        await page.locator('.comment-range-glyph').first().click();
+        reviewWidget = await getReviewWidget(page, 'Review comment body');
+        await expect(reviewWidget).toContainText('My custom reply and resolve');
     });
 });

--- a/src/test/helpers/fake-github-server.ts
+++ b/src/test/helpers/fake-github-server.ts
@@ -135,9 +135,11 @@ export class FakeGitHubServer {
                             const bodyText = variables?.body || '';
 
                             let createdComment: FakeComment | undefined;
+                            let targetThread: FakeReviewThread | undefined;
                             for (const threadsList of this.threads.values()) {
                                 const found = threadsList.find((t) => t.id === threadId);
                                 if (found) {
+                                    targetThread = found;
                                     createdComment = {
                                         id: `comment-reply-${Date.now()}`,
                                         body: bodyText,
@@ -149,6 +151,13 @@ export class FakeGitHubServer {
                                 }
                             }
 
+                            // Handle batched resolution mutation if present in the same query
+                            const isResolve = query.includes('resolveReviewThread');
+                            const isUnresolve = query.includes('unresolveReviewThread');
+                            if (targetThread && (isResolve || isUnresolve)) {
+                                targetThread.isResolved = isResolve;
+                            }
+
                             res.writeHead(200, { 'Content-Type': 'application/json' });
                             res.end(
                                 JSON.stringify({
@@ -156,6 +165,22 @@ export class FakeGitHubServer {
                                         addPullRequestReviewThreadReply: {
                                             comment: createdComment,
                                         },
+                                        ...(isResolve || isUnresolve
+                                            ? {
+                                                  resolveReviewThread: {
+                                                      thread: {
+                                                          id: threadId,
+                                                          isResolved: isResolve,
+                                                      },
+                                                  },
+                                                  unresolveReviewThread: {
+                                                      thread: {
+                                                          id: threadId,
+                                                          isResolved: isResolve,
+                                                      },
+                                                  },
+                                              }
+                                            : {}),
                                     },
                                 }),
                             );


### PR DESCRIPTION
Introduce pre-defined and custom reply actions directly to the SCM comments widget. Users can now reply with "Ack", "Done", or perform a typed reply that also resolves the thread, without needing to perform resolve operations separately. Unified SCM comment helpers in Playwright E2E tests to share the reply-submission lifecycle.