### PR TITLE
feat: add command and context menu items to view file at revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,6 +275,11 @@
                 "category": "JJ View"
             },
             {
+                "command": "jj-view.viewFileAtRevision",
+                "title": "View File at Revision...",
+                "category": "JJ View"
+            },
+            {
                 "command": "jj-view.refresh",
                 "title": "Refresh",
                 "category": "JJ View",
@@ -1032,6 +1037,11 @@
                     "command": "jj-view.compareFileWith",
                     "group": "jj-view",
                     "when": "resourceScheme == 'file'"
+                },
+                {
+                    "command": "jj-view.viewFileAtRevision",
+                    "group": "jj-view",
+                    "when": "resourceScheme == 'file'"
                 }
             ],
             "editor/context": [
@@ -1044,11 +1054,21 @@
                     "command": "jj-view.compareFileWith",
                     "group": "jj-view",
                     "when": "resourceScheme == 'file'"
+                },
+                {
+                    "command": "jj-view.viewFileAtRevision",
+                    "group": "jj-view",
+                    "when": "resourceScheme == 'file'"
                 }
             ],
             "explorer/context": [
                 {
                     "command": "jj-view.compareFileWith",
+                    "group": "jj-view",
+                    "when": "resourceScheme == 'file'"
+                },
+                {
+                    "command": "jj-view.viewFileAtRevision",
                     "group": "jj-view",
                     "when": "resourceScheme == 'file'"
                 }

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -175,6 +175,23 @@ export function extractRevision(args: unknown[]): string | undefined {
     return revs.length > 0 ? revs[0] : undefined;
 }
 
+/**
+ * Extracts a file URI from command arguments (Uri, SCM resource state, or active text editor).
+ */
+export function extractFileUri(args: unknown[]): vscode.Uri | undefined {
+    const firstArg = args[0];
+    if (firstArg instanceof vscode.Uri) {
+        return firstArg;
+    }
+    if (typeof firstArg === 'object' && firstArg !== null && 'resourceUri' in firstArg) {
+        const state = firstArg as { resourceUri: unknown };
+        if (state.resourceUri instanceof vscode.Uri) {
+            return state.resourceUri;
+        }
+    }
+    return vscode.window.activeTextEditor?.document.uri;
+}
+
 export function getErrorMessage(error: unknown): string {
     if (error instanceof Error) {
         return error.message;

--- a/src/commands/view-file-at-revision.ts
+++ b/src/commands/view-file-at-revision.ts
@@ -9,7 +9,7 @@ import { encodeJjViewQuery } from '../uri-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 import { extractFileUri, promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
-export async function compareFileWithRevisionCommand(
+export async function viewFileAtRevisionCommand(
     jj: JjService,
     outputChannel: JjLoggerChannel,
     ...args: unknown[]
@@ -18,28 +18,27 @@ export async function compareFileWithRevisionCommand(
         const fileUri = extractFileUri(args);
 
         if (!fileUri || fileUri.scheme !== 'file') {
-            vscode.window.showErrorMessage('No workspace file selected for comparison.');
+            vscode.window.showErrorMessage('No workspace file selected.');
             return;
         }
 
         const revision = await promptForRevision(jj, {
-            placeHolder: `Select an ancestor to compare ${path.basename(fileUri.fsPath)} with`,
-            emptyPrompt: `Compare ${path.basename(fileUri.fsPath)} with revision`,
-            revisionQuery: RevisionQuery.ancestorsExcluding('@'),
+            placeHolder: `Select a revision to view ${path.basename(fileUri.fsPath)} at`,
+            emptyPrompt: `View ${path.basename(fileUri.fsPath)} at revision`,
+            revisionQuery: RevisionQuery.visible(),
         });
 
         if (!revision) {
             return;
         }
 
-        const leftUri = fileUri.with({
+        const revisionUri = fileUri.with({
             scheme: 'jj-view',
             query: encodeJjViewQuery({ mode: 'revision', revision }),
         });
 
-        const title = `${path.basename(fileUri.fsPath)} (${revision} ↔ Working Copy)`;
-        await vscode.commands.executeCommand('vscode.diff', leftUri, fileUri, title);
+        await vscode.commands.executeCommand('vscode.open', revisionUri);
     } catch (err: unknown) {
-        await showJjError(err, 'Failed to compare file', jj, outputChannel);
+        await showJjError(err, 'Failed to view file at revision', jj, outputChannel);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ import {
 import { squashHunkIntoParentCommand, squashSelectionIntoParentCommand } from './commands/squash-selection';
 import { undoCommand } from './commands/undo';
 import { uploadCommand } from './commands/upload';
+import { viewFileAtRevisionCommand } from './commands/view-file-at-revision';
 import { workspaceAddCommand } from './commands/workspace-add';
 import { workspaceDeleteCommand } from './commands/workspace-delete';
 import { workspaceForgetCommand } from './commands/workspace-forget';
@@ -609,6 +610,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         }),
         registerWrappedCommand('jj-view.compareFileWith', async (_scm, jj, ...args) => {
             await compareFileWithRevisionCommand(jj, outputChannel, ...args);
+        }),
+        registerWrappedCommand('jj-view.viewFileAtRevision', async (_scm, jj, ...args) => {
+            await viewFileAtRevisionCommand(jj, outputChannel, ...args);
         }),
         registerWrappedCommand('jj-view.workspaceAdd', async (scm, jj) => {
             await workspaceAddCommand(scm, jj);

--- a/src/test/commands/view-file-at-revision.test.ts
+++ b/src/test/commands/view-file-at-revision.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { viewFileAtRevisionCommand } from '../../commands/view-file-at-revision';
+import { JjService, NO_OP_LOGGER } from '../../jj-service';
+import { TestRepo } from '../test-repo';
+import { resetMockQuickPick, setActiveItems, setSelectedItems } from '../vitest-utils';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock({
+        commands: { executeCommand: vi.fn() },
+    });
+});
+
+import { createMockLogOutputChannel } from '../test-utils';
+
+describe('viewFileAtRevisionCommand', () => {
+    let jj: JjService;
+    let repo: TestRepo;
+    let mockOutputChannel: vscode.LogOutputChannel;
+
+    beforeEach(() => {
+        repo = new TestRepo();
+        repo.init();
+        jj = new JjService(repo.path, NO_OP_LOGGER);
+        mockOutputChannel = createMockLogOutputChannel();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('opens vscode.open with jj-view uri for target file and revision', async () => {
+        repo.writeFile('file1.txt', 'content');
+        const fileUri = vscode.Uri.file(`${repo.path}/file1.txt`);
+
+        const mockQuickPick = vi.mocked(vscode.window.createQuickPick)();
+        resetMockQuickPick(mockQuickPick);
+
+        let acceptCallback: () => void = () => {};
+        vi.mocked(mockQuickPick.onDidAccept).mockImplementation((cb) => {
+            acceptCallback = cb;
+            return { dispose: () => {} };
+        });
+        vi.mocked(mockQuickPick.show).mockImplementation(() => {
+            acceptCallback();
+        });
+        setSelectedItems(mockQuickPick, [{ label: 'main', detail: 'main' }]);
+        setActiveItems(mockQuickPick, [{ label: 'main', detail: 'main' }]);
+
+        await viewFileAtRevisionCommand(jj, mockOutputChannel, fileUri);
+
+        const call = vi.mocked(vscode.commands.executeCommand).mock.calls.find((c) => c[0] === 'vscode.open');
+        expect(call).toBeDefined();
+        if (call) {
+            const targetUri = call[1] as vscode.Uri;
+            expect(targetUri.scheme).toBe('jj-view');
+            expect(targetUri.query).toBe('revision=main');
+            expect(targetUri.fsPath).toBe(fileUri.fsPath);
+        }
+    });
+});

--- a/src/test/e2e/view-file.spec.ts
+++ b/src/test/e2e/view-file.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { expect, type Page } from '@playwright/test';
+import { buildGraph, TestRepo } from '../test-repo';
+import {
+    openFileInEditor,
+    openQuickInputWithShortcut,
+    pickQuickPickItem,
+    rightClickAndSelect,
+    test,
+} from './e2e-helpers';
+
+test.describe('View File at Revision E2E', () => {
+    let repo: TestRepo;
+    let page: Page;
+
+    test.beforeEach(async ({ vscode }) => {
+        repo = new TestRepo();
+        repo.init();
+        repo.writeFile('f.txt', 'base content\n');
+        repo.describe('initial');
+
+        // Create a non-linear graph with multiple forks off of 'initial'
+        await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'f.txt': 'base content\n' } },
+            {
+                label: 'branchA1',
+                parents: ['initial'],
+                description: 'branchA1',
+                files: { 'f.txt': 'branchA1 content\n' },
+            },
+            {
+                label: 'branchA2',
+                parents: ['branchA1'],
+                description: 'branchA2',
+                files: { 'f.txt': 'branchA2 content\n' },
+            },
+            {
+                label: 'branchB1',
+                parents: ['initial'],
+                description: 'branchB1',
+                files: { 'f.txt': 'branchB1 content\n' },
+            },
+            {
+                label: 'branchB2',
+                parents: ['branchB1'],
+                description: 'branchB2',
+                files: { 'f.txt': 'branchB2 content\n' },
+            },
+            { label: 'commit1', parents: ['initial'], description: 'commit1', files: { 'f.txt': 'commit1 content\n' } },
+            {
+                label: 'commit2',
+                parents: ['commit1'],
+                description: 'commit2',
+                files: { 'f.txt': 'commit2 content\n' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const setup = await vscode.openWorkspace(repo);
+        page = setup.page;
+    });
+
+    test('View File at Revision via shortcut on non-main fork', async ({ vscode }) => {
+        await openFileInEditor(vscode, page, 'f.txt');
+        await openQuickInputWithShortcut(page, 'Control+Alt+v');
+        await pickQuickPickItem(page, 'branchA2');
+
+        const activeTab = page.getByRole('tab', { name: /f\.txt/, selected: true });
+        await expect(activeTab).toBeVisible({ timeout: 10000 });
+
+        // Verify editor content comes from branchA2 (different chain from working copy commit2)
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await expect(editor).toContainText('branchA2 content', { timeout: 5000 });
+    });
+
+    test('View File at Revision via Tab Context Menu', async ({ vscode }) => {
+        await openFileInEditor(vscode, page, 'f.txt');
+        const activeTab = page.getByRole('tab', { name: 'f.txt', selected: true });
+        await rightClickAndSelect(page, activeTab, 'View File at Revision...');
+        await pickQuickPickItem(page, 'branchB1');
+
+        const newActiveTab = page.getByRole('tab', { name: /f\.txt/, selected: true });
+        await expect(newActiveTab).toBeVisible({ timeout: 10000 });
+
+        // Verify editor content comes from branchB1 (different chain from working copy commit2)
+        const editor = page.locator('.editor-instance .monaco-editor').first();
+        await expect(editor).toContainText('branchB1 content', { timeout: 5000 });
+    });
+
+    test('View File at Revision via Explorer Context Menu', async () => {
+        // Focus file explorer to show treeitem
+        await page.keyboard.press('Control+Shift+E');
+        const treeItem = page.getByRole('treeitem', { name: 'f.txt', exact: true });
+        await expect(treeItem).toBeVisible({ timeout: 5000 });
+
+        await rightClickAndSelect(page, treeItem, 'View File at Revision...');
+        await pickQuickPickItem(page, 'commit1');
+
+        const activeTab = page.getByRole('tab', { name: /f\.txt/, selected: true });
+        await expect(activeTab).toBeVisible({ timeout: 10000 });
+    });
+});

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -224,6 +224,7 @@ export async function launchNewVSCode(
             { key: 'ctrl+alt+e', command: 'workbench.files.action.refreshFilesExplorer' },
             { key: 'ctrl+alt+c', command: 'jj-view.compareWithWorkingCopy' },
             { key: 'ctrl+alt+f', command: 'jj-view.compareFileWith' },
+            { key: 'ctrl+alt+v', command: 'jj-view.viewFileAtRevision' },
             { key: 'ctrl+alt+d', command: 'jj-view.deleteBookmark' },
         ],
         null,

--- a/src/test/jj-view-fs-provider.test.ts
+++ b/src/test/jj-view-fs-provider.test.ts
@@ -11,7 +11,7 @@ import * as vscode from 'vscode';
 import { CodeForgeRegistry } from '../code-forge-registry';
 import { JjRepositoryManager } from '../jj-repository-manager';
 import { JjViewFileSystemProvider } from '../jj-view-fs-provider';
-import { TestRepo } from './test-repo';
+import { buildGraph, TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
 
 describe('JjViewFileSystemProvider', () => {
@@ -50,5 +50,29 @@ describe('JjViewFileSystemProvider', () => {
     it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {
         const outsideUri = vscode.Uri.parse('jj-view:///outside/file.txt?revision=@');
         await expect(provider.readFile(outsideUri)).rejects.toThrowError('No Jujutsu repository found');
+    });
+
+    it('readFile retrieves file content from a revision on a different chain', async () => {
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial', files: { 'f.txt': 'initial content' } },
+            { label: 'chainA', parents: ['initial'], description: 'chainA', files: { 'f.txt': 'chain A content' } },
+            {
+                label: 'chainB',
+                parents: ['initial'],
+                description: 'chainB',
+                files: { 'f.txt': 'chain B content' },
+                isCurrentWorkingCopy: true,
+            },
+        ]);
+
+        const uri = vscode.Uri.from({
+            scheme: 'jj-view',
+            path: `${repo.path}/f.txt`,
+            query: `revision=${nodes.chainA.changeId}`,
+        });
+
+        const bytes = await provider.readFile(uri);
+        const text = Buffer.from(bytes).toString('utf8');
+        expect(text).toBe('chain A content');
     });
 });


### PR DESCRIPTION
Allow opening a read-only view of any workspace file at a specific Jujutsu revision. The command is accessible via the File Explorer context menu, editor context menu, editor title context menu, and command palette.

Add helper to extract target file URIs from command context arguments.