### PR TITLE
feat: open history diff files in working copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Access these commands from the Command Palette (`Ctrl+Shift+P` or `⌘+Shift+P`)
 - `JJ View: Delete Bookmark`: Delete a bookmark.
 - `JJ View: Commit`: Commit the current changes in the working copy (Ctrl+Enter in SCM input).
 - `JJ View: Commit (Prompt)`: Commit the current changes in the working copy, prompting for a description message first.
-- `JJ View: Open File`: Open the file associated with a change.
+- `JJ View: Open File in Working Copy`: Open the file in the working copy.
 - `JJ View: Open Changes`: Open the diff view for a file.
 - `JJ View: Add Workspace`: Create a new `jj` workspace.
 - `JJ View: Forget Workspace`: Forget a workspace without deleting its directory.

--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
             },
             {
                 "command": "jj-view.openFile",
-                "title": "Open File",
+                "title": "Open File in Working Copy",
                 "category": "JJ View",
                 "icon": "$(go-to-file)"
             },
@@ -1030,17 +1030,27 @@
                     "command": "jj-view.completeSquashRevision",
                     "group": "navigation",
                     "when": "resourceFilename == 'SQUASH_MSG'"
+                },
+                {
+                    "command": "jj-view.openFile",
+                    "group": "navigation",
+                    "when": "resourceScheme == 'jj-view' || resourceScheme == 'jj-edit'"
                 }
             ],
             "editor/title/context": [
                 {
                     "command": "jj-view.compareFileWith",
-                    "group": "jj-view",
+                    "group": "jj-view@1",
                     "when": "resourceScheme == 'file'"
                 },
                 {
+                    "command": "jj-view.openFile",
+                    "group": "jj-view@2",
+                    "when": "resourceScheme == 'jj-view' || resourceScheme == 'jj-edit'"
+                },
+                {
                     "command": "jj-view.viewFileAtRevision",
-                    "group": "jj-view",
+                    "group": "jj-view@3",
                     "when": "resourceScheme == 'file'"
                 }
             ],

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -4,14 +4,17 @@
  */
 import * as vscode from 'vscode';
 import type { JjResourceState } from '../scm-resource-state';
+import { extractFileUri } from './command-utils';
 
-// Opens the file on disk (usually the working copy version).
-// Strips the query parameter to ensure VS Code opens the local file path.
-export async function openFileCommand(resourceState: vscode.SourceControlResourceState | undefined) {
-    if (!resourceState) {
+// Opens the file on disk (working copy version).
+// Extracts the file URI from command arguments (or active text editor),
+// converts the scheme to 'file', and strips query parameters.
+export async function openFileCommand(...args: unknown[]) {
+    const resourceUri = extractFileUri(args);
+    if (!resourceUri) {
         return;
     }
-    const uri = resourceState.resourceUri.with({ query: '' });
+    const uri = resourceUri.with({ scheme: 'file', query: '' });
     await vscode.commands.executeCommand('vscode.open', uri);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -547,8 +547,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             await refreshCommand(scm);
         }),
         registerWrappedCommand('jj-view.openFile', async (_scm, _jj, ...args) => {
-            const state = args[0] as vscode.SourceControlResourceState | undefined;
-            await openFileCommand(state);
+            await openFileCommand(...args);
         }),
         registerWrappedCommand('jj-view.openChanges', async (_scm, _jj, ...args) => {
             const state = args[0] as JjResourceState | undefined;

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -7,52 +7,72 @@ import * as vscode from 'vscode';
 import { openChangesCommand, openFileCommand } from '../../commands/open';
 import type { JjResourceState } from '../../scm-resource-state';
 import { createMock } from '../test-utils';
+import { setActiveTextEditor } from '../vscode-mock';
 
-vi.mock('vscode', () => {
-    const uriFactory = (path: string, query: string = '') => ({
-        fsPath: path,
-        path: path,
-        scheme: 'file',
-        query,
-        with: (change: { query?: string }) => uriFactory(path, change.query !== undefined ? change.query : query),
-    });
-
-    return {
-        commands: {
-            executeCommand: vi.fn(),
-        },
-        Uri: {
-            file: (path: string) => uriFactory(path),
-            parse: (path: string) => uriFactory(path),
-        },
-    };
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('../vscode-mock');
+    return createVscodeMock();
 });
 
 describe('openFileCommand', () => {
     afterEach(() => {
         vi.clearAllMocks();
+        setActiveTextEditor(undefined);
     });
 
-    test('does nothing if no resource state', async () => {
-        await openFileCommand(undefined);
+    test('does nothing if no args and no active text editor', async () => {
+        await openFileCommand();
         expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
     });
 
-    test('executes vscode.open with resource uri stripped of query params', async () => {
-        // Create a URI that "starts" with a query, although the mock factory default is empty.
-        // We rely on the fact that openFileCommand calls .with({ query: '' })
+    test('executes vscode.open from SourceControlResourceState', async () => {
         const resourceState = createMock<vscode.SourceControlResourceState>({
-            resourceUri: vscode.Uri.file('/foo'),
+            resourceUri: vscode.Uri.parse('file:///foo?jj-revision=@'),
         });
 
         await openFileCommand(resourceState);
 
-        // We expect it to be called with a URI that has empty query
         expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
             'vscode.open',
             expect.objectContaining({
                 scheme: 'file',
                 path: '/foo',
+                query: '',
+            }),
+        );
+    });
+
+    test('executes vscode.open from a historical URI (jj-view scheme)', async () => {
+        const uri = vscode.Uri.parse('jj-view:///foo/bar.txt?base=c123&side=left');
+
+        await openFileCommand(uri);
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({
+                scheme: 'file',
+                path: '/foo/bar.txt',
+                query: '',
+            }),
+        );
+    });
+
+    test('executes vscode.open from activeTextEditor fallback when args are empty', async () => {
+        setActiveTextEditor(
+            createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({
+                    uri: vscode.Uri.parse('jj-edit:///baz/qux.ts?revision=rev123'),
+                }),
+            }),
+        );
+
+        await openFileCommand();
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({
+                scheme: 'file',
+                path: '/baz/qux.ts',
                 query: '',
             }),
         );
@@ -73,7 +93,6 @@ describe('openChangesCommand', () => {
         const resourceState = createMock<JjResourceState>({
             resourceUri: vscode.Uri.file('/foo'),
             revision: '@',
-            // Missing leftUri and rightUri
         });
 
         await openChangesCommand(resourceState);

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -731,7 +731,9 @@ test.describe('SCM Pane E2E', () => {
         await openScmMerge(page, /conflict\.txt/i);
 
         // 4. Open File via inline button -> should open regular editor
-        const openFileIcon = modifiedRow.getByRole('button', { name: 'Open File', exact: true }).first();
+        const openFileIcon = modifiedRow
+            .getByRole('button', { name: 'Open File in Working Copy', exact: true })
+            .first();
         await hoverAndClick(modifiedRow, openFileIcon);
         await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 5000 });
         await expect(page.locator('.monaco-diff-editor')).not.toBeVisible();

--- a/src/test/e2e/view-file.spec.ts
+++ b/src/test/e2e/view-file.spec.ts
@@ -6,8 +6,10 @@
 import { expect, type Page } from '@playwright/test';
 import { buildGraph, TestRepo } from '../test-repo';
 import {
+    focusSCM,
     openFileInEditor,
     openQuickInputWithShortcut,
+    openScmDiff,
     pickQuickPickItem,
     rightClickAndSelect,
     test,
@@ -102,5 +104,38 @@ test.describe('View File at Revision E2E', () => {
 
         const activeTab = page.getByRole('tab', { name: /f\.txt/, selected: true });
         await expect(activeTab).toBeVisible({ timeout: 10000 });
+    });
+
+    test('Open File in Working Copy via Tab Context Menu', async ({ vscode }) => {
+        await openFileInEditor(vscode, page, 'f.txt');
+        await openQuickInputWithShortcut(page, 'Control+Alt+v');
+        await pickQuickPickItem(page, 'branchA2');
+
+        const revisionTab = page.getByRole('tab', { name: /f\.txt/, selected: true });
+        await expect(revisionTab).toBeVisible({ timeout: 10000 });
+
+        // Verify editor content comes from historical revision (branchA2)
+        const historicalEditor = page.locator('.editor-instance .monaco-editor').first();
+        await expect(historicalEditor).toContainText('branchA2 content', { timeout: 5000 });
+
+        await rightClickAndSelect(page, revisionTab, 'Open File in Working Copy');
+
+        // Verify editor content changes to current working copy content (commit2)
+        const wcEditor = page.locator('.editor-instance .monaco-editor').first();
+        await expect(wcEditor).toContainText('commit2 content', { timeout: 5000 });
+    });
+
+    test('Open File in Working Copy from Diff Tab Context Menu', async () => {
+        await focusSCM(page);
+        await openScmDiff(page, 'f.txt', /commit1/);
+
+        const diffTab = page.getByRole('tab', { name: /f\.txt \(/, selected: true });
+        await expect(diffTab).toBeVisible({ timeout: 10000 });
+
+        await rightClickAndSelect(page, diffTab, 'Open File in Working Copy');
+
+        // Verify editor content switches to working copy content (commit2)
+        const wcEditor = page.locator('.editor-instance .monaco-editor').first();
+        await expect(wcEditor).toContainText('commit2 content', { timeout: 5000 });
     });
 });

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -21,6 +21,7 @@ import type { JjScmProvider } from '../jj-scm-provider';
 import { ScopedSymlink, ScopedTempDir } from './scoped-helpers';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
+import { setActiveTextEditor } from './vscode-mock';
 
 describe('resolveRepository', () => {
     let repo: TestRepo;
@@ -101,13 +102,11 @@ describe('resolveRepository', () => {
 
     it('resolves repository from active text editor when no arguments provided', () => {
         const activeUri = vscode.Uri.file(path.join(repo.path, 'other.txt'));
-        // Set up vscode mock active text editor
-        Object.defineProperty(vscode.window, 'activeTextEditor', {
-            get: () => ({
-                document: { uri: activeUri },
+        setActiveTextEditor(
+            createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({ uri: activeUri }),
             }),
-            configurable: true,
-        });
+        );
 
         const result = resolveRepository([], repoManager, scmProviders);
 
@@ -115,11 +114,7 @@ describe('resolveRepository', () => {
         expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
 
-        // Reset active text editor
-        Object.defineProperty(vscode.window, 'activeTextEditor', {
-            get: () => undefined,
-            configurable: true,
-        });
+        setActiveTextEditor(undefined);
     });
 
     it('resolves repository from active custom jj-commit editor', () => {
@@ -128,12 +123,11 @@ describe('resolveRepository', () => {
             path: '/Commit:%20abc123',
             query: `changeId=abc12345&repoRoot=${encodeURIComponent(repo.path)}`,
         });
-        Object.defineProperty(vscode.window, 'activeTextEditor', {
-            get: () => ({
-                document: { uri: commitUri },
+        setActiveTextEditor(
+            createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({ uri: commitUri }),
             }),
-            configurable: true,
-        });
+        );
 
         const result = resolveRepository([], repoManager, scmProviders);
 
@@ -141,10 +135,7 @@ describe('resolveRepository', () => {
         expect(result?.repo).toBe(resolvedRepo);
         expect(result?.scm).toBe(mockScm);
 
-        Object.defineProperty(vscode.window, 'activeTextEditor', {
-            get: () => undefined,
-            configurable: true,
-        });
+        setActiveTextEditor(undefined);
     });
 
     it('falls back to focused repository when arg and active editor are not in any repository', () => {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -3,6 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { vi } from 'vitest';
+import type * as vscode from 'vscode';
+
+let activeTextEditorState: unknown;
+
+/**
+ * Helper to set or reset vscode.window.activeTextEditor in tests without type casting.
+ */
+export function setActiveTextEditor(editor: Partial<vscode.TextEditor> | undefined): void {
+    activeTextEditorState = editor;
+}
 
 /**
  * Helper to parse a URI string into components for MockUri.
@@ -313,6 +323,12 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             },
         },
         window: {
+            get activeTextEditor() {
+                return activeTextEditorState;
+            },
+            set activeTextEditor(editor: unknown) {
+                activeTextEditorState = editor;
+            },
             showErrorMessage: vi.fn(),
             showInformationMessage: vi.fn(),
             showWarningMessage: vi.fn(),


### PR DESCRIPTION
Added an ever-missing button to open the inspected file in the working copy, which is already available in vsc-git and jjk.