### PR TITLE
feat: preserve editor selection and scroll when opening SCM files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1253,6 +1253,7 @@
         "@parcel/watcher": "^2.5.6",
         "@vscode-elements/elements": "^2.4.0",
         "@vscode/codicons": "^0.0.45",
+        "diff": "^9.0.0",
         "parse-diff": "^0.11.1",
         "prettier": "^3.8.1",
         "react": "^19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vscode/codicons':
         specifier: ^0.0.45
         version: 0.0.45
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       parse-diff:
         specifier: ^0.11.1
         version: 0.11.1
@@ -83,10 +86,10 @@ importers:
         version: 0.0.12
       '@vscode/test-electron':
         specifier: ^2.5.2
-        version: 2.5.2
+        version: 2.5.2(supports-color@8.1.1)
       '@vscode/vsce':
         specifier: ^3.9.1
-        version: 3.9.1
+        version: 3.9.1(supports-color@8.1.1)
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
@@ -113,7 +116,7 @@ importers:
         version: 21.0.1
       svgtofont:
         specifier: ^6.5.1
-        version: 6.5.1(chokidar@3.6.0)
+        version: 6.5.1(chokidar@3.6.0)(supports-color@8.1.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1037,7 +1040,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
@@ -1447,6 +1450,10 @@ packages:
 
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dom-serializer@2.0.0:
@@ -2653,7 +2660,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   renderdag-ts@https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c:
-    resolution: {tarball: https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/brychanrobot/renderdag-ts/tar.gz/22ba007b7ae2a08cef781070d441fa19ba5f197c}
     version: 1.0.0
 
   require-directory@2.1.1:
@@ -3768,13 +3775,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@npmcli/agent@3.0.0':
+  '@npmcli/agent@3.0.0(supports-color@8.1.1)':
     dependencies:
       agent-base: 7.1.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4093,8 +4100,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.2':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -4160,10 +4167,10 @@ snapshots:
     transitivePeerDependencies:
       - monocart-coverage-reports
 
-  '@vscode/test-electron@2.5.2':
+  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.7.3
@@ -4209,7 +4216,7 @@ snapshots:
       '@vscode/vsce-sign-win32-arm64': 2.0.6
       '@vscode/vsce-sign-win32-x64': 2.0.6
 
-  '@vscode/vsce@3.9.1':
+  '@vscode/vsce@3.9.1(supports-color@8.1.1)':
     dependencies:
       '@azure/identity': 4.13.0
       '@secretlint/node': 10.2.2
@@ -4232,7 +4239,7 @@ snapshots:
       minimatch: 3.1.2
       parse-semver: 1.1.1
       read: 1.0.7
-      secretlint: 10.2.2
+      secretlint: 10.2.2(supports-color@8.1.1)
       semver: 7.7.3
       tmp: 0.2.5
       typed-rest-client: 1.8.11
@@ -4683,6 +4690,8 @@ snapshots:
 
   diff@8.0.2: {}
 
+  diff@9.0.0: {}
+
   dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
@@ -5132,14 +5141,14 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -5514,9 +5523,9 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  make-fetch-happen@14.0.3:
+  make-fetch-happen@14.0.3(supports-color@8.1.1):
     dependencies:
-      '@npmcli/agent': 3.0.0
+      '@npmcli/agent': 3.0.0(supports-color@8.1.1)
       cacache: 19.0.1
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
@@ -5687,12 +5696,12 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-gyp@11.5.0:
+  node-gyp@11.5.0(supports-color@8.1.1):
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 14.0.3
+      make-fetch-happen: 14.0.3(supports-color@8.1.1)
       nopt: 8.1.0
       proc-log: 5.0.0
       semver: 7.7.3
@@ -5797,7 +5806,7 @@ snapshots:
 
   ovsx@0.10.8:
     dependencies:
-      '@vscode/vsce': 3.9.1
+      '@vscode/vsce': 3.9.1(supports-color@8.1.1)
       commander: 6.2.1
       follow-redirects: 1.15.11
       is-ci: 2.0.0
@@ -6135,7 +6144,7 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  secretlint@10.2.2:
+  secretlint@10.2.2(supports-color@8.1.1):
     dependencies:
       '@secretlint/config-creator': 10.2.2
       '@secretlint/formatter': 10.2.2
@@ -6255,7 +6264,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -6414,7 +6423,7 @@ snapshots:
       microbuffer: 1.0.0
       svgpath: 2.6.0
 
-  svgicons2svgfont@15.0.1:
+  svgicons2svgfont@15.0.1(supports-color@8.1.1):
     dependencies:
       '@types/sax': 1.2.7
       commander: 12.1.0
@@ -6439,7 +6448,7 @@ snapshots:
 
   svgpath@2.6.0: {}
 
-  svgtofont@6.5.1(chokidar@3.6.0):
+  svgtofont@6.5.1(chokidar@3.6.0)(supports-color@8.1.1):
     dependencies:
       auto-config-loader: 2.0.2
       cheerio: 1.0.0
@@ -6448,11 +6457,11 @@ snapshots:
       image2uri: 2.1.2
       nunjucks: 3.2.4(chokidar@3.6.0)
       svg2ttf: 6.0.3
-      svgicons2svgfont: 15.0.1
+      svgicons2svgfont: 15.0.1(supports-color@8.1.1)
       svgo: 3.3.3
       ttf2eot: 3.1.0
       ttf2woff: 3.0.0
-      ttf2woff2: 8.0.1
+      ttf2woff2: 8.0.1(supports-color@8.1.1)
       yargs: 17.7.2
     transitivePeerDependencies:
       - chokidar
@@ -6551,13 +6560,13 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  ttf2woff2@8.0.1:
+  ttf2woff2@8.0.1(supports-color@8.1.1):
     dependencies:
       bindings: 1.5.0
       bufferstreams: 4.0.0
       debug: 4.4.3(supports-color@8.1.1)
       nan: 2.25.0
-      node-gyp: 11.5.0
+      node-gyp: 11.5.0(supports-color@8.1.1)
       yerror: 8.0.0
     transitivePeerDependencies:
       - supports-color

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -2,9 +2,200 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import { diffArrays } from 'diff';
 import * as vscode from 'vscode';
 import type { JjResourceState } from '../scm-resource-state';
 import { extractFileUri } from './command-utils';
+
+// Exact lines are anchors; unmatched lines retain their relative position inside the intervening hunk.
+function mapHunkLine(sourceOffset: number, sourceCount: number, targetStart: number, targetCount: number): number {
+    if (targetCount === 0 || sourceCount === 1) {
+        return targetStart;
+    }
+    return targetStart + Math.round((sourceOffset * (targetCount - 1)) / (sourceCount - 1));
+}
+
+interface LineMapping {
+    lines: Map<number, number>;
+    deletedSourceLines: Set<number>;
+}
+
+function computeLineMapping(sourceLines: string[], targetLines: string[]): LineMapping {
+    const lines = new Map<number, number>();
+    const deletedSourceLines = new Set<number>();
+    let sourceIndex = 0;
+    let targetIndex = 0;
+    let hunkSourceStart = 0;
+    let hunkTargetStart = 0;
+    let hunkSourceCount = 0;
+    let hunkTargetCount = 0;
+
+    const flushHunk = () => {
+        for (let offset = 0; offset < hunkSourceCount; offset++) {
+            const sourceLine = hunkSourceStart + offset;
+            lines.set(sourceLine, mapHunkLine(offset, hunkSourceCount, hunkTargetStart, hunkTargetCount));
+            if (hunkTargetCount === 0) {
+                deletedSourceLines.add(sourceLine);
+            }
+        }
+        hunkSourceCount = 0;
+        hunkTargetCount = 0;
+    };
+
+    for (const change of diffArrays(sourceLines, targetLines)) {
+        if (!change.added && !change.removed) {
+            flushHunk();
+            for (let offset = 0; offset < change.count; offset++) {
+                lines.set(sourceIndex + offset, targetIndex + offset);
+            }
+            sourceIndex += change.count;
+            targetIndex += change.count;
+            continue;
+        }
+
+        if (hunkSourceCount === 0 && hunkTargetCount === 0) {
+            hunkSourceStart = sourceIndex;
+            hunkTargetStart = targetIndex;
+        }
+        if (change.removed) {
+            sourceIndex += change.count;
+            hunkSourceCount += change.count;
+        } else {
+            targetIndex += change.count;
+            hunkTargetCount += change.count;
+        }
+    }
+    flushHunk();
+
+    return { lines, deletedSourceLines };
+}
+
+function getVisibleCenterLine(editor: vscode.TextEditor): number | undefined {
+    const ranges = editor.visibleRanges;
+    if (!ranges || ranges.length === 0) {
+        return undefined;
+    }
+    return Math.floor((ranges[0].start.line + ranges[0].end.line) / 2);
+}
+
+interface OpenSync {
+    selections: readonly vscode.Selection[];
+    scrollCenterLine?: number;
+    sourceContent: string;
+}
+
+interface TrackedEditorState {
+    document: vscode.TextDocument;
+    selections: readonly vscode.Selection[];
+    scrollCenterLine?: number;
+}
+
+// Editor menu commands can target hidden tabs by URI, but VS Code exposes no TextEditor for their
+// selection or viewport. Retain the last visible state until the backing document is closed.
+const trackedEditorStates = new Map<string, TrackedEditorState>();
+
+function uriKey(uri: vscode.Uri): string {
+    return uri.toString();
+}
+
+function captureEditorState(editor: vscode.TextEditor): TrackedEditorState {
+    return {
+        document: editor.document,
+        selections: [...editor.selections],
+        scrollCenterLine: getVisibleCenterLine(editor),
+    };
+}
+
+function rememberEditorState(editor: vscode.TextEditor): void {
+    trackedEditorStates.set(uriKey(editor.document.uri), captureEditorState(editor));
+}
+
+export function registerOpenSyncTracking(): vscode.Disposable {
+    trackedEditorStates.clear();
+    for (const editor of vscode.window.visibleTextEditors) {
+        rememberEditorState(editor);
+    }
+    if (vscode.window.activeTextEditor) {
+        rememberEditorState(vscode.window.activeTextEditor);
+    }
+
+    const disposables = [
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            if (editor) {
+                rememberEditorState(editor);
+            }
+        }),
+        vscode.window.onDidChangeTextEditorSelection((event) => rememberEditorState(event.textEditor)),
+        vscode.window.onDidChangeTextEditorVisibleRanges((event) => rememberEditorState(event.textEditor)),
+        vscode.workspace.onDidCloseTextDocument((document) => trackedEditorStates.delete(uriKey(document.uri))),
+    ];
+
+    return new vscode.Disposable(() => {
+        for (const disposable of disposables) {
+            disposable.dispose();
+        }
+        trackedEditorStates.clear();
+    });
+}
+
+function mapPosition(mapping: LineMapping, position: vscode.Position, targetLines: string[]): vscode.Position {
+    const targetLine = mapping.lines.get(position.line) ?? targetLines.length - 1;
+    if (mapping.deletedSourceLines.has(position.line)) {
+        if (targetLine >= targetLines.length) {
+            const lastLine = targetLines.length - 1;
+            return new vscode.Position(lastLine, targetLines[lastLine].length);
+        }
+        return new vscode.Position(targetLine, 0);
+    }
+    const clampedLine = Math.min(targetLine, Math.max(0, targetLines.length - 1));
+    return new vscode.Position(clampedLine, Math.min(position.character, targetLines[clampedLine].length));
+}
+
+function mapSelection(mapping: LineMapping, selection: vscode.Selection, targetLines: string[]): vscode.Selection {
+    return new vscode.Selection(
+        mapPosition(mapping, selection.anchor, targetLines),
+        mapPosition(mapping, selection.active, targetLines),
+    );
+}
+
+function clampPosition(position: vscode.Position, targetLines: string[]): vscode.Position {
+    const line = Math.min(position.line, Math.max(0, targetLines.length - 1));
+    return new vscode.Position(line, Math.min(position.character, targetLines[line].length));
+}
+
+function findLiveEditor(uri: vscode.Uri): vscode.TextEditor | undefined {
+    const key = uriKey(uri);
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor && uriKey(activeEditor.document.uri) === key) {
+        return activeEditor;
+    }
+    return vscode.window.visibleTextEditors.find((editor) => uriKey(editor.document.uri) === key);
+}
+
+function getSourceEditorState(args: unknown[]): TrackedEditorState | undefined {
+    const explicitSourceUri = args[0] instanceof vscode.Uri ? args[0] : undefined;
+    if (explicitSourceUri) {
+        // Prefer current state when the tab is visible; context menus on hidden tabs use the remembered state.
+        const liveEditor = findLiveEditor(explicitSourceUri);
+        return liveEditor ? captureEditorState(liveEditor) : trackedEditorStates.get(uriKey(explicitSourceUri));
+    }
+
+    const activeEditor = vscode.window.activeTextEditor;
+    return activeEditor ? captureEditorState(activeEditor) : undefined;
+}
+
+function computeOpenSync(args: unknown[], openUri: vscode.Uri): OpenSync | undefined {
+    const source = getSourceEditorState(args);
+    if (!source || source.document.uri.fsPath !== openUri.fsPath) {
+        return undefined;
+    }
+
+    return {
+        selections: source.selections,
+        scrollCenterLine: source.scrollCenterLine,
+        sourceContent: source.document.getText(),
+    };
+}
 
 // Opens the file on disk (working copy version).
 // Extracts the file URI from command arguments (or active text editor),
@@ -15,7 +206,34 @@ export async function openFileCommand(...args: unknown[]) {
         return;
     }
     const uri = resourceUri.with({ scheme: 'file', query: '' });
-    await vscode.commands.executeCommand('vscode.open', uri);
+    const sync = computeOpenSync(args, uri);
+    if (!sync) {
+        await vscode.commands.executeCommand('vscode.open', uri);
+        return;
+    }
+
+    const editor = await vscode.window.showTextDocument(uri);
+    const targetContent = editor.document.getText();
+    const targetLines = targetContent.split(/\r?\n/);
+    const mapping =
+        sync.sourceContent === targetContent
+            ? undefined
+            : computeLineMapping(sync.sourceContent.split(/\r?\n/), targetLines);
+    editor.selections = sync.selections.map((selection) => {
+        const mappedSelection = mapping === undefined ? selection : mapSelection(mapping, selection, targetLines);
+        return new vscode.Selection(
+            clampPosition(mappedSelection.anchor, targetLines),
+            clampPosition(mappedSelection.active, targetLines),
+        );
+    });
+    if (sync.scrollCenterLine !== undefined) {
+        const mappedLine =
+            mapping === undefined
+                ? sync.scrollCenterLine
+                : mapPosition(mapping, new vscode.Position(sync.scrollCenterLine, 0), targetLines).line;
+        const pos = clampPosition(new vscode.Position(mappedLine, 0), targetLines);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+    }
 }
 
 // Opens the diff view for the given resource state.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ import { showMultiFileDiffCommand } from './commands/multi-diff';
 import { newCommand } from './commands/new';
 import { newAfterCommand } from './commands/new-after';
 import { newBeforeCommand } from './commands/new-before';
-import { openChangesCommand, openFileCommand } from './commands/open';
+import { openChangesCommand, openFileCommand, registerOpenSyncTracking } from './commands/open';
 import { registerProcessMonitorCommands } from './commands/process-monitor';
 import { type CommitMenuContext, rebaseOntoSelectedCommand } from './commands/rebase';
 import { redoCommand } from './commands/redo';
@@ -102,6 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     const realOutputChannel = vscode.window.createOutputChannel('JJ View', { log: true });
     const outputChannel = new JjOutputChannel(realOutputChannel);
     context.subscriptions.push(realOutputChannel);
+    context.subscriptions.push(registerOpenSyncTracking());
 
     // Get preferred binary path configuration
     const preferredPath = getJjViewConfig<string>('binaryPath');

--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -52,9 +52,9 @@ export function createJjResourceState(
             : openDiffOnClick || isDeleted
               ? diffCommand
               : {
-                    command: 'vscode.open',
+                    command: 'jj-view.openFile',
                     title: 'Open File',
-                    arguments: [resourceUri.with({ query: '' })],
+                    arguments: [{ resourceUri, rightUri, revision }],
                 };
 
     const flags: string[] = [];

--- a/src/test/commands/open.test.ts
+++ b/src/test/commands/open.test.ts
@@ -4,20 +4,62 @@
  */
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { openChangesCommand, openFileCommand } from '../../commands/open';
+import { openChangesCommand, openFileCommand, registerOpenSyncTracking } from '../../commands/open';
 import type { JjResourceState } from '../../scm-resource-state';
 import { createMock } from '../test-utils';
-import { setActiveTextEditor } from '../vscode-mock';
+import { fireDidChangeActiveTextEditor, setActiveTextEditor } from '../vscode-mock';
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
-    return createVscodeMock();
+    return createVscodeMock({
+        TextEditorRevealType: {
+            Default: 0,
+            InCenter: 1,
+            InCenterIfOutsideViewport: 2,
+            AtTop: 3,
+        },
+    });
 });
+
+function setActiveEditor(
+    uri: vscode.Uri,
+    text: string,
+    selection: vscode.Selection,
+    visibleRanges: vscode.Range[] = [],
+    selections: readonly vscode.Selection[] = [selection],
+): vscode.TextEditor {
+    const editor = createMock<vscode.TextEditor>({
+        document: createMock<vscode.TextDocument>({
+            uri,
+            getText: vi.fn().mockReturnValue(text),
+        }),
+        selection,
+        selections,
+        visibleRanges,
+        revealRange: vi.fn(),
+    });
+    vscode.window.activeTextEditor = editor;
+    return editor;
+}
+
+function setOpenTarget(uri: vscode.Uri, text: string): vscode.TextEditor {
+    const editor = createMock<vscode.TextEditor>({
+        document: createMock<vscode.TextDocument>({
+            uri,
+            getText: vi.fn().mockReturnValue(text),
+        }),
+        selections: [],
+        revealRange: vi.fn(),
+    });
+    (vscode.window.showTextDocument as ReturnType<typeof vi.fn>).mockResolvedValue(editor);
+    return editor;
+}
 
 describe('openFileCommand', () => {
     afterEach(() => {
         vi.clearAllMocks();
         setActiveTextEditor(undefined);
+        vscode.window.visibleTextEditors = [];
     });
 
     test('does nothing if no args and no active text editor', async () => {
@@ -27,7 +69,295 @@ describe('openFileCommand', () => {
 
     test('executes vscode.open from SourceControlResourceState', async () => {
         const resourceState = createMock<vscode.SourceControlResourceState>({
+            resourceUri: vscode.Uri.file('/foo').with({ query: 'jj-revision=rev123' }),
+        });
+
+        await openFileCommand(resourceState);
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({
+                scheme: 'file',
+                path: '/foo',
+                query: '',
+            }),
+        );
+    });
+
+    test('opens on-disk file even when the resource state has a revision-backed uri', async () => {
+        const rightUri = vscode.Uri.file('/foo').with({
+            scheme: 'jj-edit',
+            query: 'revision=rev123',
+        });
+        const resourceUri = vscode.Uri.file('/foo').with({ query: 'jj-revision=rev123' });
+        const resourceState = createMock<JjResourceState>({
+            resourceUri,
+            rightUri,
+            revision: 'rev123',
+        });
+
+        await openFileCommand(resourceState);
+
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({
+                scheme: 'file',
+                path: '/foo',
+                query: '',
+            }),
+        );
+    });
+
+    test('syncs all cursors and scroll position to the opened target editor', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({
+            scheme: 'jj-edit',
+            query: 'revision=rev123',
+        });
+        const resourceUri = vscode.Uri.file('/foo').with({ query: 'jj-revision=rev123' });
+        const primary = new vscode.Selection(new vscode.Position(7, 3), new vscode.Position(7, 3));
+        const secondary = new vscode.Selection(new vscode.Position(4, 6), new vscode.Position(3, 2));
+        const content = Array.from({ length: 10 }, (_, line) => `line-${line}`).join('\n');
+        setActiveEditor(revisionUri, content, primary, [new vscode.Range(6, 0, 9, 0)], [primary, secondary]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), content);
+        const resourceState = createMock<JjResourceState>({
+            resourceUri,
+            rightUri: revisionUri,
+            revision: 'rev123',
+        });
+
+        await openFileCommand(resourceState);
+
+        expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
+            expect.objectContaining({ scheme: 'file', path: '/foo', query: '' }),
+        );
+        expect(targetEditor.selections).toEqual([primary, secondary]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 7, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('maps cursor and viewport through inserted lines using unchanged anchors', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({
+            scheme: 'jj-edit',
+            query: 'revision=revB',
+        });
+        const selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, 0));
+        setActiveEditor(revisionUri, 'line1\nline2\nline5', selection, [new vscode.Range(2, 0, 2, 0)]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'line1\nline2\ninserted\nline3\nline4\nline5');
+        const resourceState = createMock<JjResourceState>({
+            resourceUri: vscode.Uri.file('/foo'),
+            revision: '@',
+        });
+
+        await openFileCommand(resourceState);
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+        ]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 5, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('remaps from the left side of a working-copy diff', async () => {
+        const diffUri = vscode.Uri.parse('jj-view:///foo?base=%40&side=left');
+        const selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, 0));
+        setActiveEditor(diffUri, 'line1\nline2\nline5', selection, [new vscode.Range(2, 0, 2, 0)]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'line1\nline2\ninserted\nline3\nline4\nline5');
+
+        await openFileCommand(diffUri);
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+        ]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 5, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('remaps stale content from the right side of a working-copy diff', async () => {
+        const diffUri = vscode.Uri.parse('jj-view:///foo?base=%40&side=right');
+        const selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, 0));
+        setActiveEditor(diffUri, 'line1\nline2\nline5', selection, [new vscode.Range(2, 0, 2, 0)]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'line1\nline2\ninserted\nline3\nline4\nline5');
+
+        await openFileCommand(diffUri);
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+        ]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 5, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('maps replacement lines proportionally between unchanged anchors', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({
+            scheme: 'jj-edit',
+            query: 'revision=revB',
+        });
+        const selection = new vscode.Selection(new vscode.Position(1, 2), new vscode.Position(3, 2));
+        setActiveEditor(revisionUri, 'before\nold1\nold2\nold3\nafter', selection, [new vscode.Range(1, 0, 3, 0)]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'before\nnew1\nnew2\nafter');
+        const resourceState = createMock<JjResourceState>({
+            resourceUri: vscode.Uri.file('/foo'),
+            revision: '@',
+        });
+
+        await openFileCommand(resourceState);
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(1, 2), new vscode.Position(2, 2)),
+        ]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 2, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('maps deleted lines to the deletion boundary', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({ scheme: 'jj-edit', query: 'revision=revB' });
+        const selection = new vscode.Selection(new vscode.Position(2, 2), new vscode.Position(2, 2));
+        setActiveEditor(revisionUri, 'before\nremoved1\nremoved2\nafter', selection);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'before\nafter');
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0)),
+        ]);
+    });
+
+    test('shrinks selections with one endpoint in a deletion without collapsing them', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({ scheme: 'jj-edit', query: 'revision=revB' });
+        const deletedActive = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(3, 5));
+        const deletedAnchor = new vscode.Selection(new vscode.Position(3, 4), new vscode.Position(4, 2));
+        setActiveEditor(
+            revisionUri,
+            'before\nkept\nremoved1\nremoved2\nafter',
+            deletedActive,
+            [],
+            [deletedActive, deletedAnchor],
+        );
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'before\nkept\nafter');
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(2, 0)),
+            new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, 2)),
+        ]);
+    });
+
+    test('clamps a trailing deletion to the final target line', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({ scheme: 'jj-edit', query: 'revision=revB' });
+        const selection = new vscode.Selection(new vscode.Position(2, 2), new vscode.Position(2, 2));
+        setActiveEditor(revisionUri, 'before\nremoved1\nremoved2', selection);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'before');
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(0, 6), new vscode.Position(0, 6)),
+        ]);
+    });
+
+    test('maps against the live target editor content', async () => {
+        const revisionUri = vscode.Uri.file('/foo').with({ scheme: 'jj-edit', query: 'revision=revB' });
+        const selection = new vscode.Selection(new vscode.Position(5, 100), new vscode.Position(3, 100));
+        setActiveEditor(revisionUri, 'line1\nline2\nline3\nline4\nline5\nline6', selection, [
+            new vscode.Range(4, 0, 5, 0),
+        ]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'short\nlast');
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(targetEditor.selections).toEqual([
+            new vscode.Selection(new vscode.Position(1, 4), new vscode.Position(1, 4)),
+        ]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 1, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
+        );
+    });
+
+    test('skips remapping when the active editor already shows the target revision', async () => {
+        const selection = new vscode.Selection(new vscode.Position(1, 2), new vscode.Position(1, 2));
+        setActiveEditor(vscode.Uri.file('/foo'), 'one\ntwo', selection);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'one\ntwo');
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(targetEditor.selections).toEqual([selection]);
+    });
+
+    test('opens normally without synchronization when the active editor is another file', async () => {
+        const selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
+        setActiveEditor(vscode.Uri.file('/other'), 'line1\nline2', selection);
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo'), revision: '@' }));
+
+        expect(vscode.window.showTextDocument).not.toHaveBeenCalled();
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({ scheme: 'file', path: '/foo', query: '' }),
+        );
+    });
+
+    test('does not sync files whose paths differ only by case', async () => {
+        const selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, 0));
+        setActiveEditor(vscode.Uri.file('/Foo.ts'), 'line1\nline2', selection);
+
+        await openFileCommand(createMock<JjResourceState>({ resourceUri: vscode.Uri.file('/foo.ts'), revision: '@' }));
+
+        expect(vscode.window.showTextDocument).not.toHaveBeenCalled();
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'vscode.open',
+            expect.objectContaining({ scheme: 'file', path: '/foo.ts', query: '' }),
+        );
+    });
+
+    test('syncs from a previously active tab when the menu supplies its uri', async () => {
+        const revisionUri = vscode.Uri.parse('jj-view:///foo?revision=revB');
+        const selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, 0));
+        setActiveTextEditor(undefined);
+        const tracking = registerOpenSyncTracking();
+
+        try {
+            const revisionEditor = setActiveEditor(revisionUri, 'line1\nline2\nline5', selection, [
+                new vscode.Range(2, 0, 2, 0),
+            ]);
+            fireDidChangeActiveTextEditor(revisionEditor);
+            const otherSelection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+            setActiveEditor(vscode.Uri.file('/other'), 'other', otherSelection);
+            const targetEditor = setOpenTarget(vscode.Uri.file('/foo'), 'line1\nline2\ninserted\nline3\nline4\nline5');
+
+            await openFileCommand(revisionUri);
+
+            expect(targetEditor.selections).toEqual([
+                new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, 0)),
+            ]);
+            expect(targetEditor.revealRange).toHaveBeenCalledWith(
+                expect.objectContaining({ start: expect.objectContaining({ line: 5, character: 0 }) }),
+                vscode.TextEditorRevealType.InCenter,
+            );
+        } finally {
+            tracking.dispose();
+        }
+    });
+
+    test('no active editor: opens without selection', async () => {
+        const resourceState = createMock<JjResourceState>({
             resourceUri: vscode.Uri.parse('file:///foo?jj-revision=@'),
+            rightUri: vscode.Uri.file('/foo').with({
+                scheme: 'jj-edit',
+                query: 'revision=rev123',
+            }),
+            revision: 'rev123',
         });
 
         await openFileCommand(resourceState);
@@ -57,24 +387,25 @@ describe('openFileCommand', () => {
         );
     });
 
-    test('executes vscode.open from activeTextEditor fallback when args are empty', async () => {
-        setActiveTextEditor(
-            createMock<vscode.TextEditor>({
-                document: createMock<vscode.TextDocument>({
-                    uri: vscode.Uri.parse('jj-edit:///baz/qux.ts?revision=rev123'),
-                }),
-            }),
-        );
+    test('syncs from activeTextEditor fallback when args are empty', async () => {
+        const revisionUri = vscode.Uri.parse('jj-edit:///baz/qux.ts?revision=rev123');
+        const selection = new vscode.Selection(new vscode.Position(1, 2), new vscode.Position(1, 2));
+        setActiveEditor(revisionUri, 'first\nsecond', selection, [new vscode.Range(0, 0, 1, 0)]);
+        const targetEditor = setOpenTarget(vscode.Uri.file('/baz/qux.ts'), 'first\nsecond');
 
         await openFileCommand();
 
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-            'vscode.open',
+        expect(vscode.window.showTextDocument).toHaveBeenCalledWith(
             expect.objectContaining({
                 scheme: 'file',
                 path: '/baz/qux.ts',
                 query: '',
             }),
+        );
+        expect(targetEditor.selections).toEqual([selection]);
+        expect(targetEditor.revealRange).toHaveBeenCalledWith(
+            expect.objectContaining({ start: expect.objectContaining({ line: 0, character: 0 }) }),
+            vscode.TextEditorRevealType.InCenter,
         );
     });
 });

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -170,13 +170,18 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok(command, 'Resource state should have a command');
         assert.strictEqual(
             command.command,
-            'vscode.open',
-            'Command should be vscode.open when openDiffOnClick is false',
+            'jj-view.openFile',
+            'Command should be jj-view.openFile when openDiffOnClick is false',
         );
         assert.strictEqual(command.arguments?.length, 1, 'Open command should have 1 argument');
-        const openUri = command.arguments?.[0] as vscode.Uri;
-        assert.strictEqual(normalize(openUri.fsPath), normalize(filePath), 'Open URI should be the file path');
-        assert.strictEqual(openUri.query, '', 'Open URI should have no query string');
+        const openArg = command.arguments?.[0] as JjResourceState;
+        assert.strictEqual(
+            normalize(openArg.resourceUri.fsPath),
+            normalize(filePath),
+            'Open resource URI should be the file path',
+        );
+        assert.ok(openArg.rightUri, 'Open command should include rightUri');
+        assert.strictEqual(normalize(openArg.rightUri.fsPath), normalize(filePath), 'rightUri should be the file path');
 
         const { diffTitle } = resourceState as JjResourceState;
         assert.ok(diffTitle, 'diffTitle should be set');

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -131,7 +131,7 @@ describe('createJjResourceState', () => {
                 openDiffOnClick: false,
                 inConflictGroup: false,
             });
-            expect(stateOpen.command?.command).toBe('vscode.open');
+            expect(stateOpen.command?.command).toBe('jj-view.openFile');
         });
 
         it('routes to diff command if openDiffOnClick is true', () => {
@@ -152,14 +152,17 @@ describe('createJjResourceState', () => {
             expect(state.command?.command).toBe('vscode.diff');
         });
 
-        it('routes to vscode.open with query stripped if openDiffOnClick is false and not deleted', () => {
+        it('routes to open file wrapper if openDiffOnClick is false and not deleted', () => {
             const state = createJjResourceState(entry, 'rev123', root, {
                 openDiffOnClick: false,
             });
 
-            expect(state.command?.command).toBe('vscode.open');
-            expect(state.command?.arguments?.[0].path).toBe('/root/file.txt');
-            expect(state.command?.arguments?.[0].query).toBe('');
+            expect(state.command?.command).toBe('jj-view.openFile');
+            expect(state.command?.arguments?.[0]).toEqual({
+                resourceUri: state.resourceUri,
+                rightUri: state.rightUri,
+                revision: 'rev123',
+            });
         });
     });
 

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -6,12 +6,17 @@ import { vi } from 'vitest';
 import type * as vscode from 'vscode';
 
 let activeTextEditorState: unknown;
+let fireDidChangeActiveTextEditorState: ((editor: vscode.TextEditor | undefined) => void) | undefined;
 
 /**
  * Helper to set or reset vscode.window.activeTextEditor in tests without type casting.
  */
 export function setActiveTextEditor(editor: Partial<vscode.TextEditor> | undefined): void {
     activeTextEditorState = editor;
+}
+
+export function fireDidChangeActiveTextEditor(editor: vscode.TextEditor | undefined): void {
+    fireDidChangeActiveTextEditorState?.(editor);
 }
 
 /**
@@ -136,8 +141,13 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
     const onDidChangeTabsEmitter = new EventEmitter<unknown>();
     const onDidChangeTabGroupsEmitter = new EventEmitter<unknown>();
     const onDidChangeWindowStateEmitter = new EventEmitter<unknown>();
+    const onDidChangeActiveTextEditorEmitter = new EventEmitter<vscode.TextEditor | undefined>();
+    fireDidChangeActiveTextEditorState = onDidChangeActiveTextEditorEmitter.fire;
+    const onDidChangeTextEditorSelectionEmitter = new EventEmitter<vscode.TextEditorSelectionChangeEvent>();
+    const onDidChangeTextEditorVisibleRangesEmitter = new EventEmitter<vscode.TextEditorVisibleRangesChangeEvent>();
     const onDidChangeConfigurationEmitter = new EventEmitter<unknown>();
     const onDidSaveTextDocumentEmitter = new EventEmitter<unknown>();
+    const onDidCloseTextDocumentEmitter = new EventEmitter<vscode.TextDocument>();
     const onDidChangeWorkspaceFoldersEmitter = new EventEmitter<unknown>();
 
     class FileSystemError extends Error {
@@ -334,6 +344,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             showWarningMessage: vi.fn(),
             showInputBox: vi.fn(),
             showQuickPick: vi.fn(),
+            showTextDocument: vi.fn(),
             createQuickPick: vi.fn().mockReturnValue({
                 items: [],
                 placeholder: '',
@@ -376,6 +387,9 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
                 close: vi.fn(),
             },
             visibleTextEditors: [],
+            onDidChangeActiveTextEditor: onDidChangeActiveTextEditorEmitter.event,
+            onDidChangeTextEditorSelection: onDidChangeTextEditorSelectionEmitter.event,
+            onDidChangeTextEditorVisibleRanges: onDidChangeTextEditorVisibleRangesEmitter.event,
             onDidChangeWindowState: onDidChangeWindowStateEmitter.event,
             state: { focused: true },
         },
@@ -428,6 +442,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             }),
             onDidChangeConfiguration: onDidChangeConfigurationEmitter.event,
             onDidSaveTextDocument: onDidSaveTextDocumentEmitter.event,
+            onDidCloseTextDocument: onDidCloseTextDocumentEmitter.event,
 
             findFiles: vi.fn().mockResolvedValue([]),
             asRelativePath: vi.fn().mockImplementation((pathOrUri: string | { fsPath: string }) => {
@@ -448,8 +463,12 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             onDidChangeTabs: onDidChangeTabsEmitter,
             onDidChangeTabGroups: onDidChangeTabGroupsEmitter,
             onDidChangeWindowState: onDidChangeWindowStateEmitter,
+            onDidChangeActiveTextEditor: onDidChangeActiveTextEditorEmitter,
+            onDidChangeTextEditorSelection: onDidChangeTextEditorSelectionEmitter,
+            onDidChangeTextEditorVisibleRanges: onDidChangeTextEditorVisibleRangesEmitter,
             onDidChangeConfiguration: onDidChangeConfigurationEmitter,
             onDidSaveTextDocument: onDidSaveTextDocumentEmitter,
+            onDidCloseTextDocument: onDidCloseTextDocumentEmitter,
             onDidChangeWorkspaceFolders: onDidChangeWorkspaceFoldersEmitter,
         },
     };


### PR DESCRIPTION
## Summary

Preserve editor selection and scroll position when opening a file’s working-copy version from a revision or diff editor.

This keeps the user’s editing context intact when moving between historical content, editable revisions, diff sides, and the working-copy file.

## Behavior

- Preserves all cursors and selection ranges.
- Preserves the visible viewport center.
- Copies positions directly when source and target content match.
- Remaps positions through inserted, removed, and replaced lines when content differs.
- Maps deleted lines to the nearest surviving boundary.
- Clamps positions to valid target lines and columns.
- Supports editor title actions and context menus, including commands invoked from inactive tabs.
- Falls back to normal file opening when no matching source editor state is available.

## Design

Line mapping uses unchanged lines as anchors. Positions within changed regions retain their relative location, while deleted regions resolve to a valid boundary in the target document.

Editor state is tracked by URI while documents remain open. Live editor state is preferred when available; inactive tabs use their last visible selection and viewport state. Tracking is registered with extension activation and disposed with the extension lifecycle.

Source and target text are compared directly instead of inferring content identity from URI schemes. This keeps synchronization compatible with future read-only or editable content providers without adding scheme-specific revision matching.

---

One problem with the current implementation: it does not open the file directly with the desired state (scroll and selection), but acts as a follow-up adjustment after opening with default state.
