### PR TITLE
feat: show hint for conflicted files in the details view

### DIFF
--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -3,9 +3,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
+import type { JjStatusEntry } from './jj-types';
 import { createJjResourceState } from './scm-resource-state';
 import { getJjViewConfig } from './utils/config-utils';
 import { formatCommitTitle } from './utils/jj-utils';
+
+export function mergeFileConflictStatus(filesWithStats: JjStatusEntry[], conflictedPaths: string[]): JjStatusEntry[] {
+    if (conflictedPaths.length === 0) {
+        return filesWithStats;
+    }
+
+    const conflictedPathSet = new Set(conflictedPaths);
+    const mergedFiles = filesWithStats.map((file) => {
+        const isConflicted = conflictedPathSet.delete(file.path);
+        return isConflicted ? { ...file, conflicted: true } : file;
+    });
+
+    for (const path of conflictedPathSet) {
+        mergedFiles.push({ path, status: 'modified', conflicted: true });
+    }
+
+    return mergedFiles;
+}
 
 export class JjCommitDocument implements vscode.CustomDocument {
     public readonly uri: vscode.Uri;
@@ -87,8 +106,9 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
 
                 const logPromise = repo.jj.getLog({ revision: changeId });
                 const changesPromise = repo.jj.getChanges(changeId).catch(() => null);
+                const conflictedFilesPromise = repo.jj.getConflictedFiles(changeId);
 
-                const logs = await logPromise;
+                const [logs, conflictedFilesForRevision] = await Promise.all([logPromise, conflictedFilesPromise]);
                 if (logs.length === 0) {
                     panels.forEach((p) => {
                         p.dispose();
@@ -97,8 +117,12 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                 }
 
                 const log = logs[0];
+                const conflictedFiles = [
+                    ...(log.changes || []).filter((file) => file.conflicted).map((file) => file.path),
+                    ...conflictedFilesForRevision,
+                ];
                 const rawFilesWithStats = await changesPromise;
-                const filesWithStats = rawFilesWithStats || log.changes || [];
+                const filesWithStats = mergeFileConflictStatus(rawFilesWithStats || log.changes || [], conflictedFiles);
 
                 for (const panel of panels) {
                     panel.webview.postMessage({
@@ -266,16 +290,21 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
         try {
             const logPromise = repo.jj.getLog({ revision: document.changeId });
             const changesPromise = repo.jj.getChanges(document.changeId).catch(() => null);
+            const conflictedFilesPromise = repo.jj.getConflictedFiles(document.changeId);
 
-            const logs = await logPromise;
+            const [logs, conflictedFilesForRevision] = await Promise.all([logPromise, conflictedFilesPromise]);
             if (logs.length === 0) {
                 panel.dispose();
                 return;
             }
 
             const log = logs[0];
+            const conflictedFiles = [
+                ...(log.changes || []).filter((file) => file.conflicted).map((file) => file.path),
+                ...conflictedFilesForRevision,
+            ];
             const rawFilesWithStats = await changesPromise;
-            const filesWithStats = rawFilesWithStats || log.changes || [];
+            const filesWithStats = mergeFileConflictStatus(rawFilesWithStats || log.changes || [], conflictedFiles);
 
             const initialDescription = (log.description || '').trim();
             const initialData = {

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -1019,19 +1019,20 @@ export class JjService {
         await this.run('new', [revision], { isMutation: true, label: 'resolve' });
     }
 
-    async getConflictedFiles(): Promise<string[]> {
+    async getConflictedFiles(revision?: string): Promise<string[]> {
         try {
-            const output = await this.run('resolve', ['--list'], {
+            const template = '"[" ++ conflicted_files.map(|file| file.path().display().escape_json()).join(",") ++ "]"';
+            const output = await this.run('log', ['--no-graph', '-r', revision ?? '@', '-T', template], {
                 useCachedSnapshot: true,
                 label: 'getConflictedFiles',
             });
-            return output
-                .split('\n')
-                .map((line) => line.trim())
-                .filter((line) => line.length > 0)
-                .map((line) => line.split(/\s+/)[0]);
+            const parsed: unknown = JSON.parse(output);
+            if (!Array.isArray(parsed) || !parsed.every((path): path is string => typeof path === 'string')) {
+                return [];
+            }
+            return parsed;
         } catch {
-            // No conflicts at this revision
+            // Conflict metadata is optional; callers can continue without it.
             return [];
         }
     }

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -114,6 +114,22 @@ test.describe('Commit Details E2E', () => {
             await expect(details.locator('text=Changed Files (2)')).toBeVisible();
         });
 
+        test('Marks the conflicted file in the file list', async () => {
+            const conflictedRow = await waitForLogCommitRow(page, 'conflicted commit');
+            await conflictedRow.click();
+
+            const shortId = nodes['conflicted-commit'].changeId.substring(0, 3);
+            await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({
+                timeout: 15000,
+            });
+
+            const details = await getDetailsWebview(page);
+            const conflictedFileRow = details.getByRole('button').filter({ hasText: 'f.txt' });
+            await expect(conflictedFileRow).toHaveCount(1);
+            await expect(conflictedFileRow).toBeVisible();
+            await expect(conflictedFileRow.getByTitle('Conflicted file')).toHaveCount(1);
+        });
+
         test('Save description via button', async () => {
             const featureRow = await waitForLogCommitRow(page, 'add feature');
 

--- a/src/test/jj-commit-details-editor-provider.test.ts
+++ b/src/test/jj-commit-details-editor-provider.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { expect, test, vi } from 'vitest';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    return createVscodeMock();
+});
+
+import { mergeFileConflictStatus } from '../jj-commit-details-editor-provider';
+
+test('mergeFileConflictStatus marks diff entries and adds conflict-only files', () => {
+    const files = mergeFileConflictStatus(
+        [{ path: 'changed.txt', status: 'modified', additions: 2, deletions: 1 }],
+        ['changed.txt', 'conflict only.txt'],
+    );
+
+    expect(files).toEqual([
+        { path: 'changed.txt', status: 'modified', additions: 2, deletions: 1, conflicted: true },
+        { path: 'conflict only.txt', status: 'modified', conflicted: true },
+    ]);
+});

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1203,6 +1203,19 @@ log = "none()"
         expect(conflictedFiles).toEqual(['conflict.txt']);
     });
 
+    test('getConflictedFiles accepts a revision', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', description: 'base', files: { 'conflict file.txt': 'base\n' } },
+            { label: 'left', parents: ['base'], description: 'left', files: { 'conflict file.txt': 'left\n' } },
+            { label: 'right', parents: ['base'], description: 'right', files: { 'conflict file.txt': 'right\n' } },
+            { label: 'merge', parents: ['left', 'right'], description: 'merge', isCurrentWorkingCopy: true },
+            { label: 'after-merge', parents: ['merge'], description: 'after merge' },
+        ]);
+
+        const conflictedFiles = await jjService.getConflictedFiles(ids.merge.changeId);
+        expect(conflictedFiles).toEqual(['conflict file.txt']);
+    });
+
     test('getConflictParts returns correct parts', async () => {
         const fileName = 'conflict.txt';
         await buildGraph(repo, [

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -9,8 +9,11 @@ import * as path from 'node:path';
 
 const tempDirs = new Set<string>();
 const testXdgConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-xdg-'));
+const testAppDataHome = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-appdata-'));
 tempDirs.add(testXdgConfigHome);
+tempDirs.add(testAppDataHome);
 process.env.XDG_CONFIG_HOME = testXdgConfigHome;
+process.env.APPDATA = testAppDataHome;
 
 function writeDefaultConfig(xdgDir: string) {
     const configDir = path.join(xdgDir, 'jj');
@@ -74,7 +77,7 @@ export class TestRepo {
     // Instead, create specific methods for each operation to ensure strictly typed usage
     // and prevent arbitrary command execution in tests.
     private exec(args: string[], options: { trim?: boolean; suppressStderr?: boolean } = {}) {
-        const env = { ...process.env, JJ_CONFIG: '' };
+        const env = { ...process.env, APPDATA: testAppDataHome, JJ_CONFIG: '' };
         const jjBinary = 'jj';
         try {
             const output = cp.execFileSync(jjBinary, ['--quiet', ...args], {
@@ -147,7 +150,7 @@ export class TestRepo {
 
             if (commands.length > 0) {
                 const cmd = commands.join(' && ');
-                const env = { ...process.env, JJ_CONFIG: '' };
+                const env = { ...process.env, APPDATA: testAppDataHome, JJ_CONFIG: '' };
                 cp.execSync(cmd, { cwd: this.path, env, stdio: 'ignore' });
             }
         } else {
@@ -169,7 +172,7 @@ export class TestRepo {
     }
 
     init() {
-        const env = { ...process.env, JJ_CONFIG: '' };
+        const env = { ...process.env, APPDATA: testAppDataHome, JJ_CONFIG: '' };
         const jjBinary = 'jj';
         cp.execFileSync(jjBinary, ['--quiet', 'git', 'init'], {
             cwd: this.path,

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -660,6 +660,18 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
                                 >
                                     {file.path}
                                 </span>
+                                {file.conflicted && (
+                                    <span
+                                        className="codicon codicon-warning"
+                                        role="img"
+                                        title="Conflicted file"
+                                        aria-label="Conflicted file"
+                                        style={{
+                                            marginLeft: '8px',
+                                            color: 'var(--vscode-gitDecoration-conflictingResourceForeground)',
+                                        }}
+                                    ></span>
+                                )}
                                 <span
                                     style={{
                                         marginLeft: 'auto',


### PR DESCRIPTION
It now retrieves conflicted files and provides them to the details view.

A warning icon will be shown after those file names.
<img width="249" height="106" alt="image" src="https://github.com/user-attachments/assets/92dd5b83-da20-4e87-a5bc-b6563042395f" />
