### PR TITLE
fix(gerrit): save comments and thread resolutions as drafts

### DIFF
--- a/src/code-forge-provider.ts
+++ b/src/code-forge-provider.ts
@@ -78,6 +78,7 @@ export interface CodeForgeComment {
     };
     body: string;
     createdAt: string;
+    isDraft?: boolean;
 }
 
 export interface CodeForgeCommentThread {

--- a/src/comments-manager.ts
+++ b/src/comments-manager.ts
@@ -349,6 +349,7 @@ export class CommentsManager implements vscode.Disposable {
                 name: c.author?.name || 'Unknown',
                 iconPath: avatarUri,
             },
+            label: c.isDraft ? 'Draft' : undefined,
             mode: vscode.CommentMode.Preview,
         };
     }

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -75,11 +75,23 @@ interface GerritCommentGql {
     in_reply_to?: string;
 }
 
+export type GerritCommentWithDraftStatus = GerritCommentGql & {
+    isDraft?: boolean;
+};
+
 interface FetchGerritOptions extends RequestInit {
     timeoutMs?: number;
 }
 
 const AUTH_HEADER_TTL_MS = 5 * 60 * 1000;
+
+function parseGerritJsonResponse<T>(text: string): T {
+    const cleanJson = text.replace(/^\)]}'\n/, '').trim();
+    if (!cleanJson) {
+        return {} as T;
+    }
+    return JSON.parse(cleanJson) as T;
+}
 
 export class GerritProvider implements CodeForgeProvider {
     public readonly id = 'gerrit';
@@ -487,6 +499,60 @@ export class GerritProvider implements CodeForgeProvider {
         return { subcommand: 'gerrit', args: ['upload', '-r', revision] };
     }
 
+    private async fetchMergedCommentsAndDrafts(
+        changeNumber: number,
+        signal?: AbortSignal,
+    ): Promise<Record<string, GerritCommentWithDraftStatus[]>> {
+        if (!this.gerritHost) {
+            return {};
+        }
+
+        const commentsUrl = `${this.gerritHost}/changes/${changeNumber}/comments`;
+        const draftsUrl = `${this.gerritHost}/changes/${changeNumber}/drafts`;
+
+        const [commentsResponse, draftsResponse] = await Promise.all([
+            this.fetchGerrit(commentsUrl, { signal }).catch(() => undefined),
+            this.fetchGerrit(draftsUrl, { signal }).catch(() => undefined),
+        ]);
+
+        if (!commentsResponse?.ok) {
+            throw new Error(`Failed to fetch Gerrit comments: ${commentsResponse?.statusText ?? 'Network error'}`);
+        }
+
+        const commentsText = await commentsResponse.text();
+        const publishedCommentsMap = parseGerritJsonResponse<Record<string, GerritCommentGql[]>>(commentsText);
+
+        let draftsMap: Record<string, GerritCommentGql[]> = {};
+        if (draftsResponse?.ok) {
+            try {
+                const draftsText = await draftsResponse.text();
+                draftsMap = parseGerritJsonResponse<Record<string, GerritCommentGql[]>>(draftsText);
+            } catch (err) {
+                this.outputChannel?.warn(`[GerritProvider] Failed to parse Gerrit draft comments response: ${err}`);
+            }
+        }
+
+        const commentsMap: Record<string, GerritCommentWithDraftStatus[]> = {};
+        const filePaths = new Set([...Object.keys(publishedCommentsMap), ...Object.keys(draftsMap)]);
+
+        for (const filePath of filePaths) {
+            const list1 = (publishedCommentsMap[filePath] || []).map((c) => ({ ...c, isDraft: false }));
+            const list2 = (draftsMap[filePath] || []).map((c) => ({ ...c, isDraft: true }));
+            const seenIds = new Set<string>();
+            const combined: GerritCommentWithDraftStatus[] = [];
+
+            for (const c of [...list1, ...list2]) {
+                if (!seenIds.has(c.id)) {
+                    seenIds.add(c.id);
+                    combined.push(c);
+                }
+            }
+            commentsMap[filePath] = combined;
+        }
+
+        return commentsMap;
+    }
+
     public async getCommentThreads(changeId: string, signal?: AbortSignal): Promise<CodeForgeCommentThread[]> {
         const changeInfo = Array.from(this.cache.values()).find((info) => info.id === changeId);
         if (!changeInfo) {
@@ -496,16 +562,7 @@ export class GerritProvider implements CodeForgeProvider {
             return [];
         }
 
-        const url = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const response = await this.fetchGerrit(url, { signal });
-        if (!response.ok) {
-            throw new Error(`Failed to fetch Gerrit comments: ${response.statusText}`);
-        }
-
-        const text = await response.text();
-        const jsonStr = text.replace(/^\)]}'\n/, '');
-        const commentsMap = JSON.parse(jsonStr) as Record<string, GerritCommentGql[]>;
-
+        const commentsMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number, signal);
         const threads: CodeForgeCommentThread[] = [];
 
         for (const [filePath, commentsList] of Object.entries(commentsMap)) {
@@ -550,6 +607,7 @@ export class GerritProvider implements CodeForgeProvider {
                         },
                         body: c.message || '',
                         createdAt: c.updated,
+                        isDraft: c.isDraft,
                     })),
                 });
             }
@@ -572,17 +630,11 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Gerrit provider not fully configured');
         }
 
-        // Fetch comments to locate parent file path and line
-        const commentsUrl = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const commentsResponse = await this.fetchGerrit(commentsUrl);
-        if (!commentsResponse.ok) {
-            throw new Error(`Failed to fetch comments to locate parent: ${commentsResponse.statusText}`);
-        }
-        const commentsText = await commentsResponse.text();
-        const commentsMap = JSON.parse(commentsText.replace(/^\)]}'\n/, '')) as Record<string, GerritCommentGql[]>;
+        const commentsMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
 
-        let parentComment: GerritCommentGql | undefined;
+        let parentComment: GerritCommentWithDraftStatus | undefined;
         let parentFilePath: string | undefined;
+
         for (const [filePath, comments] of Object.entries(commentsMap)) {
             const found = comments.find((c) => c.id === threadId);
             if (found) {
@@ -596,45 +648,51 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Parent comment thread not found');
         }
 
-        // Post review with comment reply
-        const reviewUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/review`;
-        const response = await this.fetchGerrit(reviewUrl, {
-            method: 'POST',
+        // Post draft comment reply
+        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/drafts`;
+        const response = await this.fetchGerrit(draftUrl, {
+            method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                drafts: 'KEEP',
-                comments: {
-                    [parentFilePath]: [
-                        {
-                            in_reply_to: threadId,
-                            line: parentComment.line,
-                            message: body,
-                            unresolved: resolved !== undefined ? !resolved : (parentComment.unresolved ?? true),
-                        },
-                    ],
-                },
+                path: parentFilePath,
+                line: parentComment.line,
+                message: body,
+                in_reply_to: threadId,
+                unresolved: resolved !== undefined ? !resolved : (parentComment.unresolved ?? true),
             }),
         });
 
         if (!response.ok) {
-            throw new Error(`Failed to post Gerrit reply: ${response.statusText}`);
+            throw new Error(`Failed to post Gerrit draft reply: ${response.statusText}`);
         }
 
-        // Re-fetch to retrieve the newly posted comment
-        const updatedCommentsResponse = await this.fetchGerrit(commentsUrl);
-        if (!updatedCommentsResponse.ok) {
-            throw new Error('Failed to retrieve updated comments');
+        const responseText = await response.text();
+        if (responseText) {
+            try {
+                const createdDraft = parseGerritJsonResponse<GerritCommentGql>(responseText);
+                if (createdDraft?.id) {
+                    return {
+                        id: createdDraft.id,
+                        author: {
+                            name: createdDraft.author?.name || 'Unknown',
+                            username: createdDraft.author?.username,
+                        },
+                        body: createdDraft.message || body,
+                        createdAt: createdDraft.updated || new Date().toISOString(),
+                        isDraft: true,
+                    };
+                }
+            } catch {
+                // Fallback to re-fetching
+            }
         }
-        const updatedCommentsText = await updatedCommentsResponse.text();
-        const updatedCommentsMap = JSON.parse(updatedCommentsText.replace(/^\)]}'\n/, '')) as Record<
-            string,
-            GerritCommentGql[]
-        >;
 
-        const threadComments = updatedCommentsMap[parentFilePath] || [];
+        // Re-fetch to retrieve the newly posted draft comment
+        const updatedMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
+        const threadComments = updatedMap[parentFilePath] || [];
         const replies = threadComments.filter((c) => c.in_reply_to === threadId || c.id === threadId);
         replies.sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
         const newest = replies[0];
@@ -651,6 +709,7 @@ export class GerritProvider implements CodeForgeProvider {
             },
             body: newest.message || '',
             createdAt: newest.updated,
+            isDraft: !!newest.isDraft,
         };
     }
 
@@ -663,17 +722,11 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Gerrit provider not fully configured');
         }
 
-        // Fetch comments to locate parent file path and line
-        const commentsUrl = `${this.gerritHost}/changes/${changeInfo.number}/comments`;
-        const commentsResponse = await this.fetchGerrit(commentsUrl);
-        if (!commentsResponse.ok) {
-            throw new Error(`Failed to fetch comments to locate parent: ${commentsResponse.statusText}`);
-        }
-        const commentsText = await commentsResponse.text();
-        const commentsMap = JSON.parse(commentsText.replace(/^\)]}'\n/, '')) as Record<string, GerritCommentGql[]>;
+        const commentsMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
 
-        let parentComment: GerritCommentGql | undefined;
+        let parentComment: GerritCommentWithDraftStatus | undefined;
         let parentFilePath: string | undefined;
+
         for (const [filePath, comments] of Object.entries(commentsMap)) {
             const found = comments.find((c) => c.id === threadId);
             if (found) {
@@ -687,26 +740,20 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Parent comment thread not found');
         }
 
-        // Post review with a resolution reply comment
-        const reviewUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/review`;
-        const response = await this.fetchGerrit(reviewUrl, {
-            method: 'POST',
+        // Post draft resolution reply comment
+        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/drafts`;
+        const response = await this.fetchGerrit(draftUrl, {
+            method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                drafts: 'KEEP',
-                comments: {
-                    [parentFilePath]: [
-                        {
-                            in_reply_to: threadId,
-                            line: parentComment.line,
-                            message: resolved ? 'Resolved' : 'Unresolved',
-                            unresolved: !resolved,
-                        },
-                    ],
-                },
+                path: parentFilePath,
+                line: parentComment.line,
+                message: resolved ? 'Resolved' : 'Unresolved',
+                in_reply_to: threadId,
+                unresolved: !resolved,
             }),
         });
 

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -1434,6 +1434,7 @@ async function expandReplyFormIfNeeded(reviewWidget: Locator) {
     const replyPlaceholderBtn = reviewWidget.locator('.review-thread-reply-button');
     if (await replyPlaceholderBtn.isVisible()) {
         await replyPlaceholderBtn.click();
+        await expect(reviewWidget.locator('.comment-form .monaco-editor')).toBeVisible({ timeout: 5000 });
     }
 }
 
@@ -1449,6 +1450,7 @@ async function clickCommentButton(reviewWidget: Locator, buttonLabel: string | R
         .filter({ hasText: buttonLabel })
         .first();
     await expect(button).toBeVisible();
+    await reviewWidget.page().waitForTimeout(200);
     await button.click();
     logPerf(perfLabel, start);
 }

--- a/src/test/e2e/gerrit.spec.ts
+++ b/src/test/e2e/gerrit.spec.ts
@@ -230,25 +230,26 @@ test.describe('Gerrit Integration E2E', () => {
             // Type and submit the reply
             await replyToCommentThread(page, reviewWidget, 'My Gerrit E2E reply');
 
-            // Assert that the fake server receives the review post request (reply)
+            // Assert that the fake server receives the draft post request (reply)
             await expect
                 .poll(() => {
-                    return gerrit.requests.some((req) => req.includes('/review'));
+                    return gerrit.requests.some((req) => req.includes('/drafts'));
                 })
                 .toBe(true);
 
             gerrit.clearRequests();
 
-            // Wait for the reply to be rendered in the UI
+            // Wait for the reply to be rendered in the UI and thread state to settle
             await expect(reviewWidget).toContainText('My Gerrit E2E reply');
+            await page.waitForTimeout(500);
 
             // Resolve the thread
             await resolveCommentThread(reviewWidget);
 
-            // Assert that the fake server receives the review post request (resolve)
+            // Assert that the fake server receives the draft post request (resolve)
             await expect
                 .poll(() => {
-                    return gerrit.requests.some((req) => req.includes('/review'));
+                    return gerrit.requests.some((req) => req.includes('/drafts'));
                 })
                 .toBe(true);
 
@@ -269,10 +270,10 @@ test.describe('Gerrit Integration E2E', () => {
             // Unresolve the thread
             await unresolveCommentThread(reviewWidget2);
 
-            // Assert that the fake server receives the review post request (unresolve)
+            // Assert that the fake server receives the draft post request (unresolve)
             await expect
                 .poll(() => {
-                    return gerrit.requests.some((req) => req.includes('/review'));
+                    return gerrit.requests.some((req) => req.includes('/drafts'));
                 })
                 .toBe(true);
         } finally {

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -215,6 +215,48 @@ describe('GerritProvider', () => {
             await server.stop();
         });
 
+        test('getCommentThreads fetches comments and drafts from Gerrit', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+            server.registerDrafts(123, {
+                'file.txt': [
+                    {
+                        id: 'draft-1',
+                        in_reply_to: 'comment-1',
+                        line: 10,
+                        message: 'Draft reply',
+                        updated: '2026-06-30T12:05:00Z',
+                        unresolved: true,
+                        author: { name: 'Me', username: 'me' },
+                    },
+                ],
+            });
+
+            const threads = await provider.getCommentThreads('I12345');
+            expect(threads).toHaveLength(1);
+            expect(threads[0].id).toBe('comment-1');
+            expect(threads[0].filePath).toBe('file.txt');
+            expect(threads[0].line).toBe(10);
+            expect(threads[0].isResolved).toBe(false);
+            expect(threads[0].comments).toHaveLength(2);
+            const rootComment = threads[0].comments[0];
+            const draftReply = threads[0].comments[1];
+            expect(rootComment.body).toBe('First comment');
+            expect(rootComment.isDraft).toBe(false);
+            expect(draftReply.body).toBe('Draft reply');
+            expect(draftReply.isDraft).toBe(true);
+        });
+
         test('getCommentThreads fetches comments from Gerrit', async () => {
             server.registerComments(123, {
                 'file.txt': [

--- a/src/test/helpers/fake-gerrit-server.ts
+++ b/src/test/helpers/fake-gerrit-server.ts
@@ -21,6 +21,7 @@ export interface FakeGerritComment {
 export class FakeGerritServer {
     public changes = new Map<string, GerritChange>();
     private comments = new Map<number, Record<string, FakeGerritComment[]>>(); // changeNumber -> (filePath -> comments)
+    private drafts = new Map<number, Record<string, FakeGerritComment[]>>(); // changeNumber -> (filePath -> drafts)
     private server: http.Server | undefined;
     public url = '';
     public requests: string[] = [];
@@ -53,6 +54,10 @@ export class FakeGerritServer {
 
     public registerComments(changeNumber: number, comments: Record<string, FakeGerritComment[]>) {
         this.comments.set(changeNumber, comments);
+    }
+
+    public registerDrafts(changeNumber: number, drafts: Record<string, FakeGerritComment[]>) {
+        this.drafts.set(changeNumber, drafts);
     }
 
     /**
@@ -162,6 +167,55 @@ export class FakeGerritServer {
                 if (match) {
                     const changeNumber = parseInt(match[1], 10);
                     const list = this.comments.get(changeNumber) || {};
+                    res.writeHead(200, { 'Content-Type': 'application/json' });
+                    res.end(`)]}'\n${JSON.stringify(list)}`);
+                    return;
+                }
+            }
+
+            if (urlStr.includes('/drafts')) {
+                const matchPutDraft = urlStr.match(/\/changes\/(\d+)\/revisions\/current\/drafts/);
+                if (matchPutDraft && (req.method === 'PUT' || req.method === 'POST')) {
+                    const changeNumber = parseInt(matchPutDraft[1], 10);
+                    let body = '';
+                    req.on('data', (chunk) => {
+                        body += chunk;
+                    });
+                    req.on('end', () => {
+                        const incoming = JSON.parse(body) as {
+                            path: string;
+                            line?: number;
+                            message?: string;
+                            in_reply_to?: string;
+                            unresolved?: boolean;
+                        };
+
+                        const currentDrafts = this.drafts.get(changeNumber) || {};
+                        const filePath = incoming.path;
+                        currentDrafts[filePath] = currentDrafts[filePath] || [];
+
+                        const newDraft: FakeGerritComment = {
+                            id: `draft-${Date.now()}-${Math.random()}`,
+                            line: incoming.line,
+                            message: incoming.message || '',
+                            updated: new Date().toISOString(),
+                            unresolved: incoming.unresolved,
+                            in_reply_to: incoming.in_reply_to,
+                            author: { name: 'Gerrit User', username: 'gerrit_user' },
+                        };
+                        currentDrafts[filePath].push(newDraft);
+                        this.drafts.set(changeNumber, currentDrafts);
+
+                        res.writeHead(200, { 'Content-Type': 'application/json' });
+                        res.end(`)]}'\n${JSON.stringify(newDraft)}`);
+                    });
+                    return;
+                }
+
+                const matchGetDrafts = urlStr.match(/\/changes\/(\d+)\/drafts/);
+                if (matchGetDrafts && req.method === 'GET') {
+                    const changeNumber = parseInt(matchGetDrafts[1], 10);
+                    const list = this.drafts.get(changeNumber) || {};
                     res.writeHead(200, { 'Content-Type': 'application/json' });
                     res.end(`)]}'\n${JSON.stringify(list)}`);
                     return;


### PR DESCRIPTION
Always create and manage Gerrit comments as drafts via revision draft endpoints instead of publishing directly. Fetch and merge user drafts alongside published comments, adding a visual 'Draft' badge in VS Code comment widgets.

Fixes #400