### PR TITLE
fix(refresh): recover from read timeouts and mutex rejections

### DIFF
--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -203,8 +203,12 @@ export class JjScmProvider implements vscode.Disposable {
     private _refreshMutex: Promise<void> = Promise.resolve();
 
     private async updateScmView(event: { reason: string }): Promise<void> {
-        // Chain the refresh execution to ensure serial execution
+        // Chain the refresh execution to ensure serial execution.
+        // Log and swallow any prior rejection so that a failed/timed-out refresh does not permanently stall future refresh calls.
         this._refreshMutex = this._refreshMutex
+            .catch((err) => {
+                this.outputChannel.error(`[ScmProvider] Previous updateScmView failed: ${err}`);
+            })
             .then(async () => {
                 if (this._disposed) {
                     return;

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -28,6 +28,7 @@ export interface JjLogOptions {
 // Safety timeout: if a mutation takes longer than this, unblock file watcher
 const ONE_MINUTE = 60_000;
 const MUTATION_TIMEOUT_MS = ONE_MINUTE;
+const READ_TIMEOUT_MS = 30_000;
 const UPLOAD_TIMEOUT_MS = 6 * ONE_MINUTE;
 
 const IS_WINDOWS = process.platform === 'win32';
@@ -239,14 +240,27 @@ export class JjService {
 
         const isMutation = !!options.isMutation;
         let timeout: NodeJS.Timeout | undefined;
+        let timedOut = false;
 
         try {
             const { stdout } = await new Promise<{ stdout: string | Buffer }>((resolve, reject) => {
+                const duration = options.timeout ?? (isMutation ? MUTATION_TIMEOUT_MS : READ_TIMEOUT_MS);
+                let childProcess: cp.ChildProcess | undefined;
+
+                timeout = setTimeout(() => {
+                    timedOut = true;
+                    const opType = isMutation ? 'Mutation operation' : 'Read operation';
+                    const timeoutMsg = `${opType} timed out after ${duration / 1000}s`;
+                    this.logger.warn(`[${timeoutMsg}] ${commandStr}`);
+                    if (childProcess) {
+                        try {
+                            childProcess.kill();
+                        } catch {}
+                    }
+                    reject(new Error(timeoutMsg));
+                }, duration);
+
                 if (isMutation) {
-                    const duration = options.timeout ?? MUTATION_TIMEOUT_MS;
-                    timeout = setTimeout(() => {
-                        reject(new Error(`Mutation operation timed out after ${duration / 1000}s`));
-                    }, duration);
                     this._operationTimeouts.set(opId, timeout);
                 }
 
@@ -262,7 +276,10 @@ export class JjService {
                     ...options,
                 };
 
-                cp.execFile(this.binaryPath, allArgs, finalOptions, (err, stdout, stderr) => {
+                childProcess = cp.execFile(this.binaryPath, allArgs, finalOptions, (err, stdout, stderr) => {
+                    if (timedOut) {
+                        return;
+                    }
                     const duration = performance.now() - start;
                     const cachedInfo = options.useCachedSnapshot ? ' (cached)' : '';
                     this.logger.debug(`[${duration.toFixed(0)}ms]${cachedInfo} ${commandStr}`);

--- a/src/test/write-op-timeout.test.ts
+++ b/src/test/write-op-timeout.test.ts
@@ -125,4 +125,26 @@ describe('JjService Write Operation Timeout', () => {
         // Should still be 0, not negative (no double-decrement)
         expect(jjService.writeOpCount).toBe(0);
     });
+
+    test('read operation times out after 30 seconds', async () => {
+        let killed = false;
+        vi.mocked(cp.execFile).mockImplementation(() => {
+            return {
+                kill: () => {
+                    killed = true;
+                },
+            } as cp.ChildProcess;
+        });
+
+        const logPromise = jjService.getLog();
+        let rejectionError: Error | undefined;
+        logPromise.catch((e: Error) => {
+            rejectionError = e;
+        });
+
+        await vi.advanceTimersByTimeAsync(31_000);
+
+        expect(rejectionError?.message).toContain('Read operation timed out after 30s');
+        expect(killed).toBe(true);
+    });
 });

--- a/tooling/jj/repo-config.toml
+++ b/tooling/jj/repo-config.toml
@@ -1,5 +1,5 @@
 [aliases]
-sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s 'roots(mutable())' -d main@origin --skip-emptied && jj log"]
+sync = ["util", "exec", "--", "sh", "-c", "jj git fetch && jj rebase -s 'roots(mutable())' -d main@origin --skip-emptied && jj log --no-pager"]
 upload = ["util", "exec", "--", "node", "tooling/jj/upload.ts"]
 
 [fix.tools.biome]


### PR DESCRIPTION
Enforce a 30-second timeout on CLI read operations in JjService to terminate blocked subprocesses, handle rejections in ScmProvider refresh mutex to prevent promise chain lockups, and add --no-pager to the repo sync alias.