### PR TITLE
chore(config): standardize workspace setting lookups using config-utils

### DIFF
--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -10,6 +10,7 @@ import * as vscode from 'vscode';
 import { DirectoryWatcher } from './directory-watcher';
 import type { JjService } from './jj-service';
 import { Poller } from './poller';
+import { getJjViewConfig } from './utils/config-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 
 export class ChangeDetectionManager implements vscode.Disposable {
@@ -139,8 +140,7 @@ export class ChangeDetectionManager implements vscode.Disposable {
         if (this._disposed) {
             return;
         }
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const mode = config.get<'polling' | 'watch'>('fileWatcherMode', 'polling');
+        const mode = getJjViewConfig<'polling' | 'watch'>('fileWatcherMode', 'polling') ?? 'polling';
         this.outputChannel.debug(`[ChangeDetectionManager] File watcher mode: ${mode}`);
 
         const modeChanged = this._fileWatcherMode !== mode;

--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -8,6 +8,7 @@ import type { CodeForgeProviderFactory } from './code-forge-provider-factory';
 import type { CodeForgeRegistry } from './code-forge-registry';
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo, CommitParent, JjLogEntry } from './jj-types';
+import { getJjViewConfig } from './utils/config-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 import { TimerBucket } from './utils/timer-bucket';
 
@@ -182,7 +183,7 @@ export class CodeForgeService implements vscode.Disposable {
         try {
             const remotes = await this.jjService.getGitRemotes();
             const repoRoot = await this.jjService.getRepoRoot();
-            const preferredId = vscode.workspace.getConfiguration('jj-view').get<string>('codeForge.provider');
+            const preferredId = getJjViewConfig<string>('codeForge.provider');
 
             let detectedProvider: CodeForgeProvider | undefined;
 

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -11,6 +11,7 @@ import type { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
+import { getJjViewConfig } from '../utils/config-utils';
 import { formatCommitDescription } from '../utils/format-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 
@@ -242,7 +243,7 @@ export async function promptForRevision(
         ...options,
     };
 
-    const maxMutableAncestors = vscode.workspace.getConfiguration('jj-view').get<number>('maxMutableAncestors', 10);
+    const maxMutableAncestors = getJjViewConfig<number>('maxMutableAncestors', 10) ?? 10;
     const limit = maxMutableAncestors + 1;
 
     try {
@@ -421,13 +422,13 @@ export async function maybeFormatDescriptionOnSave(
     scmProvider: JjScmProvider,
     revision: string = '@',
 ): Promise<string> {
-    const config = vscode.workspace.getConfiguration('jj-view', scmProvider.repo?.rootUri);
-    const formatOnSave = config.get<boolean>('commit.formatDescriptionOnSave', false);
+    const scope = scmProvider.repo?.rootUri;
+    const formatOnSave = getJjViewConfig<boolean>('commit.formatDescriptionOnSave', false, scope);
     if (!formatOnSave) {
         return description;
     }
 
-    const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler', 72);
+    const bodyWidthRuler = getJjViewConfig<number>('commit.bodyWidthRuler', 72, scope) ?? 72;
     description = await formatCommitDescription(description, bodyWidthRuler);
 
     if (revision === '@') {

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import type { CodeForgeService } from '../code-forge-service';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getJjViewConfig } from '../utils/config-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 import { extractRevision, showJjError, withDelayedProgress } from './command-utils';
 
@@ -17,8 +18,7 @@ export async function uploadCommand(
     outputChannel: JjLoggerChannel,
 ): Promise<void> {
     const revision = extractRevision(args);
-    const config = vscode.workspace.getConfiguration('jj-view');
-    const customCommand = config.get<string>('uploadCommand');
+    const customCommand = getJjViewConfig<string>('uploadCommand');
     const hasCustomCommand = !!(customCommand && customCommand.trim().length > 0);
     try {
         let subcommand = '';

--- a/src/commands/workspace-add.ts
+++ b/src/commands/workspace-add.ts
@@ -7,6 +7,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getJjViewConfig } from '../utils/config-utils';
 import { getErrorMessage } from './command-utils';
 
 /**
@@ -18,8 +19,7 @@ export async function workspaceAddCommand(scmProvider: JjScmProvider, jj: JjServ
         const mainRoot = await jj.getMainWorkspaceRoot();
 
         // 2. Get workspaces location from config
-        const config = vscode.workspace.getConfiguration('jj-view');
-        let workspacesLocation = config.get<string>('workspacesLocation', '.workspaces');
+        let workspacesLocation = getJjViewConfig<string>('workspacesLocation', '.workspaces') ?? '.workspaces';
 
         // Resolve relative paths against the main repo root
         if (!path.isAbsolute(workspacesLocation)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,7 @@ import { TOGGLEABLE_COMMIT_ACTIONS } from './jj-types';
 import { JjViewFileSystemProvider } from './jj-view-fs-provider';
 import type { JjResourceState } from './scm-resource-state';
 import { resolveJjBinary } from './utils/binary-utils';
+import { getJjViewConfig } from './utils/config-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 import { JjOutputChannel } from './utils/output-channel';
 
@@ -100,8 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     context.subscriptions.push(realOutputChannel);
 
     // Get preferred binary path configuration
-    const config = vscode.workspace.getConfiguration('jj-view');
-    const preferredPath = config.get<string>('binaryPath');
+    const preferredPath = getJjViewConfig<string>('binaryPath');
     let resolvedBinaryPath: string | undefined;
     try {
         resolvedBinaryPath = await resolveJjBinary(preferredPath, workspaceRoot);
@@ -111,8 +111,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
     // Configure configurations update listener
     const updateBinaryPath = async () => {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const preferredPath = config.get<string>('binaryPath');
+        const preferredPath = getJjViewConfig<string>('binaryPath');
 
         let resolvedPath: string | undefined;
         let errorMessage: string | undefined;
@@ -144,7 +143,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     };
 
     const setOpenDiffOnClickContext = () => {
-        const value = vscode.workspace.getConfiguration('jj-view').get<boolean>('openDiffOnClick', true);
+        const value = getJjViewConfig<boolean>('openDiffOnClick', true);
         vscode.commands.executeCommand('setContext', JjContextKey.OpenDiffOnClick, value);
     };
     setOpenDiffOnClickContext();

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -14,6 +14,7 @@ import type {
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
+import { getJjViewConfig } from './utils/config-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
 import { getGerritAuthHeader, resolveGitRoot } from './utils/gerrit-credential-utils';
 import { detectGerritHost } from './utils/gerrit-host-detection';
@@ -112,7 +113,7 @@ export class GerritProvider implements CodeForgeProvider {
     constructor(private outputChannel?: JjLoggerChannel) {}
 
     public async detect(repoRoot: string, remotes: GitRemote[]): Promise<boolean> {
-        const binaryPath = vscode.workspace.getConfiguration('jj-view').get<string>('binaryPath') || 'jj';
+        const binaryPath = getJjViewConfig<string>('binaryPath', 'jj') || 'jj';
         const gitRoot = await resolveGitRoot(repoRoot, binaryPath);
 
         if (this.repoRoot !== repoRoot) {

--- a/src/git-colocation.ts
+++ b/src/git-colocation.ts
@@ -5,6 +5,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from './jj-service';
+import { getJjViewConfig, getWorkspaceConfig, updateJjViewConfig } from './utils/config-utils';
 
 let hasRun = false;
 
@@ -33,16 +34,14 @@ export async function checkGitColocation(jj: JjService): Promise<void> {
         return;
     }
 
-    const gitConfig = vscode.workspace.getConfiguration('git');
-    const isGitEnabled = gitConfig.get<boolean>('enabled') !== false;
+    const isGitEnabled = getWorkspaceConfig<boolean>('git', 'enabled') !== false;
     const isGitExtensionPresent = !!vscode.extensions.getExtension('vscode.git');
 
     if (!isGitEnabled || !isGitExtensionPresent) {
         return;
     }
 
-    const jjViewConfig = vscode.workspace.getConfiguration('jj-view');
-    const isSuppressed = jjViewConfig.get<boolean>('suppressGitColocationWarning') === true;
+    const isSuppressed = getJjViewConfig<boolean>('suppressGitColocationWarning') === true;
 
     if (isSuppressed) {
         return;
@@ -59,6 +58,6 @@ export async function checkGitColocation(jj: JjService): Promise<void> {
     if (result === disableAction) {
         await vscode.commands.executeCommand('workbench.action.openSettings', 'git.enabled');
     } else if (result === ignoreAction) {
-        await jjViewConfig.update('suppressGitColocationWarning', true, vscode.ConfigurationTarget.Global);
+        await updateJjViewConfig('suppressGitColocationWarning', true, vscode.ConfigurationTarget.Global);
     }
 }

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -14,6 +14,7 @@ import type {
 } from './code-forge-provider';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
+import { getJjViewConfig } from './utils/config-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 
@@ -111,7 +112,7 @@ export class GitLabProvider implements CodeForgeProvider {
     }
 
     public async detect(_workspaceRoot: string, remotes: GitRemote[]): Promise<boolean> {
-        const preferredHost = vscode.workspace.getConfiguration('jj-view').get<string>('gitlab.host')?.trim();
+        const preferredHost = getJjViewConfig<string>('gitlab.host')?.trim();
 
         const remotePriority = (name: string): number => {
             const lower = name.toLowerCase();

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -4,6 +4,7 @@
  */
 import * as vscode from 'vscode';
 import { createJjResourceState } from './scm-resource-state';
+import { getJjViewConfig } from './utils/config-utils';
 import { formatCommitTitle } from './utils/jj-utils';
 
 export class JjCommitDocument implements vscode.CustomDocument {
@@ -76,12 +77,13 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                     continue;
                 }
 
-                const config = vscode.workspace.getConfiguration('jj-view', state?.document.repoRoot);
-                const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-                const logTheme = config.get<string>('logTheme', 'default');
-                const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
-                const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
-                const formatDescriptionOnSave = config.get<boolean>('commit.formatDescriptionOnSave', false);
+                const scope = state?.document.repoRoot;
+                const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1, scope) ?? 1;
+                const logTheme = getJjViewConfig<string>('logTheme', 'default', scope) ?? 'default';
+                const titleWidthRuler = getJjViewConfig<number>('commit.titleWidthRuler', undefined, scope);
+                const bodyWidthRuler = getJjViewConfig<number>('commit.bodyWidthRuler', undefined, scope);
+                const formatDescriptionOnSave =
+                    getJjViewConfig<boolean>('commit.formatDescriptionOnSave', false, scope) ?? false;
 
                 const logPromise = repo.jj.getLog({ revision: changeId });
                 const changesPromise = repo.jj.getChanges(changeId).catch(() => null);
@@ -245,12 +247,13 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             enableCommandUris: true,
         };
 
-        const config = vscode.workspace.getConfiguration('jj-view', document.repoRoot);
-        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-        const logTheme = config.get<string>('logTheme', 'default');
-        const titleWidthRuler = config.get<number>('commit.titleWidthRuler');
-        const bodyWidthRuler = config.get<number>('commit.bodyWidthRuler');
-        const formatDescriptionOnSave = config.get<boolean>('commit.formatDescriptionOnSave', false);
+        const scope = document.repoRoot;
+        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1, scope) ?? 1;
+        const logTheme = getJjViewConfig<string>('logTheme', 'default', scope) ?? 'default';
+        const titleWidthRuler = getJjViewConfig<number>('commit.titleWidthRuler', undefined, scope);
+        const bodyWidthRuler = getJjViewConfig<number>('commit.bodyWidthRuler', undefined, scope);
+        const formatDescriptionOnSave =
+            getJjViewConfig<boolean>('commit.formatDescriptionOnSave', false, scope) ?? false;
         const repo = this.getRepositoryForRoot(document.repoRoot);
         if (!repo) {
             this._repositoryManager.outputChannel.info(
@@ -493,8 +496,7 @@ export async function openCommitDetails(
     isDivergent?: boolean,
     changeIdOffset?: number,
 ): Promise<void> {
-    const config = vscode.workspace.getConfiguration('jj-view');
-    const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+    const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
     const title = formatCommitTitle(
         {
             change_id: changeId,

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -11,6 +11,7 @@ import { JjContextKey } from './jj-context-keys';
 import type { JjRepository } from './jj-repository';
 import type { JjService } from './jj-service';
 import { type JjLogEntry, TOGGLEABLE_COMMIT_ACTIONS, type ToggleableCommitAction } from './jj-types';
+import { getJjViewConfig } from './utils/config-utils';
 import { canAbsorbCommit } from './utils/jj-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 
@@ -145,9 +146,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 this.outputChannel?.info('[JjLogWebviewProvider] View became visible, re-rendering');
                 this._renderCommits(this._cachedCommits);
             } else {
-                const config = vscode.workspace.getConfiguration('jj-view');
-                const currentTheme = config.get<string>('logTheme', 'default');
-                const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
+                const currentTheme = getJjViewConfig<string>('logTheme', 'default') ?? 'default';
+                const graphLabelAlignment = getJjViewConfig<string>('graphLabelAlignment', 'aligned') ?? 'aligned';
                 const hiddenActions = this._getHiddenActions();
                 webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
                     view: 'graph',
@@ -161,9 +161,8 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             }
         });
 
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const initialTheme = config.get<string>('logTheme', 'default');
-        const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
+        const initialTheme = getJjViewConfig<string>('logTheme', 'default') ?? 'default';
+        const graphLabelAlignment = getJjViewConfig<string>('graphLabelAlignment', 'aligned') ?? 'aligned';
         const hiddenActions = this._getHiddenActions();
         webviewView.webview.html = this._getHtmlForWebview(webviewView.webview, {
             view: 'graph',
@@ -432,10 +431,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
     }
 
     private _renderCommits(commits: JjLogEntry[]) {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
-        const logTheme = config.get<string>('logTheme', 'default');
-        const graphLabelAlignment = config.get<string>('graphLabelAlignment', 'aligned');
+        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
+        const logTheme = getJjViewConfig<string>('logTheme', 'default') ?? 'default';
+        const graphLabelAlignment = getJjViewConfig<string>('graphLabelAlignment', 'aligned') ?? 'aligned';
 
         const cf = this._codeForge;
         if (cf?.isEnabled) {

--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -1092,8 +1092,7 @@ export class JjRepositoryManager implements vscode.Disposable {
      * - 'openEditors': only register on-demand when files are opened.
      */
     private getAutoRepositoryDetectionConfig(): boolean | string {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        return config.get<boolean | string>('autoRepositoryDetection', true);
+        return getJjViewConfig<boolean | string>('autoRepositoryDetection', true) ?? true;
     }
 
     /**
@@ -1102,8 +1101,7 @@ export class JjRepositoryManager implements vscode.Disposable {
      * @returns An array of path strings configured to scan.
      */
     private getScanRepositoriesConfig(): string[] {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        return config.get<string[]>('scanRepositories', []);
+        return getJjViewConfig<string[]>('scanRepositories', []) ?? [];
     }
 
     /**
@@ -1112,8 +1110,7 @@ export class JjRepositoryManager implements vscode.Disposable {
      * @returns An array of path strings configured to ignore.
      */
     private getIgnoredRepositoriesConfig(): string[] {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        return config.get<string[]>('ignoredRepositories', []);
+        return getJjViewConfig<string[]>('ignoredRepositories', []) ?? [];
     }
 
     /**

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -20,6 +20,7 @@ import { JjService } from './jj-service';
 import type { JjLogEntry, JjStatusEntry } from './jj-types';
 import type { JjViewFileSystemProvider } from './jj-view-fs-provider';
 import { createJjResourceState, type JjResourceState } from './scm-resource-state';
+import { getJjViewConfig } from './utils/config-utils';
 import { canAbsorbCommit, canSquashCommit, formatDisplayChangeId, isMutableCommit } from './utils/jj-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
 
@@ -219,9 +220,8 @@ export class JjScmProvider implements vscode.Disposable {
                 const start = performance.now();
                 try {
                     // 1. Fetch data in parallel for performance
-                    const config = vscode.workspace.getConfiguration('jj-view');
-                    const maxMutableAncestors = config.get<number>('maxMutableAncestors', 10);
-                    const openDiffOnClick = config.get<boolean>('openDiffOnClick', true);
+                    const maxMutableAncestors = getJjViewConfig<number>('maxMutableAncestors', 10) ?? 10;
+                    const openDiffOnClick = getJjViewConfig<boolean>('openDiffOnClick', true) ?? true;
                     const limit = maxMutableAncestors + 1;
 
                     // Chain getLog directly off getLogIds so it runs concurrently with getChildren and getConflictedFiles
@@ -351,8 +351,7 @@ export class JjScmProvider implements vscode.Disposable {
                     this._workingCopyStatuses.clear();
 
                     if (currentEntry) {
-                        const config = vscode.workspace.getConfiguration('jj-view');
-                        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+                        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
                         const shortId = formatDisplayChangeId(
                             currentEntry.change_id,
                             currentEntry.change_id_shortest,
@@ -409,8 +408,7 @@ export class JjScmProvider implements vscode.Disposable {
                     for (let i = 0; i < ancestorsToDisplay.length; i++) {
                         const { entry: ancestorEntry, prefix, isMutable, canSquash } = ancestorsToDisplay[i];
 
-                        const config = vscode.workspace.getConfiguration('jj-view');
-                        const minChangeIdLength = config.get<number>('minChangeIdLength', 1);
+                        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
                         const shortId = formatDisplayChangeId(
                             ancestorEntry.change_id,
                             ancestorEntry.change_id_shortest,

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -48,7 +48,7 @@ export const NO_OP_LOGGER: JjServiceLogger = {
     debug: () => {},
 };
 
-export type JjServiceConfigProvider = <T>(key: string, defaultValue?: T) => T | undefined;
+export type JjServiceConfigProvider<S = never> = <T>(key: string, defaultValue?: T, scope?: S) => T | undefined;
 
 export interface JjServiceOptions {
     binaryPath?: string;

--- a/src/refresh-scheduler.ts
+++ b/src/refresh-scheduler.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
+import { getJjViewConfig } from './utils/config-utils';
 
 export class RefreshScheduler implements vscode.Disposable {
     private _debounceTimer: NodeJS.Timeout | undefined;
@@ -22,16 +23,14 @@ export class RefreshScheduler implements vscode.Disposable {
     constructor(
         private refreshCallback: (options: { forceSnapshot: boolean; reason?: string }) => void | Promise<void>,
     ) {
-        const config = vscode.workspace.getConfiguration('jj-view');
-        this._baseDebounce = config.get<number>('refreshDebounceMillis', 100);
-        this._maxMultiplier = config.get<number>('refreshDebounceMaxMultiplier', 4);
+        this._baseDebounce = getJjViewConfig<number>('refreshDebounceMillis', 100) ?? 100;
+        this._maxMultiplier = getJjViewConfig<number>('refreshDebounceMaxMultiplier', 4) ?? 4;
 
         // Listen for configuration changes
         vscode.workspace.onDidChangeConfiguration((e) => {
             if (e.affectsConfiguration('jj-view')) {
-                const newConfig = vscode.workspace.getConfiguration('jj-view');
-                this._baseDebounce = newConfig.get<number>('refreshDebounceMillis', 100);
-                this._maxMultiplier = newConfig.get<number>('refreshDebounceMaxMultiplier', 4);
+                this._baseDebounce = getJjViewConfig<number>('refreshDebounceMillis', 100) ?? 100;
+                this._maxMultiplier = getJjViewConfig<number>('refreshDebounceMaxMultiplier', 4) ?? 4;
             }
         });
     }

--- a/src/utils/config-utils.ts
+++ b/src/utils/config-utils.ts
@@ -9,7 +9,42 @@ import type { JjServiceConfigProvider } from '../jj-service';
  * Standard configuration provider for 'jj-view' extension settings.
  * Passable directly to JjServiceOptions.getConfig.
  */
-export const getJjViewConfig: JjServiceConfigProvider = <T>(key: string, defaultValue?: T): T | undefined => {
-    const config = vscode.workspace.getConfiguration('jj-view');
+export const getJjViewConfig: JjServiceConfigProvider<vscode.ConfigurationScope | null> = <T>(
+    key: string,
+    defaultValue?: T,
+    scope?: vscode.ConfigurationScope | null,
+): T | undefined => {
+    const config =
+        scope !== undefined
+            ? vscode.workspace.getConfiguration('jj-view', scope)
+            : vscode.workspace.getConfiguration('jj-view');
     return defaultValue !== undefined ? config.get<T>(key, defaultValue) : config.get<T>(key);
 };
+
+/**
+ * Utility to get configuration values from any workspace configuration section.
+ */
+export function getWorkspaceConfig<T>(
+    section: string,
+    key: string,
+    defaultValue?: T,
+    scope?: vscode.ConfigurationScope | null,
+): T | undefined {
+    const config =
+        scope !== undefined
+            ? vscode.workspace.getConfiguration(section, scope)
+            : vscode.workspace.getConfiguration(section);
+    return defaultValue !== undefined ? config.get<T>(key, defaultValue) : config.get<T>(key);
+}
+
+/**
+ * Utility to update a 'jj-view' configuration setting.
+ */
+export function updateJjViewConfig(
+    key: string,
+    value: unknown,
+    target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global,
+): Thenable<void> {
+    const config = vscode.workspace.getConfiguration('jj-view');
+    return config.update(key, value, target);
+}

--- a/src/utils/gerrit-host-detection.ts
+++ b/src/utils/gerrit-host-detection.ts
@@ -5,8 +5,8 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import * as vscode from 'vscode';
 import type { GitRemote } from '../code-forge-provider';
+import { getJjViewConfig } from './config-utils';
 import { getGitConfig } from './gerrit-credential-utils';
 import type { JjLoggerChannel } from './output-channel';
 
@@ -35,7 +35,7 @@ export function normalizeHostUrl(hostUrl: string): string {
  */
 function getHostFromSettings(outputChannel?: JjLoggerChannel): string | undefined {
     outputChannel?.debug('[GerritDetector] Checking VS Code settings for jj-view.gerrit.host...');
-    const settingHost = vscode.workspace.getConfiguration('jj-view').get<string>('gerrit.host')?.trim();
+    const settingHost = getJjViewConfig<string>('gerrit.host')?.trim();
     if (settingHost) {
         if (settingHost.toLowerCase() === 'true' || settingHost.toLowerCase() === 'false') {
             outputChannel?.debug(


### PR DESCRIPTION
Centralize all extension configuration reads and updates across providers, commands, services, and managers using helper utilities in `config-utils`. This ensures consistent setting resolution and simplifies scoped configuration access throughout the codebase.