### PR TITLE
test: add FakeConfigStore utility and standardize test configuration

### DIFF
--- a/src/test/code-forge-auth.test.ts
+++ b/src/test/code-forge-auth.test.ts
@@ -5,14 +5,14 @@
 import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { type AuthResult, CodeForgeAuthManager } from '../code-forge-auth';
-import { createMock, createMockLogOutputChannel } from './test-utils';
+import { createMock, createMockLogOutputChannel, FakeConfigStore } from './test-utils';
+
+const fakeConfigStore = new FakeConfigStore();
 
 // Mock VS Code
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: () => ({
-            get: vi.fn(),
-        }),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
     },
     window: {
         showWarningMessage: vi.fn(),

--- a/src/test/code-forge-service.test.ts
+++ b/src/test/code-forge-service.test.ts
@@ -7,8 +7,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { NO_OP_LOGGER } from '../jj-service';
+import { FakeConfigStore } from './test-utils';
 
-const mockConfigStore = new Map<string, unknown>();
+const fakeConfigStore = new FakeConfigStore();
 let mockConfigListener: ((e: { affectsConfiguration(section: string): boolean }) => void) | undefined;
 let mockWindowStateListener: ((e: { focused: boolean }) => void) | undefined;
 
@@ -17,11 +18,7 @@ vi.mock('vscode', async () => {
     return createVscodeMock({
         workspace: {
             workspaceFolders: [{ uri: { fsPath: '/root' } }],
-            getConfiguration: vi.fn().mockReturnValue({
-                get: vi.fn().mockImplementation((key: string, defaultValue: unknown) => {
-                    return mockConfigStore.has(key) ? mockConfigStore.get(key) : defaultValue;
-                }),
-            }),
+            getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
             onDidChangeConfiguration: vi.fn().mockImplementation((listener) => {
                 mockConfigListener = listener;
                 return { dispose: vi.fn() };
@@ -91,7 +88,7 @@ describe('CodeForgeService Tests', () => {
     let jjService2: JjService;
 
     beforeEach(() => {
-        mockConfigStore.clear();
+        fakeConfigStore.clear();
         registry = new CodeForgeRegistry();
 
         repo1 = new TestRepo();
@@ -263,7 +260,7 @@ describe('CodeForgeService Tests', () => {
         registry.register({ id: 'provider-b', create: () => providerB });
 
         // Set preferred provider setting
-        mockConfigStore.set('codeForge.provider', 'provider-b');
+        fakeConfigStore.set('codeForge.provider', 'provider-b');
 
         const service = new CodeForgeService(repo1.path, jjService1, registry);
         await service.awaitReady();
@@ -272,7 +269,7 @@ describe('CodeForgeService Tests', () => {
         expect(service.activeProvider).toBe(providerB);
 
         // Reset preferred setting
-        mockConfigStore.delete('codeForge.provider');
+        fakeConfigStore.clear();
 
         service.dispose();
     });

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -12,23 +12,15 @@ import { GitHubProvider } from '../../github-provider';
 import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { buildGraph, TestRepo } from '../test-repo';
-import { createMock, createMockLogOutputChannel } from '../test-utils';
+import { createMock, createMockLogOutputChannel, FakeConfigStore } from '../test-utils';
 
-// Mock dependencies
-const mockConfig = {
-    get: vi.fn(),
-};
+const fakeConfigStore = new FakeConfigStore();
 
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('../vscode-mock');
     return createVscodeMock({
         workspace: {
-            getConfiguration: vi.fn((section) => {
-                if (section === 'jj-view') {
-                    return mockConfig;
-                }
-                return { get: vi.fn() };
-            }),
+            getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         },
     });
 });
@@ -53,7 +45,7 @@ describe('uploadCommand', () => {
             refresh: vi.fn().mockResolvedValue(undefined),
         });
         mockOutputChannel = createMockLogOutputChannel({ appendLine: vi.fn(), show: vi.fn() });
-        mockConfig.get.mockReset();
+        fakeConfigStore.clear();
         vi.mocked(vscode.window.showErrorMessage).mockClear();
         vi.mocked(vscode.commands.executeCommand).mockClear();
     });
@@ -85,12 +77,7 @@ describe('uploadCommand', () => {
         repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
         // Setup config to return 'git push' ONLY when queried for 'uploadCommand'
-        mockConfig.get.mockImplementation((key: string) => {
-            if (key === 'uploadCommand') {
-                return 'git push';
-            }
-            return undefined;
-        });
+        fakeConfigStore.set('uploadCommand', 'git push');
 
         await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
 
@@ -118,7 +105,7 @@ describe('uploadCommand', () => {
         repo.gitPush('feature-x');
         repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
 
         await uploadCommand(scmProvider, jjService, codeForgeService, ['feature-x'], mockOutputChannel);
 
@@ -146,7 +133,7 @@ describe('uploadCommand', () => {
         repo.gitPush('feature-x');
         repo.bookmarkMove('feature-x', ids.commitB.changeId);
 
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
 
         // This simulates the webview payload: { changeId: 'feature-x' }
         await uploadCommand(scmProvider, jjService, codeForgeService, [{ changeId: 'feature-x' }], mockOutputChannel);
@@ -165,7 +152,7 @@ describe('uploadCommand', () => {
             },
         ]);
 
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
 
         const badProvider = createMock<GitHubProvider>({
             getUploadCommand: () => ({
@@ -216,12 +203,7 @@ describe('uploadCommand', () => {
         ]);
 
         // Use an invalid custom command that will fail
-        mockConfig.get.mockImplementation((key: string) => {
-            if (key === 'uploadCommand') {
-                return 'git push-nonexistent';
-            }
-            return undefined;
-        });
+        fakeConfigStore.set('uploadCommand', 'git push-nonexistent');
 
         const showErrorMessage = vscode.window.showErrorMessage as (
             message: string,
@@ -248,7 +230,7 @@ describe('uploadCommand', () => {
 
         const remoteRepo = await setupRemote();
 
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
 
         const mockAuthManager = createMock<CodeForgeAuthManager>({
             registerProvider: vi.fn(),
@@ -287,7 +269,7 @@ describe('uploadCommand', () => {
             },
         ]);
 
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
 
         const mockAuthManager = createMock<CodeForgeAuthManager>({
             registerProvider: vi.fn(),

--- a/src/test/gerrit-host-detection.test.ts
+++ b/src/test/gerrit-host-detection.test.ts
@@ -8,29 +8,19 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
-import * as vscode from 'vscode';
 import { detectGerritHost, normalizeHostUrl, parseRemoteUrl } from '../utils/gerrit-host-detection';
-import { createMock } from './test-utils';
+import { FakeConfigStore } from './test-utils';
+
+const fakeConfigStore = new FakeConfigStore();
 
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: vi.fn(() => ({
-            get: vi.fn(),
-        })),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
     },
 }));
 
 function mockGerritHostSetting(value: string | undefined): void {
-    vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue(
-        createMock<vscode.WorkspaceConfiguration>({
-            get: (key: string) => {
-                if (key === 'gerrit.host') {
-                    return value;
-                }
-                return undefined;
-            },
-        }),
-    );
+    fakeConfigStore.set('gerrit.host', value);
 }
 
 describe('Gerrit Host Detection Utilities', () => {

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -8,21 +8,28 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import type { ChangeStatusRequest } from '../code-forge-provider';
 import { GerritProvider } from '../gerrit-provider';
 import type { JjService } from '../jj-service';
 import type { CodeForgeChangeInfo } from '../jj-types';
 import { resolveGerritChangeKey, stripGerritTrailers } from '../utils/gerrit-utils';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
-import { accessPrivate, createMock, createMockLogOutputChannel, exposePrivate, setPrivate } from './test-utils';
+import {
+    accessPrivate,
+    createMock,
+    createMockLogOutputChannel,
+    exposePrivate,
+    FakeConfigStore,
+    setPrivate,
+} from './test-utils';
+
+let fakeConfigStore = new FakeConfigStore();
 
 // Mock VS Code
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: vi.fn(() => ({
-            get: vi.fn(),
-        })),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         onDidChangeConfiguration: vi.fn(),
     },
     Disposable: class {
@@ -68,19 +75,14 @@ describe('GerritProvider', () => {
     let mockOutputChannel: vscode.LogOutputChannel;
 
     beforeEach(() => {
+        fakeConfigStore = new FakeConfigStore();
         mockJjService = createMock<JjService>({});
         mockOutputChannel = createMockLogOutputChannel({ appendLine: vi.fn() });
         provider = new GerritProvider(mockOutputChannel);
     });
 
     test('detect trims and checks for blank gerrit.host setting', async () => {
-        const getMock = vi.fn().mockReturnValue('   '); // whitespace only
-        vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-            get: getMock,
-            has: vi.fn(),
-            update: vi.fn(),
-            inspect: vi.fn(),
-        } as unknown as vscode.WorkspaceConfiguration);
+        fakeConfigStore.set('gerrit.host', '   '); // whitespace only
 
         // With blank host, should fall back to checking .gitreview/remotes and return false since they don't exist
         const result = await provider.detect('/root', []);
@@ -94,18 +96,7 @@ describe('GerritProvider', () => {
         cp.execSync(`git init --bare "${gitRoot}"`);
         cp.execSync(`git --git-dir="${gitRoot}" config gerrit.host "git-config-host.example.com"`);
 
-        // Mock workspace config to return undefined for gerrit.host
-        vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
-            get: (key: string) => {
-                if (key === 'binaryPath') {
-                    return 'jj';
-                }
-                return undefined;
-            },
-            has: vi.fn(),
-            update: vi.fn(),
-            inspect: vi.fn(),
-        } as unknown as vscode.WorkspaceConfiguration);
+        fakeConfigStore.set('binaryPath', 'jj');
 
         setPrivate(provider, 'repoRoot', tempRepoDir);
         setPrivate(provider, 'gitRoot', gitRoot);

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -15,17 +15,14 @@ import { JjService, NO_OP_LOGGER } from '../jj-service';
 import * as credentialUtils from '../utils/gerrit-credential-utils';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
 import { TestRepo } from './test-repo';
-import { accessPrivate, exposePrivate } from './test-utils';
+import { accessPrivate, exposePrivate, FakeConfigStore } from './test-utils';
 import { asMock } from './vitest-utils';
 
-// Mock VS Code
-const mockConfig = {
-    get: vi.fn(),
-};
+const fakeConfigStore = new FakeConfigStore();
 
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: () => mockConfig,
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         onDidChangeConfiguration: vi.fn(),
     },
     Disposable: class {
@@ -70,7 +67,7 @@ describe('GerritService Detection', () => {
     beforeEach(async () => {
         repo = new TestRepo();
         repo.init();
-        mockConfig.get.mockReset();
+        fakeConfigStore.clear();
 
         mockOnDidChangeWindowState = asMock(vscode.window.onDidChangeWindowState);
         mockOnDidChangeWindowState.mockReset();
@@ -114,12 +111,7 @@ describe('GerritService Detection', () => {
     }
 
     test('Detects from extension setting (highest priority)', async () => {
-        mockConfig.get.mockImplementation((key: string) => {
-            if (key === 'gerrit.host') {
-                return 'https://setting-host.com';
-            }
-            return undefined;
-        });
+        fakeConfigStore.set('gerrit.host', 'https://setting-host.com');
 
         service = initService();
         await service.awaitReady();
@@ -212,7 +204,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses prioritizes Description Change-Id', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -233,7 +225,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses prioritizes Link trailer when Change-Id is missing', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -251,7 +243,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses extracts change number from different Link formats', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -284,7 +276,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses prioritizes Change-Id over Link trailer', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -306,7 +298,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses falls back to Computed Change-Id', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -330,7 +322,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses ignores commit SHA if Change-Id logic fails (or just returns undefined)', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -342,7 +334,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses handles invalid JJ Change-Id gracefully', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -361,7 +353,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses updates cache when status changes', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -389,7 +381,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses detects changes', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -425,7 +417,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses returns false if no changes', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -460,7 +452,7 @@ describe('GerritService Detection', () => {
     test('startPolling preserves cache and fires onDidUpdate', async () => {
         vi.useFakeTimers();
 
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
         expect(service.isEnabled).toBe(true);
@@ -500,7 +492,7 @@ describe('GerritService Detection', () => {
     });
 
     test('forceRefresh preserves cache and fires onDidUpdate', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
         expect(service.isEnabled).toBe(true);
@@ -533,7 +525,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses parses changed files', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -569,7 +561,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses detects extra local files as not synced', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -610,7 +602,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses detects description mismatch as not synced', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -647,7 +639,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses accepts matching description regardless of whitespace', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -684,7 +676,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses ignores Change-Id footer differences', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -720,7 +712,7 @@ describe('GerritService Detection', () => {
     });
 
     test('ensureFreshStatuses ignores Link trailer footer differences during sync', async () => {
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -759,7 +751,7 @@ describe('GerritService Detection', () => {
 
     test('requestRefreshWithBackoffs schedules multiple refreshes', async () => {
         vi.useFakeTimers();
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -788,7 +780,7 @@ describe('GerritService Detection', () => {
 
     test('requestRefreshWithBackoffs cancels previous wave when called again', async () => {
         vi.useFakeTimers();
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         service = initService();
         await service.awaitReady();
 
@@ -810,7 +802,7 @@ describe('GerritService Detection', () => {
         vi.setSystemTime(20000); // Start at t=20s to ensure throttling logic works (20000 > 10000)
 
         // Setup to be enabled
-        mockConfig.get.mockReturnValue(fakeGerritServer.url);
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
 
         // Initialize service
         service = initService();
@@ -857,7 +849,7 @@ describe('GerritService Detection', () => {
         vi.useFakeTimers();
 
         // Start with no config so detection fails
-        mockConfig.get.mockReturnValue(undefined);
+        fakeConfigStore.clear();
         service = initService();
         await service.awaitReady();
         expect(service.isEnabled).toBe(false);
@@ -911,9 +903,7 @@ describe('GerritService Detection', () => {
 
     test('detectActiveProvider fires onDidUpdate only when host status changes', async () => {
         // Start disabled
-        mockConfig.get.mockImplementation(() => {
-            return undefined;
-        });
+        fakeConfigStore.clear();
         service = initService();
         await service.awaitReady();
         expect(service.isEnabled).toBe(false);
@@ -928,12 +918,7 @@ describe('GerritService Detection', () => {
         expect(updateCount).toBe(0);
 
         // Set config so it succeeds
-        mockConfig.get.mockImplementation((key: string) => {
-            if (key === 'gerrit.host') {
-                return fakeGerritServer.url;
-            }
-            return undefined;
-        });
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
         await service.detectActiveProvider(true);
         expect(service.isEnabled).toBe(true);
         expect(updateCount).toBe(1);
@@ -943,9 +928,7 @@ describe('GerritService Detection', () => {
         expect(updateCount).toBe(1);
 
         // Change config back to undefined, should fire when disabled
-        mockConfig.get.mockImplementation(() => {
-            return undefined;
-        });
+        fakeConfigStore.clear();
         await service.detectActiveProvider(true);
         expect(service.isEnabled).toBe(false);
         expect(updateCount).toBe(2);

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -11,16 +11,13 @@ import { JjService, NO_OP_LOGGER } from '../jj-service';
 import type { CodeForgeChangeInfo, JjLogEntry } from '../jj-types';
 import { FakeGerritServer } from './helpers/fake-gerrit-server';
 import { TestRepo } from './test-repo';
-import { createMock, exposePrivate } from './test-utils';
+import { createMock, exposePrivate, FakeConfigStore } from './test-utils';
 
-// Mock VS Code configuration
-const mockConfig = {
-    get: vi.fn(),
-};
+const fakeConfigStore = new FakeConfigStore();
 
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: () => mockConfig,
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         onDidChangeConfiguration: vi.fn(),
     },
     Disposable: class {
@@ -65,12 +62,7 @@ describe('Gerrit Sync Verification', () => {
             'probeGerritHost',
         ).mockResolvedValue(true);
 
-        mockConfig.get.mockImplementation((key: string) => {
-            if (key === 'gerrit.host') {
-                return fakeGerritServer.url;
-            }
-            return undefined;
-        });
+        fakeConfigStore.set('gerrit.host', fakeGerritServer.url);
     });
 
     afterEach(async () => {

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -11,14 +11,21 @@ import { JjService } from '../jj-service';
 import type { CodeForgeChangeInfo } from '../jj-types';
 import { FakeGitHubServer } from './helpers/fake-github-server';
 import { TestRepo } from './test-repo';
-import { accessPrivate, createMock, createMockLogOutputChannel, exposePrivate, setPrivate } from './test-utils';
+import {
+    accessPrivate,
+    createMock,
+    createMockLogOutputChannel,
+    exposePrivate,
+    FakeConfigStore,
+    setPrivate,
+} from './test-utils';
+
+const fakeConfigStore = new FakeConfigStore();
 
 // Mock VS Code
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: () => ({
-            get: vi.fn(),
-        }),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         onDidChangeConfiguration: vi.fn(),
     },
     window: {

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -9,13 +9,20 @@ import type { AuthManageItem, ChangeStatusRequest } from '../code-forge-provider
 import { GitLabProvider } from '../gitlab-provider';
 import type { CodeForgeChangeInfo } from '../jj-types';
 import { FakeGitLabServer } from './helpers/fake-gitlab-server';
-import { accessPrivate, createMock, createMockLogOutputChannel, exposePrivate, setPrivate } from './test-utils';
+import {
+    accessPrivate,
+    createMock,
+    createMockLogOutputChannel,
+    exposePrivate,
+    FakeConfigStore,
+    setPrivate,
+} from './test-utils';
+
+const fakeConfigStore = new FakeConfigStore();
 
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: () => ({
-            get: vi.fn(),
-        }),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
         onDidChangeConfiguration: vi.fn(),
     },
     window: {

--- a/src/test/refresh-scheduler.test.ts
+++ b/src/test/refresh-scheduler.test.ts
@@ -4,12 +4,13 @@
  */
 import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 import { RefreshScheduler } from '../refresh-scheduler';
+import { FakeConfigStore } from './test-utils';
 
-const getConfigurationMock = vi.fn();
+let fakeConfigStore: FakeConfigStore;
 
 vi.mock('vscode', () => ({
     workspace: {
-        getConfiguration: (...args: unknown[]) => getConfigurationMock(...args),
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
     },
     Disposable: class {},
 }));
@@ -22,17 +23,9 @@ describe('RefreshScheduler', () => {
         vi.useFakeTimers();
         refreshFn = vi.fn().mockResolvedValue(undefined);
 
-        // Default config
-        getConfigurationMock.mockReturnValue({
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'refreshDebounceMillis') {
-                    return 100;
-                }
-                if (key === 'refreshDebounceMaxMultiplier') {
-                    return 4;
-                }
-                return defaultValue;
-            },
+        fakeConfigStore = new FakeConfigStore({
+            refreshDebounceMillis: 100,
+            refreshDebounceMaxMultiplier: 4,
         });
 
         scheduler = new RefreshScheduler(refreshFn);
@@ -170,19 +163,6 @@ describe('RefreshScheduler', () => {
     });
 
     test('should read updated base debounce setting dynamically on subsequent triggers', async () => {
-        let currentDebounce = 100;
-        getConfigurationMock.mockImplementation(() => ({
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'refreshDebounceMillis') {
-                    return currentDebounce;
-                }
-                if (key === 'refreshDebounceMaxMultiplier') {
-                    return 4;
-                }
-                return defaultValue;
-            },
-        }));
-
         // First trigger with initial debounce (100ms)
         scheduler.trigger();
         await vi.advanceTimersByTimeAsync(100);
@@ -191,8 +171,8 @@ describe('RefreshScheduler', () => {
         // Wait for scheduler cycle to reset to idle
         await vi.advanceTimersByTimeAsync(200);
 
-        // Update configuration value
-        currentDebounce = 500;
+        // Update configuration value declaratively
+        fakeConfigStore.set('refreshDebounceMillis', 500);
 
         // Second trigger should use updated debounce (500ms)
         scheduler.trigger();
@@ -204,18 +184,10 @@ describe('RefreshScheduler', () => {
     });
 
     test('should read updated max multiplier dynamically on subsequent triggers', async () => {
-        let maxMultiplier = 2;
-        getConfigurationMock.mockImplementation(() => ({
-            get: (key: string, defaultValue: unknown) => {
-                if (key === 'refreshDebounceMillis') {
-                    return 100;
-                }
-                if (key === 'refreshDebounceMaxMultiplier') {
-                    return maxMultiplier;
-                }
-                return defaultValue;
-            },
-        }));
+        fakeConfigStore.setAll({
+            refreshDebounceMillis: 100,
+            refreshDebounceMaxMultiplier: 2,
+        });
 
         // 1st trigger: wait 100ms (multiplier starts at 1, max is 2)
         scheduler.trigger();
@@ -228,7 +200,7 @@ describe('RefreshScheduler', () => {
         expect(refreshFn).toHaveBeenCalledTimes(2);
 
         // Update max multiplier dynamically
-        maxMultiplier = 4;
+        fakeConfigStore.set('refreshDebounceMaxMultiplier', 4);
 
         // 3rd trigger during 200ms wait
         scheduler.trigger();

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -115,3 +115,72 @@ export class CallbackWaiter<T = void> {
         return (value: T) => this.recordCall(value);
     }
 }
+
+/**
+ * A stateful fake implementation of configuration for tests without relying on a mocking framework.
+ *
+ * Example usage:
+ * ```ts
+ * const config = new FakeConfigStore({
+ *     refreshDebounceMillis: 100,
+ *     refreshDebounceMaxMultiplier: 4,
+ * });
+ *
+ * // Use with vscode.workspace.getConfiguration mock/fake:
+ * getConfigurationMock.mockImplementation(() => config.toWorkspaceConfiguration());
+ *
+ * // Or pass provider directly to JjService or helpers:
+ * const jjService = new JjService({ getConfig: config.provider });
+ *
+ * // Dynamically update config during tests:
+ * config.set('refreshDebounceMillis', 500);
+ * ```
+ */
+export class FakeConfigStore {
+    private readonly _store: Map<string, unknown>;
+
+    constructor(initialConfig: Record<string, unknown> = {}) {
+        this._store = new Map(Object.entries(initialConfig));
+    }
+
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        if (this._store.has(key)) {
+            return this._store.get(key) as T;
+        }
+        return defaultValue;
+    }
+
+    set(key: string, value: unknown): void {
+        this._store.set(key, value);
+    }
+
+    setAll(values: Record<string, unknown>): void {
+        for (const [k, v] of Object.entries(values)) {
+            this._store.set(k, v);
+        }
+    }
+
+    clear(): void {
+        this._store.clear();
+    }
+
+    get provider(): <T>(key: string, defaultValue?: T) => T | undefined {
+        return <T>(key: string, defaultValue?: T) => this.get<T>(key, defaultValue);
+    }
+
+    toWorkspaceConfiguration() {
+        return {
+            get: <T>(key: string, defaultValue?: T): T | undefined => this.get<T>(key, defaultValue),
+            has: (key: string): boolean => this._store.has(key),
+            inspect: <T>(key: string) => ({
+                key,
+                defaultValue: undefined,
+                globalValue: this._store.get(key) as T | undefined,
+                workspaceValue: undefined,
+            }),
+            update: async (key: string, value: unknown): Promise<void> => {
+                this._store.set(key, value);
+            },
+        };
+    }
+}


### PR DESCRIPTION
Introduce FakeConfigStore as a stateful fake implementation of VS Code configuration and update test suites to use it directly. This removes repetitive Vitest mocking setup across test files while enabling clean, declarative test configuration updates.