### PR TITLE
perf(jj-service): memoize getChanges

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -67,6 +67,8 @@ export class JjService {
     private _nextOpId = 0;
     private _diffCache = new Map<string, { tempDir: string; expires: number }>();
     private _diffCachePromises = new Map<string, Promise<{ tempDir: string; expires: number }>>();
+    private _changesCache = new Map<string, { entries: JjStatusEntry[]; expires: number }>();
+    private _changesCachePromises = new Map<string, Promise<JjStatusEntry[]>>();
     private _mutationMutex: Promise<void> = Promise.resolve();
 
     constructor(
@@ -735,6 +737,8 @@ export class JjService {
         this._diffCachePromises.clear();
         const keys = Array.from(this._diffCache.keys());
         await Promise.all(keys.map((revision) => this.cleanupDiffCache(revision)));
+        this._changesCachePromises.clear();
+        this._changesCache.clear();
     }
 
     private async cleanupDiffCache(revision: string) {
@@ -1103,6 +1107,38 @@ export class JjService {
     }
 
     async getChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {
+        const cacheKey = toRevision ? `${revision}..${toRevision}` : revision;
+
+        const inProgress = this._changesCachePromises.get(cacheKey);
+        if (inProgress) {
+            const entries = await inProgress;
+            return entries.map((e) => ({ ...e }));
+        }
+
+        const cached = this._changesCache.get(cacheKey);
+        if (cached && Date.now() < cached.expires) {
+            return cached.entries.map((e) => ({ ...e }));
+        }
+
+        const fetchPromise = (async () => {
+            const entries = await this._doGetChanges(revision, toRevision);
+            this._changesCache.set(cacheKey, {
+                entries,
+                expires: Date.now() + 5 * 60_000,
+            });
+            return entries;
+        })();
+
+        this._changesCachePromises.set(cacheKey, fetchPromise);
+        try {
+            const entries = await fetchPromise;
+            return entries.map((e) => ({ ...e }));
+        } finally {
+            this._changesCachePromises.delete(cacheKey);
+        }
+    }
+
+    private async _doGetChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {
         const args = ['--git'];
         if (toRevision) {
             args.push('--from', revision, '--to', toRevision);

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -171,4 +171,49 @@ describe('JjService Diff Tests', () => {
         expect(content.left).toBe('');
         expect(content.right).toBe('');
     });
+
+    test('getChanges caches results and deduplicates concurrent in-flight requests', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'file1.txt': 'initial\n' } },
+            { label: 'child', parents: ['base'], files: { 'file1.txt': 'updated\n', 'file2.txt': 'created\n' } },
+        ]);
+        const commitId = ids.child.commitId;
+
+        // Concurrent calls (thundering herd)
+        const [changes1, changes2] = await Promise.all([
+            jjService.getChanges(commitId),
+            jjService.getChanges(commitId),
+        ]);
+
+        expect(changes1).toEqual(changes2);
+        expect(changes1.length).toBe(2);
+
+        // Subsequent cached call
+        const changes3 = await jjService.getChanges(commitId);
+        expect(changes3).toEqual(changes1);
+    });
+
+    test('getChanges invalidates cache on clearCache or mutation', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'test.txt': 'v1\n' } },
+            { label: 'child', parents: ['base'], files: { 'test.txt': 'v2\n' } },
+        ]);
+
+        const initialChanges = await jjService.getChanges(ids.child.changeId);
+        expect(initialChanges.length).toBe(1);
+        expect(initialChanges[0].path).toBe('test.txt');
+
+        // Make mutation in child commit using repo
+        repo.edit(ids.child.changeId);
+        await repo.writeFiles({ 'extra.txt': 'new\n' });
+
+        // Before clearCache / mutation, calling getChanges with cached key without clearCache would return old entries
+        // Running status (which is a mutation in JjService) or explicit clearCache invalidates the cache
+        await jjService.clearCache();
+
+        const updatedChanges = await jjService.getChanges(ids.child.changeId);
+        expect(updatedChanges.length).toBe(2);
+        const paths = updatedChanges.map((c) => c.path).sort();
+        expect(paths).toEqual(['extra.txt', 'test.txt']);
+    });
 });


### PR DESCRIPTION
Add caching and concurrent request deduplication to JjService.getChanges, using the same TTL and mutation invalidation rules as the diff cache.