### PR TITLE
chore(jj-service): generalize caching strategy with generic AsyncCache

### DIFF
--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -18,6 +18,7 @@ import {
 import type { JjBookmark, JjLogEntry, JjStatusEntry, JjWorkspace } from './jj-types';
 import type { SelectionRange } from './patch-helper';
 import * as PatchHelper from './patch-helper';
+import { AsyncCache } from './utils/async-cache';
 
 export interface JjLogOptions {
     revision?: string;
@@ -65,10 +66,12 @@ export class JjService {
     private _lastWriteTime = 0;
     private _operationTimeouts = new Map<number, NodeJS.Timeout>();
     private _nextOpId = 0;
-    private _diffCache = new Map<string, { tempDir: string; expires: number }>();
-    private _diffCachePromises = new Map<string, Promise<{ tempDir: string; expires: number }>>();
-    private _changesCache = new Map<string, { entries: JjStatusEntry[]; expires: number }>();
-    private _changesCachePromises = new Map<string, Promise<JjStatusEntry[]>>();
+    private _diffCache = new AsyncCache<string, { tempDir: string; expires: number }>({
+        onEvict: (entry) => fs.rm(entry.tempDir, { recursive: true, force: true }).catch(() => {}),
+    });
+    private _changesCache = new AsyncCache<string, JjStatusEntry[]>({
+        clone: (entries) => entries.map((e) => ({ ...e })),
+    });
     private _mutationMutex: Promise<void> = Promise.resolve();
 
     constructor(
@@ -661,92 +664,51 @@ export class JjService {
      * Extracts all changed files into a temporary directory using a single 'jj diffedit' call.
      */
     async getDiffForRevision(revision: string, force: boolean = false): Promise<{ tempDir: string; expires: number }> {
-        // Check for an in-progress warming operation for this revision
-        if (!force) {
-            const inProgress = this._diffCachePromises.get(revision);
-            if (inProgress) {
-                return inProgress;
-            }
+        if (force) {
+            await this._diffCache.delete(revision);
         }
-
-        const cached = this._diffCache.get(revision);
-        if (cached && !force && Date.now() < cached.expires) {
-            return cached;
-        }
-
-        // Expired or missing: warm the cache
-        const warmingPromise = this._warmDiffCache(revision, cached);
-        this._diffCachePromises.set(revision, warmingPromise);
-        return warmingPromise;
+        return this._diffCache.getOrFetch(revision, () => this._warmDiffCache(revision));
     }
 
-    private async _warmDiffCache(
-        revision: string,
-        oldEntry?: { tempDir: string; expires: number },
-    ): Promise<{ tempDir: string; expires: number }> {
-        try {
-            // Cleanup first if we're forcing or it expired
-            if (oldEntry) {
-                await this.cleanupDiffCache(revision);
-            }
+    private async _warmDiffCache(revision: string): Promise<{ tempDir: string; expires: number }> {
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jj-bulk-diff-'));
+        const leftDir = path.join(tempDir, 'left');
+        const rightDir = path.join(tempDir, 'right');
 
-            const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jj-bulk-diff-'));
-            const leftDir = path.join(tempDir, 'left');
-            const rightDir = path.join(tempDir, 'right');
+        try {
+            await fs.mkdir(leftDir, { recursive: true });
+            await fs.mkdir(rightDir, { recursive: true });
+
+            const normalizedScriptPath = this.getScriptPath('batch-diff');
+            const toolName = 'vscode-bulk-capture';
+            const toolConfig = this.getToolConfigArgs(toolName, normalizedScriptPath, [
+                '$left',
+                '$right',
+                leftDir.split(path.sep).join('/'),
+                rightDir.split(path.sep).join('/'),
+            ]);
 
             try {
-                await fs.mkdir(leftDir, { recursive: true });
-                await fs.mkdir(rightDir, { recursive: true });
-
-                const normalizedScriptPath = this.getScriptPath('batch-diff');
-                const toolName = 'vscode-bulk-capture';
-                const toolConfig = this.getToolConfigArgs(toolName, normalizedScriptPath, [
-                    '$left',
-                    '$right',
-                    leftDir.split(path.sep).join('/'),
-                    rightDir.split(path.sep).join('/'),
-                ]);
-
-                try {
-                    await this.run(
-                        'diffedit',
-                        ['-r', revision, '--ignore-immutable', '--tool', toolName, ...toolConfig],
-                        { useCachedSnapshot: true, label: `getDiffForRevision ${revision}` },
-                    );
-                } catch {
-                    // Expected exit 1
-                }
-
-                const entry = {
-                    tempDir,
-                    expires: Date.now() + 5 * 60_000,
-                };
-                this._diffCache.set(revision, entry);
-                return entry;
-            } catch (err) {
-                await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
-                throw err;
+                await this.run('diffedit', ['-r', revision, '--ignore-immutable', '--tool', toolName, ...toolConfig], {
+                    useCachedSnapshot: true,
+                    label: `getDiffForRevision ${revision}`,
+                });
+            } catch {
+                // Expected exit 1
             }
-        } finally {
-            // Always remove the promise from the map when finished
-            this._diffCachePromises.delete(revision);
+
+            return {
+                tempDir,
+                expires: Date.now() + 5 * 60_000,
+            };
+        } catch (err) {
+            await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+            throw err;
         }
     }
 
     async clearCache(): Promise<void> {
-        this._diffCachePromises.clear();
-        const keys = Array.from(this._diffCache.keys());
-        await Promise.all(keys.map((revision) => this.cleanupDiffCache(revision)));
-        this._changesCachePromises.clear();
-        this._changesCache.clear();
-    }
-
-    private async cleanupDiffCache(revision: string) {
-        const cached = this._diffCache.get(revision);
-        if (cached) {
-            this._diffCache.delete(revision);
-            await fs.rm(cached.tempDir, { recursive: true, force: true }).catch(() => {});
-        }
+        await Promise.all([this._diffCache.clear(), this._changesCache.clear()]);
     }
 
     private async runMutation<T>(op: () => Promise<T>): Promise<T> {
@@ -1108,34 +1070,7 @@ export class JjService {
 
     async getChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {
         const cacheKey = toRevision ? `${revision}..${toRevision}` : revision;
-
-        const inProgress = this._changesCachePromises.get(cacheKey);
-        if (inProgress) {
-            const entries = await inProgress;
-            return entries.map((e) => ({ ...e }));
-        }
-
-        const cached = this._changesCache.get(cacheKey);
-        if (cached && Date.now() < cached.expires) {
-            return cached.entries.map((e) => ({ ...e }));
-        }
-
-        const fetchPromise = (async () => {
-            const entries = await this._doGetChanges(revision, toRevision);
-            this._changesCache.set(cacheKey, {
-                entries,
-                expires: Date.now() + 5 * 60_000,
-            });
-            return entries;
-        })();
-
-        this._changesCachePromises.set(cacheKey, fetchPromise);
-        try {
-            const entries = await fetchPromise;
-            return entries.map((e) => ({ ...e }));
-        } finally {
-            this._changesCachePromises.delete(cacheKey);
-        }
+        return this._changesCache.getOrFetch(cacheKey, () => this._doGetChanges(revision, toRevision));
     }
 
     private async _doGetChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {

--- a/src/test/utils/async-cache.test.ts
+++ b/src/test/utils/async-cache.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import { AsyncCache } from '../../utils/async-cache';
+
+describe('AsyncCache Unit Tests', () => {
+    test('fetches and caches results on cache miss', async () => {
+        const cache = new AsyncCache<string, number>();
+        const fetcher = vi.fn().mockResolvedValue(42);
+
+        const val1 = await cache.getOrFetch('key1', fetcher);
+        expect(val1).toBe(42);
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        const val2 = await cache.getOrFetch('key1', fetcher);
+        expect(val2).toBe(42);
+        expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    test('deduplicates concurrent in-flight requests (thundering herd)', async () => {
+        const cache = new AsyncCache<string, string>();
+        let resolvePromise: (value: string) => void = () => {};
+        const fetcher = vi.fn().mockImplementation(
+            () =>
+                new Promise<string>((resolve) => {
+                    resolvePromise = resolve;
+                }),
+        );
+
+        const promise1 = cache.getOrFetch('key1', fetcher);
+        const promise2 = cache.getOrFetch('key1', fetcher);
+
+        expect(fetcher).toHaveBeenCalledTimes(1);
+
+        resolvePromise('data');
+
+        const [res1, res2] = await Promise.all([promise1, promise2]);
+        expect(res1).toBe('data');
+        expect(res2).toBe('data');
+    });
+
+    test('expires cached entries after TTL', async () => {
+        const cache = new AsyncCache<string, string>({ ttlMs: 50 });
+        let counter = 0;
+        const fetcher = vi.fn().mockImplementation(async () => `val_${++counter}`);
+
+        const res1 = await cache.getOrFetch('key1', fetcher);
+        expect(res1).toBe('val_1');
+
+        // Wait past TTL
+        await new Promise((resolve) => setTimeout(resolve, 60));
+
+        const res2 = await cache.getOrFetch('key1', fetcher);
+        expect(res2).toBe('val_2');
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    test('executes onEvict callback on delete and clear', async () => {
+        const onEvict = vi.fn();
+        const cache = new AsyncCache<string, { id: number }>({ onEvict });
+
+        await cache.getOrFetch('item1', async () => ({ id: 1 }));
+        await cache.getOrFetch('item2', async () => ({ id: 2 }));
+
+        expect(cache.has('item1')).toBe(true);
+
+        await cache.delete('item1');
+        expect(onEvict).toHaveBeenCalledWith({ id: 1 });
+        expect(cache.has('item1')).toBe(false);
+
+        await cache.clear();
+        expect(onEvict).toHaveBeenCalledWith({ id: 2 });
+    });
+
+    test('applies clone option to returned values', async () => {
+        const cache = new AsyncCache<string, { count: number }>({
+            clone: (val) => ({ ...val }),
+        });
+
+        const initial = await cache.getOrFetch('key', async () => ({ count: 1 }));
+        initial.count = 99; // Mutate returned value
+
+        const hit = await cache.getOrFetch('key', async () => ({ count: 1 }));
+        expect(hit.count).toBe(1); // Cached value was preserved
+    });
+});

--- a/src/utils/async-cache.ts
+++ b/src/utils/async-cache.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface AsyncCacheOptions<V> {
+    /** Default Time-To-Live in milliseconds for cached entries (default: 5 minutes) */
+    ttlMs?: number;
+    /** Optional cleanup hook called when an entry is evicted or cleared */
+    onEvict?: (value: V) => Promise<void> | void;
+    /** Optional clone function applied to returned values to prevent external mutation */
+    clone?: (value: V) => V;
+}
+
+export class AsyncCache<K = string, V = unknown> {
+    private readonly _cache = new Map<K, { value: V; expires: number }>();
+    private readonly _promises = new Map<K, Promise<V>>();
+    private readonly _defaultTtlMs: number;
+    private readonly _onEvict?: (value: V) => Promise<void> | void;
+    private readonly _clone?: (value: V) => V;
+
+    constructor(options: AsyncCacheOptions<V> = {}) {
+        this._defaultTtlMs = options.ttlMs ?? 5 * 60_000;
+        this._onEvict = options.onEvict;
+        this._clone = options.clone;
+    }
+
+    async getOrFetch(key: K, fetcher: () => Promise<V>, ttlMs?: number): Promise<V> {
+        const inProgress = this._promises.get(key);
+        if (inProgress) {
+            const val = await inProgress;
+            return this._clone ? this._clone(val) : val;
+        }
+
+        const cached = this._cache.get(key);
+        if (cached && Date.now() < cached.expires) {
+            return this._clone ? this._clone(cached.value) : cached.value;
+        }
+
+        const promise = (async () => {
+            if (cached && this._onEvict) {
+                this._cache.delete(key);
+                await this._onEvict(cached.value);
+            }
+
+            const value = await fetcher();
+            this._cache.set(key, {
+                value,
+                expires: Date.now() + (ttlMs ?? this._defaultTtlMs),
+            });
+            return value;
+        })();
+
+        this._promises.set(key, promise);
+        try {
+            const val = await promise;
+            return this._clone ? this._clone(val) : val;
+        } finally {
+            this._promises.delete(key);
+        }
+    }
+
+    async clear(): Promise<void> {
+        this._promises.clear();
+        const entries = Array.from(this._cache.values());
+        this._cache.clear();
+
+        if (this._onEvict) {
+            const onEvict = this._onEvict;
+            await Promise.all(entries.map((e) => onEvict(e.value)));
+        }
+    }
+
+    async delete(key: K): Promise<boolean> {
+        this._promises.delete(key);
+        const cached = this._cache.get(key);
+        if (cached) {
+            this._cache.delete(key);
+            if (this._onEvict) {
+                await this._onEvict(cached.value);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    has(key: K): boolean {
+        const cached = this._cache.get(key);
+        return Boolean(cached && Date.now() < cached.expires);
+    }
+}


### PR DESCRIPTION
Introduce an AsyncCache class to centralize TTL-based caching, thundering herd in-flight request deduplication, value cloning, and eviction cleanup hooks, and update JjService to use it for diff and changes caching.