### PR TITLE
test: add E2E failure extraction tooling and fix test workspace cleanup

### DIFF
--- a/.agents/skills/run-tests/SKILL.md
+++ b/.agents/skills/run-tests/SKILL.md
@@ -119,20 +119,28 @@ You MUST run individual test cases when writing a new test or debugging a broken
   *(Note: You can find the `<artifact-directory-path>` in the conversation details/metadata, e.g., `<appDataDir>/brain/<conversation-id>`)*
   This will place failure screenshots directly into your artifact folder, making them instantly available for the `view_file` tool.
 
-### 4. Debugging E2E Tests (Automatic Failure Diagnostics)
+### 4. Debugging E2E Tests (Automatic Failure Diagnostics & Artifact Parsing)
 
 **Purpose:** When locators fail in E2E tests, it's often due to the complex, nested structure of VS Code. Playwright is configured to automatically dump the visual and DOM state on failure.
 
-**Diagnostic Outputs:**
-Whenever an E2E test fails, the test runner automatically saves two diagnostic files in the output directory:
+**Diagnostic Outputs & Failure Script:**
+Whenever an E2E test fails, the test runner automatically saves two diagnostic files in `test-results/` and `playwright-report/`:
 1. **Screenshot:** `test-failure.png` showing the visual editor/workspace state.
 2. **DOM HTML:** `test-failure.html` containing the complete DOM structure (including shadow roots and iframes).
 
-You can directly read the automatically generated `test-failure.html` using the `view_file` tool to inspect selectors and find elements at the time of the failure.
+**Parsing Failure Artifacts:**
+Run `pnpm test:failures` after any E2E test run to immediately list all failed spec files, error stack traces, and direct `file://` links to screenshot images and DOM HTML files:
+```bash
+pnpm test:failures
+```
+
+You MUST use `pnpm test:failures` after test runs to identify failure artifact paths, and use `view_file` to inspect the exact `test-failure.png` screenshot images and `test-failure.html` DOM dumps to diagnose root causes visually.
 
 ## Mandatory Debugging Practice
 
 When writing a new test or investigating a failure:
 
-1. **Never** run the full test suite over and over.
-2. **Always** apply the filtering commands listed above to restrict execution to the single test case or file you are working on. This drastically speeds up the feedback loop and simplifies debugging output.
+1. **Never** run the full test suite over and over without filtering.
+2. **Always** apply the filtering commands listed above to restrict execution to the single test case or file you are working on during development.
+3. **Always** run `pnpm test:failures` when test failures occur, inspect all `test-failure.png` screenshots using `view_file`, and address root causes empirically.
+

--- a/package.json
+++ b/package.json
@@ -1217,6 +1217,7 @@
         "test:screenshots": "playwright test",
         "test:e2e": "node esbuild.js && pnpm build:tests && playwright test -c playwright.e2e.config.ts",
         "test:unit": "vitest run",
+        "test:failures": "node tooling/parse-test-failures.ts",
         "release:encode": "node .agents/scripts/encode-release-notes.ts"
     },
     "devDependencies": {

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -1430,11 +1430,15 @@ export async function getReviewWidget(page: Page, expectedText?: string): Promis
 /**
  * Expands the comment reply input form if it is not already visible.
  */
-async function expandReplyFormIfNeeded(reviewWidget: Locator) {
+async function expandReplyFormIfNeeded(reviewWidget: Locator, force = false) {
     const replyPlaceholderBtn = reviewWidget.locator('.review-thread-reply-button');
-    if (await replyPlaceholderBtn.isVisible()) {
+    const formActions = reviewWidget.locator('.form-actions');
+
+    const needsExpansion = force || (await replyPlaceholderBtn.isVisible()) || !(await formActions.isVisible());
+    if (needsExpansion) {
+        await expect(replyPlaceholderBtn).toBeVisible({ timeout: 5000 });
         await replyPlaceholderBtn.click();
-        await expect(reviewWidget.locator('.comment-form .monaco-editor')).toBeVisible({ timeout: 5000 });
+        await expect(formActions).toBeVisible({ timeout: 5000 });
     }
 }
 
@@ -1449,7 +1453,14 @@ async function clickCommentButton(reviewWidget: Locator, buttonLabel: string | R
         .locator('.form-actions button, .form-actions [role="button"]')
         .filter({ hasText: buttonLabel })
         .first();
-    await expect(button).toBeVisible();
+
+    try {
+        await expect(button).toBeVisible({ timeout: 2000 });
+    } catch {
+        await expandReplyFormIfNeeded(reviewWidget, true);
+        await expect(button).toBeVisible({ timeout: 5000 });
+    }
+
     await reviewWidget.page().waitForTimeout(200);
     await button.click();
     logPerf(perfLabel, start);
@@ -1469,7 +1480,13 @@ async function submitTypedCommentReply(
     await expandReplyFormIfNeeded(reviewWidget);
 
     const editor = reviewWidget.locator('.comment-form .monaco-editor');
-    await expect(editor).toBeVisible();
+    try {
+        await expect(editor).toBeVisible({ timeout: 2000 });
+    } catch {
+        await expandReplyFormIfNeeded(reviewWidget, true);
+        await expect(editor).toBeVisible({ timeout: 5000 });
+    }
+
     await editor.click();
     await page.keyboard.type(text);
 
@@ -1477,7 +1494,14 @@ async function submitTypedCommentReply(
         .locator('.form-actions button, .form-actions [role="button"]')
         .filter({ hasText: buttonLabel })
         .first();
-    await expect(button).toBeVisible();
+
+    try {
+        await expect(button).toBeVisible({ timeout: 2000 });
+    } catch {
+        await expandReplyFormIfNeeded(reviewWidget, true);
+        await expect(button).toBeVisible({ timeout: 5000 });
+    }
+
     await button.click();
     logPerf(perfLabel, start);
 }

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -84,6 +84,7 @@ export interface VSCodeFixture {
     app?: ElectronApplication;
     page?: Page;
     userDataDir: string;
+    requestReset(): void;
     openWorkspace(
         repo: { path: string },
         extraSettings?: Record<string, unknown>,
@@ -1087,13 +1088,21 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
         return this.activeContext;
     }
 
+    requestReset(): void {
+        if (globalActiveContext) {
+            globalActiveContext.needsReset = true;
+        }
+    }
+
     async cleanupAfterTest() {
         const start = Date.now();
         if (this.activeContext) {
             try {
                 const windows = this.activeContext.app.windows();
+                let hadAuxiliaryWindow = false;
                 for (const win of windows) {
                     if (win !== this.activeContext.page && !win.isClosed()) {
+                        hadAuxiliaryWindow = true;
                         // Start closing the window asynchronously
                         const closePromise = win.close();
 
@@ -1120,6 +1129,9 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
                             () => {},
                         );
                     }
+                }
+                if (hadAuxiliaryWindow) {
+                    this.requestReset();
                 }
             } catch {
                 // Ignore errors closing auxiliary windows

--- a/src/test/e2e/workspace.spec.ts
+++ b/src/test/e2e/workspace.spec.ts
@@ -219,6 +219,7 @@ test.describe('Workspace Management E2E', () => {
         await rightClickAndSelect(page, openPill, 'Open in Current Window');
 
         await expectWindowTitle(page, openWs);
+        vscode.requestReset();
     });
 
     test('Open Workspace in New Window via context menu', async ({ vscode }) => {
@@ -235,15 +236,19 @@ test.describe('Workspace Management E2E', () => {
 
         const openPill = await waitForLogPill(page, openWs, 'workspace');
 
-        await withNewWindow({
-            app,
-            action: () => rightClickAndSelect(page, openPill, 'Open in New Window'),
-            callback: async (newPage) => {
-                await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
+        try {
+            await withNewWindow({
+                app,
+                action: () => rightClickAndSelect(page, openPill, 'Open in New Window'),
+                callback: async (newPage) => {
+                    await expect(newPage.locator('.monaco-workbench')).toBeVisible({ timeout: 15000 });
 
-                await expectWindowTitle(newPage, openWs);
-            },
-            errorMessage: 'Failed to open workspace in new window via context menu',
-        });
+                    await expectWindowTitle(newPage, openWs);
+                },
+                errorMessage: 'Failed to open workspace in new window via context menu',
+            });
+        } finally {
+            vscode.requestReset();
+        }
     });
 });

--- a/tooling/parse-test-failures.ts
+++ b/tooling/parse-test-failures.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import zlib from 'node:zlib';
+
+interface Attachment {
+    name: string;
+    contentType: string;
+    path?: string;
+}
+
+interface TestResult {
+    status: string;
+    duration: number;
+    errors: Array<{ message: string }>;
+    attachments: Attachment[];
+}
+
+interface TestCase {
+    title: string;
+    results: TestResult[];
+}
+
+interface TestSuite {
+    fileName: string;
+    tests: TestCase[];
+    suites?: TestSuite[];
+}
+
+function parseZipEntries(zipBuffer: Buffer): Map<string, Buffer> {
+    const entries = new Map<string, Buffer>();
+    let offset = 0;
+
+    while (offset < zipBuffer.length - 30) {
+        // Local file header signature 0x04034b50 ("PK\x03\x04")
+        if (zipBuffer.readUInt32LE(offset) !== 0x04034b50) {
+            break;
+        }
+
+        const compression = zipBuffer.readUInt16LE(offset + 8);
+        const compressedSize = zipBuffer.readUInt32LE(offset + 18);
+        const fileNameLen = zipBuffer.readUInt16LE(offset + 26);
+        const extraLen = zipBuffer.readUInt16LE(offset + 28);
+
+        const fileName = zipBuffer.toString('utf-8', offset + 30, offset + 30 + fileNameLen);
+        const dataStart = offset + 30 + fileNameLen + extraLen;
+        const compressedData = zipBuffer.subarray(dataStart, dataStart + compressedSize);
+
+        let fileData: Buffer;
+        if (compression === 0) {
+            fileData = compressedData;
+        } else if (compression === 8) {
+            fileData = zlib.inflateRawSync(compressedData);
+        } else {
+            fileData = Buffer.alloc(0);
+        }
+
+        entries.set(fileName, fileData);
+        offset = dataStart + compressedSize;
+    }
+
+    return entries;
+}
+
+export function findFailedTestArtifacts() {
+    const rootDir = process.cwd();
+    const reportHtmlPath = path.join(rootDir, 'playwright-report', 'index.html');
+    const testResultsDir = path.join(rootDir, 'test-results');
+
+    console.log('=== Playwright Test Failure Artifact Finder ===\n');
+
+    let foundFailures = 0;
+
+    // 1. Try parsing playwright-report/index.html zip payload
+    if (fs.existsSync(reportHtmlPath)) {
+        const htmlContent = fs.readFileSync(reportHtmlPath, 'utf-8');
+        const match = htmlContent.match(/(UEsDB[A-Za-z0-9+/=\s]+)/);
+
+        if (match) {
+            const b64Data = match[1].replace(/\s+/g, '');
+            const zipBuffer = Buffer.from(b64Data, 'base64');
+            const entries = parseZipEntries(zipBuffer);
+
+            for (const [filename, content] of entries) {
+                if (filename.endsWith('.json') && filename !== 'report.json') {
+                    try {
+                        const suiteData: TestSuite = JSON.parse(content.toString('utf-8'));
+                        const processSuite = (suite: TestSuite) => {
+                            const specFile = suite.fileName || filename;
+                            for (const test of suite.tests || []) {
+                                for (const result of test.results || []) {
+                                    if (result.status !== 'passed' && result.status !== 'skipped') {
+                                        foundFailures++;
+                                        console.log(`\n❌ [FAILURE #${foundFailures}]`);
+                                        console.log(`   Spec File: ${specFile}`);
+                                        console.log(`   Test Title: ${test.title}`);
+                                        if (result.errors && result.errors.length > 0) {
+                                            const firstErr = result.errors[0].message.split('\n')[0];
+                                            console.log(`   Error Message: ${firstErr}`);
+                                        }
+
+                                        console.log('   Artifacts:');
+                                        for (const att of result.attachments || []) {
+                                            if (att.path) {
+                                                const absPath = path.resolve(rootDir, 'playwright-report', att.path);
+                                                console.log(`     - [${att.name}] file://${absPath}`);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            for (const childSuite of suite.suites || []) {
+                                processSuite(childSuite);
+                            }
+                        };
+                        processSuite(suiteData);
+                    } catch {
+                        // ignore malformed JSON entry
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Also scan test-results directory directly for disk artifacts
+    if (fs.existsSync(testResultsDir)) {
+        const artifactFiles: string[] = [];
+        const scanDir = (dir: string) => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    scanDir(fullPath);
+                } else if (entry.name === 'test-failure.png' || entry.name === 'test-failure.html') {
+                    artifactFiles.push(fullPath);
+                }
+            }
+        };
+        scanDir(testResultsDir);
+
+        if (artifactFiles.length > 0) {
+            console.log(`\n=== Found ${artifactFiles.length} Artifact Files in test-results/ ===`);
+            for (const file of artifactFiles) {
+                console.log(`   file://${file}`);
+            }
+        }
+    }
+
+    if (foundFailures === 0) {
+        console.log('No test failures found in the most recent report.');
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+    findFailedTestArtifacts();
+}


### PR DESCRIPTION
Introduce a failure extraction utility (pnpm test:failures) to parse Playwright HTML reports and inspect failure artifacts automatically. Enhance E2E test helper robustness when interacting with review widgets, and add context reset triggers in VS Code test fixtures to prevent state pollution across window management tests.