### PR TITLE
test: deflake SCM tree item locators and working copy setup

### DIFF
--- a/src/test/e2e-helpers.test.ts
+++ b/src/test/e2e-helpers.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { escapeXPathString, toPlainSearchString } from './e2e/e2e-helpers';
+
+describe('e2e-helpers XPath & Regex Utilities', () => {
+    describe('escapeXPathString', () => {
+        it('wraps plain strings in double quotes', () => {
+            expect(escapeXPathString('file3.txt')).toBe('"file3.txt"');
+            expect(escapeXPathString('Working Copy')).toBe('"Working Copy"');
+        });
+
+        it('wraps strings containing double quotes in single quotes', () => {
+            expect(escapeXPathString('file "3".txt')).toBe('\'file "3".txt\'');
+        });
+
+        it('wraps strings containing single quotes in double quotes', () => {
+            expect(escapeXPathString("file's_copy.txt")).toBe('"file\'s_copy.txt"');
+        });
+
+        it('uses concat for strings containing both single and double quotes', () => {
+            expect(escapeXPathString('file\'s "test".txt')).toBe('concat("file\'s ", \'"\', "test", \'"\', ".txt")');
+        });
+    });
+
+    describe('toPlainSearchString', () => {
+        it('returns plain strings unmodified', () => {
+            expect(toPlainSearchString('file.txt')).toBe('file.txt');
+        });
+
+        it('extracts plain string from simple RegExp patterns', () => {
+            expect(toPlainSearchString(/Working Copy/i)).toBe('Working Copy');
+            expect(toPlainSearchString(/file\.txt/)).toBe('file.txt');
+        });
+
+        it('extracts longest substring from wildcard or alternation regex patterns', () => {
+            expect(toPlainSearchString(/@-1:.*side 1/)).toBe('side 1');
+            expect(toPlainSearchString(/\[tag\]/)).toBe('[tag]');
+        });
+    });
+});

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -495,7 +495,7 @@ export async function hoverAndClick(row: Locator, button: Locator) {
         await row.hover();
         // Wait for the button to be visible because VS Code renders inline actions on hover
         await expect(button).toBeVisible({ timeout: 1000 });
-        await button.click({ force: true });
+        await button.click();
     }, `Failed to click inline action button on row`).toPass({ timeout: 10000 });
     logPerf('hoverAndClick', start);
 }
@@ -519,9 +519,12 @@ export const SCM_ACTIONS = {
 /**
  * Robustly clicks an inline action button on an SCM tree item (row or group) by its title.
  */
-export async function clickScmAction(page: Page, rowName: string | RegExp, actionTitle: string) {
+export async function clickScmAction(page: Page, rowName: string | RegExp | Locator, actionTitle: string) {
     const start = Date.now();
-    const row = page.getByRole('treeitem', { name: rowName }).first();
+    const row =
+        typeof rowName === 'string' || rowName instanceof RegExp
+            ? page.getByRole('treeitem', { name: rowName }).first()
+            : rowName;
     await expect(row).toBeVisible({ timeout: 5000 });
 
     const iconMap: Record<string, string> = {
@@ -691,6 +694,52 @@ export async function expectScmDescription(page: Page, expected: string | RegExp
 }
 
 /**
+ * Safely converts a string into a valid XPath 1.0 string literal,
+ * handling single quotes, double quotes, or both using XPath `concat()`.
+ */
+export function escapeXPathString(str: string): string {
+    if (!str.includes('"')) {
+        return `"${str}"`;
+    }
+    if (!str.includes("'")) {
+        return `'${str}'`;
+    }
+    const parts = str.split('"');
+    const concatArgs: string[] = [];
+    for (let i = 0; i < parts.length; i++) {
+        if (parts[i].length > 0) {
+            concatArgs.push(`"${parts[i]}"`);
+        }
+        if (i < parts.length - 1) {
+            concatArgs.push(`'"'`);
+        }
+    }
+    return `concat(${concatArgs.join(', ')})`;
+}
+
+/**
+ * Converts a text string or RegExp pattern into a plain search substring for XPath matching.
+ *
+ * Supported RegExp pattern shapes:
+ * - Literals and escaped regex symbols (e.g. /file\.txt/i -> "file.txt")
+ * - Simple wildcards and alternation (e.g. /@-1:.*side 1/ -> "side 1")
+ *
+ * Complex patterns (e.g. lookarounds or nested groups) are reduced to their longest
+ * plain-text string fragment.
+ */
+export function toPlainSearchString(pattern: string | RegExp): string {
+    if (typeof pattern === 'string') {
+        return pattern;
+    }
+    const plain = pattern.source.replace(/\\([.*+?^${}()|[\]\\])/g, '$1').replace(/[\^$]/g, '');
+    const parts = plain
+        .split(/\.\*|\.\+|\?|\|/)
+        .map((p) => p.trim())
+        .filter(Boolean);
+    return parts.sort((a, b) => b.length - a.length)[0] || plain;
+}
+
+/**
  * Locates an SCM tree item, optionally matching a parent group name.
  */
 export async function getScmItemLocator(
@@ -699,46 +748,23 @@ export async function getScmItemLocator(
     groupName?: string | RegExp,
 ): Promise<Locator> {
     const start = Date.now();
-    let result: Locator;
+    const fileStr = toPlainSearchString(fileName);
+    const fileLiteral = escapeXPathString(fileStr);
+    const fileMatch = `contains(@aria-label, ${fileLiteral}) or contains(., ${fileLiteral})`;
+
+    let xpath: string;
     if (groupName) {
-        const allItems = await page.getByRole('treeitem').all();
-        let groupIdx = -1;
-        const groupNamePattern = groupName instanceof RegExp ? groupName : new RegExp(groupName, 'i');
-        const fileNamePattern = fileName instanceof RegExp ? fileName : new RegExp(fileName, 'i');
+        const groupStr = toPlainSearchString(groupName);
+        const groupLiteral = escapeXPathString(groupStr);
+        const groupMatch = `contains(@aria-label, ${groupLiteral}) or contains(., ${groupLiteral})`;
+        const precedingGroupHeader = `(preceding-sibling::div[@role="treeitem"][@aria-level="1"])[last()][${groupMatch}]`;
 
-        for (let i = 0; i < allItems.length; i++) {
-            const label = (await allItems[i].getAttribute('aria-label')) || '';
-            if (groupNamePattern.test(label)) {
-                groupIdx = i;
-                break;
-            }
-        }
-
-        if (groupIdx === -1) {
-            throw new Error(`Group "${groupName}" not found`);
-        }
-
-        let foundItem: Locator | undefined;
-        for (let i = groupIdx + 1; i < allItems.length; i++) {
-            const label = (await allItems[i].getAttribute('aria-label')) || '';
-            const level = await allItems[i].getAttribute('aria-level');
-
-            if (fileNamePattern.test(label)) {
-                foundItem = allItems[i];
-                break;
-            }
-
-            if (level === '1') {
-                throw new Error(`File "${fileName}" not found in group "${groupName}"`);
-            }
-        }
-        if (!foundItem) {
-            throw new Error(`File "${fileName}" not found in group "${groupName}"`);
-        }
-        result = foundItem;
+        xpath = `//div[@role="treeitem"][@aria-level="2"][${fileMatch}][${precedingGroupHeader}]`;
     } else {
-        result = page.getByRole('treeitem', { name: fileName }).first();
+        xpath = `//div[@role="treeitem"][@aria-level="2"][${fileMatch}]`;
     }
+
+    const result = page.locator(`xpath=${xpath}`).first();
     logPerf('getScmItemLocator', start);
     return result;
 }
@@ -750,17 +776,13 @@ export async function expectFileInScmGroup(
     page: Page,
     groupNamePattern: RegExp | string,
     fileNamePattern: RegExp | string,
+    options: { timeout?: number } = {},
 ): Promise<Locator> {
     const start = Date.now();
-    let locator: Locator | undefined;
-    await expect(async () => {
-        locator = await getScmItemLocator(page, fileNamePattern, groupNamePattern);
-        await expect(locator).toBeVisible({ timeout: 1000 });
-    }).toPass({ timeout: 15000 });
+    const locator = await getScmItemLocator(page, fileNamePattern, groupNamePattern);
+    const timeout = options.timeout ?? 10000;
+    await expect(locator).toBeVisible({ timeout });
     logPerf('expectFileInScmGroup', start);
-    if (!locator) {
-        throw new Error(`File "${fileNamePattern}" not found in group "${groupNamePattern}"`);
-    }
     return locator;
 }
 

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -384,19 +384,17 @@ test.describe('SCM Pane E2E', () => {
             await expect(rightEditor).toContainText('edited from diff', { timeout: 1000 });
         }).toPass({ timeout: 5000 });
 
-        // Save and ensure JJ picks it up.
-        // Ensure focus before save
-        await rightEditor.click();
-        await page.keyboard.press('Control+s');
-
         // Verify file content on disk and in jj using toPass polling
         await expect(async () => {
+            await rightEditor.click();
+            await page.keyboard.press('Control+S');
+
             const diskContent = fs.readFileSync(path.join(repo.path, 'file2.txt'), 'utf8').trim();
             expect(diskContent).toBe('edited from diff');
 
             const content = repo.getFileContent('@', 'file2.txt').trim();
             expect(content).toBe('edited from diff');
-        }).toPass({ timeout: 10000, intervals: [50, 100, 250, 500] });
+        }).toPass({ timeout: 10000, intervals: [100, 250, 500] });
 
         // Create a chain (initial -> wc_commit -> new_wc) to verify squash into a non-immediate ancestor
         await focusSCM(page);
@@ -406,17 +404,19 @@ test.describe('SCM Pane E2E', () => {
 
         await expect(async () => {
             expect(repo.getParents('@').length).toBe(1);
-        }).toPass({ timeout: 5000 });
+            expect(repo.getDiffSummary('@')).toBe('');
+        }).toPass({ timeout: 10000 });
         // Now we have initial -> wc_commit -> new_wc
         // Modify file3.txt in the new working copy
         repo.writeFile('file3.txt', 'new mod3');
 
-        // Click the SCM refresh button
+        // Click the SCM refresh button and wait for file3.txt to appear in SCM Working Copy
         const refreshButton = page.getByRole('button', { name: 'Refresh' }).first();
-        await refreshButton.click();
-
-        // Wait for file3.txt to appear in SCM Working Copy
-        const newWcFileRow = await expectFileInScmGroup(page, /Working Copy/i, 'file3.txt');
+        let newWcFileRow!: Locator;
+        await expect(async () => {
+            await refreshButton.click();
+            newWcFileRow = await expectFileInScmGroup(page, /Working Copy/i, 'file3.txt', { timeout: 1000 });
+        }).toPass({ timeout: 10000 });
 
         // Hover to reveal inline actions
         await newWcFileRow.hover();
@@ -497,8 +497,8 @@ test.describe('SCM Pane E2E', () => {
         await focusSCM(page);
 
         // 3. Squash File to Child (Pull from Ancestor)
-        // Groups are expanded by default, so f2.txt is already visible.
-        await clickScmAction(page, /f2\.txt/, SCM_ACTIONS.SquashFilesIntoChild);
+        const ancestorF2Row = await expectFileInScmGroup(page, /ancestor/i, 'f2.txt');
+        await clickScmAction(page, ancestorF2Row, SCM_ACTIONS.SquashFilesIntoChild);
 
         // Assert via repo that f2.txt from ancestor was moved to working copy
         // and the UI SCM tree has refreshed to reflect the new state.


### PR DESCRIPTION
Refine SCM tree item locator strategy using live XPath sibling lookups to accurately match files under their parent groups, remove force-click overrides in hover helpers, and synchronize working copy creation before file modifications to eliminate E2E flakiness.