### PR TITLE
test: add ensureTextRegex helper and poll SCM description input

### DIFF
--- a/src/test/e2e-helpers.test.ts
+++ b/src/test/e2e-helpers.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { escapeXPathString, toPlainSearchString } from './e2e/e2e-helpers';
+import { ensureTextRegex, escapeXPathString, toPlainSearchString } from './e2e/e2e-helpers';
 
 describe('e2e-helpers XPath & Regex Utilities', () => {
     describe('escapeXPathString', () => {
@@ -38,6 +38,48 @@ describe('e2e-helpers XPath & Regex Utilities', () => {
         it('extracts longest substring from wildcard or alternation regex patterns', () => {
             expect(toPlainSearchString(/@-1:.*side 1/)).toBe('side 1');
             expect(toPlainSearchString(/\[tag\]/)).toBe('[tag]');
+        });
+    });
+
+    describe('ensureTextRegex', () => {
+        it('returns RegExp instances unchanged', () => {
+            const regex = /custom-pattern/i;
+            expect(ensureTextRegex(regex)).toBe(regex);
+        });
+
+        it('converts simple single-word strings into literal matching regexes', () => {
+            const regex = ensureTextRegex('hello');
+            expect(regex.test('hello')).toBe(true);
+            expect(regex.test('say hello world')).toBe(true);
+            expect(regex.test('world')).toBe(false);
+        });
+
+        it('handles multi-word strings with varied whitespace and permits arbitrary text between words', () => {
+            const regex = ensureTextRegex('  first   second \t third  ');
+            expect(regex.test('first second third')).toBe(true);
+            expect(regex.test('first\nsecond\nthird')).toBe(true);
+            expect(regex.test('first word second test third')).toBe(true);
+            expect(regex.test('first third')).toBe(false);
+        });
+
+        it('fully escapes regex special characters and preserves literal semantics', () => {
+            const specialString = 'a+b*c? (test) [bar] ^start $end';
+            const regex = ensureTextRegex(specialString);
+            expect(regex.test('a+b*c? (test) [bar] ^start $end')).toBe(true);
+            expect(regex.test('abc (test) [bar] ^start $end')).toBe(false);
+            expect(regex.test('a+b*c? test bar start end')).toBe(false);
+        });
+
+        it('defines explicit behavior for empty or whitespace-only strings', () => {
+            const emptyRegex = ensureTextRegex('');
+            expect(emptyRegex.source).toBe('(?:)');
+            expect(emptyRegex.test('')).toBe(true);
+            expect(emptyRegex.test('any content')).toBe(true);
+
+            const whitespaceRegex = ensureTextRegex('   \t \n  ');
+            expect(whitespaceRegex.source).toBe('(?:)');
+            expect(whitespaceRegex.test('')).toBe(true);
+            expect(whitespaceRegex.test('any content')).toBe(true);
         });
     });
 });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -677,19 +677,43 @@ export async function setScmDescription(page: Page, description: string, vscode?
 }
 
 /**
+ * Ensures the given text pattern or `RegExp` is returned as a `RegExp`.
+ *
+ * - If `expected` is already a `RegExp`, it is returned unchanged.
+ * - If `expected` is a `string`, it is converted into a pattern that matches
+ *   whitespace-separated words across line wraps in VS Code UI editors.
+ */
+export function ensureTextRegex(expected: string | RegExp): RegExp {
+    if (expected instanceof RegExp) {
+        return expected;
+    }
+
+    // Split input into words and escape special regex control characters in each word
+    const words = expected
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
+    // Join words with '.*' so line breaks and editor wrapping between words still match
+    return new RegExp(words.join('.*'), 's');
+}
+
+/**
  * Asserts that the SCM input row contains the expected description.
  * Handles VS Code's text wrapping/concatenation.
  */
 export async function expectScmDescription(page: Page, expected: string | RegExp) {
     const start = Date.now();
     const scmInputRow = page.getByRole('treeitem', { name: 'Source Control Input' }).first();
-    if (expected instanceof RegExp) {
-        await expect(scmInputRow).toHaveText(expected);
-    } else {
-        const words = expected.trim().split(/\s+/).filter(Boolean);
-        const regexPattern = words.map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*');
-        await expect(scmInputRow).toHaveText(new RegExp(regexPattern));
-    }
+    const regex = ensureTextRegex(expected);
+
+    await expect(async () => {
+        await expect(scmInputRow.locator('.monaco-editor')).toHaveText(regex, { timeout: 1000 });
+    }, `Failed waiting for SCM description to match "${expected}"`).toPass({
+        timeout: 15000,
+        intervals: [100, 250, 500],
+    });
     logPerf('expectScmDescription', start);
 }
 

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -59,12 +59,19 @@ test.describe('SCM Pane E2E', () => {
         const mergeConflictsHeader = page.getByRole('treeitem', { name: 'Merge Conflicts' });
         const workingCopyHeader = page.getByRole('treeitem', { name: /Working Copy/ });
 
-        await expect(mergeConflictsHeader).toBeVisible();
-        await expect(workingCopyHeader).toBeVisible();
+        // Extended timeout for merge conflict groups to remain stable under parallel CPU load.
+        const GROUP_VISIBILITY_TIMEOUT = 10_000;
+
+        await expect(mergeConflictsHeader).toBeVisible({ timeout: GROUP_VISIBILITY_TIMEOUT });
+        await expect(workingCopyHeader).toBeVisible({ timeout: GROUP_VISIBILITY_TIMEOUT });
 
         // Verify ancestor groups (merge commit is empty, showing parents @-2^1 and @-2^2)
-        await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({ timeout: 5000 });
-        await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible();
+        await expect(page.getByRole('treeitem', { name: /@-2\^1:.*side 1/ })).toBeVisible({
+            timeout: GROUP_VISIBILITY_TIMEOUT,
+        });
+        await expect(page.getByRole('treeitem', { name: /@-2\^2:.*side 2/ })).toBeVisible({
+            timeout: GROUP_VISIBILITY_TIMEOUT,
+        });
 
         // Verify SCM input is populated with working copy description
         await expectScmDescription(page, 'my working copy');


### PR DESCRIPTION
Add ensureTextRegex helper to normalize string patterns for Monaco editor wrapping, poll SCM input text directly with toPass, and extend group visibility timeouts to handle parallel test CPU load cleanly.