### PR TITLE
fix(scm): prevent refresh deadlocks and fix webview repository binding

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -420,6 +420,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         scmProviders.set(repo.rootUri.fsPath, scmProvider);
         activeScmSubscriptions.set(repo.rootUri.fsPath, composite);
 
+        if (
+            !logWebviewProvider.repository ||
+            repositoryManager.focusedRepository?.rootUri.fsPath === repo.rootUri.fsPath
+        ) {
+            logWebviewProvider.updateRepository(repo).catch((err) => {
+                outputChannel.error(`[Extension] Failed to update webview repository: ${err}`);
+            });
+        }
+
         // Fire and forget: check if we should warn about git colocation
         checkGitColocation(repo.jj).catch((e) =>
             outputChannel.error(`[Extension] Colocation check failed for ${repoPrefix}: ${e}`),
@@ -439,7 +448,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     repositoryManager.onDidChangeFocusedRepository((repo) => {
         focusedRepoActiveProviderSub?.dispose();
         if (repo) {
-            logWebviewProvider.updateRepository(repo);
+            logWebviewProvider.updateRepository(repo).catch((err) => {
+                outputChannel.error(`[Extension] Failed to update webview repository: ${err}`);
+            });
             const scm = scmProviders.get(repo.rootUri.fsPath);
             if (scm) {
                 vscode.commands.executeCommand('setContext', JjContextKey.ParentMutable, scm.parentMutable);

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -92,6 +92,10 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         });
     }
 
+    public get repository(): JjRepository | undefined {
+        return this._repo;
+    }
+
     public get jj(): JjService | undefined {
         return this._repo?.jj;
     }
@@ -109,7 +113,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
         const cf = this._codeForge;
         if (cf) {
             this._codeForgeDisposable = cf.onDidUpdate(() => this.refreshCodeForge());
-            await cf.detectActiveProvider(true);
+            cf.detectActiveProvider(true).catch((e) =>
+                this.outputChannel?.error(`[JjLogWebviewProvider] Code forge detection failed: ${e}`),
+            );
         }
         this._updateTitle();
         await this.refresh('repoChanged');
@@ -360,12 +366,21 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     return;
                 }
 
+                const targetRepoPath = this._repo.rootUri.fsPath;
                 // Default jj log (usually local heads/roots)
                 const logStart = performance.now();
                 commits = await jj.getLog({
                     omitChanges: true,
                     includeNearestVisibleAncestors: true,
                 });
+
+                if (this._repo?.rootUri.fsPath !== targetRepoPath) {
+                    this.outputChannel?.info(
+                        `[JjLogWebviewProvider] Repository changed during log fetch (was ${targetRepoPath}, now ${this._repo?.rootUri.fsPath}). Discarding stale log entries.`,
+                    );
+                    return;
+                }
+
                 const logDuration = performance.now() - logStart;
                 this.outputChannel?.info(
                     `[JjLogWebviewProvider] jj log took ${logDuration.toFixed(0)}ms, found ${commits.length} commits`,

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -201,346 +201,324 @@ export class JjScmProvider implements vscode.Disposable {
         return path.join(os.tmpdir(), `jj-view-squash-${hash}`);
     }
 
-    private _refreshMutex: Promise<void> = Promise.resolve();
-
     private async updateScmView(event: { reason: string }): Promise<void> {
-        // Chain the refresh execution to ensure serial execution.
-        // Log and swallow any prior rejection so that a failed/timed-out refresh does not permanently stall future refresh calls.
-        this._refreshMutex = this._refreshMutex
-            .catch((err) => {
-                this.outputChannel.error(`[ScmProvider] Previous updateScmView failed: ${err}`);
-            })
-            .then(async () => {
-                if (this._disposed) {
-                    return;
+        if (this._disposed) {
+            return;
+        }
+        const reasonStr = event.reason ? ` (reason: ${event.reason})` : '';
+        const msg = `Updating JJ Scm${reasonStr}...`;
+        this.outputChannel.info(msg);
+        const start = performance.now();
+        try {
+            // 1. Fetch data in parallel for performance
+            const maxMutableAncestors = getJjViewConfig<number>('maxMutableAncestors', 10) ?? 10;
+            const openDiffOnClick = getJjViewConfig<boolean>('openDiffOnClick', true) ?? true;
+            const limit = maxMutableAncestors + 1;
+
+            // Chain getLog directly off getLogIds so it runs concurrently with getChildren and getConflictedFiles
+            const bulkLogPromise = this.jj
+                .getLogIds({ revision: `(::@ & mutable()) | parents(roots(::@ & mutable()))`, limit })
+                .then((commitIds) => Promise.all(commitIds.map((id) => this.jj.getLog({ revision: id }))));
+
+            const [bulkLogEntries, children, conflictedPaths] = await Promise.all([
+                bulkLogPromise,
+                this.jj.getChildren('@'),
+                this.jj.getConflictedFiles(),
+            ]);
+
+            const bulkLog = bulkLogEntries.map((entries) => entries[0]).filter(Boolean);
+
+            // Extract current entry from bulk log (it should be the first one with is_current_working_copy or just the first entry)
+            const currentEntry = bulkLog.find((e) => e.is_current_working_copy) || bulkLog[0];
+            this._currentEntry = currentEntry;
+            const bulkLogMap = new Map<string, JjLogEntry>(bulkLog.map((entry) => [entry.commit_id, entry]));
+
+            let parentMutable = false;
+            const hasChild = children.length > 0;
+
+            if (currentEntry) {
+                const parentRefs = currentEntry.parents;
+
+                if (parentRefs && parentRefs.length > 0) {
+                    const firstParent = parentRefs[0];
+                    parentMutable = !firstParent.is_immutable;
                 }
-                const reasonStr = event.reason ? ` (reason: ${event.reason})` : '';
-                const msg = `Updating JJ Scm${reasonStr}...`;
-                this.outputChannel.info(msg);
-                const start = performance.now();
-                try {
-                    // 1. Fetch data in parallel for performance
-                    const maxMutableAncestors = getJjViewConfig<number>('maxMutableAncestors', 10) ?? 10;
-                    const openDiffOnClick = getJjViewConfig<boolean>('openDiffOnClick', true) ?? true;
-                    const limit = maxMutableAncestors + 1;
+            }
 
-                    // Chain getLog directly off getLogIds so it runs concurrently with getChildren and getConflictedFiles
-                    const bulkLogPromise = this.jj
-                        .getLogIds({ revision: `(::@ & mutable()) | parents(roots(::@ & mutable()))`, limit })
-                        .then((commitIds) => Promise.all(commitIds.map((id) => this.jj.getLog({ revision: id }))));
+            this._parentMutable = parentMutable;
+            this._hasChild = hasChild;
 
-                    const [bulkLogEntries, children, conflictedPaths] = await Promise.all([
-                        bulkLogPromise,
-                        this.jj.getChildren('@'),
-                        this.jj.getConflictedFiles(),
-                    ]);
+            if (currentEntry) {
+                const desc = currentEntry.description ? currentEntry.description.trim() : '';
+                const commitId = currentEntry.change_id;
 
-                    const bulkLog = bulkLogEntries.map((entries) => entries[0]).filter(Boolean);
+                // Update input box if:
+                // 1. It's empty
+                // 2. We switched to a different commit (context switch)
+                // 3. The value matches what we last populated (no user edits)
+                if (
+                    this._sourceControl.inputBox.value === '' ||
+                    this._lastKnownCommitId !== commitId ||
+                    this._sourceControl.inputBox.value === this._lastKnownDescription
+                ) {
+                    this._sourceControl.inputBox.value = desc;
+                    this._lastKnownDescription = desc;
+                    this._lastKnownCommitId = commitId;
+                }
+            }
 
-                    // Extract current entry from bulk log (it should be the first one with is_current_working_copy or just the first entry)
-                    const currentEntry = bulkLog.find((e) => e.is_current_working_copy) || bulkLog[0];
-                    this._currentEntry = currentEntry;
-                    const bulkLogMap = new Map<string, JjLogEntry>(bulkLog.map((entry) => [entry.commit_id, entry]));
+            if (this.isFocused()) {
+                await vscode.commands.executeCommand('setContext', JjContextKey.ParentMutable, parentMutable);
+                await vscode.commands.executeCommand('setContext', JjContextKey.HasChild, hasChild);
+            }
 
-                    let parentMutable = false;
-                    const hasChild = children.length > 0;
+            // 2. Find Mutable Ancestors (traverse graph)
+            let currentFocus = currentEntry;
+            let ancestorDepth = 1;
+            const ancestorsToDisplay: {
+                entry: JjLogEntry;
+                prefix: string;
+                isMutable: boolean;
+                canSquash: boolean;
+            }[] = [];
 
-                    if (currentEntry) {
-                        const parentRefs = currentEntry.parents;
-
-                        if (parentRefs && parentRefs.length > 0) {
-                            const firstParent = parentRefs[0];
-                            parentMutable = !firstParent.is_immutable;
-                        }
+            if (currentFocus) {
+                while (currentFocus && ancestorsToDisplay.length < maxMutableAncestors) {
+                    if (!currentFocus.parents || currentFocus.parents.length === 0) {
+                        break;
                     }
 
-                    this._parentMutable = parentMutable;
-                    this._hasChild = hasChild;
+                    // For the prefix, we use @-1, @-2. For merge parents, @-1^1, @-1^2 etc.
+                    const isMerge = currentFocus.parents.length > 1;
 
-                    if (currentEntry) {
-                        const desc = currentEntry.description ? currentEntry.description.trim() : '';
-                        const commitId = currentEntry.change_id;
-
-                        // Update input box if:
-                        // 1. It's empty
-                        // 2. We switched to a different commit (context switch)
-                        // 3. The value matches what we last populated (no user edits)
-                        if (
-                            this._sourceControl.inputBox.value === '' ||
-                            this._lastKnownCommitId !== commitId ||
-                            this._sourceControl.inputBox.value === this._lastKnownDescription
-                        ) {
-                            this._sourceControl.inputBox.value = desc;
-                            this._lastKnownDescription = desc;
-                            this._lastKnownCommitId = commitId;
-                        }
-                    }
-
-                    if (this.isFocused()) {
-                        await vscode.commands.executeCommand('setContext', JjContextKey.ParentMutable, parentMutable);
-                        await vscode.commands.executeCommand('setContext', JjContextKey.HasChild, hasChild);
-                    }
-
-                    // 2. Find Mutable Ancestors (traverse graph)
-                    let currentFocus = currentEntry;
-                    let ancestorDepth = 1;
-                    const ancestorsToDisplay: {
-                        entry: JjLogEntry;
-                        prefix: string;
-                        isMutable: boolean;
-                        canSquash: boolean;
-                    }[] = [];
-
-                    if (currentFocus) {
-                        while (currentFocus && ancestorsToDisplay.length < maxMutableAncestors) {
-                            if (!currentFocus.parents || currentFocus.parents.length === 0) {
-                                break;
-                            }
-
-                            // For the prefix, we use @-1, @-2. For merge parents, @-1^1, @-1^2 etc.
-                            const isMerge = currentFocus.parents.length > 1;
-
-                            // Get all parent entries from the bulk map
-                            const parentEntries = currentFocus.parents.map((parent) => {
-                                return bulkLogMap.get(parent.commit_id);
-                            });
-
-                            for (let i = 0; i < parentEntries.length; i++) {
-                                const parentEntry = parentEntries[i];
-                                if (!parentEntry || parentEntry.is_immutable) {
-                                    continue;
-                                }
-
-                                const prefix = isMerge ? `@-${ancestorDepth}^${i + 1}` : `@-${ancestorDepth}`;
-
-                                const canSquash =
-                                    !parentEntry.is_immutable &&
-                                    parentEntry.parents !== undefined &&
-                                    parentEntry.parents.length > 0 &&
-                                    !parentEntry.parents[0].is_immutable;
-
-                                ancestorsToDisplay.push({
-                                    entry: parentEntry,
-                                    prefix,
-                                    isMutable: !parentEntry.is_immutable,
-                                    canSquash,
-                                });
-                            }
-
-                            // Stop traversing if it's a merge commit
-                            if (isMerge) {
-                                break;
-                            }
-
-                            // Move to the single parent for the next iteration
-                            const singleParentEntry = parentEntries[0];
-                            if (!singleParentEntry || singleParentEntry.is_immutable) {
-                                break; // Stop if the parent is immutable or not found
-                            }
-
-                            currentFocus = singleParentEntry;
-                            ancestorDepth++;
-                        }
-                    }
-
-                    // 3. Update Working Copy Group & Collect Decorations
-                    const decorationMap = new Map<string, JjStatusEntry>();
-
-                    // Working Copy Changes
-                    const changes = currentEntry?.changes || [];
-                    this._workingCopyStatuses.clear();
-
-                    if (currentEntry) {
-                        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
-                        const shortId = formatDisplayChangeId(
-                            currentEntry.change_id,
-                            currentEntry.change_id_shortest,
-                            minChangeIdLength,
-                        );
-                        this._workingCopyGroup.label = `Working Copy - ${shortId}`;
-                    } else {
-                        this._workingCopyGroup.label = 'Working Copy';
-                    }
-
-                    const wcFlags = [ScmContextValue.GroupAllowShowMultiFileDiff, ScmContextValue.GroupAllowAbandon];
-                    if (currentEntry) {
-                        if (canAbsorbCommit(currentEntry)) {
-                            wcFlags.push(ScmContextValue.GroupAllowAbsorb);
-                        }
-                        if (canSquashCommit(currentEntry)) {
-                            wcFlags.push(ScmContextValue.GroupAllowSquash);
-                        }
-                    }
-                    this._workingCopyGroup.contextValue = wcFlags.join(' ');
-
-                    // Working copy items are squashable if the parent is mutable
-                    this._workingCopyGroup.resourceStates = changes.map((c) => {
-                        const state = this.toResourceState(c, currentEntry?.change_id || '@', {
-                            squashable: parentMutable,
-                            multipleAncestors: ancestorsToDisplay.length > 1,
-                            openDiffOnClick,
-                            hasChild,
-                        });
-                        decorationMap.set(state.resourceUri.toString(), c);
-                        this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
-                        return state;
+                    // Get all parent entries from the bulk map
+                    const parentEntries = currentFocus.parents.map((parent) => {
+                        return bulkLogMap.get(parent.commit_id);
                     });
 
-                    // 4. Update Conflict Group (conflictedPaths fetched above)
-                    this._conflictGroup.resourceStates = conflictedPaths.map((path) => {
-                        const entry: JjStatusEntry = { path, status: 'modified', conflicted: true };
-                        const state = this.toResourceState(entry, currentEntry?.change_id || '@', {
-                            openDiffOnClick,
-                            inConflictGroup: true,
-                        });
-                        decorationMap.set(state.resourceUri.toString(), entry);
-                        return state;
-                    });
-
-                    // 5. Update Parent Groups
-                    // Dispose excess parent groups
-                    while (this._parentGroups.length > ancestorsToDisplay.length) {
-                        const group = this._parentGroups.pop();
-                        group?.dispose();
-                    }
-
-                    // Populate the SCM groups
-                    for (let i = 0; i < ancestorsToDisplay.length; i++) {
-                        const { entry: ancestorEntry, prefix, isMutable, canSquash } = ancestorsToDisplay[i];
-
-                        const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
-                        const shortId = formatDisplayChangeId(
-                            ancestorEntry.change_id,
-                            ancestorEntry.change_id_shortest,
-                            minChangeIdLength,
-                        );
-                        const desc = ancestorEntry.description?.trim() || '(no description)';
-                        const subject = desc.split('\n', 1 /* limit */)[0].trim();
-                        const label = `${prefix}: ${shortId} - ${subject}`;
-
-                        // Reuse existing group or create new one
-                        let group: vscode.SourceControlResourceGroup;
-                        const groupFlags = [
-                            ScmContextValue.GroupAllowShowMultiFileDiff,
-                            ScmContextValue.GroupAllowShowDetails,
-                        ];
-                        if (isMutableCommit(ancestorEntry)) {
-                            groupFlags.push(ScmContextValue.GroupAllowEdit);
-                        }
-                        if (canSquashCommit(ancestorEntry)) {
-                            groupFlags.push(ScmContextValue.GroupAllowSquash);
-                        }
-                        const contextValue = groupFlags.join(' ');
-
-                        if (i < this._parentGroups.length) {
-                            group = this._parentGroups[i];
-                            group.label = label;
-                            group.contextValue = contextValue;
-                        } else {
-                            const groupId = `ancestor-${i}`;
-                            group = this._sourceControl.createResourceGroup(groupId, label);
-                            group.hideWhenEmpty = false;
-                            group.contextValue = contextValue;
-                            this._parentGroups.push(group);
+                    for (let i = 0; i < parentEntries.length; i++) {
+                        const parentEntry = parentEntries[i];
+                        if (!parentEntry || parentEntry.is_immutable) {
+                            continue;
                         }
 
-                        const parentChanges = ancestorEntry.changes || [];
-                        group.resourceStates = parentChanges.map((c: JjStatusEntry) => {
-                            // Level i ancestor has (ancestorsToDisplay.length - 1 - i) mutable ancestors below it.
-                            const remainingAncestors = ancestorsToDisplay.length - 1 - i;
-                            const state = this.toResourceState(c, ancestorEntry.change_id, {
-                                editable: isMutable,
-                                squashable: canSquash,
-                                multipleAncestors: remainingAncestors > 0,
-                                openDiffOnClick,
-                            });
-                            decorationMap.set(state.resourceUri.toString(), c);
-                            return state;
+                        const prefix = isMerge ? `@-${ancestorDepth}^${i + 1}` : `@-${ancestorDepth}`;
+
+                        const canSquash =
+                            !parentEntry.is_immutable &&
+                            parentEntry.parents !== undefined &&
+                            parentEntry.parents.length > 0 &&
+                            !parentEntry.parents[0].is_immutable;
+
+                        ancestorsToDisplay.push({
+                            entry: parentEntry,
+                            prefix,
+                            isMutable: !parentEntry.is_immutable,
+                            canSquash,
                         });
                     }
 
-                    // Update Decoration
-                    this.decorationProvider.updateScmAndTrackedStatus(decorationMap);
-
-                    // Update SCM Count - Only count Working Copy changes
-                    // VS Code sums all groups by default if count is not set, so we must set it explicitly.
-                    this._sourceControl.count = this._workingCopyGroup.resourceStates.length;
-                } catch (e: unknown) {
-                    const err = e as { message?: string };
-                    if (JjService.isIndexLockError(e)) {
-                        const repoRoot = await this.jj.getRepoRoot();
-                        const lockPath = path.join(repoRoot, '.git', 'index.lock');
-                        const DELETE_LOCK = 'Delete Lock File';
-                        vscode.window
-                            .showErrorMessage(
-                                `jj failed: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.`,
-                                DELETE_LOCK,
-                                'Show Log',
-                            )
-                            .then(async (selection) => {
-                                if (selection === DELETE_LOCK) {
-                                    try {
-                                        await fs.unlink(lockPath);
-                                        this.outputChannel.info(`[Info] Deleted lock file at ${lockPath}`);
-                                        await this.refresh({ forceSnapshot: true, reason: 'lock file deleted' });
-                                    } catch (unlinkErr) {
-                                        this.outputChannel.error(
-                                            `[Error] Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
-                                        );
-                                        vscode.window.showErrorMessage(
-                                            `Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
-                                        );
-                                    }
-                                } else if (selection === 'Show Log') {
-                                    this.outputChannel.show();
-                                }
-                            });
-                    } else if (
-                        err.message &&
-                        ((err.message.includes('Object') && err.message.includes('not found')) ||
-                            err.message.includes('No such file or directory'))
-                    ) {
-                        this.outputChannel.error(
-                            `[${this.repo.rootUri.fsPath}] Ignored transient error during refresh: ${getErrorMessage(e)}`,
-                        );
-                    } else {
-                        this.outputChannel.error(
-                            `[${this.repo.rootUri.fsPath}] Error refreshing JJ SCM: ${getErrorMessage(e)}`,
-                        );
-                        console.error(`Error refreshing JJ SCM for ${this.repo.rootUri.fsPath}:`, e);
+                    // Stop traversing if it's a merge commit
+                    if (isMerge) {
+                        break;
                     }
-                } finally {
-                    if (!this._disposed) {
-                        const duration = performance.now() - start;
-                        try {
-                            this.outputChannel.info(`JJ SCM refresh took ${duration.toFixed(0)}ms`);
-                        } catch {
-                            // Ignore channel closed errors
-                        }
-                        this._onDidChangeStatus.fire();
 
-                        // Invalidate caches once state is fully updated to ensure
-                        // that when VS Code re-queries, it sees the most up-to-date state.
-                        this.viewFileSystemProvider?.invalidateCache();
-                        this.editProvider?.invalidateCache();
-
-                        // Re-assigning quickDiffProvider is a known workaround to force
-                        // VS Code to re-evaluate provideOriginalResource for all open editors.
-                        this._sourceControl.quickDiffProvider = this;
-
-                        await this._diffTabCleaner.closeInvalidDiffEditors();
+                    // Move to the single parent for the next iteration
+                    const singleParentEntry = parentEntries[0];
+                    if (!singleParentEntry || singleParentEntry.is_immutable) {
+                        break; // Stop if the parent is immutable or not found
                     }
+
+                    currentFocus = singleParentEntry;
+                    ancestorDepth++;
                 }
-            })
-            .catch((err) => {
+            }
+
+            // 3. Update Working Copy Group & Collect Decorations
+            const decorationMap = new Map<string, JjStatusEntry>();
+
+            // Working Copy Changes
+            const changes = currentEntry?.changes || [];
+            this._workingCopyStatuses.clear();
+
+            if (currentEntry) {
+                const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
+                const shortId = formatDisplayChangeId(
+                    currentEntry.change_id,
+                    currentEntry.change_id_shortest,
+                    minChangeIdLength,
+                );
+                this._workingCopyGroup.label = `Working Copy - ${shortId}`;
+            } else {
+                this._workingCopyGroup.label = 'Working Copy';
+            }
+
+            const wcFlags = [ScmContextValue.GroupAllowShowMultiFileDiff, ScmContextValue.GroupAllowAbandon];
+            if (currentEntry) {
+                if (canAbsorbCommit(currentEntry)) {
+                    wcFlags.push(ScmContextValue.GroupAllowAbsorb);
+                }
+                if (canSquashCommit(currentEntry)) {
+                    wcFlags.push(ScmContextValue.GroupAllowSquash);
+                }
+            }
+            this._workingCopyGroup.contextValue = wcFlags.join(' ');
+
+            // Working copy items are squashable if the parent is mutable
+            this._workingCopyGroup.resourceStates = changes.map((c) => {
+                const state = this.toResourceState(c, currentEntry?.change_id || '@', {
+                    squashable: parentMutable,
+                    multipleAncestors: ancestorsToDisplay.length > 1,
+                    openDiffOnClick,
+                    hasChild,
+                });
+                decorationMap.set(state.resourceUri.toString(), c);
+                this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
+                return state;
+            });
+
+            // 4. Update Conflict Group (conflictedPaths fetched above)
+            this._conflictGroup.resourceStates = conflictedPaths.map((path) => {
+                const entry: JjStatusEntry = { path, status: 'modified', conflicted: true };
+                const state = this.toResourceState(entry, currentEntry?.change_id || '@', {
+                    openDiffOnClick,
+                    inConflictGroup: true,
+                });
+                decorationMap.set(state.resourceUri.toString(), entry);
+                return state;
+            });
+
+            // 5. Update Parent Groups
+            // Dispose excess parent groups
+            while (this._parentGroups.length > ancestorsToDisplay.length) {
+                const group = this._parentGroups.pop();
+                group?.dispose();
+            }
+
+            // Populate the SCM groups
+            for (let i = 0; i < ancestorsToDisplay.length; i++) {
+                const { entry: ancestorEntry, prefix, isMutable, canSquash } = ancestorsToDisplay[i];
+
+                const minChangeIdLength = getJjViewConfig<number>('minChangeIdLength', 1) ?? 1;
+                const shortId = formatDisplayChangeId(
+                    ancestorEntry.change_id,
+                    ancestorEntry.change_id_shortest,
+                    minChangeIdLength,
+                );
+                const desc = ancestorEntry.description?.trim() || '(no description)';
+                const subject = desc.split('\n', 1 /* limit */)[0].trim();
+                const label = `${prefix}: ${shortId} - ${subject}`;
+
+                // Reuse existing group or create new one
+                let group: vscode.SourceControlResourceGroup;
+                const groupFlags = [ScmContextValue.GroupAllowShowMultiFileDiff, ScmContextValue.GroupAllowShowDetails];
+                if (isMutableCommit(ancestorEntry)) {
+                    groupFlags.push(ScmContextValue.GroupAllowEdit);
+                }
+                if (canSquashCommit(ancestorEntry)) {
+                    groupFlags.push(ScmContextValue.GroupAllowSquash);
+                }
+                const contextValue = groupFlags.join(' ');
+
+                if (i < this._parentGroups.length) {
+                    group = this._parentGroups[i];
+                    group.label = label;
+                    group.contextValue = contextValue;
+                } else {
+                    const groupId = `ancestor-${i}`;
+                    group = this._sourceControl.createResourceGroup(groupId, label);
+                    group.hideWhenEmpty = false;
+                    group.contextValue = contextValue;
+                    this._parentGroups.push(group);
+                }
+
+                const parentChanges = ancestorEntry.changes || [];
+                group.resourceStates = parentChanges.map((c: JjStatusEntry) => {
+                    // Level i ancestor has (ancestorsToDisplay.length - 1 - i) mutable ancestors below it.
+                    const remainingAncestors = ancestorsToDisplay.length - 1 - i;
+                    const state = this.toResourceState(c, ancestorEntry.change_id, {
+                        editable: isMutable,
+                        squashable: canSquash,
+                        multipleAncestors: remainingAncestors > 0,
+                        openDiffOnClick,
+                    });
+                    decorationMap.set(state.resourceUri.toString(), c);
+                    return state;
+                });
+            }
+
+            // Update Decoration
+            this.decorationProvider.updateScmAndTrackedStatus(decorationMap);
+
+            // Update SCM Count - Only count Working Copy changes
+            // VS Code sums all groups by default if count is not set, so we must set it explicitly.
+            this._sourceControl.count = this._workingCopyGroup.resourceStates.length;
+        } catch (e: unknown) {
+            const err = e as { message?: string };
+            if (JjService.isIndexLockError(e)) {
+                const repoRoot = await this.jj.getRepoRoot();
+                const lockPath = path.join(repoRoot, '.git', 'index.lock');
+                const DELETE_LOCK = 'Delete Lock File';
+                vscode.window
+                    .showErrorMessage(
+                        `jj failed: Git index is locked. Another process may have crashed. Delete .git/index.lock to resolve.`,
+                        DELETE_LOCK,
+                        'Show Log',
+                    )
+                    .then(async (selection) => {
+                        if (selection === DELETE_LOCK) {
+                            try {
+                                await fs.unlink(lockPath);
+                                this.outputChannel.info(`[Info] Deleted lock file at ${lockPath}`);
+                                await this.refresh({ forceSnapshot: true, reason: 'lock file deleted' });
+                            } catch (unlinkErr) {
+                                this.outputChannel.error(
+                                    `[Error] Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
+                                );
+                                vscode.window.showErrorMessage(
+                                    `Failed to delete lock file: ${getErrorMessage(unlinkErr)}`,
+                                );
+                            }
+                        } else if (selection === 'Show Log') {
+                            this.outputChannel.show();
+                        }
+                    });
+            } else if (
+                err.message &&
+                ((err.message.includes('Object') && err.message.includes('not found')) ||
+                    err.message.includes('No such file or directory'))
+            ) {
+                this.outputChannel.error(
+                    `[${this.repo.rootUri.fsPath}] Ignored transient error during refresh: ${getErrorMessage(e)}`,
+                );
+            } else {
+                this.outputChannel.error(
+                    `[${this.repo.rootUri.fsPath}] Error refreshing JJ SCM: ${getErrorMessage(e)}`,
+                );
+                console.error(`Error refreshing JJ SCM for ${this.repo.rootUri.fsPath}:`, e);
+            }
+        } finally {
+            if (!this._disposed) {
+                const duration = performance.now() - start;
                 try {
-                    this.outputChannel.info(`[ScmProvider] Refresh mutex encountered unhandled rejection: ${err}`);
+                    this.outputChannel.info(`JJ SCM refresh took ${duration.toFixed(0)}ms`);
                 } catch {
                     // Ignore channel closed errors
                 }
-            });
+                this._onDidChangeStatus.fire();
 
-        return this._refreshMutex;
+                // Invalidate caches once state is fully updated to ensure
+                // that when VS Code re-queries, it sees the most up-to-date state.
+                this.viewFileSystemProvider?.invalidateCache();
+                this.editProvider?.invalidateCache();
+
+                // Re-assigning quickDiffProvider is a known workaround to force
+                // VS Code to re-evaluate provideOriginalResource for all open editors.
+                this._sourceControl.quickDiffProvider = this;
+
+                await this._diffTabCleaner.closeInvalidDiffEditors();
+            }
+        }
     }
 
     async abandon(revisions: string[]) {
@@ -576,7 +554,6 @@ export class JjScmProvider implements vscode.Disposable {
         }
         const r = resourceStates[0];
         const uri = r.resourceUri;
-        // const relativePath = vscode.workspace.asRelativePath(uri);
 
         try {
             const encodedPath = encodeURIComponent(uri.fsPath);

--- a/src/refresh-scheduler.ts
+++ b/src/refresh-scheduler.ts
@@ -84,10 +84,10 @@ export class RefreshScheduler implements vscode.Disposable {
                     await this.refreshCallback({ forceSnapshot, reason: reasons || undefined });
                 } catch (e) {
                     console.error('Refresh failed in scheduler:', e);
+                } finally {
+                    // Resolve all waiting promises
+                    this._resolvePending();
                 }
-
-                // Resolve all waiting promises
-                this._resolvePending();
 
                 this._multiplier = Math.min(this._multiplier + 1, this._maxMultiplier);
                 this._scheduleNextRun();

--- a/src/test/refresh-queue-cleanup.test.ts
+++ b/src/test/refresh-queue-cleanup.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { RefreshScheduler } from '../refresh-scheduler';
+import { AsyncEventEmitter } from '../utils/async-event-emitter';
+import { CoalescingQueue } from '../utils/coalescing-queue';
+import { FakeConfigStore } from './test-utils';
+
+let fakeConfigStore: FakeConfigStore;
+
+vi.mock('vscode', () => ({
+    workspace: {
+        getConfiguration: () => fakeConfigStore.toWorkspaceConfiguration(),
+    },
+    Disposable: class {},
+}));
+
+describe('Refresh Pipeline Cleanup & Error Recovery', () => {
+    beforeEach(() => {
+        fakeConfigStore = new FakeConfigStore({
+            refreshDebounceMillis: 50,
+            refreshDebounceMaxMultiplier: 2,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    test('AsyncEventEmitter fires all listeners safely even if one throws an error', async () => {
+        const emitter = new AsyncEventEmitter<{ reason: string }>();
+        const executed: string[] = [];
+
+        emitter.event(async (evt) => {
+            executed.push(`l1:${evt.reason}`);
+            throw new Error('Listener 1 failed');
+        });
+
+        emitter.event(async (evt) => {
+            executed.push(`l2:${evt.reason}`);
+        });
+
+        await expect(emitter.fire({ reason: 'manual' })).resolves.toBeUndefined();
+        expect(executed).toEqual(['l1:manual', 'l2:manual']);
+    });
+
+    test('CoalescingQueue executes queued tasks sequentially even when active task rejects', async () => {
+        let executionCount = 0;
+        const taskLogs: string[] = [];
+
+        const queue = new CoalescingQueue(async () => {
+            executionCount++;
+            taskLogs.push(`run-${executionCount}`);
+            if (executionCount === 1) {
+                throw new Error('Task 1 error');
+            }
+        });
+
+        const p1 = queue.run();
+        const p2 = queue.run();
+
+        await expect(p1).rejects.toThrow('Task 1 error');
+        await expect(p2).resolves.toBeUndefined();
+
+        expect(taskLogs).toEqual(['run-1', 'run-2']);
+    });
+
+    test('RefreshScheduler recovers from failed refreshCallback without locking future triggers', async () => {
+        vi.useFakeTimers();
+
+        let callCount = 0;
+        const scheduler = new RefreshScheduler(async () => {
+            callCount++;
+            if (callCount === 1) {
+                throw new Error('First callback failure');
+            }
+        });
+
+        // 1st trigger fails
+        const p1 = scheduler.trigger({ reason: 'r1' });
+        await vi.advanceTimersByTimeAsync(50);
+        await expect(p1).resolves.toBeUndefined();
+        expect(callCount).toBe(1);
+
+        // Quiet period to let scheduler reset to idle
+        await vi.advanceTimersByTimeAsync(100);
+
+        // 2nd trigger should execute cleanly
+        const p2 = scheduler.trigger({ reason: 'r2' });
+        await vi.advanceTimersByTimeAsync(50);
+        await expect(p2).resolves.toBeUndefined();
+        expect(callCount).toBe(2);
+
+        scheduler.dispose();
+    });
+});

--- a/src/test/refresh-scheduler.test.ts
+++ b/src/test/refresh-scheduler.test.ts
@@ -215,4 +215,25 @@ describe('RefreshScheduler', () => {
         await vi.advanceTimersByTimeAsync(100);
         expect(refreshFn).toHaveBeenCalledTimes(4);
     });
+
+    test('should resolve pending promise and recover when refreshCallback rejects', async () => {
+        refreshFn.mockRejectedValueOnce(new Error('Refresh error'));
+
+        const promise = scheduler.trigger();
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(refreshFn).toHaveBeenCalledTimes(1);
+        await expect(promise).resolves.toBeUndefined();
+
+        // Advance timers for quiet period so scheduler resets to idle state
+        await vi.advanceTimersByTimeAsync(200);
+
+        // Next trigger should execute normally
+        refreshFn.mockResolvedValueOnce(undefined);
+        const promise2 = scheduler.trigger();
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(refreshFn).toHaveBeenCalledTimes(2);
+        await expect(promise2).resolves.toBeUndefined();
+    });
 });

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -4,8 +4,10 @@
  */
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
+import type { CodeForgeService } from '../code-forge-service';
 import { JjCommitDetailsEditorProvider } from '../jj-commit-details-editor-provider';
 import { JjLogWebviewProvider } from '../jj-log-webview-provider';
+import type { JjRepository } from '../jj-repository';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
@@ -44,22 +46,26 @@ suite('Webview Initialization Integration Test', () => {
     let provider: JjLogWebviewProvider;
     let repo: TestRepo;
     let disposables: vscode.Disposable[] = [];
+    let testContext: Awaited<ReturnType<typeof createTestRepositoryContext>>;
+    let commitDetailsProvider: JjCommitDetailsEditorProvider;
+    let extensionUri: vscode.Uri;
+    let outputChannel: ReturnType<typeof createMockLogOutputChannel>;
 
     setup(async () => {
         repo = new TestRepo();
         await repo.init();
 
-        const outputChannel = createMockLogOutputChannel({
+        outputChannel = createMockLogOutputChannel({
             appendLine: () => {},
         });
-        const extensionUri = vscode.Uri.file(__dirname);
-        const context = await createTestRepositoryContext(repo.path, outputChannel);
-        disposables.push(context);
+        extensionUri = vscode.Uri.file(__dirname);
+        testContext = await createTestRepositoryContext(repo.path, outputChannel);
+        disposables.push(testContext);
 
-        const commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, context.repositoryManager);
+        commitDetailsProvider = new JjCommitDetailsEditorProvider(extensionUri, testContext.repositoryManager);
         provider = new JjLogWebviewProvider(
             extensionUri,
-            context.repository,
+            testContext.repository,
             commitDetailsProvider,
             () => {},
             createMock<vscode.ExtensionContext>({
@@ -141,5 +147,119 @@ suite('Webview Initialization Integration Test', () => {
         assert.ok(htmlAfter.includes('window.vscodeInitialData ='), 'HTML should contain initial data');
         assert.ok(htmlAfter.includes(id2), 'HTML should contain the commit ID from the cache');
         assert.ok(htmlAfter.includes('Test Commit 2'), 'HTML should contain the description from the cache');
+    });
+
+    test('repository getter returns undefined until updateRepository is called', async () => {
+        const unattachedProvider = new JjLogWebviewProvider(
+            extensionUri,
+            /* repo */ undefined,
+            commitDetailsProvider,
+            /* onSelectionChange */ () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
+            outputChannel,
+        );
+
+        assert.strictEqual(unattachedProvider.repository, undefined, 'repository should initially be undefined');
+
+        await unattachedProvider.updateRepository(testContext.repository);
+        assert.strictEqual(
+            unattachedProvider.repository,
+            testContext.repository,
+            'repository should be updated after updateRepository call',
+        );
+    });
+
+    test('updateRepository does not block on pending CodeForge detection', async () => {
+        let resolveDetection!: () => void;
+        const pendingDetection = new Promise<void>((resolve) => {
+            resolveDetection = resolve;
+        });
+
+        const mockRepo = createMock<JjRepository>({
+            rootUri: vscode.Uri.file('/tmp/slow-repo'),
+            isValid: async () => true,
+            jj: testContext.repository.jj,
+            codeForge: createMock<CodeForgeService>({
+                onDidUpdate: () => ({ dispose: () => {} }),
+                detectActiveProvider: () => pendingDetection,
+            }),
+        });
+
+        const unattachedProvider = new JjLogWebviewProvider(
+            extensionUri,
+            /* repo */ undefined,
+            commitDetailsProvider,
+            /* onSelectionChange */ () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
+            outputChannel,
+        );
+
+        let completed = false;
+        const updatePromise = unattachedProvider.updateRepository(mockRepo).then(() => {
+            completed = true;
+        });
+
+        await updatePromise;
+        assert.strictEqual(completed, true, 'updateRepository should complete without awaiting detectActiveProvider');
+        assert.strictEqual(unattachedProvider.repository, mockRepo);
+
+        resolveDetection();
+    });
+
+    test('updateRepository logs and ignores detectActiveProvider errors', async () => {
+        const rejectingDetectionError = new Error('cf failed');
+        let loggedError: unknown;
+        const mockOutputChannel = createMockLogOutputChannel({
+            error: (msg: string) => {
+                loggedError = msg;
+            },
+        });
+
+        const mockRepo = createMock<JjRepository>({
+            rootUri: vscode.Uri.file('/tmp/reject-repo'),
+            isValid: async () => true,
+            jj: testContext.repository.jj,
+            codeForge: createMock<CodeForgeService>({
+                onDidUpdate: () => ({ dispose: () => {} }),
+                detectActiveProvider: () => Promise.reject(rejectingDetectionError),
+            }),
+        });
+
+        const unattachedProvider = new JjLogWebviewProvider(
+            extensionUri,
+            /* repo */ undefined,
+            commitDetailsProvider,
+            /* onSelectionChange */ () => {},
+            createMock<vscode.ExtensionContext>({
+                globalState: createMock<vscode.ExtensionContext['globalState']>({
+                    get: () => [],
+                    update: () => Promise.resolve(),
+                    setKeysForSync: () => {},
+                }),
+            }),
+            mockOutputChannel,
+        );
+
+        await unattachedProvider.updateRepository(mockRepo);
+        // Allow microtasks to execute the background catch handler
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        assert.strictEqual(unattachedProvider.repository, mockRepo);
+        assert.ok(
+            typeof loggedError === 'string' && loggedError.includes('Code forge detection failed'),
+            'outputChannel.error should be called when detectActiveProvider rejects',
+        );
     });
 });


### PR DESCRIPTION
Remove redundant inner `_refreshMutex` promise chain from `JjScmProvider.updateScmView`, relying on `JjRepository`'s `CoalescingQueue` to eliminate nested queue deadlocks.

Guarantee `RefreshScheduler` resolves waiting promises in a `finally` block so scheduler execution continues after error or rejection.

Ensure `logWebviewProvider.updateRepository` binds to the opened repository on startup and make CodeForge detection non-blocking so multi-repo workspace initialization does not hang.

Add targeted unit and integration tests verifying error recovery, non-blocking repository updates, and queue cleanup across the refresh pipeline.

Fixes: #335