### PR TITLE
feat(dnd): add more keyboard shortcuts for drag/drop in log

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ Visualize your `jj` repo history with a clear, interactive graph.
 - **Inspect Changes**: Click on any node to view details and diffs.
 - **Context Actions**: Right-click nodes to perform actions like editing, squashing, or abandoning changes.
 - **Drag & Drop Workflows**:
-    - **Rebase Source**: Drag a commit onto another to rebase it (and its children) onto the target.
-    - **Rebase Revision**: Hold `Ctrl` (or `⌘` on macOS) while dragging to rebase only the specific revision.
+    - **Rebase Branch (default)**: Drag a commit onto another to rebase the source commit and all of its descendants onto the target.
+    - **Rebase Revision**: Press `R` while dragging to rebase only the specific revision.
+    - **Squash Into**: Press `S` while dragging to squash the source commit into the target commit.
+    - **Squash Onto**: Press `Shift+S` while dragging to create a new commit containing the source's changes on top of the target commit.
+    - **Duplicate Onto**: Press `D` while dragging to duplicate the source commit on top of the target commit.
+    - **Merge Revisions**: Press `M` while dragging to create a new revision that merges both commits (setting both the source and target commits as parents).
     - **Move Bookmarks**: Drag bookmark pills from one commit to another to move them.
 - **Selection**:
     - **Multi-Select**: `Ctrl+Click` (or `⌘+Click`) to select multiple commits.

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -251,27 +251,19 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     }
                     break;
                 case 'moveBookmark':
-                    if (this.jj) {
-                        await this.jj.moveBookmark(data.payload.bookmark, data.payload.targetChangeId);
-                        await vscode.commands.executeCommand('jj-view.refresh');
-                    }
+                    await this.handleMoveBookmark(data.payload);
                     break;
                 case 'rebaseCommit':
-                    if (this.jj) {
-                        try {
-                            await withDelayedProgress(
-                                'Rebasing...',
-                                this.jj.rebase(
-                                    data.payload.sourceChangeId,
-                                    data.payload.targetChangeId,
-                                    data.payload.mode,
-                                ),
-                            );
-                            await vscode.commands.executeCommand('jj-view.refresh');
-                        } catch (err) {
-                            await showJjError(err, 'Failed to rebase', this.jj, this.outputChannel);
-                        }
-                    }
+                    await this.handleRebaseCommit(data.payload);
+                    break;
+                case 'squashCommit':
+                    await this.handleSquashCommit(data.payload);
+                    break;
+                case 'duplicateCommit':
+                    await this.handleDuplicateCommit(data.payload);
+                    break;
+                case 'mergeCommit':
+                    await this.handleMergeCommit(data.payload);
                     break;
                 case 'upload':
                     await vscode.commands.executeCommand('jj-view.upload', data.payload);
@@ -543,6 +535,79 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                 <script nonce="${nonce}" src="${scriptUri}"></script>
             </body>
             </html>`;
+    }
+
+    private async executeJjMutation(
+        progressTitle: string,
+        failureMessage: string,
+        operation: (jj: JjService) => Promise<unknown>,
+    ): Promise<void> {
+        if (!this.jj) {
+            return;
+        }
+        try {
+            await withDelayedProgress(progressTitle, operation(this.jj));
+            await vscode.commands.executeCommand('jj-view.refresh');
+        } catch (err) {
+            await showJjError(err, failureMessage, this.jj, this.outputChannel);
+        }
+    }
+
+    private async handleMoveBookmark(payload: { bookmark: string; targetChangeId: string }): Promise<void> {
+        if (!payload?.bookmark || !payload?.targetChangeId) {
+            return;
+        }
+        return this.executeJjMutation('Moving bookmark...', 'Failed to move bookmark', (jj) =>
+            jj.moveBookmark(payload.bookmark, payload.targetChangeId),
+        );
+    }
+
+    private async handleRebaseCommit(payload: {
+        sourceChangeId: string;
+        targetChangeId: string;
+        mode: 'source' | 'revision';
+    }): Promise<void> {
+        if (!payload?.sourceChangeId || !payload?.targetChangeId || payload.sourceChangeId === payload.targetChangeId) {
+            return;
+        }
+        return this.executeJjMutation('Rebasing...', 'Failed to rebase', (jj) =>
+            jj.rebase(payload.sourceChangeId, payload.targetChangeId, payload.mode),
+        );
+    }
+
+    private async handleSquashCommit(payload: {
+        sourceChangeId: string;
+        targetChangeId: string;
+        mode: 'into' | 'onto';
+    }): Promise<void> {
+        if (!payload?.sourceChangeId || !payload?.targetChangeId || payload.sourceChangeId === payload.targetChangeId) {
+            return;
+        }
+        const options =
+            payload.mode === 'onto'
+                ? { ontoRevision: payload.targetChangeId }
+                : { intoRevision: payload.targetChangeId };
+        return this.executeJjMutation('Squashing...', 'Failed to squash', (jj) =>
+            jj.squashRevision({ revision: payload.sourceChangeId, ...options }),
+        );
+    }
+
+    private async handleDuplicateCommit(payload: { sourceChangeId: string; targetChangeId?: string }): Promise<void> {
+        if (!payload?.sourceChangeId || payload.sourceChangeId === payload.targetChangeId) {
+            return;
+        }
+        return this.executeJjMutation('Duplicating...', 'Failed to duplicate', (jj) =>
+            jj.duplicate(payload.sourceChangeId, payload.targetChangeId ? { onto: payload.targetChangeId } : {}),
+        );
+    }
+
+    private async handleMergeCommit(payload: { sourceChangeId: string; targetChangeId: string }): Promise<void> {
+        if (!payload?.sourceChangeId || !payload?.targetChangeId || payload.sourceChangeId === payload.targetChangeId) {
+            return;
+        }
+        return this.executeJjMutation('Creating merge commit...', 'Failed to create merge commit', (jj) =>
+            jj.new({ parents: [payload.sourceChangeId, payload.targetChangeId] }),
+        );
     }
 }
 

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -779,6 +779,7 @@ export class JjService {
      * @param options.paths Files to squash. If empty, squashes all changes in the revision.
      * @param options.revision The revision to squash from.
      * @param options.intoRevision The revision to squash into.
+     * @param options.ontoRevision Target revision to squash onto (creating a new commit on top of destination).
      * @param options.message New description for the destination revision.
      * @param options.useDestinationMessage If true, keeps the destination revision's description.
      */
@@ -787,17 +788,33 @@ export class JjService {
             paths?: string[];
             revision?: string;
             intoRevision?: string;
+            ontoRevision?: string;
             message?: string;
             useDestinationMessage?: boolean;
         } = {},
     ): Promise<void> {
-        const { paths = [], revision, intoRevision, message, useDestinationMessage } = options;
+        const { paths = [], revision, intoRevision, ontoRevision, message, useDestinationMessage } = options;
+        if (intoRevision && ontoRevision) {
+            throw new Error('Cannot specify both intoRevision and ontoRevision.');
+        }
+        if (revision && (revision === intoRevision || revision === ontoRevision)) {
+            throw new Error('Cannot squash revision into or onto itself.');
+        }
         const args: string[] = [];
         const relativePaths = paths.map((p) => this.toRelative(p));
 
-        if (revision && intoRevision) {
+        if (ontoRevision) {
+            // Squash onto target (creating a new commit on top of ontoRevision)
+            if (revision) {
+                args.push('--from', revision);
+            }
+            args.push('--onto', ontoRevision);
+        } else if (intoRevision) {
             // Squash from one revision into another
-            args.push('--from', revision, '--into', intoRevision);
+            if (revision) {
+                args.push('--from', revision);
+            }
+            args.push('--into', intoRevision);
         } else if (revision) {
             // Squash this revision into its parent
             args.push('-r', revision);
@@ -835,8 +852,13 @@ export class JjService {
         return this.run('rebase', args, { isMutation: true, label: 'rebase' });
     }
 
-    async duplicate(revision: string): Promise<string> {
-        return this.run('duplicate', [revision], { isMutation: true, label: 'duplicate' });
+    async duplicate(revision: string, options: { onto?: string } = {}): Promise<string> {
+        const args: string[] = [];
+        if (options.onto) {
+            args.push('-o', options.onto);
+        }
+        args.push(revision);
+        return this.run('duplicate', args, { isMutation: true, label: 'duplicate' });
     }
 
     async abandon(revisions: string | string[]): Promise<string> {

--- a/src/test/drag-modifiers.test.ts
+++ b/src/test/drag-modifiers.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import {
+    BUILT_IN_MODIFIERS,
+    type PressedKeysState,
+    resolveActiveModifier,
+    SQUASH_ONTO_MODIFIER,
+} from '../webview/utils/drag-modifiers';
+
+describe('DragModifierFramework', () => {
+    const emptyKeys: PressedKeysState = {
+        r: false,
+        shift: false,
+        s: false,
+        d: false,
+        m: false,
+    };
+
+    it('contains all 6 built-in modifiers in registry', () => {
+        expect(BUILT_IN_MODIFIERS.length).toBe(6);
+    });
+
+    it('resolves Rebase Branch by default when no keys are pressed', () => {
+        const modifier = resolveActiveModifier(emptyKeys);
+        expect(modifier.id).toBe('rebase-branch');
+        expect(modifier.label).toBe('Rebase Branch');
+        expect(modifier.description).toBe('Rebase branch (source & descendants)');
+        expect(modifier.badgeText).toBe('Rebase branch here');
+        expect(modifier.shortcutHint).toBe('Default');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'rebaseCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2', mode: 'source' },
+        });
+    });
+
+    it('resolves Rebase Revision when R is pressed', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, r: true });
+        expect(modifier.id).toBe('rebase-revision');
+        expect(modifier.label).toBe('Rebase Revision Only');
+        expect(modifier.description).toBe('Rebase revision only');
+        expect(modifier.badgeText).toBe('Rebase revision here');
+        expect(modifier.shortcutHint).toBe('R');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'rebaseCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2', mode: 'revision' },
+        });
+    });
+
+    it('resolves Squash Into when S is pressed without Shift', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, s: true });
+        expect(modifier.id).toBe('squash-into');
+        expect(modifier.label).toBe('Squash Into Target');
+        expect(modifier.description).toBe('Squash source commit into target');
+        expect(modifier.badgeText).toBe('Squash into target here');
+        expect(modifier.shortcutHint).toBe('S');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'squashCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2', mode: 'into' },
+        });
+    });
+
+    it('resolves Squash Onto when Shift+S is pressed', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, shift: true, s: true });
+        expect(modifier.id).toBe('squash-onto');
+        expect(modifier.label).toBe('Squash Onto Target');
+        expect(modifier.description).toBe('Squash source onto target (new commit on top of target)');
+        expect(modifier.badgeText).toBe('Squash onto target here');
+        expect(modifier.shortcutHint).toBe('Shift + S');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'squashCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2', mode: 'onto' },
+        });
+    });
+
+    it('resolves Duplicate when D is pressed', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, d: true });
+        expect(modifier.id).toBe('duplicate');
+        expect(modifier.label).toBe('Duplicate Onto Target');
+        expect(modifier.description).toBe('Duplicate source commit on top of target');
+        expect(modifier.badgeText).toBe('Duplicate onto target here');
+        expect(modifier.shortcutHint).toBe('D');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'duplicateCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2' },
+        });
+    });
+
+    it('resolves Merge Revision when M is pressed', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, m: true });
+        expect(modifier.id).toBe('merge');
+        expect(modifier.label).toBe('Merge Revisions');
+        expect(modifier.description).toBe('Create new revision merging source & target');
+        expect(modifier.badgeText).toBe('Merge with target here');
+        expect(modifier.shortcutHint).toBe('M');
+        expect(modifier.buildMessagePayload('c1', 'c2')).toEqual({
+            type: 'mergeCommit',
+            payload: { sourceChangeId: 'c1', targetChangeId: 'c2' },
+        });
+    });
+
+    it('prioritizes Shift+S over S alone when both shift and s are true', () => {
+        const modifier = resolveActiveModifier({ ...emptyKeys, shift: true, s: true });
+        expect(modifier.id).toBe(SQUASH_ONTO_MODIFIER.id);
+    });
+
+    it('uses standard VS Code theme token variable for Squash Onto accent color', () => {
+        expect(SQUASH_ONTO_MODIFIER.accentColor).toBe('var(--vscode-charts-magenta)');
+    });
+
+    it('pre-sorts BUILT_IN_MODIFIERS by priority in descending order', () => {
+        const priorities = BUILT_IN_MODIFIERS.map((m) => m.priority);
+        const isSorted = priorities.every((p, i) => i === 0 || p <= priorities[i - 1]);
+        expect(isSorted).toBe(true);
+    });
+});

--- a/src/test/e2e/context-menu.spec.ts
+++ b/src/test/e2e/context-menu.spec.ts
@@ -4,14 +4,11 @@
  */
 
 import { expect, type Page } from '@playwright/test';
-import { buildGraph, type CommitId, TestRepo } from '../test-repo';
+import { buildGraph, type CommitId, ROOT_ID, TestRepo } from '../test-repo';
 import {
-    entry,
     expectModifiedFiles,
-    expectTree,
     focusJJLog,
     getLogWebview,
-    ROOT_ID,
     rightClickAndSelect,
     selectCommits,
     test,
@@ -20,6 +17,7 @@ import {
     waitForLogCommitRow,
     waitForLogPill,
     waitForTab,
+    waitForTree,
 } from './e2e-helpers';
 
 test.describe('JJ Log Context Menu E2E', () => {
@@ -70,11 +68,11 @@ test.describe('JJ Log Context Menu E2E', () => {
         const commit2Row = await waitForLogCommitRow(page, 'commit2');
         await rightClickAndSelect(page, commit2Row, 'Abandon');
 
-        await expectTree(repo, [
-            `@ ${entry('*', '(empty)', initialId)}`,
-            entry(commit1Id, 'commit1', initialId),
-            entry(initialId, 'initial', dummyId),
-            entry(dummyId, 'dummy', ROOT_ID),
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
         ]);
         // Undo — the button is a header action on the JJ Log pane
         const undoBtn = page.getByRole('button', { name: 'Undo' }).first();
@@ -82,11 +80,11 @@ test.describe('JJ Log Context Menu E2E', () => {
         await undoBtn.click();
 
         // After undo, commit2 should be restored as the working copy
-        await expectTree(repo, [
-            `@ ${entry(commit2Id, 'commit2', initialId)}`,
-            entry(commit1Id, 'commit1', initialId),
-            entry(initialId, 'initial', dummyId),
-            entry(dummyId, 'dummy', ROOT_ID),
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
         ]);
     });
 
@@ -103,15 +101,13 @@ test.describe('JJ Log Context Menu E2E', () => {
 
         // After "New Before" initial:
         // root -> dummyId -> middle (@) -> initial -> {commit1, commit2}
-        await expect(async () => {
-            await expectTree(repo, [
-                entry(commit2Id, 'commit2', initialId),
-                entry(commit1Id, 'commit1', initialId),
-                entry(initialId, 'initial', '*'),
-                `@ ${entry('*', '(empty)', dummyId)}`,
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: '*' },
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('Multi-select Abandon', async () => {
@@ -127,10 +123,10 @@ test.describe('JJ Log Context Menu E2E', () => {
         // Right click commit 1 and abandon
         await rightClickAndSelect(page, commit1Row, 'Abandon');
 
-        await expectTree(repo, [
-            `@ ${entry('*', '(empty)', initialId)}`,
-            entry(initialId, 'initial', dummyId),
-            entry(dummyId, 'dummy', ROOT_ID),
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
         ]);
     });
 
@@ -154,15 +150,13 @@ test.describe('JJ Log Context Menu E2E', () => {
         // After "New Before" on multi-select [commit2, commit1]: a new empty commit
         // is inserted before both (as their new parent), and @ moves there.
         // Tree: root -> dummyId -> initial -> middle (@) -> {commit1, commit2}
-        await expect(async () => {
-            await expectTree(repo, [
-                entry(commit1Id, 'commit1', '*'),
-                entry(commit2Id, 'commit2', '*'),
-                `@ ${entry('*', '(empty)', initialId)}`,
-                entry(initialId, 'initial', dummyId),
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { changeId: commit1Id, description: 'commit1', parents: '*' },
+            { changeId: commit2Id, description: 'commit2', parents: '*' },
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('New After (Single)', async () => {
@@ -180,15 +174,13 @@ test.describe('JJ Log Context Menu E2E', () => {
 
         // After "New After" initial:
         // root -> dummyId -> initial -> middle (@) -> {commit1, commit2}
-        await expect(async () => {
-            await expectTree(repo, [
-                entry(commit1Id, 'commit1', '*'),
-                entry(commit2Id, 'commit2', '*'),
-                `@ ${entry('*', '(empty)', initialId)}`,
-                entry(initialId, 'initial', dummyId),
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { changeId: commit1Id, description: 'commit1', parents: '*' },
+            { changeId: commit2Id, description: 'commit2', parents: '*' },
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('Multi-select New After', async () => {
@@ -223,19 +215,17 @@ test.describe('JJ Log Context Menu E2E', () => {
         // is inserted after both (as their new child).
         // Then child1 and child2 are rebased on top of the new commit.
         // Tree: root -> dummyId -> initial -> {commit1, commit2} -> middle (@) -> {child1, child2}
-        await expect(async () => {
-            await expectTree(repo, [
-                entry(child1Id, 'child1', '*'),
-                entry(child2Id, 'child2', '*'),
-                expect.stringMatching(
-                    new RegExp(`^@ [a-z0-9]+ \\[(${commit1Id},${commit2Id}|${commit2Id},${commit1Id})\\] \\(empty\\)$`),
-                ),
-                entry(commit2Id, 'commit2', initialId),
-                entry(commit1Id, 'commit1', initialId),
-                entry(initialId, 'initial', dummyId),
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { changeId: child1Id, description: 'child1', parents: '*' },
+            { changeId: child2Id, description: 'child2', parents: '*' },
+            expect.stringMatching(
+                new RegExp(`^@ [a-z0-9]+ \\[(${commit1Id},${commit2Id}|${commit2Id},${commit1Id})\\] \\(empty\\)$`),
+            ),
+            { changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('Edit', async () => {
@@ -267,12 +257,12 @@ test.describe('JJ Log Context Menu E2E', () => {
         const commit1Id = nodes.commit1.changeId;
         const initialId = nodes.initial.changeId;
 
-        await expectTree(repo, [
+        await waitForTree(repo, [
             expect.stringMatching(new RegExp(`^[a-z0-9]+ \\[${initialId}\\] commit1$`)),
-            `@ ${entry(commit2Id, 'commit2', initialId)}`,
-            entry(commit1Id, 'commit1', initialId),
-            entry(initialId, 'initial', dummyId),
-            entry(dummyId, 'dummy', ROOT_ID),
+            { isWorkingCopy: true, changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
         ]);
     });
 
@@ -291,15 +281,13 @@ test.describe('JJ Log Context Menu E2E', () => {
         await rightClickAndSelect(page, commit1Row, 'New Merge Change');
 
         // Verification: a new merge commit should be created
-        await expect(async () => {
-            await expectTree(repo, [
-                `@ ${entry('*', '(empty)', [commit1Id, commit2Id])}`,
-                entry(commit2Id, 'commit2', initialId),
-                entry(commit1Id, 'commit1', initialId),
-                entry(initialId, 'initial', dummyId),
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: [commit1Id, commit2Id] },
+            { changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: commit1Id, description: 'commit1', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('Rebase onto Selected', async () => {
@@ -315,14 +303,12 @@ test.describe('JJ Log Context Menu E2E', () => {
         await rightClickAndSelect(page, commit1Row, 'Rebase onto Selected');
 
         // Verification: commit1 should now be a child of commit2
-        await expect(async () => {
-            await expectTree(repo, [
-                entry(commit1Id, 'commit1', commit2Id),
-                `@ ${entry(commit2Id, 'commit2', initialId)}`,
-                entry(initialId, 'initial', dummyId),
-                entry(dummyId, 'dummy', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { changeId: commit1Id, description: 'commit1', parents: commit2Id },
+            { isWorkingCopy: true, changeId: commit2Id, description: 'commit2', parents: initialId },
+            { changeId: initialId, description: 'initial', parents: dummyId },
+            { changeId: dummyId, description: 'dummy', parents: ROOT_ID },
+        ]);
     });
 
     test('Delete Bookmark', async () => {

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -7,7 +7,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, type Locator } from '@playwright/test';
 import type { Frame, Page } from 'playwright';
-import type { TestRepo } from '../test-repo';
+import { type ExpectedTreeItem, expectTree, type TestRepo } from '../test-repo';
+
+export type { ExpectedTreeItem, TestRepo, TreeEntrySpec } from '../test-repo';
+
 import { logPerf } from './perf-logger';
 import {
     type VSCodeContext as FixtureVSCodeContext,
@@ -292,59 +295,24 @@ export async function getLogWebview(page: Page, timeout: number = 30000): Promis
 }
 
 /**
- * Asserts that the repo log matches the expected structure.
+ * Waits for the repo log tree to match the expected structure, polling until it passes or times out.
  */
-export async function expectTree(repo: TestRepo, expected: unknown[]) {
+export async function waitForTree(
+    repo: TestRepo,
+    expected: ExpectedTreeItem[],
+    options?: { timeout?: number },
+): Promise<void> {
+    const timeout = options?.timeout ?? 10000;
     const start = Date.now();
-    let lastActual: string[] = [];
-    let iterations = 0;
-    try {
-        await expect
-            .poll(
-                async () => {
-                    iterations++;
-                    // Output format: [@] change_id [parent1,parent2] description
-                    const log = repo.getLog(
-                        'all()',
-                        'if(current_working_copy, "@ ", "") ++ change_id ++ " [" ++ parents.map(|p| p.change_id()).join(",") ++ "] " ++ if(description, description.first_line(), "(empty)") ++ "\\n"',
-                    );
-                    const actual = log
-                        .split('\n')
-                        .filter((l) => l.trim())
-                        .filter((line) => !line.startsWith('zzzzzzzz'));
-                    lastActual = actual;
-                    return actual;
-                },
-                {
-                    timeout: 10000,
-                    message: 'Tree mismatch',
-                    intervals: [20, 50, 100, 250, 500],
-                },
-            )
-            .toEqual(
-                expected.map((e) => {
-                    if (typeof e === 'string' && e.includes('*')) {
-                        // Escape regex characters except for our * wildcard
-                        const escaped = e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[a-z0-9]+');
-                        return expect.stringMatching(new RegExp(`^${escaped}$`));
-                    }
-                    return e;
-                }),
-            );
-    } catch (e: unknown) {
-        const formatTree = (tree: unknown[]) => tree.map((line) => `  ${String(line)}`).join('\n');
-        if (e instanceof Error) {
-            e.message = `${e.message}\n\nExpected Tree:\n${formatTree(expected)}\n\nActual Tree:\n${formatTree(lastActual)}`;
-        }
-        throw e;
-    }
-    logPerf('expectTree', start, /* prefix= */ undefined, `(iterations: ${iterations})`);
-}
 
-/** Helper to format an entry for expectTree */
-export function entry(changeId: string, description: string, parents?: string | string[]): string {
-    const p = Array.isArray(parents) ? parents.join(',') : parents || '';
-    return `${changeId} [${p}] ${description}`;
+    await expect(async () => {
+        expectTree(repo, expected);
+    }).toPass({
+        timeout,
+        intervals: [20, 50, 100, 250, 500],
+    });
+
+    logPerf('waitForTree', start);
 }
 
 /**
@@ -444,8 +412,8 @@ export async function rightClickAndSelect(page: Page, target: Locator, label: st
 /**
  * Simulates a drag and drop action between two locators.
  */
-export async function dragAndDrop(page: Page, options: { source: Locator; target: Locator }) {
-    const { source, target } = options;
+export async function dragAndDrop(page: Page, options: { source: Locator; target: Locator; key?: string }) {
+    const { source, target, key } = options;
     await source.scrollIntoViewIfNeeded();
     await target.scrollIntoViewIfNeeded();
 
@@ -459,12 +427,19 @@ export async function dragAndDrop(page: Page, options: { source: Locator; target
         throw new Error('Could not get bounding box for target locator');
     }
 
+    const keys = key ? key.split('+') : [];
+    for (const k of keys) {
+        await page.keyboard.down(k);
+    }
     await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
     await page.mouse.down();
     await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {
         steps: 10,
     });
     await page.mouse.up();
+    for (const k of keys.reverse()) {
+        await page.keyboard.up(k);
+    }
 }
 
 /**

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -4,20 +4,18 @@
  */
 
 import { expect } from '@playwright/test';
-import { buildGraph, TestRepo } from '../test-repo';
+import { buildGraph, ROOT_ID, TestRepo } from '../test-repo';
 import {
     clickLogAction,
     dragAndDrop,
-    entry,
-    expectTree,
     focusJJLog,
     getLogWebview,
     pickQuickPickItem,
-    ROOT_ID,
     test,
     triggerRefresh,
     waitForLogCommitRow,
     waitForLogPill,
+    waitForTree,
     waitForWebviewCommitRemoved,
     waitForWebviewWorkingCopy,
 } from './e2e-helpers';
@@ -106,27 +104,35 @@ test.describe('JJ Log Pane E2E', () => {
         }).toPass({ timeout: 5000 });
 
         // Verify full tree: [merge, wc, side_branch, initial, dummy]
-        await expect(async () => {
-            const mergeChangeId = repo.getChangeId('@');
-            await expectTree(repo, [
-                `@ ${entry(mergeChangeId, '(empty)', [nodes.side_branch.changeId, nodes.wc.changeId])}`,
-                entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
-                entry(nodes.side_branch.changeId, 'side branch', nodes.initial.changeId),
-                entry(nodes.initial.changeId, 'initial setup', dummyId),
-                entry(dummyId, '(empty)', ROOT_ID),
-            ]);
-        }).toPass();
+        const mergeChangeId = repo.getChangeId('@');
+        await waitForTree(repo, [
+            {
+                isWorkingCopy: true,
+                changeId: mergeChangeId,
+                description: '(empty)',
+                parents: [nodes.side_branch.changeId, nodes.wc.changeId],
+            },
+            { changeId: nodes.wc.changeId, description: 'working tree', parents: nodes.initial.changeId },
+            { changeId: nodes.side_branch.changeId, description: 'side branch', parents: nodes.initial.changeId },
+            { changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
+        ]);
 
         // 2. Undo
         const undoAction = page.getByRole('button', { name: 'Undo' }).first();
         await undoAction.click();
 
         // Assert the merge change was undone accurately
-        await expectTree(repo, [
-            `@ ${entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId)}`,
-            entry(nodes.side_branch.changeId, 'side branch', nodes.initial.changeId),
-            entry(nodes.initial.changeId, 'initial setup', dummyId),
-            entry(dummyId, '(empty)', ROOT_ID),
+        await waitForTree(repo, [
+            {
+                isWorkingCopy: true,
+                changeId: nodes.wc.changeId,
+                description: 'working tree',
+                parents: nodes.initial.changeId,
+            },
+            { changeId: nodes.side_branch.changeId, description: 'side branch', parents: nodes.initial.changeId },
+            { changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
         ]);
     });
 
@@ -167,17 +173,13 @@ test.describe('JJ Log Pane E2E', () => {
         repo.writeFile('child.txt', 'child content');
 
         // Tree: [new_child(@), wc, branch, initial, dummy]
-        // Order: child is newest head, wc is other head.
-        await expect(async () => {
-            const childId = repo.getChangeId('@');
-            await expectTree(repo, [
-                `@ ${entry(childId, '(empty)', nodes.branch.changeId)}`,
-                entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
-                entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-                entry(nodes.initial.changeId, 'initial setup', dummyId),
-                entry(dummyId, '(empty)', ROOT_ID),
-            ]);
-        }).toPass();
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: childId, description: '(empty)', parents: nodes.branch.changeId },
+            { changeId: nodes.wc.changeId, description: 'working tree', parents: nodes.branch.changeId },
+            { changeId: nodes.branch.changeId, description: 'branch commit', parents: nodes.initial.changeId },
+            { changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
+        ]);
         await waitForWebviewWorkingCopy(page, childId);
 
         // 2. Prepare for squash: move working copy away from the new child
@@ -185,12 +187,12 @@ test.describe('JJ Log Pane E2E', () => {
         await clickLogAction(page, { changeId: initialId }, 'Edit Commit');
 
         // Tree is the same commits, just @ moved. Order: [child, wc, branch, initial, dummy]
-        await expectTree(repo, [
-            entry(childId, '(empty)', nodes.branch.changeId),
-            entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
-            entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
-            entry(dummyId, '(empty)', ROOT_ID),
+        await waitForTree(repo, [
+            { changeId: childId, description: '(empty)', parents: nodes.branch.changeId },
+            { changeId: nodes.wc.changeId, description: 'working tree', parents: nodes.branch.changeId },
+            { changeId: nodes.branch.changeId, description: 'branch commit', parents: nodes.initial.changeId },
+            { isWorkingCopy: true, changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
         ]);
         await waitForWebviewWorkingCopy(page, initialId);
 
@@ -198,11 +200,11 @@ test.describe('JJ Log Pane E2E', () => {
         await clickLogAction(page, { changeId: childId }, 'Squash');
 
         // After squash: child is gone. branch has its changes.
-        await expectTree(repo, [
-            entry(nodes.wc.changeId, 'working tree', nodes.branch.changeId),
-            entry(nodes.branch.changeId, 'branch commit', nodes.initial.changeId),
-            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
-            entry(dummyId, '(empty)', ROOT_ID),
+        await waitForTree(repo, [
+            { changeId: nodes.wc.changeId, description: 'working tree', parents: nodes.branch.changeId },
+            { changeId: nodes.branch.changeId, description: 'branch commit', parents: nodes.initial.changeId },
+            { isWorkingCopy: true, changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
         ]);
         await waitForWebviewCommitRemoved(page, childId);
 
@@ -211,10 +213,10 @@ test.describe('JJ Log Pane E2E', () => {
 
         // After abandon branch: branch is gone. wc (child of branch) becomes child of initial.
         // Tree: [wc, initial(@)]
-        await expectTree(repo, [
-            entry(nodes.wc.changeId, 'working tree', nodes.initial.changeId),
-            `@ ${entry(nodes.initial.changeId, 'initial setup', dummyId)}`,
-            entry(dummyId, '(empty)', ROOT_ID),
+        await waitForTree(repo, [
+            { changeId: nodes.wc.changeId, description: 'working tree', parents: nodes.initial.changeId },
+            { isWorkingCopy: true, changeId: nodes.initial.changeId, description: 'initial setup', parents: dummyId },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
         ]);
         await waitForWebviewCommitRemoved(page, branchId);
     });
@@ -257,6 +259,126 @@ test.describe('JJ Log Pane E2E', () => {
             const parents = repo.getParents(nodes.source.changeId);
             expect(parents).toContain(nodes.target.changeId);
         }).toPass({ timeout: 10000 });
+    });
+
+    test('Drag and Drop Commit with s key squashes source into target', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        const dummyId = repo.getChangeId('@');
+        const nodes = await buildGraph(repo, [
+            { label: 'target', description: 'target commit', files: { 'target.txt': 'base' } },
+            {
+                label: 'source',
+                parents: ['target'],
+                description: 'source commit',
+                files: { 'source.txt': 'mod' },
+            },
+        ]);
+
+        const { page } = await vscode.openWorkspace(repo);
+        await focusJJLog(page);
+
+        const sourceRow = await waitForLogCommitRow(page, { changeId: nodes.source.changeId });
+        const targetRow = await waitForLogCommitRow(page, { changeId: nodes.target.changeId });
+
+        await dragAndDrop(page, { source: sourceRow, target: targetRow, key: 's' });
+
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: nodes.target.changeId },
+            {
+                changeId: nodes.target.changeId,
+                description: 'target commit',
+                parents: dummyId,
+                files: { 'target.txt': 'base', 'source.txt': 'mod' },
+            },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
+        ]);
+    });
+
+    test('Drag and Drop Commit with Shift+s key squashes source onto target', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        const dummyId = repo.getChangeId('@');
+        const nodes = await buildGraph(repo, [
+            { label: 'target', description: 'target commit', files: { 'target.txt': 'base' } },
+            {
+                label: 'source',
+                parents: ['root()'],
+                description: 'source commit',
+                files: { 'source.txt': 'mod' },
+            },
+        ]);
+
+        const { page } = await vscode.openWorkspace(repo);
+        await focusJJLog(page);
+
+        const sourceRow = await waitForLogCommitRow(page, { changeId: nodes.source.changeId });
+        const targetRow = await waitForLogCommitRow(page, { changeId: nodes.target.changeId });
+
+        await dragAndDrop(page, { source: sourceRow, target: targetRow, key: 'Shift+s' });
+
+        await waitForTree(repo, [
+            { isWorkingCopy: true, changeId: '*', description: '(empty)', parents: ROOT_ID },
+            {
+                changeId: '*',
+                description: 'source commit',
+                parents: nodes.target.changeId,
+                files: { 'source.txt': 'mod' },
+            },
+            {
+                changeId: nodes.target.changeId,
+                description: 'target commit',
+                parents: dummyId,
+                files: { 'target.txt': 'base' },
+            },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
+        ]);
+    });
+
+    test('Drag and Drop Commit with d key duplicates source onto target', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        const dummyId = repo.getChangeId('@');
+        const nodes = await buildGraph(repo, [
+            { label: 'target', description: 'target commit', files: { 'target.txt': 'base' } },
+            {
+                label: 'source',
+                parents: ['root()'],
+                description: 'source to duplicate',
+                files: { 'source.txt': 'mod' },
+            },
+        ]);
+
+        const { page } = await vscode.openWorkspace(repo);
+        await focusJJLog(page);
+
+        const sourceRow = await waitForLogCommitRow(page, { changeId: nodes.source.changeId });
+        const targetRow = await waitForLogCommitRow(page, { changeId: nodes.target.changeId });
+
+        await dragAndDrop(page, { source: sourceRow, target: targetRow, key: 'd' });
+
+        await waitForTree(repo, [
+            {
+                changeId: '*',
+                description: 'source to duplicate',
+                parents: nodes.target.changeId,
+                files: { 'source.txt': 'mod' },
+            },
+            {
+                isWorkingCopy: true,
+                changeId: nodes.source.changeId,
+                description: 'source to duplicate',
+                parents: ROOT_ID,
+                files: { 'source.txt': 'mod' },
+            },
+            {
+                changeId: nodes.target.changeId,
+                description: 'target commit',
+                parents: dummyId,
+                files: { 'target.txt': 'base' },
+            },
+            { changeId: dummyId, description: '(empty)', parents: ROOT_ID },
+        ]);
     });
 
     test('Delete Bookmark (Command Palette/Quick Pick Flow)', async ({ vscode }) => {

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -6,26 +6,24 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { expect, type Locator } from '@playwright/test';
-import { buildGraph, TestRepo } from '../test-repo';
+import { buildGraph, ROOT_ID, TestRepo } from '../test-repo';
 import {
     clickContextMenuItem,
     clickScmAction,
-    entry,
     expectFileInScmGroup,
     expectScmDescription,
-    expectTree,
     focusSCM,
     hoverAndClick,
     openScmDiff,
     openScmFile,
     openScmMerge,
     pickQuickPickItem,
-    ROOT_ID,
     SCM_ACTIONS,
     selectLine,
     setScmDescription,
     test,
     waitForTab,
+    waitForTree,
 } from './e2e-helpers';
 
 test.describe('SCM Pane E2E', () => {
@@ -116,11 +114,11 @@ test.describe('SCM Pane E2E', () => {
         await newButton.click();
 
         // Wait for UI to reflect empty input box and tree to update
-        await expectTree(repo, [
+        await waitForTree(repo, [
             expect.stringMatching(new RegExp(`^@ [a-z0-9]+ \\[${prevWcId}\\] \\(empty\\)$`)),
-            entry(prevWcId, '(empty)', initialId),
-            entry(initialId, 'Updated description explicitly', workspaceRootId),
-            entry(workspaceRootId, '(empty)', ROOT_ID),
+            { changeId: prevWcId, description: '(empty)', parents: initialId },
+            { changeId: initialId, description: 'Updated description explicitly', parents: workspaceRootId },
+            { changeId: workspaceRootId, description: '(empty)', parents: ROOT_ID },
         ]);
     });
 

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -505,6 +505,53 @@ log = "none()"
         expect(rootContent).toBe('new content');
     });
 
+    test('squash command --from --onto creates a new commit on top of specified target', async () => {
+        // Setup: Root -> A -> B
+        const ids = await buildGraph(repo, [
+            { label: 'root', description: 'root' },
+            { label: 'A', parents: ['root'], description: 'A' },
+            {
+                label: 'B',
+                parents: ['root'],
+                description: 'B changes',
+                files: { 'onto-file.txt': 'onto content' },
+            },
+        ]);
+        const aId = ids.A.changeId;
+        const bId = ids.B.changeId;
+
+        // Squash B onto A (creates a new commit with A as parent)
+        await jjService.squashRevision({ revision: bId, ontoRevision: aId });
+
+        // Get the newly created commit on top of A
+        const children = repo.getChildren(aId);
+        expect(children.length).toBeGreaterThan(0);
+        const newCommitId = children[0];
+
+        // Verify the file content was preserved in the new commit on top of A
+        const newCommitContent = repo.getFileContent(newCommitId, 'onto-file.txt');
+        expect(newCommitContent).toBe('onto content');
+
+        // Verify its parent is A
+        const parents = repo.getParents(newCommitId);
+        expect(parents).toContain(aId);
+    });
+
+    test('squashRevision throws error when revision equals intoRevision or ontoRevision', async () => {
+        await expect(jjService.squashRevision({ revision: 'rev1', intoRevision: 'rev1' })).rejects.toThrow(
+            'Cannot squash revision into or onto itself.',
+        );
+        await expect(jjService.squashRevision({ revision: 'rev1', ontoRevision: 'rev1' })).rejects.toThrow(
+            'Cannot squash revision into or onto itself.',
+        );
+    });
+
+    test('squashRevision throws error when both intoRevision and ontoRevision are specified', async () => {
+        await expect(
+            jjService.squashRevision({ revision: 'rev1', intoRevision: 'rev2', ontoRevision: 'rev3' }),
+        ).rejects.toThrow('Cannot specify both intoRevision and ontoRevision.');
+    });
+
     test('squash without paths squashes entire commit', async () => {
         // Setup: Parent -> Child
         await buildGraph(repo, [
@@ -828,6 +875,29 @@ log = "none()"
         const logs = repo.getLog('all()', 'change_id ++ " " ++ description').split('\n');
         const duplicates = logs.filter((l) => l.includes('original'));
         expect(duplicates.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('duplicate command with onto creates copy with target as parent', async () => {
+        repo.describe('target-parent');
+        const targetId = repo.getChangeId('@');
+        repo.new(['root()']);
+        repo.describe('to-duplicate');
+        const sourceId = repo.getChangeId('@');
+
+        await jjService.duplicate(sourceId, { onto: targetId });
+
+        const logs = repo.getLog('all()', 'change_id ++ " " ++ description').split('\n');
+        const duplicates = logs.filter((l) => l.includes('to-duplicate'));
+        expect(duplicates.length).toBeGreaterThanOrEqual(2);
+
+        // Find the duplicate changeId (not equal to sourceId)
+        const duplicateEntry = duplicates.find((l) => !l.startsWith(sourceId));
+        expect(duplicateEntry).toBeDefined();
+        if (duplicateEntry) {
+            const dupChangeId = duplicateEntry.split(' ')[0];
+            const parents = repo.getParents(dupChangeId);
+            expect(parents).toContain(targetId);
+        }
     });
 
     test('abandon command removes revision', async () => {

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -6,6 +6,7 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { match, P } from 'ts-pattern';
 
 const tempDirs = new Set<string>();
 const testXdgConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), 'jj-view-test-xdg-'));
@@ -532,6 +533,153 @@ export class TestRepo {
             ops.push({ id, description });
         }
         return ops;
+    }
+
+    expectTree(expected: ExpectedTreeItem[]): void {
+        expectTree(this, expected);
+    }
+}
+
+export const ROOT_ID = 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+
+export interface TreeEntrySpec {
+    changeId?: string;
+    description: string;
+    parents?: string | string[];
+    files?: Record<string, string>;
+    isWorkingCopy?: boolean;
+}
+
+export interface CustomAsymmetricMatcher {
+    asymmetricMatch?(other: string): boolean;
+    [key: string]: string | boolean | RegExp | ((other: string) => boolean) | undefined;
+}
+
+export type ExpectedTreeItem = string | TreeEntrySpec | RegExp | CustomAsymmetricMatcher;
+
+function matchesLine(exp: ExpectedTreeItem, act: string): boolean {
+    return match(exp)
+        .with(P.string, (str) => {
+            if (str.includes('*')) {
+                const escaped = str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '[a-z0-9]+');
+                return new RegExp(`^${escaped}$`).test(act);
+            }
+            return act === str;
+        })
+        .with(P.instanceOf(RegExp), (r) => r.test(act))
+        .with(
+            P.when((val): val is CustomAsymmetricMatcher =>
+                Boolean(
+                    val &&
+                        typeof val === 'object' &&
+                        'asymmetricMatch' in val &&
+                        typeof (val as CustomAsymmetricMatcher).asymmetricMatch === 'function',
+                ),
+            ),
+            (matcher) => matcher.asymmetricMatch?.(act) ?? false,
+        )
+        .otherwise(() => String(exp) === act);
+}
+
+function getExpectedLine(item: ExpectedTreeItem): ExpectedTreeItem {
+    return match(item)
+        .with(P.string, (s) => s)
+        .with(P.instanceOf(RegExp), (r) => r)
+        .with({ description: P.string }, (spec) => {
+            const changeId = spec.changeId ?? '*';
+            const p = Array.isArray(spec.parents) ? spec.parents.join(',') : spec.parents || '';
+            const prefix = spec.isWorkingCopy ? '@ ' : '';
+            return `${prefix}${changeId} [${p}] ${spec.description}`;
+        })
+        .otherwise(() => item);
+}
+
+function fetchActualTree(repo: TestRepo): string[] {
+    const template =
+        'if(current_working_copy, "@ ", "") ++ change_id ++ " [" ++ parents.map(|p| p.change_id()).join(",") ++ "] " ++ if(description, description.first_line(), "(empty)") ++ "\\n"';
+    const log = repo.getLog('all()', template);
+    return log
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0 && !l.startsWith('zzzzzzzz'));
+}
+
+function verifyTreeLines(expectedLines: ExpectedTreeItem[], actualLines: string[]): void {
+    if (actualLines.length !== expectedLines.length) {
+        throw new Error(`Length mismatch: expected ${expectedLines.length} lines, got ${actualLines.length}`);
+    }
+
+    for (let i = 0; i < expectedLines.length; i++) {
+        const exp = expectedLines[i];
+        const act = actualLines[i];
+        if (!matchesLine(exp, act)) {
+            throw new Error(`Line ${i} mismatch: expected "${String(exp)}", got "${act}"`);
+        }
+    }
+}
+
+function verifyEntryFiles(repo: TestRepo, item: ExpectedTreeItem, actualLine: string): void {
+    const files = match(item)
+        .with({ files: P.select(P.not(P.nullish)) }, (f) => f)
+        .otherwise(() => undefined);
+
+    if (!files) {
+        return;
+    }
+
+    const matchResult = actualLine.match(/^(?:@\s+)?([a-z0-9]+)\s+\[/);
+    const actualChangeId = matchResult
+        ? matchResult[1]
+        : match(item)
+              .with({ changeId: P.select(P.string) }, (id) => id)
+              .otherwise(() => undefined);
+
+    if (!actualChangeId || actualChangeId === '*') {
+        return;
+    }
+
+    for (const [filePath, expectedContent] of Object.entries(files)) {
+        const actualContent = repo.getFileContent(actualChangeId, filePath);
+        if (actualContent !== expectedContent) {
+            throw new Error(
+                `File content mismatch for ${filePath} at change ${actualChangeId}: expected "${expectedContent}", got "${actualContent}"`,
+            );
+        }
+    }
+}
+
+function formatTreeLine(item: ExpectedTreeItem): string {
+    return match(item)
+        .with(P.string, (s) => s)
+        .with(P.instanceOf(RegExp), (r) => String(r))
+        .with({ description: P.string }, (spec) => {
+            const changeId = spec.changeId ?? '*';
+            const p = Array.isArray(spec.parents) ? spec.parents.join(',') : spec.parents || '';
+            const prefix = spec.isWorkingCopy ? '@ ' : '';
+            return `${prefix}${changeId} [${p}] ${spec.description}`;
+        })
+        .otherwise((val) => String(val));
+}
+
+/**
+ * Asserts that the repo log matches the expected structure, and optionally verifies file contents.
+ */
+export function expectTree(repo: TestRepo, expected: ExpectedTreeItem[]): void {
+    const expectedLines = expected.map(getExpectedLine);
+    const actualLines = fetchActualTree(repo);
+
+    try {
+        verifyTreeLines(expectedLines, actualLines);
+
+        for (let i = 0; i < expected.length; i++) {
+            verifyEntryFiles(repo, expected[i], actualLines[i]);
+        }
+    } catch (err: unknown) {
+        const lastError = err as Error;
+        const formatTree = (tree: ExpectedTreeItem[]) => tree.map((line) => `  ${formatTreeLine(line)}`).join('\n');
+        throw new Error(
+            `expectTree failed (${lastError.message})\n\nExpected Tree:\n${formatTree(expectedLines)}\n\nActual Tree:\n${formatTree(actualLines)}`,
+        );
     }
 }
 

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -336,8 +336,157 @@ suite('Webview Commands End-to-End Integration Test', () => {
             },
         });
 
-        // 4. Verify B's parent is now A
+        // Verify B's parent is now A
         const parents = repo.getParents(idB);
         assert.strictEqual(parents[0], idA, 'B should be rebased onto A');
+    });
+
+    test('Squash commit (into) squashes source into target', async () => {
+        repo.describe('Target A');
+        const idA = repo.getChangeId('@');
+
+        repo.new([idA]);
+        repo.describe('Source B');
+        const idB = repo.getChangeId('@');
+
+        await messageHandler({
+            type: 'squashCommit',
+            payload: {
+                sourceChangeId: idB,
+                targetChangeId: idA,
+                mode: 'into',
+            },
+        });
+
+        const logOutput = repo.log();
+        assert.ok(logOutput.includes('Target A'), 'Target A should exist');
+        assert.ok(!logOutput.includes(idB), 'Source B changeId should be abandoned');
+    });
+
+    test('Squash commit (onto) squashes source onto target (creating commit on top of target)', async () => {
+        repo.describe('Target A');
+        const idA = repo.getChangeId('@');
+
+        repo.new(['root()']);
+        repo.describe('Source B');
+        const idB = repo.getChangeId('@');
+
+        await messageHandler({
+            type: 'squashCommit',
+            payload: {
+                sourceChangeId: idB,
+                targetChangeId: idA,
+                mode: 'onto',
+            },
+        });
+
+        const logOutput = repo.log();
+        assert.ok(logOutput.includes('Target A'), 'Target A should exist');
+    });
+
+    test('Duplicate commit duplicates onto target', async () => {
+        repo.describe('Target A');
+        const idA = repo.getChangeId('@');
+
+        repo.new(['root()']);
+        repo.describe('Source B');
+        const idB = repo.getChangeId('@');
+
+        await messageHandler({
+            type: 'duplicateCommit',
+            payload: {
+                sourceChangeId: idB,
+                targetChangeId: idA,
+            },
+        });
+
+        const logOutput = repo.log();
+        assert.ok(logOutput.includes('Source B'), 'Duplicated commit should exist');
+    });
+
+    test('Merge commit creates revision with both parents', async () => {
+        repo.describe('Parent A');
+        const idA = repo.getChangeId('@');
+
+        repo.new(['root()']);
+        repo.describe('Parent B');
+        const idB = repo.getChangeId('@');
+
+        await messageHandler({
+            type: 'mergeCommit',
+            payload: {
+                sourceChangeId: idB,
+                targetChangeId: idA,
+            },
+        });
+
+        const parents = repo.getParents('@');
+        assert.strictEqual(parents.length, 2, 'New working copy should have 2 parents');
+        assert.ok(parents.includes(idA), 'Should include Parent A');
+        assert.ok(parents.includes(idB), 'Should include Parent B');
+    });
+
+    test('Squash commit (into) with identical source and target is a no-op', async () => {
+        repo.describe('Commit A');
+        const idA = repo.getChangeId('@');
+        const initialLog = repo.log();
+
+        await messageHandler({
+            type: 'squashCommit',
+            payload: {
+                sourceChangeId: idA,
+                targetChangeId: idA,
+                mode: 'into',
+            },
+        });
+
+        const finalLog = repo.log();
+        assert.strictEqual(
+            finalLog,
+            initialLog,
+            'Repo log should remain unchanged for squashCommit with identical source and target',
+        );
+    });
+
+    test('Duplicate commit with identical source and target is a no-op', async () => {
+        repo.describe('Source A');
+        const idA = repo.getChangeId('@');
+        const initialLog = repo.log();
+
+        await messageHandler({
+            type: 'duplicateCommit',
+            payload: {
+                sourceChangeId: idA,
+                targetChangeId: idA,
+            },
+        });
+
+        const finalLog = repo.log();
+        assert.strictEqual(
+            finalLog,
+            initialLog,
+            'Repo log should remain unchanged for duplicateCommit with identical source and target',
+        );
+    });
+
+    test('Merge commit with missing sourceChangeId is a no-op', async () => {
+        repo.describe('Target A');
+        const idA = repo.getChangeId('@');
+        const initialLog = repo.log();
+
+        await messageHandler({
+            type: 'mergeCommit',
+            payload: {
+                sourceChangeId: '',
+                targetChangeId: idA,
+            },
+        });
+
+        const finalLog = repo.log();
+        assert.strictEqual(
+            finalLog,
+            initialLog,
+            'Repo log should remain unchanged for mergeCommit with missing sourceChangeId',
+        );
     });
 });

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -19,6 +19,7 @@ import { BookmarkPill } from './components/Bookmark';
 import { CommitDetails } from './components/CommitDetails';
 import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
+import { useDragModifiers } from './hooks/useDragModifiers';
 import { snapToCursorLeft } from './utils/modifiers';
 import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
 
@@ -62,7 +63,7 @@ const App: React.FC = () => {
 
     // Drag State
     const [activeDragItem, setActiveDragItem] = React.useState<DragItem | null>(null);
-    const [isCtrlPressed, setIsCtrlPressed] = React.useState(false);
+    const { activeModifier, resetKeys } = useDragModifiers();
 
     // Configure sensors with activation constraint to prevent accidental drags on click
     const sensors = useSensors(
@@ -81,10 +82,6 @@ const App: React.FC = () => {
 
     React.useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Control' || e.key === 'Meta') {
-                setIsCtrlPressed(true);
-            }
-
             // Escape to deselect
             if (e.key === 'Escape') {
                 setSelectedCommitIds(new Set());
@@ -97,18 +94,11 @@ const App: React.FC = () => {
                 });
             }
         };
-        const handleKeyUp = (e: KeyboardEvent) => {
-            if (e.key === 'Control' || e.key === 'Meta') {
-                setIsCtrlPressed(false);
-            }
-        };
 
         window.addEventListener('keydown', handleKeyDown);
-        window.addEventListener('keyup', handleKeyUp);
 
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
-            window.removeEventListener('keyup', handleKeyUp);
         };
     }, []);
 
@@ -302,75 +292,86 @@ const App: React.FC = () => {
         setActiveDragItem(event.active.data.current as DragItem);
     };
 
+    const handleDragCancel = () => {
+        setActiveDragItem(null);
+        resetKeys();
+    };
+
     const handleDragEnd = (event: DragEndEvent) => {
         const { active, over } = event;
         setActiveDragItem(null);
 
-        if (!over || active.id === over.id || !active.data.current || !over.data.current) {
-            return;
-        }
+        try {
+            if (!over || active.id === over.id || !active.data.current || !over.data.current) {
+                return;
+            }
 
-        const activeType = (active.data.current as DragItem).type;
+            const activeType = (active.data.current as DragItem).type;
 
-        if (activeType === 'bookmark') {
-            // bookmark-NAME -> NAME
-            const bookmarkName = (active.data.current as DragItem & { type: 'bookmark' }).name;
-            const bookmarkRemote = (active.data.current as DragItem & { type: 'bookmark' }).remote;
-            // commit-ID -> ID
-            const targetChangeId = over.data.current.changeId;
+            if (activeType === 'bookmark') {
+                // bookmark-NAME -> NAME
+                const bookmarkName = (active.data.current as DragItem & { type: 'bookmark' }).name;
+                const bookmarkRemote = (active.data.current as DragItem & { type: 'bookmark' }).remote;
+                // commit-ID -> ID
+                const targetChangeId = over.data.current.changeId;
 
-            // Optimistic Update
-            setCommits((prevCommits) => {
-                // Check if move is actually needed (and find source)
-                const sourceCommit = prevCommits.find((c) =>
-                    c.bookmarks?.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote),
-                );
+                // Optimistic Update
+                setCommits((prevCommits) => {
+                    // Check if move is actually needed (and find source)
+                    const sourceCommit = prevCommits.find((c) =>
+                        c.bookmarks?.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote),
+                    );
 
-                if (!sourceCommit || sourceCommit.change_id === targetChangeId) {
-                    return prevCommits;
+                    if (!sourceCommit || sourceCommit.change_id === targetChangeId) {
+                        return prevCommits;
+                    }
+
+                    return prevCommits.map((commit) => {
+                        let newBookmarks = commit.bookmarks || [];
+
+                        // Remove from source
+                        if (newBookmarks.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote)) {
+                            newBookmarks = newBookmarks.filter(
+                                (b) => !(b.name === bookmarkName && b.remote === bookmarkRemote),
+                            );
+                        }
+
+                        // Add to target
+                        if (commit.change_id === targetChangeId) {
+                            newBookmarks = [...newBookmarks, { name: bookmarkName, remote: bookmarkRemote }];
+                        }
+
+                        // Return new object if changed
+                        if (newBookmarks !== commit.bookmarks) {
+                            const updated = { ...commit, bookmarks: newBookmarks };
+                            return updated;
+                        }
+                        return commit;
+                    });
+                });
+
+                // Send to extension
+                vscode.postMessage({
+                    type: 'moveBookmark',
+                    payload: { bookmark: bookmarkName, targetChangeId },
+                });
+            } else if (activeType === 'commit') {
+                if (over.data.current.type !== 'commit') {
+                    return;
+                }
+                const sourceChangeId = (active.data.current as DragItem & { type: 'commit' }).changeId;
+                const targetChangeId = (over.data.current as { changeId?: string }).changeId;
+
+                // Self-target drop safeguard or invalid target
+                if (!targetChangeId || sourceChangeId === targetChangeId) {
+                    return;
                 }
 
-                return prevCommits.map((commit) => {
-                    let newBookmarks = commit.bookmarks || [];
-
-                    // Remove from source
-                    if (newBookmarks.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote)) {
-                        newBookmarks = newBookmarks.filter(
-                            (b) => !(b.name === bookmarkName && b.remote === bookmarkRemote),
-                        );
-                    }
-
-                    // Add to target
-                    if (commit.change_id === targetChangeId) {
-                        newBookmarks = [...newBookmarks, { name: bookmarkName, remote: bookmarkRemote }];
-                    }
-
-                    // Return new object if changed
-                    if (newBookmarks !== commit.bookmarks) {
-                        const updated = { ...commit, bookmarks: newBookmarks };
-                        return updated;
-                    }
-                    return commit;
-                });
-            });
-
-            // Send to extension
-            vscode.postMessage({
-                type: 'moveBookmark',
-                payload: { bookmark: bookmarkName, targetChangeId },
-            });
-        } else if (activeType === 'commit') {
-            const sourceChangeId = (active.data.current as DragItem & { type: 'commit' }).changeId;
-            const targetChangeId = over.data.current.changeId;
-
-            // Detect modifier keys from the activator event or our state
-            // Prefer tracking state for consistency with UI
-            const mode = isCtrlPressed ? 'revision' : 'source';
-
-            vscode.postMessage({
-                type: 'rebaseCommit',
-                payload: { sourceChangeId, targetChangeId, mode },
-            });
+                const message = activeModifier.buildMessagePayload(sourceChangeId, targetChangeId);
+                vscode.postMessage(message);
+            }
+        } finally {
+            resetKeys();
         }
     };
 
@@ -419,6 +420,7 @@ const App: React.FC = () => {
                 collisionDetection={pointerWithin}
                 onDragStart={handleDragStart}
                 onDragEnd={handleDragEnd}
+                onDragCancel={handleDragCancel}
             >
                 {/* biome-ignore lint/a11y/noStaticElementInteractions: Background click to deselect is a common pattern in graph views */}
                 {/* biome-ignore lint/a11y/useKeyWithClickEvents: Escape key handles keyboard deselection separately */}
@@ -446,6 +448,7 @@ const App: React.FC = () => {
                         graphLabelAlignment={graphLabelAlignment}
                         theme={theme}
                         hiddenActions={hiddenActions}
+                        activeModifier={activeModifier}
                     />
                 </div>
                 {/*
@@ -469,7 +472,7 @@ const App: React.FC = () => {
                         ) : activeDragItem.type === 'commit' ? (
                             <CommitDragPreview
                                 commit={activeDragItem}
-                                isCtrlPressed={isCtrlPressed}
+                                activeModifier={activeModifier}
                                 minChangeIdLength={minChangeIdLength}
                             />
                         ) : null

--- a/src/webview/components/CommitDragPreview.tsx
+++ b/src/webview/components/CommitDragPreview.tsx
@@ -5,20 +5,22 @@
 import type * as React from 'react';
 import type { JjLogEntry } from '../../jj-types';
 import { getChangeIdDisplayLength, shortenChangeId } from '../../utils/jj-utils';
+import { BUILT_IN_MODIFIERS, type DragActionModifier, REBASE_BRANCH_MODIFIER } from '../utils/drag-modifiers';
+
+const AVAILABLE_MODIFIERS = BUILT_IN_MODIFIERS.filter((m) => m.id !== 'rebase-branch');
+// Put 2 longest modifiers (Squash Onto, Squash Into) in row 1, remaining 3 (Duplicate, Merge, Rebase Rev) in row 2
+const MODIFIER_ROW1 = AVAILABLE_MODIFIERS.slice(0, 2);
+const MODIFIER_ROW2 = AVAILABLE_MODIFIERS.slice(2);
 
 export const CommitDragPreview: React.FC<{
     commit: JjLogEntry;
-    isCtrlPressed: boolean;
+    activeModifier?: DragActionModifier;
     minChangeIdLength: number;
-}> = ({ commit, isCtrlPressed, minChangeIdLength }) => {
+}> = ({ commit, activeModifier: activeModifierProp, minChangeIdLength }) => {
     // Mode Logic
-    const mode = isCtrlPressed ? 'revision' : 'source';
-    const isRevisionMode = mode === 'revision';
+    const activeModifier = activeModifierProp || REBASE_BRANCH_MODIFIER;
 
-    // Theme Colors
-    const branchColor = 'var(--vscode-charts-blue)';
-    const revisionColor = 'var(--vscode-charts-orange)';
-    const activeColor = isRevisionMode ? revisionColor : branchColor;
+    const activeColor = activeModifier.accentColor;
 
     // ID Formatting
     const fullId = commit.commit_id || '';
@@ -26,106 +28,217 @@ export const CommitDragPreview: React.FC<{
     const shortId = commit.change_id_shortest || shortenChangeId(fullId, idDisplayLength);
     const remainderId = fullId.substring(shortId.length, idDisplayLength);
 
-    return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'row',
-                backgroundColor: 'var(--vscode-editor-background)',
-                border: `1px solid var(--vscode-focusBorder)`, // Solid border
-                borderRadius: '4px',
-                boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-                width: '280px', // Fixed manageable width
-                height: '50px', // Compact height
-                overflow: 'hidden',
-                fontFamily: 'var(--vscode-editor-font-family)',
-                fontSize: 'var(--vscode-editor-font-size)',
-                // Optimization: Remove transitions to prevent fighting with dnd-kit
-                transition: 'none',
-                // Optimization: Promote to layer
-                willChange: 'transform',
-                // Optimization: Don't block mouse events so we can detect what's underneath
-                pointerEvents: 'none',
-            }}
-        >
-            {/* Left Handle */}
-            <div
+    const renderModifierBadge = (modifier: DragActionModifier) => {
+        const isCurrent = activeModifier.id === modifier.id;
+        return (
+            <span
+                key={modifier.id}
                 style={{
-                    width: '6px',
-                    backgroundColor: activeColor,
-                    height: '100%',
-                    flexShrink: 0,
-                }}
-            />
-
-            {/* Content Area */}
-            <div
-                style={{
-                    flex: 1,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    padding: '0 10px',
-                    minWidth: 0, // Enable truncation
+                    ...styles.badgeContainer,
+                    backgroundColor: isCurrent
+                        ? 'var(--vscode-keybindingTable-headerBackground, rgba(255, 255, 255, 0.12))'
+                        : 'transparent',
+                    border: isCurrent ? `1px solid ${activeColor}` : '1px solid transparent',
                 }}
             >
-                {/* Row 1: Description (Primary) */}
-                <div
+                <kbd
                     style={{
-                        fontWeight: 'bold',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        marginBottom: '2px',
-                        color: 'var(--vscode-foreground)',
+                        ...styles.badgeKbd,
+                        color: isCurrent ? activeColor : 'var(--vscode-keybindingLabel-foreground, inherit)',
+                        fontWeight: isCurrent ? 'bold' : 'normal',
                     }}
                 >
-                    {commit.description || '(no description)'}
-                </div>
+                    {modifier.shortcutHint}
+                </kbd>
+                <span
+                    style={{
+                        ...styles.badgeLabel,
+                        color: isCurrent ? activeColor : 'var(--vscode-descriptionForeground)',
+                        fontWeight: isCurrent ? 'bold' : 'normal',
+                    }}
+                >
+                    {modifier.shortLabel || modifier.label}
+                </span>
+            </span>
+        );
+    };
 
-                {/* Row 2: ID + Status (Secondary) */}
+    return (
+        <div style={styles.card}>
+            <div style={styles.contentRow}>
+                {/* Left Handle */}
                 <div
                     style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        fontSize: '0.9em',
-                        color: 'var(--vscode-descriptionForeground)',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
+                        ...styles.leftHandle,
+                        backgroundColor: activeColor,
                     }}
-                >
-                    {/* ID */}
-                    <span
-                        style={{
-                            fontFamily: 'var(--vscode-editor-font-family)',
-                            marginRight: '8px',
-                            display: 'flex',
-                        }}
-                    >
-                        <span
-                            style={{ color: 'var(--vscode-gitDecoration-addedResourceForeground)', fontWeight: 'bold' }}
-                        >
-                            {shortId}
+                />
+
+                {/* Content Area */}
+                <div style={styles.contentArea}>
+                    {/* Row 1: Description (Primary) */}
+                    <div style={styles.descriptionRow}>{commit.description || '(no description)'}</div>
+
+                    {/* Row 2: ID + Status */}
+                    <div style={styles.idStatusRow}>
+                        {/* ID */}
+                        <span style={styles.idSpan}>
+                            <span style={styles.shortId}>{shortId}</span>
+                            <span style={styles.remainderId}>{remainderId}</span>
                         </span>
-                        <span style={{ opacity: 0.7 }}>{remainderId}</span>
-                    </span>
 
-                    {/* Separator */}
-                    <span style={{ marginRight: '8px', opacity: 0.5 }}>•</span>
+                        {/* Separator */}
+                        <span style={styles.dotSeparator}>•</span>
 
-                    {/* Combined Status Text */}
-                    <span
-                        style={{
-                            color: activeColor,
-                            fontWeight: 500,
-                            display: 'flex',
-                            alignItems: 'center',
-                        }}
-                    >
-                        {isRevisionMode ? 'Rebase revision only' : 'Rebase branch (Ctrl for rev)'}
+                        {/* Action Label */}
+                        <span style={{ ...styles.actionLabel, color: activeColor }}>{activeModifier.label}</span>
+                    </div>
+                </div>
+            </div>
+
+            {/* Bottom Shortcut Hint Footer */}
+            <div style={styles.footer}>
+                <div style={styles.footerDescriptionRow}>
+                    <span>
+                        <strong style={{ color: activeColor }}>{activeModifier.shortcutHint}</strong>:{' '}
+                        {activeModifier.description}
                     </span>
+                </div>
+                <div style={styles.badgeMatrix}>
+                    <div style={styles.badgeRow}>{MODIFIER_ROW1.map(renderModifierBadge)}</div>
+                    <div style={styles.badgeRow}>{MODIFIER_ROW2.map(renderModifierBadge)}</div>
                 </div>
             </div>
         </div>
     );
+};
+
+const styles: Record<string, React.CSSProperties> = {
+    card: {
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: 'var(--vscode-editor-background)',
+        border: '1px solid var(--vscode-focusBorder)',
+        borderRadius: '4px',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+        width: '300px',
+        overflow: 'hidden',
+        fontFamily: 'var(--vscode-editor-font-family)',
+        fontSize: 'var(--vscode-editor-font-size)',
+        transition: 'none',
+        willChange: 'transform',
+        pointerEvents: 'none',
+    },
+    contentRow: {
+        display: 'flex',
+        flexDirection: 'row',
+        height: '48px',
+    },
+    leftHandle: {
+        width: '6px',
+        height: '100%',
+        flexShrink: 0,
+    },
+    contentArea: {
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: '0 10px',
+        minWidth: 0,
+    },
+    descriptionRow: {
+        fontWeight: 'bold',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        marginBottom: '2px',
+        color: 'var(--vscode-foreground)',
+    },
+    idStatusRow: {
+        display: 'flex',
+        alignItems: 'center',
+        fontSize: '0.9em',
+        color: 'var(--vscode-descriptionForeground)',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+    },
+    idSpan: {
+        fontFamily: 'var(--vscode-editor-font-family)',
+        marginRight: '8px',
+        display: 'flex',
+    },
+    shortId: {
+        color: 'var(--vscode-gitDecoration-addedResourceForeground)',
+        fontWeight: 'bold',
+    },
+    remainderId: {
+        opacity: 0.7,
+    },
+    dotSeparator: {
+        marginRight: '8px',
+        opacity: 0.5,
+    },
+    actionLabel: {
+        fontWeight: 600,
+        display: 'flex',
+        alignItems: 'center',
+    },
+    footer: {
+        backgroundColor: 'var(--vscode-editor-lineHighlightBackground, rgba(255,255,255,0.05))',
+        borderTop: '1px solid var(--vscode-widget-border, rgba(255,255,255,0.1))',
+        padding: '6px 8px',
+        fontSize: '0.75em',
+        color: 'var(--vscode-descriptionForeground)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+        fontFamily: 'var(--vscode-editor-font-family)',
+    },
+    footerDescriptionRow: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    },
+    badgeMatrix: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '4px',
+        fontSize: '0.95em',
+        backgroundColor: 'var(--vscode-sideBar-background, var(--vscode-editorWidget-background, rgba(0, 0, 0, 0.2)))',
+        border: '1px solid var(--vscode-widget-border, rgba(255, 255, 255, 0.08))',
+        borderRadius: '3px',
+        padding: '4px 6px',
+        marginTop: '2px',
+        overflow: 'hidden',
+    },
+    badgeRow: {
+        display: 'flex',
+        gap: '6px',
+        alignItems: 'center',
+        overflow: 'hidden',
+    },
+    badgeContainer: {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '3px',
+        padding: '1px 4px',
+        borderRadius: '3px',
+        whiteSpace: 'nowrap',
+    },
+    badgeKbd: {
+        fontSize: '0.85em',
+        fontFamily: 'var(--vscode-editor-font-family)',
+        padding: '0 3px',
+        borderRadius: '3px',
+        backgroundColor: 'var(--vscode-keybindingLabel-background, rgba(0, 0, 0, 0.2))',
+        border: '1px solid var(--vscode-keybindingLabel-border, rgba(255, 255, 255, 0.2))',
+        whiteSpace: 'nowrap',
+    },
+    badgeLabel: {
+        whiteSpace: 'nowrap',
+    },
 };

--- a/src/webview/components/CommitGraph.tsx
+++ b/src/webview/components/CommitGraph.tsx
@@ -15,6 +15,7 @@ import {
     ROW_HEIGHT_NORMAL,
 } from '../layout-constants';
 import { computeCompactRowMaxX, computeGap, computeGraphAreaWidth, computeMaxShortestIdLength } from '../layout-utils';
+import type { DragActionModifier } from '../utils/drag-modifiers';
 import { CommitNode } from './CommitNode';
 import { GraphRail } from './GraphRail';
 
@@ -26,6 +27,7 @@ interface CommitGraphProps {
     graphLabelAlignment?: string;
     theme?: string;
     hiddenActions?: Set<CommitAction>;
+    activeModifier?: DragActionModifier;
 }
 
 export const CommitGraph: React.FC<CommitGraphProps> = ({
@@ -36,6 +38,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
     graphLabelAlignment = 'aligned',
     theme = 'default',
     hiddenActions,
+    activeModifier,
 }) => {
     // Total graph width calculation
     // Dynamic sizing based on font
@@ -191,6 +194,7 @@ export const CommitGraph: React.FC<CommitGraphProps> = ({
                                 hasImmutableSelection={hasImmutableSelection}
                                 idDisplayLength={maxShortestIdLength}
                                 hiddenActions={hiddenActions}
+                                activeModifier={activeModifier}
                             />
                         </div>
                     );

--- a/src/webview/components/CommitNode.tsx
+++ b/src/webview/components/CommitNode.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import type { ActionPayload, CommitAction, JjBookmark, JjLogEntry } from '../../jj-types';
 import { COMMIT_ROW_PADDING_LEFT } from '../layout-constants';
 import { computeCommitActions } from '../utils/commit-utils';
+import type { DragActionModifier } from '../utils/drag-modifiers';
 import { BookmarkPill, DraggableBookmark, TagPill, WorkspacePill } from './Bookmark';
 import { IconButton } from './IconButton';
 
@@ -23,6 +24,7 @@ interface CommitNodeProps {
     hasImmutableSelection: boolean;
     idDisplayLength: number;
     hiddenActions?: Set<CommitAction>;
+    activeModifier?: DragActionModifier;
 }
 
 export const CommitNode: React.FC<CommitNodeProps> = ({
@@ -34,6 +36,7 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
     hasImmutableSelection,
     idDisplayLength,
     hiddenActions = new Set(),
+    activeModifier,
 }) => {
     const isImmutable = commit.is_immutable || false;
     const isCurrentWorkingCopy = commit.is_current_working_copy;
@@ -100,12 +103,11 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
     // 2. Drop Logic (Additive)
     if (isOver) {
         const activeType = active?.data?.current?.type;
-        // Only show row outline for commit drops (rebase).
+        // Only show row outline for commit drops.
         // Bookmarks show a specific ghost pill instead.
         if (activeType === 'commit') {
-            // Use box-shadow 'inset' to create a border effect that renders reliably over backgrounds
-            // Using list.activeSelectionForeground often ensures high contrast
-            outline = '2px dashed var(--vscode-list-activeSelectionForeground)';
+            const dropColor = activeModifier?.accentColor || 'var(--vscode-list-activeSelectionForeground)';
+            outline = `2px dashed ${dropColor}`;
         }
     }
 
@@ -411,6 +413,23 @@ export const CommitNode: React.FC<CommitNodeProps> = ({
                         {commit.tags?.map((tag: string) => (
                             <TagPill key={tag} tag={tag} />
                         ))}
+
+                        {isOver && active?.data?.current?.type === 'commit' && (
+                            <span
+                                style={{
+                                    backgroundColor: activeModifier?.accentColor || 'var(--vscode-charts-blue)',
+                                    color: 'var(--vscode-editor-background, #fff)',
+                                    fontSize: '0.8em',
+                                    fontWeight: 'bold',
+                                    padding: '1px 6px',
+                                    borderRadius: '3px',
+                                    marginLeft: '8px',
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {activeModifier?.badgeText || 'Drop here'}
+                            </span>
+                        )}
 
                         {isOver &&
                             active?.data?.current?.type === 'bookmark' &&

--- a/src/webview/hooks/useDragModifiers.ts
+++ b/src/webview/hooks/useDragModifiers.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as React from 'react';
+import type { PressedKeysState } from '../utils/drag-modifiers';
+import { resolveActiveModifier } from '../utils/drag-modifiers';
+
+const initialKeys: PressedKeysState = {
+    r: false,
+    shift: false,
+    s: false,
+    d: false,
+    m: false,
+};
+
+function isEditableElement(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return true;
+    }
+    return !!target.closest('input, textarea, select, [contenteditable="true"]');
+}
+
+function getPressedKeyProperty(e: KeyboardEvent, isPressed: boolean): keyof PressedKeysState | null {
+    // Ignore keydown action shortcuts if the user is typing in an editable field
+    if (isPressed && isEditableElement(e.target)) {
+        return null;
+    }
+
+    if (e.key === 'Shift') {
+        return 'shift';
+    }
+
+    // Ignore single-character action shortcuts if combined with Ctrl, Cmd/Meta, or Alt
+    if (isPressed && (e.ctrlKey || e.metaKey || e.altKey)) {
+        return null;
+    }
+
+    const lower = e.key.toLowerCase();
+    if (lower === 'r') {
+        return 'r';
+    }
+    if (lower === 's') {
+        return 's';
+    }
+    if (lower === 'd') {
+        return 'd';
+    }
+    if (lower === 'm') {
+        return 'm';
+    }
+    return null;
+}
+
+export function useDragModifiers() {
+    const [pressedKeys, setPressedKeys] = React.useState<PressedKeysState>(initialKeys);
+
+    const resetKeys = React.useCallback(() => {
+        setPressedKeys(initialKeys);
+    }, []);
+
+    React.useEffect(() => {
+        const handleKeyEvent = (e: KeyboardEvent, isPressed: boolean) => {
+            const prop = getPressedKeyProperty(e, isPressed);
+            if (!prop) {
+                return;
+            }
+
+            setPressedKeys((prev) => {
+                if (prev[prop] === isPressed) {
+                    return prev;
+                }
+                return { ...prev, [prop]: isPressed };
+            });
+        };
+
+        const handleKeyDown = (e: KeyboardEvent) => handleKeyEvent(e, true);
+        const handleKeyUp = (e: KeyboardEvent) => handleKeyEvent(e, false);
+
+        window.addEventListener('keydown', handleKeyDown);
+        window.addEventListener('keyup', handleKeyUp);
+        window.addEventListener('blur', resetKeys);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.removeEventListener('keyup', handleKeyUp);
+            window.removeEventListener('blur', resetKeys);
+        };
+    }, [resetKeys]);
+
+    const activeModifier = React.useMemo(() => resolveActiveModifier(pressedKeys), [pressedKeys]);
+
+    return {
+        pressedKeys,
+        activeModifier,
+        resetKeys,
+    };
+}

--- a/src/webview/utils/drag-modifiers.ts
+++ b/src/webview/utils/drag-modifiers.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface PressedKeysState {
+    r: boolean;
+    shift: boolean;
+    s: boolean;
+    d: boolean;
+    m: boolean;
+}
+
+export type WebviewDragMessage =
+    | { type: 'rebaseCommit'; payload: { sourceChangeId: string; targetChangeId: string; mode: 'source' | 'revision' } }
+    | { type: 'squashCommit'; payload: { sourceChangeId: string; targetChangeId: string; mode: 'into' | 'onto' } }
+    | { type: 'duplicateCommit'; payload: { sourceChangeId: string; targetChangeId?: string } }
+    | { type: 'mergeCommit'; payload: { sourceChangeId: string; targetChangeId: string } };
+
+export interface DragActionModifier {
+    id: string;
+    label: string;
+    shortLabel?: string;
+    description: string;
+    badgeText: string;
+    shortcutHint: string;
+    accentColor: string;
+    priority: number;
+    matches: (keys: PressedKeysState) => boolean;
+    buildMessagePayload: (sourceChangeId: string, targetChangeId?: string) => WebviewDragMessage;
+}
+
+export const REBASE_BRANCH_MODIFIER: DragActionModifier = {
+    id: 'rebase-branch',
+    label: 'Rebase Branch',
+    shortLabel: 'Rebase Branch',
+    description: 'Rebase branch (source & descendants)',
+    badgeText: 'Rebase branch here',
+    shortcutHint: 'Default',
+    accentColor: 'var(--vscode-charts-blue)',
+    priority: 0,
+    matches: () => true,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'rebaseCommit',
+        payload: { sourceChangeId, targetChangeId: targetChangeId || '', mode: 'source' },
+    }),
+};
+
+export const REBASE_REVISION_MODIFIER: DragActionModifier = {
+    id: 'rebase-revision',
+    label: 'Rebase Revision Only',
+    shortLabel: 'Rebase Rev',
+    description: 'Rebase revision only',
+    badgeText: 'Rebase revision here',
+    shortcutHint: 'R',
+    accentColor: 'var(--vscode-charts-orange)',
+    priority: 10,
+    matches: (keys) => keys.r,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'rebaseCommit',
+        payload: { sourceChangeId, targetChangeId: targetChangeId || '', mode: 'revision' },
+    }),
+};
+
+export const SQUASH_INTO_MODIFIER: DragActionModifier = {
+    id: 'squash-into',
+    label: 'Squash Into Target',
+    shortLabel: 'Squash Into',
+    description: 'Squash source commit into target',
+    badgeText: 'Squash into target here',
+    shortcutHint: 'S',
+    accentColor: 'var(--vscode-charts-purple)',
+    priority: 10,
+    matches: (keys) => keys.s && !keys.shift,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'squashCommit',
+        payload: { sourceChangeId, targetChangeId: targetChangeId || '', mode: 'into' },
+    }),
+};
+
+export const SQUASH_ONTO_MODIFIER: DragActionModifier = {
+    id: 'squash-onto',
+    label: 'Squash Onto Target',
+    shortLabel: 'Squash Onto',
+    description: 'Squash source onto target (new commit on top of target)',
+    badgeText: 'Squash onto target here',
+    shortcutHint: 'Shift + S',
+    accentColor: 'var(--vscode-charts-magenta)',
+    priority: 20,
+    matches: (keys) => keys.shift && keys.s,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'squashCommit',
+        payload: { sourceChangeId, targetChangeId: targetChangeId || '', mode: 'onto' },
+    }),
+};
+
+export const DUPLICATE_MODIFIER: DragActionModifier = {
+    id: 'duplicate',
+    label: 'Duplicate Onto Target',
+    shortLabel: 'Duplicate',
+    description: 'Duplicate source commit on top of target',
+    badgeText: 'Duplicate onto target here',
+    shortcutHint: 'D',
+    accentColor: 'var(--vscode-charts-green)',
+    priority: 10,
+    matches: (keys) => keys.d,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'duplicateCommit',
+        payload: targetChangeId ? { sourceChangeId, targetChangeId } : { sourceChangeId },
+    }),
+};
+
+export const MERGE_MODIFIER: DragActionModifier = {
+    id: 'merge',
+    label: 'Merge Revisions',
+    shortLabel: 'Merge',
+    description: 'Create new revision merging source & target',
+    badgeText: 'Merge with target here',
+    shortcutHint: 'M',
+    accentColor: 'var(--vscode-charts-yellow)',
+    priority: 10,
+    matches: (keys) => keys.m,
+    buildMessagePayload: (sourceChangeId, targetChangeId) => ({
+        type: 'mergeCommit',
+        payload: { sourceChangeId, targetChangeId: targetChangeId || '' },
+    }),
+};
+
+const UNSORTED_MODIFIERS: DragActionModifier[] = [
+    SQUASH_ONTO_MODIFIER,
+    SQUASH_INTO_MODIFIER,
+    DUPLICATE_MODIFIER,
+    MERGE_MODIFIER,
+    REBASE_REVISION_MODIFIER,
+    REBASE_BRANCH_MODIFIER,
+];
+
+export const BUILT_IN_MODIFIERS: DragActionModifier[] = [...UNSORTED_MODIFIERS].sort((a, b) => b.priority - a.priority);
+
+export function resolveActiveModifier(keys: PressedKeysState): DragActionModifier {
+    for (const modifier of BUILT_IN_MODIFIERS) {
+        if (modifier.matches(keys)) {
+            return modifier;
+        }
+    }
+    return REBASE_BRANCH_MODIFIER;
+}


### PR DESCRIPTION
Replace the ctrl modifier and expand the list of available modifiers. The drag preview now renders a shortcut matrix displaying active key hints.

Supported shortcuts:

- R: Rebase revision only (excluding descendants)
- S: Squash source commit into target commit
- Shift+S: Squash source commit onto target commit
- D: Duplicate source commit onto target commit
- M: Merge source and target commits into a new revision

Fixes #399