### PR TITLE
fix(commit-details): handle files with spaces and standardize deleted file status

### DIFF
--- a/src/commands/compare-all-files-with-revision.ts
+++ b/src/commands/compare-all-files-with-revision.ts
@@ -33,7 +33,7 @@ export async function compareAllFilesWithRevisionCommand(
         await withDelayedProgress(
             `Comparing ${rev} with all files...`,
             (async (): Promise<void> => {
-                const changes = await jj.getChanges(rev, '@');
+                const changes = await jj.getChangesBetween(rev, '@');
 
                 if (changes.length === 0) {
                     vscode.window.showInformationMessage(`No differences found between ${rev} and working copy.`);

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -66,7 +66,6 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
                     new vscode.ThemeColor('gitDecoration.modifiedResourceForeground'),
                 );
             case 'deleted':
-            case 'removed':
                 return new vscode.FileDecoration(
                     'D',
                     'Deleted',

--- a/src/jj-schemas.ts
+++ b/src/jj-schemas.ts
@@ -30,21 +30,54 @@ export const CommitParentSchema = z.object({
 });
 export type CommitParent = z.infer<typeof CommitParentSchema>;
 
-export const JjStatusEntrySchema = z.object({
+/**
+ * Normalizes backslashes in relative file paths to POSIX forward slashes.
+ */
+export function normalizePath(val: unknown): unknown {
+    if (typeof val === 'string') {
+        return val.replace(/\\/g, '/');
+    }
+    return val;
+}
+
+export const NormalizedPathSchema = z.preprocess(normalizePath, z.string());
+
+export const JjFileChangeSchema = z.object({
     /** The relative path of the file modified. */
-    path: z.string(),
+    path: NormalizedPathSchema,
     /** The old path if the file was renamed or copied. */
-    oldPath: z.string().optional(),
+    oldPath: NormalizedPathSchema.optional(),
     /** The operation type performed on the file. */
-    status: z.enum(['modified', 'added', 'removed', 'renamed', 'copied', 'deleted']),
+    status: z.enum(['modified', 'added', 'renamed', 'copied', 'deleted']),
+    /** Whether the file is currently conflicted. */
+    conflicted: z.boolean().optional(),
+});
+export type JjFileChange = z.infer<typeof JjFileChangeSchema>;
+
+export const JjFileChangeWithStatsSchema = JjFileChangeSchema.extend({
     /** The number of added lines. */
     additions: z.number().optional(),
     /** The number of deleted lines. */
     deletions: z.number().optional(),
-    /** Whether the file is currently conflicted. */
-    conflicted: z.boolean().optional(),
 });
-export type JjStatusEntry = z.infer<typeof JjStatusEntrySchema>;
+export type JjFileChangeWithStats = z.infer<typeof JjFileChangeWithStatsSchema>;
+
+/** Legacy alias for JjFileChangeWithStats */
+export const JjStatusEntrySchema = JjFileChangeWithStatsSchema;
+export type JjStatusEntry = JjFileChangeWithStats;
+
+export const DiffStatEntrySchema = z.object({
+    path: NormalizedPathSchema,
+    additions: z.number().default(0),
+    deletions: z.number().default(0),
+});
+export type DiffStatEntry = z.infer<typeof DiffStatEntrySchema>;
+
+export const ChangesAndStatsOutputSchema = z.object({
+    changes: z.array(JjFileChangeSchema).default([]),
+    stats: z.array(DiffStatEntrySchema).default([]),
+});
+export type ChangesAndStatsOutput = z.infer<typeof ChangesAndStatsOutputSchema>;
 
 /**
  * Metadata retrieved from a code forge about a specific Change/PR.

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -6,10 +6,21 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import type { z } from 'zod';
 import type { IJjTrackedProcess, JjProcessTracker } from './jj-process-tracker';
-import { JjBookmarkSchema, JjLogEntrySchema, JjWorkspaceSchema } from './jj-schemas';
+import {
+    ChangesAndStatsOutputSchema,
+    type DiffStatEntry,
+    JjBookmarkSchema,
+    type JjFileChange,
+    JjFileChangeSchema,
+    type JjFileChangeWithStats,
+    JjLogEntrySchema,
+    JjWorkspaceSchema,
+} from './jj-schemas';
 import {
     BOOKMARK_SCHEMA,
+    buildDiffFileSchema,
     buildLogTemplate,
     CHANGE_ID_EXPR,
     LOG_ENTRY_SCHEMA,
@@ -382,25 +393,7 @@ export class JjService {
             useCachedSnapshot: true,
             label: 'getBookmarks',
         });
-        const trimmed = output.trim();
-        if (!trimmed) {
-            return [];
-        }
-        try {
-            const jsonListString = `[${trimmed.replace(/\r?\n/g, ',')}]`;
-            const parsed = JSON.parse(jsonListString);
-            const validation = JjBookmarkSchema.array().safeParse(parsed);
-            if (!validation.success) {
-                this.logger.error(
-                    `Failed to validate bookmarks JSON: ${validation.error.message}. Raw output: ${output}`,
-                );
-                return [];
-            }
-            return validation.data;
-        } catch (e) {
-            this.logger.error(`Failed to parse bookmarks JSON: ${e}. Raw output: ${output}`);
-            return [];
-        }
+        return this._parseJsonLines(output, JjBookmarkSchema, 'getBookmarks');
     }
 
     async moveBookmark(name: string, toRevision: string): Promise<string> {
@@ -447,34 +440,10 @@ export class JjService {
         }
 
         const output = await this.run('log', args, { useCachedSnapshot: true, label: 'getLog' });
-        const entries: JjLogEntry[] = [];
-        const visibleIds = new Set<string>();
-
-        for (const line of output.trim().split('\n')) {
-            if (!line) {
-                continue;
-            }
-            const jsonStart = line.indexOf('{');
-            if (jsonStart === -1) {
-                continue;
-            }
-            const jsonPart = line.substring(jsonStart);
-            try {
-                const parsed = JSON.parse(jsonPart);
-                const validation = JjLogEntrySchema.safeParse(parsed);
-                if (!validation.success) {
-                    console.error(`Failed to validate log entry: ${validation.error.message}`, line);
-                    continue;
-                }
-                const entry = validation.data;
-                entries.push(entry);
-                visibleIds.add(entry.change_id);
-            } catch (e) {
-                console.error('Failed to parse log entry:', line, e);
-            }
-        }
+        const entries = this._parseJsonLines(output, JjLogEntrySchema, 'getLog');
 
         if (includeNearestVisibleAncestors) {
+            const visibleIds = new Set<string>(entries.map((e) => e.change_id));
             await this._resolveNearestVisibleAncestors(entries, visibleIds, revision);
         }
 
@@ -978,26 +947,7 @@ export class JjService {
             useCachedSnapshot: true,
             label: 'getWorkspaces',
         });
-        const infos: JjWorkspace[] = [];
-        for (const line of output.split('\n')) {
-            const trimmed = line.trim();
-            if (!trimmed) {
-                continue;
-            }
-            try {
-                const parsed = JSON.parse(trimmed);
-                const validation = JjWorkspaceSchema.safeParse(parsed);
-                if (!validation.success) {
-                    console.error(`Failed to validate workspace info: ${validation.error.message}`, line);
-                    continue;
-                }
-                const info = validation.data;
-                infos.push(info);
-            } catch (e) {
-                console.error('Failed to parse workspace info line:', line, e);
-            }
-        }
-        return infos;
+        return this._parseJsonLines(output, JjWorkspaceSchema, 'getWorkspaces');
     }
 
     async getWorkspaceRoot(workspaceName?: string): Promise<string> {
@@ -1090,88 +1040,107 @@ export class JjService {
         return this.run('status', [], { isMutation: true, useCachedSnapshot: false, label: 'status' });
     }
 
-    async getChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {
-        const cacheKey = toRevision ? `${revision}..${toRevision}` : revision;
-        return this._changesCache.getOrFetch(cacheKey, () => this._doGetChanges(revision, toRevision));
+    async getChanges(revision: string): Promise<JjFileChangeWithStats[]> {
+        return this._changesCache.getOrFetch(revision, () => this._doGetChanges(revision));
     }
 
-    private async _doGetChanges(revision: string, toRevision?: string): Promise<JjStatusEntry[]> {
-        const args = ['--git'];
-        if (toRevision) {
-            args.push('--from', revision, '--to', toRevision);
-        } else {
-            args.push('-r', revision);
-        }
-        const output = await this.run('diff', args, { useCachedSnapshot: true, label: 'getChanges' });
-        const entries: JjStatusEntry[] = [];
+    /**
+     * Retrieves the file changes between two revisions (`fromRevision` and `toRevision`).
+     */
+    async getChangesBetween(fromRevision: string, toRevision: string): Promise<JjFileChange[]> {
+        const cacheKey = `${fromRevision}..${toRevision}`;
+        return this._changesCache.getOrFetch(cacheKey, () => this._doGetChangesBetween(fromRevision, toRevision));
+    }
 
-        const lines = output.split('\n');
-        let currentEntry: JjStatusEntry | null = null;
-        let isHeader = true;
-
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-
-            if (line.startsWith('diff --git')) {
-                if (currentEntry) {
-                    entries.push(currentEntry);
-                }
-                currentEntry = { path: '', status: 'modified', additions: 0, deletions: 0 };
-                isHeader = true;
-                const parts = line.split(' ');
-                if (parts.length >= 4) {
-                    const bPath = parts[parts.length - 1];
-                    currentEntry.path = bPath.startsWith('b/') ? bPath.substring(2) : bPath;
-                }
-                continue;
-            }
-
-            if (!currentEntry) {
-                continue;
-            }
-
-            if (isHeader) {
-                if (line.startsWith('new file mode') || line.startsWith('--- /dev/null')) {
-                    currentEntry.status = 'added';
-                } else if (line.startsWith('deleted file mode') || line.startsWith('+++ /dev/null')) {
-                    currentEntry.status = 'deleted';
-                } else if (line.startsWith('rename from ')) {
-                    currentEntry.status = 'renamed';
-                    currentEntry.oldPath = line.substring('rename from '.length).trim();
-                } else if (line.startsWith('rename to')) {
-                    currentEntry.path = line.substring('rename to '.length).trim();
-                } else if (line.startsWith('+++ b/')) {
-                    currentEntry.path = line.substring('+++ b/'.length).trim();
-                    isHeader = false;
-                } else if (line.startsWith('--- a/') && currentEntry.status === 'deleted') {
-                    currentEntry.path = line.substring('--- a/'.length).trim();
-                } else if (line.startsWith('@@')) {
-                    isHeader = false;
-                }
-            }
-
-            if (!isHeader) {
-                if (line.startsWith('+') && !line.startsWith('+++')) {
-                    currentEntry.additions = (currentEntry.additions || 0) + 1;
-                } else if (line.startsWith('-') && !line.startsWith('---')) {
-                    currentEntry.deletions = (currentEntry.deletions || 0) + 1;
-                }
-            }
-        }
-
-        if (currentEntry) {
-            entries.push(currentEntry);
-        }
-
-        entries.forEach((e) => {
-            if (e.path.startsWith('"') && e.path.endsWith('"')) {
-                try {
-                    e.path = JSON.parse(e.path);
-                } catch (_) {}
-            }
+    private async _doGetChanges(revision: string): Promise<JjFileChangeWithStats[]> {
+        const combinedTemplate = buildLogTemplate({
+            changes: {
+                type: 'array',
+                expr: 'self.diff().files()',
+                itemSchema: buildDiffFileSchema('item'),
+            },
+            stats: {
+                type: 'array',
+                expr: 'self.diff().stat().files()',
+                itemSchema: {
+                    path: { type: 'json', expr: 'item.path().display()' },
+                    additions: { type: 'raw', expr: 'item.lines_added()' },
+                    deletions: { type: 'raw', expr: 'item.lines_removed()' },
+                },
+            },
         });
 
-        return entries;
+        const output = await this.run('log', ['-r', revision, '--no-graph', '-T', combinedTemplate], {
+            useCachedSnapshot: true,
+            label: 'getChanges',
+        });
+        const entries = this._parseJsonLines(output, ChangesAndStatsOutputSchema, 'getChanges');
+        if (entries.length === 0) {
+            return [];
+        }
+
+        if (entries.length > 1) {
+            this.logger.warn(
+                `Expected single commit for revision '${revision}' in getChanges, but got ${entries.length} entries.`,
+            );
+        }
+
+        const { changes, stats } = entries[0];
+        const statsMap = new Map<string, DiffStatEntry>(stats.map((s) => [s.path, s]));
+
+        return changes.map((c) => {
+            const stat = statsMap.get(c.path);
+            return {
+                ...c,
+                additions: stat?.additions ?? 0,
+                deletions: stat?.deletions ?? 0,
+            };
+        });
+    }
+
+    private async _doGetChangesBetween(fromRevision: string, toRevision: string): Promise<JjFileChange[]> {
+        const diffTemplate = buildLogTemplate(buildDiffFileSchema('self'));
+
+        const output = await this.run('diff', ['-T', diffTemplate, '--from', fromRevision, '--to', toRevision], {
+            useCachedSnapshot: true,
+            label: 'getChangesBetween',
+        });
+
+        return this._parseJsonLines(output, JjFileChangeSchema, 'getChangesBetween');
+    }
+
+    private _parseJsonLines<T>(output: string, schema: z.ZodType<T>, label: string): T[] {
+        const items: T[] = [];
+        let parseErrorCount = 0;
+
+        for (const line of output.trim().split('\n')) {
+            if (!line) {
+                continue;
+            }
+            const jsonStart = line.indexOf('{');
+            if (jsonStart === -1) {
+                continue;
+            }
+            try {
+                const parsed = JSON.parse(line.substring(jsonStart));
+                const validation = schema.safeParse(parsed);
+                if (validation.success) {
+                    items.push(validation.data);
+                } else {
+                    parseErrorCount++;
+                    this.logger.debug(`Failed to validate ${label} entry: ${validation.error.message} (line: ${line})`);
+                }
+            } catch (e) {
+                parseErrorCount++;
+                this.logger.debug(`Failed to parse ${label} entry (line: ${line}): ${e}`);
+            }
+        }
+
+        if (parseErrorCount > 0) {
+            this.logger.warn(`Encountered ${parseErrorCount} invalid JSON entries while parsing ${label} output.`);
+        }
+
+        return items;
     }
 
     async getWorkingCopyChanges(): Promise<JjStatusEntry[]> {

--- a/src/jj-template-builder.ts
+++ b/src/jj-template-builder.ts
@@ -17,7 +17,24 @@ export type JjTemplateField =
     | { type: 'stringArray'; expr: string; itemExpr: string } // Array of simple strings
     | { type: 'rawArray'; expr: string; itemExpr: string } // Array of raw values (booleans, numbers)
     | { type: 'object'; fields: Record<string, JjTemplateField> } // Nested object
-    | { type: 'nullable'; expr: string; valueExpr: string }; // Nullable with if()
+    | { type: 'nullable'; expr: string; valueExpr: string } // Nullable with if()
+    | { type: 'optionalField'; where: string; valueExpr: string }; // Conditionally included object field
+
+function buildObjectFields(fields: Record<string, JjTemplateField>): string {
+    const parts: string[] = [];
+    const entries = Object.entries(fields);
+    for (let i = 0; i < entries.length; i++) {
+        const [key, field] = entries[i];
+        if (field.type === 'optionalField') {
+            const prefix = i === 0 ? `"\\"${key}\\": "` : `", \\"${key}\\": "`;
+            parts.push(`if(${field.where}, ${prefix} ++ ${field.valueExpr}, "")`);
+        } else {
+            const prefix = i === 0 ? `"\\"${key}\\": "` : `", \\"${key}\\": "`;
+            parts.push(`${prefix} ++ ${buildTemplateExpr(field)}`);
+        }
+    }
+    return parts.join(' ++ ');
+}
 
 function buildTemplateExpr(field: JjTemplateField): string {
     switch (field.type) {
@@ -30,11 +47,7 @@ function buildTemplateExpr(field: JjTemplateField): string {
         case 'timestamp':
             return `"\\"" ++ ${field.expr}.local().format("%Y-%m-%dT%H:%M:%S%:z") ++ "\\""`;
         case 'array': {
-            // Generate item template from itemSchema
-            const itemParts = Object.entries(field.itemSchema).map(([key, itemField]) => {
-                return `"\\"${key}\\": " ++ ${buildTemplateExpr(itemField)}`;
-            });
-            const itemTemplate = `"{" ++ ${itemParts.join(' ++ ", " ++ ')} ++ "}"`;
+            const itemTemplate = `"{" ++ ${buildObjectFields(field.itemSchema)} ++ "}"`;
             return `"[" ++ ${field.expr}.map(|item| ${itemTemplate}).join(",") ++ "]"`;
         }
         case 'stringArray':
@@ -42,25 +55,41 @@ function buildTemplateExpr(field: JjTemplateField): string {
         case 'rawArray':
             return `"[" ++ ${field.expr}.map(|item| ${field.itemExpr}).join(",") ++ "]"`;
         case 'object': {
-            const parts = Object.entries(field.fields).map(
-                ([key, value]) => `"\\"${key}\\": " ++ ${buildTemplateExpr(value)}`,
-            );
-            return `"{" ++ ${parts.join(' ++ ", " ++ ')} ++ "}"`;
+            return `"{" ++ ${buildObjectFields(field.fields)} ++ "}"`;
         }
         case 'nullable':
             return `if(${field.expr}, "\\"" ++ ${field.valueExpr} ++ "\\"", "null")`;
+        case 'optionalField':
+            return `if(${field.where}, ${field.valueExpr}, "null")`;
     }
 }
 
 export function buildLogTemplate(schema: Record<string, JjTemplateField>): string {
-    const parts = Object.entries(schema).map(([key, field]) => {
-        return `"\\"${key}\\": " ++ ${buildTemplateExpr(field)}`;
-    });
-    return `"{" ++ ${parts.join(' ++ ", " ++ ')} ++ "}\\n"`;
+    return `"{" ++ ${buildObjectFields(schema)} ++ "}\\n"`;
 }
 export const CHANGE_ID_EXPR = 'if(divergent || hidden, change_id ++ "/" ++ change_offset, change_id)';
 export const CHANGE_ID_ITEM_EXPR =
     'if(item.divergent() || item.hidden(), item.change_id() ++ "/" ++ item.change_offset(), item.change_id())';
+
+/**
+ * Common schema fields for a single file diff entry (path, oldPath, status, conflicted).
+ * @param varName The template variable name ('item' when iterating over self.diff().files(), or 'self' for jj diff -T).
+ */
+export function buildDiffFileSchema(varName: 'item' | 'self'): Record<string, JjTemplateField> {
+    return {
+        path: { type: 'json', expr: `${varName}.path().display()` },
+        oldPath: {
+            type: 'optionalField',
+            where: `${varName}.status() == "renamed" || ${varName}.status() == "copied"`,
+            valueExpr: `${varName}.source().path().display().escape_json()`,
+        },
+        status: {
+            type: 'raw',
+            expr: `if(${varName}.status() == "removed", "\\"deleted\\"", ${varName}.status().escape_json())`,
+        },
+        conflicted: { type: 'raw', expr: `${varName}.target().conflict()` },
+    };
+}
 
 // Schema for JjLogEntry - defines how to serialize each field
 export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
@@ -121,12 +150,7 @@ export const LOG_ENTRY_SCHEMA: Record<string, JjTemplateField> = {
     changes: {
         type: 'array',
         expr: 'self.diff().files()',
-        itemSchema: {
-            path: { type: 'json', expr: 'item.path().display()' },
-            oldPath: { type: 'json', expr: 'item.source().path().display()' },
-            status: { type: 'string', expr: 'item.status()' },
-            conflicted: { type: 'raw', expr: 'item.target().conflict()' },
-        },
+        itemSchema: buildDiffFileSchema('item'),
     },
 };
 

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -7,12 +7,23 @@ import type {
     CodeForgeChangeInfo,
     CommitParent,
     JjBookmark,
+    JjFileChange,
+    JjFileChangeWithStats,
     JjLogEntry,
     JjStatusEntry,
     JjWorkspace,
 } from './jj-schemas';
 
-export type { CodeForgeChangeInfo, CommitParent, JjBookmark, JjLogEntry, JjStatusEntry, JjWorkspace };
+export type {
+    CodeForgeChangeInfo,
+    CommitParent,
+    JjBookmark,
+    JjFileChange,
+    JjFileChangeWithStats,
+    JjLogEntry,
+    JjStatusEntry,
+    JjWorkspace,
+};
 
 export type CommitAction = 'newChild' | 'edit' | 'squash' | 'abandon' | 'openCodeForge' | 'upload';
 

--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -32,7 +32,7 @@ export function createJjResourceState(
     const { leftUri, rightUri, resourceUri } = createDiffUris(entry, revision, root, options);
 
     const openDiffOnClick = options.openDiffOnClick ?? true;
-    const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
+    const isDeleted = entry.status === 'deleted';
 
     const diffTitle = `${entry.path} (${isCurrentWorkingCopy ? 'Working Copy' : revision})`;
 
@@ -86,7 +86,7 @@ export function createJjResourceState(
         diffTitle,
         decorations: {
             faded: false,
-            strikeThrough: entry.status === 'removed',
+            strikeThrough: entry.status === 'deleted',
         },
         contextValue,
         revision,

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -21,32 +21,278 @@ describe('JjService Diff Tests', () => {
 
     afterEach(() => {});
 
-    test('getChanges with from/to revisions correctly identifies arbitrary changes', async () => {
+    test('getChangesBetween correctly calculates net changes across complex diamond merge graph', async () => {
         const ids = await buildGraph(repo, [
-            { label: 'v1', files: { 'a.txt': 'v1\n', 'b.txt': 'keep\n' } },
-            { label: 'v2', parents: ['v1'], files: { 'a.txt': 'v2\n', 'c.txt': 'new\n' } },
-            { label: 'v3', parents: ['v2'], files: { 'a.txt': 'v3\n', 'c.txt': 'newer\n', 'd.txt': 'fresh\n' } },
+            {
+                label: 'root',
+                files: {
+                    'shared.txt': 'root shared\n',
+                    'common.txt': 'root common\n',
+                    'deleted_in_merge.txt': 'to be deleted\n',
+                    'nested/deep_file.txt': 'original deep\n',
+                },
+            },
+            {
+                label: 'featureA',
+                parents: ['root'],
+                files: { 'common.txt': 'featureA common\n', 'feature_a.txt': 'added in A\n' },
+            },
+            {
+                label: 'featureA2',
+                parents: ['featureA'],
+                files: { 'shared.txt': 'featureA2 shared\n' },
+            },
+            {
+                label: 'featureB',
+                parents: ['root'],
+                files: {
+                    'common.txt': 'featureB common\n',
+                    'feature_b.txt': 'added in B\n',
+                    'path with space/file.txt': 'space file\n',
+                },
+            },
+            {
+                label: 'featureB2',
+                parents: ['featureB'],
+                files: { 'path with space/file.txt': 'space file modified\n' },
+            },
+            {
+                label: 'merge',
+                parents: ['featureA2', 'featureB2'],
+                files: { 'common.txt': 'resolved common\n' },
+            },
         ]);
 
-        repo.edit(ids.v2.changeId);
-        repo.deleteFile('b.txt');
+        repo.edit(ids.featureA2.changeId);
+        repo.deleteFile('deleted_in_merge.txt');
 
-        const changes = await jjService.getChanges(ids.v1.changeId, ids.v3.changeId);
+        // 1. Compare root vs merge across the diamond graph
+        const changesVsRoot = await jjService.getChangesBetween(ids.root.changeId, ids.merge.changeId);
+        changesVsRoot.sort((a, b) => a.path.localeCompare(b.path));
 
-        const simplifiedChanges = changes.map((c) => ({ path: c.path, status: c.status }));
-        simplifiedChanges.sort((a, b) => a.path.localeCompare(b.path));
-
-        expect(simplifiedChanges).toEqual([
-            { path: 'a.txt', status: 'modified' },
-            { path: 'b.txt', status: 'deleted' },
-            { path: 'c.txt', status: 'added' },
-            { path: 'd.txt', status: 'added' },
+        expect(changesVsRoot).toEqual([
+            { path: 'common.txt', status: 'modified', conflicted: false },
+            { path: 'deleted_in_merge.txt', status: 'deleted', conflicted: false },
+            { path: 'feature_a.txt', status: 'added', conflicted: false },
+            { path: 'feature_b.txt', status: 'added', conflicted: false },
+            { path: 'path with space/file.txt', status: 'added', conflicted: false },
+            { path: 'shared.txt', status: 'modified', conflicted: false },
         ]);
+
+        // 2. Compare divergent sibling branches (featureA vs featureB2)
+        const changesDivergent = await jjService.getChangesBetween(ids.featureA.changeId, ids.featureB2.changeId);
+        changesDivergent.sort((a, b) => a.path.localeCompare(b.path));
+
+        expect(changesDivergent).toEqual([
+            { path: 'common.txt', status: 'modified', conflicted: false },
+            { path: 'feature_a.txt', status: 'deleted', conflicted: false },
+            { path: 'feature_b.txt', status: 'added', conflicted: false },
+            { path: 'path with space/file.txt', status: 'added', conflicted: false },
+        ]);
+    });
+
+    test('getChangesBetween compares ancestor against multi-level stacked commits leading to @', async () => {
+        const ids = await buildGraph(repo, [
+            {
+                label: 'base',
+                files: { 'file_a.txt': 'a1\n', 'file_b.txt': 'b1\n', 'file_c.txt': 'c1\n', 'dir/file_d.txt': 'd1\n' },
+            },
+            { label: 'step1', parents: ['base'], files: { 'file_a.txt': 'a2\n', 'step1.txt': 'step1\n' } },
+            { label: 'step2', parents: ['step1'], files: { 'dir/file_d.txt': 'd2\n' } },
+            { label: 'step3', parents: ['step2'], files: { 'file with spaces in path/data.json': '{"key": "val"}\n' } },
+            { label: 'step4', parents: ['step3'], files: { 'step1.txt': 'step1 modified\n', 'file_a.txt': 'a3\n' } },
+            { label: 'wc', parents: ['step4'], files: { 'dir/file_d.txt': 'd3\n' } },
+        ]);
+
+        repo.edit(ids.step2.changeId);
+        repo.deleteFile('file_b.txt');
+
+        repo.edit(ids.wc.changeId);
+        repo.deleteFile('file_c.txt');
+
+        const changes = await jjService.getChangesBetween(ids.base.changeId, '@');
+        changes.sort((a, b) => a.path.localeCompare(b.path));
+
+        expect(changes).toEqual([
+            { path: 'dir/file_d.txt', status: 'modified', conflicted: false },
+            { path: 'file with spaces in path/data.json', status: 'added', conflicted: false },
+            { path: 'file_a.txt', status: 'modified', conflicted: false },
+            { path: 'file_b.txt', status: 'deleted', conflicted: false },
+            { path: 'file_c.txt', status: 'deleted', conflicted: false },
+            { path: 'step1.txt', status: 'added', conflicted: false },
+        ]);
+    });
+
+    test('getChangesBetween correctly detects conflict status across multi-parent merge', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'root', files: { 'conflict.txt': 'base content\n' } },
+            { label: 'branch1', parents: ['root'], files: { 'conflict.txt': 'branch1 content\n' } },
+            { label: 'branch2', parents: ['root'], files: { 'conflict.txt': 'branch2 content\n' } },
+            { label: 'merge', parents: ['branch1', 'branch2'] },
+        ]);
+
+        const changes = await jjService.getChangesBetween(ids.root.changeId, ids.merge.changeId);
+
+        expect(changes).toEqual([
+            {
+                path: 'conflict.txt',
+                status: 'modified',
+                conflicted: true,
+            },
+        ]);
+    });
+
+    test('getChangesBetween returns empty array when comparing identical revisions', async () => {
+        const ids = await buildGraph(repo, [{ label: 'v1', files: { 'file.txt': 'content\n' } }]);
+
+        const changes = await jjService.getChangesBetween(ids.v1.changeId, ids.v1.changeId);
+
+        expect(changes).toEqual([]);
+    });
+
+    test('getChangesBetween caches range results and deduplicates concurrent calls', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'a.txt': 'base\n' } },
+            { label: 'child', parents: ['base'], files: { 'a.txt': 'child\n' } },
+        ]);
+
+        const [changes1, changes2] = await Promise.all([
+            jjService.getChangesBetween(ids.base.changeId, ids.child.changeId),
+            jjService.getChangesBetween(ids.base.changeId, ids.child.changeId),
+        ]);
+
+        expect(changes1).toEqual(changes2);
+        expect(changes1).toEqual([
+            {
+                path: 'a.txt',
+                status: 'modified',
+                conflicted: false,
+            },
+        ]);
+    });
+
+    test('getChanges correctly identifies files with spaces in their names', async () => {
+        const ids = await buildGraph(repo, [{ label: 'v1', files: { 'file with a space.txt': 'hello\n' } }]);
+
+        const changes = await jjService.getChanges(ids.v1.changeId);
+
+        expect(changes).toEqual([
+            {
+                path: 'file with a space.txt',
+                status: 'added',
+                conflicted: false,
+                additions: 1,
+                deletions: 0,
+            },
+        ]);
+    });
+
+    test('getChanges handles additions, modifications, deletions, and line counts accurately', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'modified.txt': 'line1\nline2\n', 'deleted.txt': 'goodbye\n' } },
+            {
+                label: 'child',
+                parents: ['base'],
+                files: {
+                    'added.txt': 'new line 1\nnew line 2\n',
+                    'modified.txt': 'line1\nmodified line 2\nline3\n',
+                },
+            },
+        ]);
+
+        repo.edit(ids.child.changeId);
+        repo.deleteFile('deleted.txt');
+
+        const changes = await jjService.getChanges(ids.child.changeId);
+        changes.sort((a, b) => a.path.localeCompare(b.path));
+
+        expect(changes).toEqual([
+            {
+                path: 'added.txt',
+                status: 'added',
+                conflicted: false,
+                additions: 2,
+                deletions: 0,
+            },
+            {
+                path: 'deleted.txt',
+                status: 'deleted',
+                conflicted: false,
+                additions: 0,
+                deletions: 1,
+            },
+            {
+                path: 'modified.txt',
+                status: 'modified',
+                conflicted: false,
+                additions: 2,
+                deletions: 1,
+            },
+        ]);
+    });
+
+    test('getChanges correctly calculates additions and deletions for renamed files', async () => {
+        const oldFile = 'old_name.txt';
+        const newFile = 'new_name.txt';
+        const baseContent = 'line1\nline2\nline3\nline4\nline5\n'.repeat(10);
+        const modifiedContent = `${baseContent}line_added_1\nline_added_2\n`;
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { [oldFile]: baseContent } },
+            {
+                label: 'child',
+                parents: ['base'],
+            },
+        ]);
+
+        repo.edit(ids.child.changeId);
+        repo.moveFile(oldFile, newFile);
+        repo.writeFile(newFile, modifiedContent);
+
+        const changes = await jjService.getChanges(ids.child.changeId);
+
+        const renamedEntry = changes.find((c) => c.path === newFile);
+        expect(renamedEntry).toBeDefined();
+        expect(renamedEntry).toMatchObject({
+            path: newFile,
+            status: 'renamed',
+            oldPath: oldFile,
+            additions: 2,
+            deletions: 0,
+        });
+    });
+
+    test('getChanges calculates additions and deletions for files in renamed directories', async () => {
+        const oldDir = 'old_dir/nested/file.txt';
+        const newDir = 'new_dir/nested/file.txt';
+        const baseContent = 'line1\nline2\n';
+        const modifiedContent = 'line1\nline2\nline3\n';
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { [oldDir]: baseContent } },
+            { label: 'child', parents: ['base'] },
+        ]);
+
+        repo.edit(ids.child.changeId);
+        repo.moveFile(oldDir, newDir);
+        repo.writeFile(newDir, modifiedContent);
+
+        const changes = await jjService.getChanges(ids.child.changeId);
+
+        const renamedEntry = changes.find((c) => c.path === newDir);
+        expect(renamedEntry).toBeDefined();
+        expect(renamedEntry).toMatchObject({
+            path: newDir,
+            status: 'renamed',
+            oldPath: oldDir,
+            additions: 1,
+            deletions: 0,
+        });
     });
 
     test('getDiffForRevision handles thundering herd concurrently', async () => {
         const ids = await buildGraph(repo, [{ label: 'base', files: { 'test.txt': 'content' } }]);
-        const commitId = ids.base.commitId;
+        const { commitId } = ids.base;
 
         const results = await Promise.all([
             jjService.getDiffForRevision(commitId),
@@ -137,6 +383,21 @@ describe('JjService Diff Tests', () => {
         const d = await jjService.getDiffContent(commitId, 'd.txt');
         expect(d.left).toBe('');
         expect(d.right).toBe('d1\n');
+    });
+
+    test('getDiffContent handles files with spaces in their names and nested directories with spaces', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'v1', files: { 'my folder with space/my file with space.txt': 'original line\n' } },
+            {
+                label: 'v2',
+                parents: ['v1'],
+                files: { 'my folder with space/my file with space.txt': 'original line\nmodified line\n' },
+            },
+        ]);
+
+        const diff = await jjService.getDiffContent(ids.v2.commitId, 'my folder with space/my file with space.txt');
+        expect(diff.left).toBe('original line\n');
+        expect(diff.right).toBe('original line\nmodified line\n');
     });
 
     test('getDiffContent works on an immutable revision', async () => {

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1322,7 +1322,7 @@ log = "none()"
         expect(modified?.status).toBe('modified');
 
         expect(deleted).toBeDefined();
-        expect(deleted?.status).toBe('removed');
+        expect(deleted?.status).toBe('deleted');
     });
 
     test('moveBookmark moves bookmark to revision', async () => {

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -143,8 +143,8 @@ describe('createJjResourceState', () => {
             expect(state.command?.arguments).toEqual([state.leftUri, state.rightUri, 'file.txt (rev123)']);
         });
 
-        it('routes to diff command if status is deleted/removed, even if openDiffOnClick is false', () => {
-            const deletedEntry: JjStatusEntry = { path: 'file.txt', status: 'removed' };
+        it('routes to diff command if status is deleted, even if openDiffOnClick is false', () => {
+            const deletedEntry: JjStatusEntry = { path: 'file.txt', status: 'deleted' };
             const state = createJjResourceState(deletedEntry, 'rev123', root, {
                 openDiffOnClick: false,
             });
@@ -164,8 +164,8 @@ describe('createJjResourceState', () => {
     });
 
     describe('Decorations', () => {
-        it('sets strikeThrough for removed entries', () => {
-            const entry: JjStatusEntry = { path: 'file.txt', status: 'removed' };
+        it('sets strikeThrough for deleted entries', () => {
+            const entry: JjStatusEntry = { path: 'file.txt', status: 'deleted' };
             const state = createJjResourceState(entry, 'rev123', root);
             expect(state.decorations?.strikeThrough).toBe(true);
         });

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -338,6 +338,7 @@ export class TestRepo {
     moveFile(oldPath: string, newPath: string) {
         const fullOldPath = path.join(this.path, oldPath);
         const fullNewPath = path.join(this.path, newPath);
+        fs.mkdirSync(path.dirname(fullNewPath), { recursive: true });
         fs.renameSync(fullOldPath, fullNewPath);
         this.snapshot();
     }

--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -77,10 +77,10 @@ describe('createDiffUris', () => {
         expect(rightUri.query).toContain('side=right');
     });
 
-    it('handles removed files in working copy correctly', () => {
+    it('handles deleted files in working copy correctly', () => {
         const entry: JjStatusEntry = {
             path: 'deleted.txt',
-            status: 'removed',
+            status: 'deleted',
         };
         const revision = '@';
 
@@ -91,7 +91,7 @@ describe('createDiffUris', () => {
         expect(leftUri.query).toContain(`base=${ENCODED_AT}`);
         expect(leftUri.query).toContain('side=left');
 
-        // DESIRED FIX: Removed files in working copy should use jj-view scheme for right side
+        // Removed files in working copy should use jj-view scheme for right side
         // to avoid "File not found" errors in VS Code.
         expect(rightUri.scheme).toBe('jj-view');
         expect(rightUri.path).toBe('/root/deleted.txt');
@@ -99,23 +99,10 @@ describe('createDiffUris', () => {
         expect(rightUri.query).toContain('side=right');
     });
 
-    it('handles deleted status in working copy correctly', () => {
+    it('handles deleted files in ancestors correctly', () => {
         const entry: JjStatusEntry = {
             path: 'deleted.txt',
             status: 'deleted',
-        };
-        const revision = '@';
-
-        const { rightUri } = createDiffUris(entry, revision, root);
-
-        expect(rightUri.scheme).toBe('jj-view');
-        expect(rightUri.query).toContain('side=right');
-    });
-
-    it('handles removed files in ancestors correctly', () => {
-        const entry: JjStatusEntry = {
-            path: 'deleted.txt',
-            status: 'removed',
         };
         const revision = 'rev1';
 

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -67,7 +67,7 @@ export function createDiffUris(
     });
 
     let rightUri: vscode.Uri;
-    const isDeleted = entry.status === 'removed' || entry.status === 'deleted';
+    const isDeleted = entry.status === 'deleted';
     if (isDeleted) {
         rightUri = vscode.Uri.from({
             scheme: 'jj-view',

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -703,7 +703,6 @@ function getFileIcon(status: string): string {
         case 'added':
         case 'copied':
             return 'diff-added';
-        case 'removed':
         case 'deleted':
             return 'diff-removed';
         case 'modified':
@@ -720,7 +719,6 @@ function getFileColor(status: string): string {
         case 'added':
         case 'copied':
             return 'var(--vscode-gitDecoration-addedResourceForeground)';
-        case 'removed':
         case 'deleted':
             return 'var(--vscode-gitDecoration-deletedResourceForeground)';
         case 'modified':


### PR DESCRIPTION
Fixes #420 handling of file paths containing spaces in commit detail views

Also unify file status representations by replacing legacy 'removed' status values with 'deleted' across SCM resources, decorators, and URI utilities, and update revision range diffing to leverage structured template outputs and change statistics.