### PR TITLE
feat: add syntax highlighting for `*.jjdescription` files

### DIFF
--- a/languages/jj-commit.language-configuration.json
+++ b/languages/jj-commit.language-configuration.json
@@ -1,0 +1,18 @@
+{
+    "comments": {
+        "lineComment": {
+            "comment": "JJ:",
+            "noIndent": true
+        },
+        "blockComment": ["JJ:", " "]
+    },
+    "brackets": [["{", "}"], ["[", "]"], ["(", ")"]],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "\"", "close": "\"", "notIn": ["string"] },
+        { "open": "`", "close": "`", "notIn": ["string", "comment"] }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -1184,7 +1184,27 @@
                     "when": "config.jj-view.showProcessMonitorPanel"
                 }
             ]
-        }
+        },
+        "languages": [
+            {
+                "id": "jj-commit",
+                "aliases": [
+                    "JJ Commit Message",
+                    "jj-commit"
+                ],
+                "extensions": [
+                    ".jjdescription"
+                ],
+                "configuration": "./languages/jj-commit.language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "jj-commit",
+                "scopeName": "text.jj-commit",
+                "path": "./syntaxes/jj-commit.tmLanguage.json"
+            }
+        ]
     },
     "scripts": {
         "setup-jj": "node tooling/jj/setup.ts",

--- a/syntaxes/jj-commit.tmLanguage.json
+++ b/syntaxes/jj-commit.tmLanguage.json
@@ -1,0 +1,72 @@
+{
+    "name": "JJ Commit Message",
+    "scopeName": "text.jj-commit",
+    "patterns": [
+        {
+            "comment": "diff presented at the end of the commit message when using jj describe with diff template",
+            "name": "meta.embedded.diff.jj-commit",
+            "contentName": "source.diff",
+            "begin": "(?=^diff\\ \\-\\-git)",
+            "end": "\\z",
+            "patterns": [
+                {
+                    "include": "source.diff"
+                }
+            ]
+        },
+        {
+            "comment": "User supplied message",
+            "name": "meta.scope.message.jj-commit",
+            "begin": "^(?!JJ:)",
+            "end": "^(?=JJ:)",
+            "patterns": [
+                {
+                    "comment": "Mark > 50 lines as deprecated, > 72 as illegal",
+                    "name": "meta.scope.subject.jj-commit",
+                    "match": "\\G.{0,50}(.{0,22}(.*))$",
+                    "captures": {
+                        "1": {
+                            "name": "invalid.deprecated.line-too-long.jj-commit"
+                        },
+                        "2": {
+                            "name": "invalid.illegal.line-too-long.jj-commit"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "comment": "JJ supplied metadata in a number of lines starting with JJ:",
+            "name": "meta.scope.metadata.jj-commit",
+            "begin": "^(?=JJ:)",
+            "contentName": "comment.line.indicator.jj-commit",
+            "end": "^(?!JJ:)",
+            "patterns": [
+                {
+                    "match": "^JJ:\\s+((M|R) .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.changed.jj-commit"
+                        }
+                    }
+                },
+                {
+                    "match": "^JJ:\\s+(A .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.inserted.jj-commit"
+                        }
+                    }
+                },
+                {
+                    "match": "^JJ:\\s+(D .*)$",
+                    "captures": {
+                        "1": {
+                            "name": "markup.deleted.jj-commit"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Based off of jjk's, with slight modifications for modern VSCode versions.

jjk is MIT, which is compatible with Apache, but I don't know if I should include a copy of the MIT license or not.