### PR TITLE
rpc: adopt Zod message validation and webview logger for host IPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ media/custom-icons/
 playwright-report/
 src/webview/themes.generated.ts
 media/themes.generated.css
+build/
 *.log

--- a/src/common/ipc-schemas.ts
+++ b/src/common/ipc-schemas.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+import { JjBookmarkSchema, JjLogEntrySchema, JjStatusEntrySchema } from '../jj-schemas';
+
+export const ActionPayloadSchema = z.object({
+    changeId: z.string(),
+    isImmutable: z.boolean().optional(),
+    url: z.string().optional(),
+    multiSelect: z.boolean().optional(),
+    changeIdShortest: z.string().optional(),
+    isDivergent: z.boolean().optional(),
+    changeIdOffset: z.number().optional(),
+});
+export type ActionPayload = z.infer<typeof ActionPayloadSchema>;
+
+export const WebviewPayloadSchema = z.object({
+    commits: z.array(JjLogEntrySchema).optional(),
+    minChangeIdLength: z.number().optional(),
+    theme: z.string().optional(),
+    graphLabelAlignment: z.string().optional(),
+    hiddenActions: z.array(z.string()).optional(),
+    changeId: z.string().optional(),
+    commitId: z.string().optional(),
+    description: z.string().optional(),
+    files: z.array(JjStatusEntrySchema).optional(),
+    isImmutable: z.boolean().optional(),
+    isEmpty: z.boolean().optional(),
+    isConflict: z.boolean().optional(),
+    author: z
+        .object({
+            name: z.string(),
+            email: z.string(),
+            timestamp: z.string(),
+        })
+        .optional(),
+    committer: z
+        .object({
+            name: z.string(),
+            email: z.string(),
+            timestamp: z.string(),
+        })
+        .optional(),
+    bookmarks: z.array(JjBookmarkSchema).optional(),
+    tags: z.array(z.string()).optional(),
+    titleWidthRuler: z.number().optional(),
+    bodyWidthRuler: z.number().optional(),
+    formatDescriptionOnSave: z.boolean().optional(),
+});
+export type WebviewPayload = z.infer<typeof WebviewPayloadSchema>;
+
+export const WebviewToHostMessageSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('webviewLoaded') }),
+    z.object({ type: z.literal('newChild'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('edit'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('squash'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('abandon'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('select'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('undo') }),
+    z.object({ type: z.literal('redo') }),
+    z.object({ type: z.literal('getDetails'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('new') }),
+    z.object({
+        type: z.literal('newBefore'),
+        payload: z.object({ changeIds: z.array(z.string()).optional() }),
+    }),
+    z.object({
+        type: z.literal('newAfter'),
+        payload: z.object({ changeIds: z.array(z.string()).optional() }),
+    }),
+    z.object({
+        type: z.literal('resolve'),
+        payload: z.object({ path: z.string() }),
+    }),
+    z.object({
+        type: z.literal('moveBookmark'),
+        payload: z.object({ bookmark: z.string(), targetChangeId: z.string() }),
+    }),
+    z.object({
+        type: z.literal('rebaseCommit'),
+        payload: z.object({
+            sourceChangeId: z.string(),
+            targetChangeId: z.string(),
+            mode: z.enum(['revision', 'source']),
+        }),
+    }),
+    z.object({
+        type: z.literal('squashCommit'),
+        payload: z.object({ sourceChangeId: z.string(), targetChangeId: z.string(), mode: z.enum(['into', 'onto']) }),
+    }),
+    z.object({
+        type: z.literal('duplicateCommit'),
+        payload: z.object({ sourceChangeId: z.string(), targetChangeId: z.string().optional() }),
+    }),
+    z.object({
+        type: z.literal('mergeCommit'),
+        payload: z.object({ sourceChangeId: z.string(), targetChangeId: z.string() }),
+    }),
+    z.object({ type: z.literal('upload'), payload: ActionPayloadSchema }),
+    z.object({
+        type: z.literal('showComments'),
+        payload: z.object({ changeId: z.string() }),
+    }),
+    z.object({
+        type: z.literal('selectionChange'),
+        payload: z.object({ commitIds: z.array(z.string()), hasImmutableSelection: z.boolean().optional() }),
+    }),
+    z.object({
+        type: z.literal('setContextKey'),
+        payload: z.object({ key: z.string(), value: z.unknown() }),
+    }),
+    z.object({
+        type: z.literal('openCodeForge'),
+        payload: z.object({ url: z.string() }),
+    }),
+    z.object({
+        type: z.literal('saveDescription'),
+        payload: z.object({ changeId: z.string(), description: z.string() }),
+    }),
+    z.object({
+        type: z.literal('descriptionChanged'),
+        payload: z.object({
+            description: z.string(),
+            selectionStart: z.number().optional(),
+            selectionEnd: z.number().optional(),
+        }),
+    }),
+    z.object({
+        type: z.literal('saveFileText'),
+        payload: z.object({ filePath: z.string(), content: z.string() }),
+    }),
+    z.object({
+        type: z.literal('openDiff'),
+        payload: z.object({
+            file: JjStatusEntrySchema,
+            changeId: z.string(),
+            isImmutable: z.boolean().optional(),
+        }),
+    }),
+    z.object({
+        type: z.literal('openMultiDiff'),
+        payload: z.object({ changeId: z.string() }),
+    }),
+]);
+export type WebviewToHostMessage = z.infer<typeof WebviewToHostMessageSchema>;
+
+export const HostToWebviewMessageSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('updateData'), payload: WebviewPayloadSchema.optional() }),
+    z.object({ type: z.literal('updateDetails'), payload: WebviewPayloadSchema.optional() }),
+    z.object({ type: z.literal('updateTheme'), payload: z.object({ theme: z.string() }) }),
+    z.object({ type: z.literal('saveComplete'), payload: z.object({ description: z.string() }).optional() }),
+    z.object({ type: z.literal('saveFailed') }),
+]);
+export type HostToWebviewMessage = z.infer<typeof HostToWebviewMessageSchema>;

--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+
+export type DiscriminatedMessage<K extends string = 'type'> = {
+    [P in K]: string;
+};
+
+export type MessageHandlerMap<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
+    [V in TMessage[K]]?: (message: Extract<TMessage, Record<K, V>>) => unknown | Promise<unknown>;
+};
+
+export interface LoggerLike {
+    info?(message: string, ...args: unknown[]): void;
+    warn?(message: string, ...args: unknown[]): void;
+    error(message: string, ...args: unknown[]): void;
+}
+
+export interface WebviewRpcDispatcherOptions<K extends string = 'type'> {
+    discriminatorKey?: K;
+    logger?: LoggerLike;
+    messenger?: WebviewPostMessageLike;
+    onError?: (error: unknown, rawMessage: unknown) => void;
+}
+
+export const loggerSchema = z.object({
+    type: z.literal('logMessage'),
+    payload: z.object({
+        level: z.enum(['info', 'warn', 'error']),
+        message: z.string(),
+        details: z.string().optional(),
+    }),
+});
+
+export const rpcResponseSchema = z.object({
+    type: z.literal('__rpc_response__'),
+    requestId: z.string(),
+    result: z.unknown().optional(),
+    error: z.string().optional(),
+});
+
+type PendingPromise = {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+};
+
+export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> {
+    private readonly discriminatorKey: K;
+    private readonly pendingRequests = new Map<string, PendingPromise>();
+
+    constructor(
+        private readonly schema: z.ZodType<TMessage>,
+        private readonly handlers: MessageHandlerMap<TMessage, K>,
+        private readonly options?: WebviewRpcDispatcherOptions<K>,
+    ) {
+        this.discriminatorKey = options?.discriminatorKey ?? ('type' as K);
+    }
+
+    public registerPendingRequest(requestId: string): Promise<unknown> {
+        return new Promise((resolve, reject) => {
+            this.pendingRequests.set(requestId, { resolve, reject });
+        });
+    }
+
+    private handleRpcResponse(rawMessage: unknown): boolean {
+        const responseParse = rpcResponseSchema.safeParse(rawMessage);
+        if (!responseParse.success) {
+            return false;
+        }
+        const { requestId, result, error } = responseParse.data;
+        const pending = this.pendingRequests.get(requestId);
+        if (pending) {
+            this.pendingRequests.delete(requestId);
+            if (error !== undefined) {
+                pending.reject(new Error(error));
+            } else {
+                pending.resolve(result);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private async handleLogMessage(rawMessage: unknown): Promise<boolean> {
+        const logMsgParse = loggerSchema.safeParse(rawMessage);
+        if (!logMsgParse.success) {
+            return false;
+        }
+
+        const { level, message, details } = logMsgParse.data.payload;
+        const logStr = details ? `${message}: ${details}` : message;
+        if (level === 'info') {
+            this.options?.logger?.info?.(logStr);
+        } else if (level === 'warn') {
+            this.options?.logger?.warn?.(logStr);
+        } else {
+            this.options?.logger?.error(logStr);
+        }
+
+        const customHandler = (this.handlers as Record<string, unknown>).logMessage;
+        if (typeof customHandler === 'function') {
+            await (customHandler as (msg: unknown) => Promise<void>)(rawMessage);
+        }
+        return true;
+    }
+
+    public async dispatch(rawMessage: unknown): Promise<boolean> {
+        if (this.handleRpcResponse(rawMessage)) {
+            return true;
+        }
+
+        if (await this.handleLogMessage(rawMessage)) {
+            return true;
+        }
+
+        const parseResult = this.schema.safeParse(rawMessage);
+        if (!parseResult.success) {
+            const isUnknownDiscriminator = parseResult.error.issues.some((issue) => issue.code === 'invalid_union');
+            if (isUnknownDiscriminator) {
+                return false;
+            }
+            this.options?.logger?.error('Webview RPC validation failed', parseResult.error);
+            this.options?.onError?.(parseResult.error, rawMessage);
+            return false;
+        }
+
+        const message = parseResult.data;
+        const typeValue = message[this.discriminatorKey] as TMessage[K];
+        const handler = this.handlers[typeValue];
+        const requestId = (rawMessage as Record<string, unknown>)?.requestId as string | undefined;
+
+        if (typeof handler === 'function') {
+            try {
+                const result = await handler(message as Extract<TMessage, Record<K, typeof typeValue>>);
+                if (requestId && this.options?.messenger) {
+                    this.options.messenger.postMessage({
+                        type: '__rpc_response__',
+                        requestId,
+                        result,
+                    });
+                }
+                return true;
+            } catch (err) {
+                const errorMessage = err instanceof Error ? err.message : String(err);
+                this.options?.logger?.error(`Webview RPC handler error (${String(typeValue)})`, err);
+                this.options?.onError?.(err, rawMessage);
+
+                if (requestId && this.options?.messenger) {
+                    this.options.messenger.postMessage({
+                        type: '__rpc_response__',
+                        requestId,
+                        error: errorMessage,
+                    });
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+}
+
+export function createWebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+    schema: z.ZodType<TMessage>,
+    handlers: MessageHandlerMap<TMessage, K>,
+    options?: WebviewRpcDispatcherOptions<K>,
+): WebviewRpcDispatcher<TMessage, K> {
+    return new WebviewRpcDispatcher<TMessage, K>(schema, handlers, options);
+}
+
+export type RpcClientMethods<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
+    [V in TMessage[K]]: (
+        ...args: Omit<Extract<TMessage, Record<K, V>>, K | 'requestId'> extends Record<string, never>
+            ? []
+            : [payload: Omit<Extract<TMessage, Record<K, V>>, K | 'requestId'>]
+    ) => Promise<unknown>;
+};
+
+export interface WebviewPostMessageLike {
+    postMessage(message: unknown): unknown;
+}
+
+export interface WebviewRpcPendingRequestRegisterable {
+    registerPendingRequest(requestId: string): Promise<unknown>;
+}
+
+export interface WebviewRpcClientOptions<
+    K extends string = 'type',
+    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
+> {
+    discriminatorKey?: K;
+    dispatcher?: WebviewRpcDispatcher<TResponseMsg, K> | WebviewRpcPendingRequestRegisterable;
+}
+
+export function createWebviewRpcClient<
+    TMessage extends DiscriminatedMessage<K>,
+    K extends string = 'type',
+    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
+>(
+    webview: WebviewPostMessageLike,
+    schema?: z.ZodType<TMessage>,
+    options?: WebviewRpcClientOptions<K, TResponseMsg>,
+): RpcClientMethods<TMessage, K> {
+    let requestIdCounter = 0;
+    const discriminatorKey = options?.discriminatorKey ?? ('type' as K);
+
+    return new Proxy({} as RpcClientMethods<TMessage, K>, {
+        get(_target, prop: string) {
+            return (payload?: Record<string, unknown>) => {
+                const requestId = `req_${Date.now()}_${++requestIdCounter}`;
+                const message = {
+                    [discriminatorKey]: prop,
+                    requestId,
+                    ...(payload ?? {}),
+                };
+
+                if (schema) {
+                    const parseResult = schema.safeParse(message);
+                    if (!parseResult.success) {
+                        throw new Error(`Invalid RPC message '${prop}': ${parseResult.error.message}`);
+                    }
+                }
+
+                let pendingPromise: Promise<unknown> | undefined;
+                if (options?.dispatcher) {
+                    pendingPromise = options.dispatcher.registerPendingRequest(requestId);
+                }
+
+                const sendResult = webview.postMessage(message);
+                if (pendingPromise) {
+                    return pendingPromise;
+                }
+                return Promise.resolve(sendResult);
+            };
+        },
+    });
+}

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
+import { WebviewToHostMessageSchema } from './common/ipc-schemas';
+import { createWebviewRpcDispatcher } from './common/webview-rpc-dispatcher';
 import { createJjResourceState } from './scm-resource-state';
 import { getJjViewConfig } from './utils/config-utils';
 import { formatCommitTitle } from './utils/jj-utils';
@@ -306,21 +308,19 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
             document.persistedDescription = initialDescription;
             document.draftDescription = initialDescription;
 
-            panel.webview.onDidReceiveMessage(async (message) => {
-                switch (message.type) {
-                    case 'webviewLoaded':
-                        break;
-                    case 'descriptionChanged': {
-                        const newText = message.payload.description;
+            const dispatcher = createWebviewRpcDispatcher(
+                WebviewToHostMessageSchema,
+                {
+                    webviewLoaded: async () => {},
+                    descriptionChanged: async (msg) => {
+                        const newText = msg.payload.description;
                         const newSelection = {
-                            start: message.payload.selectionStart,
-                            end: message.payload.selectionEnd,
+                            start: msg.payload.selectionStart ?? 0,
+                            end: msg.payload.selectionEnd ?? 0,
                         };
 
-                        // Update current document state immediately so 'Save' always has latest
                         document.draftDescription = newText;
 
-                        // Debounce the undo stack push so typing doesn't create thousands of undo points.
                         let state = this._documentStates.get(document.changeId);
                         if (!state) {
                             state = {
@@ -331,7 +331,6 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                             };
                             this._documentStates.set(document.changeId, state);
                         } else {
-                            // Update the panel reference so flush uses the latest active panel
                             state.panel = panel;
                         }
 
@@ -343,22 +342,15 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                         state.debounceTimer = setTimeout(() => {
                             this._flushDebounce(document.changeId);
                         }, 200);
-                        break;
-                    }
-                    case 'saveDescription': {
-                        const newText = message.payload.description;
+                    },
+                    saveDescription: async (msg) => {
+                        const newText = msg.payload.description;
                         document.draftDescription = newText;
-
-                        // Flush any pending undo history so it remains 'behind' the save point
                         this._flushDebounce(document.changeId);
-
-                        // Natively trigger save which will call our saveCustomDocument
                         await vscode.commands.executeCommand('workbench.action.files.save');
-                        break;
-                    }
-                    case 'openDiff': {
-                        const { file, changeId, isImmutable } = message.payload;
-
+                    },
+                    openDiff: async (msg) => {
+                        const { file, changeId, isImmutable } = msg.payload;
                         const state = createJjResourceState(file, changeId, repo.jj.workspaceRoot, {
                             editable: !isImmutable,
                             openDiffOnClick: true,
@@ -370,12 +362,18 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
                                 ...(state.command.arguments ?? []),
                             );
                         }
-                        break;
-                    }
-                    case 'openMultiDiff':
-                        await vscode.commands.executeCommand('jj-view.showMultiFileDiff', message.payload.changeId);
-                        break;
-                }
+                    },
+                    openMultiDiff: async (msg) => {
+                        await vscode.commands.executeCommand('jj-view.showMultiFileDiff', msg.payload.changeId);
+                    },
+                },
+                {
+                    messenger: panel.webview,
+                },
+            );
+
+            panel.webview.onDidReceiveMessage(async (message) => {
+                return await dispatcher.dispatch(message);
             });
         } catch (_) {
             panel.dispose();

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -6,6 +6,8 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { CodeForgeService } from './code-forge-service';
 import { showJjError, withDelayedProgress } from './commands/command-utils';
+import { WebviewToHostMessageSchema } from './common/ipc-schemas';
+import { createWebviewRpcDispatcher } from './common/webview-rpc-dispatcher';
 import { JjCommitDetailsEditorProvider, openCommitDetails } from './jj-commit-details-editor-provider';
 import { JjContextKey } from './jj-context-keys';
 import type { JjRepository } from './jj-repository';
@@ -180,100 +182,98 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             },
         });
 
-        webviewView.webview.onDidReceiveMessage(async (data) => {
-            switch (data.type) {
-                case 'webviewLoaded':
+        const dispatcher = createWebviewRpcDispatcher(
+            WebviewToHostMessageSchema,
+            {
+                webviewLoaded: async () => {
                     await this.refresh();
-                    break;
-                case 'openCodeForge':
-                    if (data.payload.url) {
-                        await vscode.env.openExternal(vscode.Uri.parse(data.payload.url));
+                },
+                openCodeForge: async (msg) => {
+                    if (msg.payload.url) {
+                        await vscode.env.openExternal(vscode.Uri.parse(msg.payload.url));
                     }
-                    break;
-                case 'newChild':
-                    // new(message?, parent?)
-                    await vscode.commands.executeCommand('jj-view.new', data.payload);
-                    break;
-                case 'squash':
-                    // Route through extension command to reuse safe squash logic (editor, etc.)
-                    // Pass the whole payload
-                    await vscode.commands.executeCommand('jj-view.squashRevisionIntoParent', data.payload);
-                    // Refresh is handled by the command event listener
-                    break;
-                case 'edit':
-                    await vscode.commands.executeCommand('jj-view.edit', data.payload);
-                    break;
-                case 'select': {
+                },
+                newChild: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.new', msg.payload);
+                },
+                squash: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.squashRevisionIntoParent', msg.payload);
+                },
+                edit: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.edit', msg.payload);
+                },
+                select: async (msg) => {
                     if (!this.jj) {
-                        break;
+                        return;
                     }
-                    const details = await this.jj.showDetails(data.payload.changeId);
+                    const details = await this.jj.showDetails(msg.payload.changeId);
                     // biome-ignore lint/suspicious/noControlCharactersInRegex: Standard regex for stripping ANSI escape codes
                     const cleanDetails = details.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
-                    vscode.workspace.openTextDocument({ content: cleanDetails, language: 'plaintext' }).then((doc) =>
-                        vscode.window.showTextDocument(doc, {
-                            preview: true,
-                            viewColumn: vscode.ViewColumn.Beside,
-                        }),
-                    );
-                    break;
-                }
-                case 'undo':
+                    const doc = await vscode.workspace.openTextDocument({
+                        content: cleanDetails,
+                        language: 'plaintext',
+                    });
+                    await vscode.window.showTextDocument(doc, {
+                        preview: true,
+                        viewColumn: vscode.ViewColumn.Beside,
+                    });
+                },
+                undo: async () => {
                     await vscode.commands.executeCommand('jj-view.undo');
-                    break;
-                case 'redo':
+                },
+                redo: async () => {
                     await vscode.commands.executeCommand('jj-view.redo');
-                    break;
-                case 'abandon':
-                    await vscode.commands.executeCommand('jj-view.abandon', data.payload);
-                    break;
-                case 'getDetails':
+                },
+                abandon: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.abandon', msg.payload);
+                },
+                getDetails: async (msg) => {
                     await this.createCommitDetailsPanel(
-                        data.payload.changeId,
-                        data.payload.changeIdShortest,
-                        data.payload.isDivergent,
-                        data.payload.changeIdOffset,
+                        msg.payload.changeId,
+                        msg.payload.changeIdShortest,
+                        msg.payload.isDivergent,
+                        msg.payload.changeIdOffset,
                     );
-                    break;
-                case 'new':
+                },
+                new: async () => {
                     await vscode.commands.executeCommand('jj-view.new');
-                    break;
-                case 'newBefore':
-                    await vscode.commands.executeCommand('jj-view.newBefore', ...(data.payload.changeIds || []));
-                    break;
-                case 'newAfter':
-                    await vscode.commands.executeCommand('jj-view.newAfter', ...(data.payload.changeIds || []));
-                    break;
-                case 'resolve':
+                },
+                newBefore: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.newBefore', ...(msg.payload.changeIds || []));
+                },
+                newAfter: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.newAfter', ...(msg.payload.changeIds || []));
+                },
+                resolve: async (msg) => {
                     if (this.jj) {
-                        await this.jj.resolve(data.payload);
+                        await this.jj.resolve(msg.payload.path);
                         await vscode.commands.executeCommand('jj-view.refresh');
                     }
-                    break;
-                case 'moveBookmark':
-                    await this.handleMoveBookmark(data.payload);
-                    break;
-                case 'rebaseCommit':
-                    await this.handleRebaseCommit(data.payload);
-                    break;
-                case 'squashCommit':
-                    await this.handleSquashCommit(data.payload);
-                    break;
-                case 'duplicateCommit':
-                    await this.handleDuplicateCommit(data.payload);
-                    break;
-                case 'mergeCommit':
-                    await this.handleMergeCommit(data.payload);
-                    break;
-                case 'upload':
-                    await vscode.commands.executeCommand('jj-view.upload', data.payload);
-                    break;
-                case 'showComments':
-                    await vscode.commands.executeCommand('jj-view.showComments', data.payload.changeId);
-                    break;
-                case 'selectionChange': {
-                    const count = data.payload.commitIds.length;
-                    const hasImmutable = !!data.payload.hasImmutableSelection;
+                },
+                moveBookmark: async (msg) => {
+                    await this.handleMoveBookmark(msg.payload);
+                },
+                rebaseCommit: async (msg) => {
+                    await this.handleRebaseCommit(msg.payload);
+                },
+                squashCommit: async (msg) => {
+                    await this.handleSquashCommit(msg.payload);
+                },
+                duplicateCommit: async (msg) => {
+                    await this.handleDuplicateCommit(msg.payload);
+                },
+                mergeCommit: async (msg) => {
+                    await this.handleMergeCommit(msg.payload);
+                },
+                upload: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.upload', msg.payload);
+                },
+                showComments: async (msg) => {
+                    await vscode.commands.executeCommand('jj-view.showComments', msg.payload.changeId);
+                },
+                selectionChange: async (msg) => {
+                    const count = msg.payload.commitIds.length;
+                    const hasImmutable = !!msg.payload.hasImmutableSelection;
 
                     if (count !== 1) {
                         const tabsToClose: vscode.Tab[] = [];
@@ -304,17 +304,14 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                         }
                     }
 
-                    // Compute Capabilities
                     const allowAbandon = count > 0 && !hasImmutable;
                     const allowMerge = count > 1;
                     const allowNewBefore = count > 0 && !hasImmutable;
 
-                    // Calculate parent mutability for absorb command
-                    // Only applicable for single selection where parents are mutable
                     let parentMutable = false;
                     if (count === 1) {
                         const selectedCommit = this._cachedCommits.find(
-                            (c) => c.change_id === data.payload.commitIds[0],
+                            (c) => c.change_id === msg.payload.commitIds[0],
                         );
                         if (selectedCommit) {
                             parentMutable = canAbsorbCommit(selectedCommit);
@@ -327,11 +324,18 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                     vscode.commands.executeCommand('setContext', JjContextKey.SelectionParentMutable, parentMutable);
 
                     if (this._onSelectionChange) {
-                        this._onSelectionChange(data.payload.commitIds);
+                        this._onSelectionChange(msg.payload.commitIds);
                     }
-                    break;
-                }
-            }
+                },
+            },
+            {
+                logger: this.outputChannel,
+                messenger: webviewView.webview,
+            },
+        );
+
+        webviewView.webview.onDidReceiveMessage(async (message) => {
+            return await dispatcher.dispatch(message);
         });
     }
 

--- a/src/test/webview-logger.test.ts
+++ b/src/test/webview-logger.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, test, vi } from 'vitest';
+import { WebviewLogger, type WebviewVsCodeApi } from '../webview/webview-logger';
+
+describe('WebviewLogger', () => {
+    test('logs error to console and posts logMessage to vscodeApi', () => {
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const mockVscodeApi: WebviewVsCodeApi = {
+            postMessage: vi.fn(),
+        };
+
+        const logger = new WebviewLogger('TestTag', mockVscodeApi);
+        const err = new Error('Test failure');
+
+        logger.error('Something failed', err);
+
+        expect(consoleSpy).toHaveBeenCalledWith('[TestTag] Something failed', err);
+
+        expect(mockVscodeApi.postMessage).toHaveBeenCalledWith({
+            type: 'logMessage',
+            payload: {
+                level: 'error',
+                message: '[TestTag] Something failed',
+                details: expect.stringContaining('Test failure'),
+            },
+        });
+
+        consoleSpy.mockRestore();
+    });
+
+    test('logs info and warn to console and posts logMessage to vscodeApi', () => {
+        const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const mockVscodeApi: WebviewVsCodeApi = {
+            postMessage: vi.fn(),
+        };
+
+        const logger = new WebviewLogger('TestTag', mockVscodeApi);
+
+        logger.info('Info message', 'details-info');
+        logger.warn('Warn message', 'details-warn');
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith('[TestTag] Info message', 'details-info');
+        expect(consoleWarnSpy).toHaveBeenCalledWith('[TestTag] Warn message', 'details-warn');
+
+        expect(mockVscodeApi.postMessage).toHaveBeenCalledWith({
+            type: 'logMessage',
+            payload: {
+                level: 'info',
+                message: '[TestTag] Info message',
+                details: 'details-info',
+            },
+        });
+
+        expect(mockVscodeApi.postMessage).toHaveBeenCalledWith({
+            type: 'logMessage',
+            payload: {
+                level: 'warn',
+                message: '[TestTag] Warn message',
+                details: 'details-warn',
+            },
+        });
+
+        consoleInfoSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
+    });
+
+    test('works gracefully when vscodeApi is undefined', () => {
+        const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const logger = new WebviewLogger('TestTag');
+
+        logger.info('Standalone info message');
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith('[TestTag] Standalone info message', '');
+        consoleInfoSpy.mockRestore();
+    });
+});

--- a/src/test/webview-rpc-dispatcher.test.ts
+++ b/src/test/webview-rpc-dispatcher.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, test, vi } from 'vitest';
+import { z } from 'zod';
+import { createWebviewRpcClient, createWebviewRpcDispatcher } from '../common/webview-rpc-dispatcher';
+
+describe('WebviewRpcDispatcher', () => {
+    const testSchema = z.discriminatedUnion('type', [
+        z.object({ type: z.literal('ping'), value: z.string() }),
+        z.object({ type: z.literal('count'), amount: z.number() }),
+    ]);
+
+    test('dispatches valid messages to their registered handlers', async () => {
+        const pingFn = vi.fn();
+        const countFn = vi.fn();
+
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {
+            ping: pingFn,
+            count: countFn,
+        });
+
+        const handledPing = await dispatcher.dispatch({ type: 'ping', value: 'hello' });
+        expect(handledPing).toBe(true);
+        expect(pingFn).toHaveBeenCalledWith({ type: 'ping', value: 'hello' });
+        expect(countFn).not.toHaveBeenCalled();
+
+        const handledCount = await dispatcher.dispatch({ type: 'count', amount: 42 });
+        expect(handledCount).toBe(true);
+        expect(countFn).toHaveBeenCalledWith({ type: 'count', amount: 42 });
+    });
+
+    test('returns false and ignores invalid messages', async () => {
+        const pingFn = vi.fn();
+        const countFn = vi.fn();
+
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {
+            ping: pingFn,
+            count: countFn,
+        });
+
+        const invalidType = await dispatcher.dispatch({ type: 'unknown' });
+        expect(invalidType).toBe(false);
+
+        const invalidPayload = await dispatcher.dispatch({ type: 'count', amount: 'not a number' });
+        expect(invalidPayload).toBe(false);
+
+        const nonObject = await dispatcher.dispatch('just a string');
+        expect(nonObject).toBe(false);
+
+        expect(pingFn).not.toHaveBeenCalled();
+        expect(countFn).not.toHaveBeenCalled();
+    });
+
+    test('supports custom discriminator keys', async () => {
+        const customSchema = z.discriminatedUnion('command', [
+            z.object({ command: z.literal('open'), path: z.string() }),
+            z.object({ command: z.literal('close') }),
+        ]);
+
+        const openFn = vi.fn();
+        const closeFn = vi.fn();
+
+        const dispatcher = createWebviewRpcDispatcher(
+            customSchema,
+            {
+                open: openFn,
+                close: closeFn,
+            },
+            { discriminatorKey: 'command' },
+        );
+
+        const handled = await dispatcher.dispatch({ command: 'open', path: '/foo' });
+        expect(handled).toBe(true);
+        expect(openFn).toHaveBeenCalledWith({ command: 'open', path: '/foo' });
+    });
+
+    test('automatically dispatches baseline logMessage to logger', async () => {
+        const mockLogger = {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        };
+
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {}, { logger: mockLogger });
+
+        const infoHandled = await dispatcher.dispatch({
+            type: 'logMessage',
+            payload: { level: 'info', message: 'Ready', details: 'Initialized' },
+        });
+        expect(infoHandled).toBe(true);
+        expect(mockLogger.info).toHaveBeenCalledWith('Ready: Initialized');
+
+        const warnHandled = await dispatcher.dispatch({
+            type: 'logMessage',
+            payload: { level: 'warn', message: 'Caution' },
+        });
+        expect(warnHandled).toBe(true);
+        expect(mockLogger.warn).toHaveBeenCalledWith('Caution');
+
+        const errHandled = await dispatcher.dispatch({
+            type: 'logMessage',
+            payload: { level: 'error', message: 'Failure', details: 'Details' },
+        });
+        expect(errHandled).toBe(true);
+        expect(mockLogger.error).toHaveBeenCalledWith('Failure: Details');
+    });
+
+    test('dispatches custom logMessage handler with raw message', async () => {
+        const customLogMessageHandler = vi.fn(async (_message) => {
+            await Promise.resolve();
+        });
+
+        const rawLogMessage = {
+            type: 'logMessage',
+            payload: { level: 'info', message: 'custom log message' },
+        };
+
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {
+                logMessage: customLogMessageHandler,
+            } as never,
+            {},
+        );
+
+        const handled = await dispatcher.dispatch(rawLogMessage);
+
+        expect(handled).toBe(true);
+        expect(customLogMessageHandler).toHaveBeenCalledTimes(1);
+        expect(customLogMessageHandler).toHaveBeenCalledWith(rawLogMessage);
+    });
+});
+
+describe('createWebviewRpcClient', () => {
+    const testSchema = z.discriminatedUnion('type', [
+        z.object({ type: z.literal('ping'), value: z.string() }),
+        z.object({ type: z.literal('count'), amount: z.number() }),
+    ]);
+
+    test('invokes webview.postMessage with type and payload', () => {
+        const mockWebview = {
+            postMessage: vi.fn().mockReturnValue(Promise.resolve(true)),
+        };
+
+        const client = createWebviewRpcClient(mockWebview, testSchema);
+
+        client.ping({ value: 'hello' });
+        expect(mockWebview.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'ping',
+                value: 'hello',
+            }),
+        );
+
+        client.count({ amount: 10 });
+        expect(mockWebview.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'count',
+                amount: 10,
+            }),
+        );
+    });
+
+    test('validates payload against Zod schema and throws on invalid structure', () => {
+        const mockWebview = {
+            postMessage: vi.fn().mockReturnValue(Promise.resolve(true)),
+        };
+
+        const client = createWebviewRpcClient(mockWebview, testSchema);
+
+        // @ts-expect-error testing invalid payload type at runtime
+        expect(() => client.count({ amount: 'invalid' })).toThrowError(/Invalid RPC message 'count'/);
+        expect(mockWebview.postMessage).not.toHaveBeenCalled();
+    });
+
+    test('supports request-response promise resolution and exception propagation', async () => {
+        const rpcSchema = z.discriminatedUnion('type', [
+            z.object({ type: z.literal('greet'), name: z.string(), requestId: z.string().optional() }),
+            z.object({ type: z.literal('fail'), requestId: z.string().optional() }),
+        ]);
+
+        const messenger = {
+            postMessage: vi.fn((msg) => {
+                dispatcher.dispatch(msg);
+                return Promise.resolve(true);
+            }),
+        };
+
+        const dispatcher = createWebviewRpcDispatcher(
+            rpcSchema,
+            {
+                greet: async (msg) => `Hello ${msg.name}`,
+                fail: async () => {
+                    throw new Error('Something went wrong');
+                },
+            },
+            { messenger },
+        );
+
+        const client = createWebviewRpcClient(messenger, rpcSchema, { dispatcher });
+
+        const greeting = await client.greet({ name: 'Alice' });
+        expect(greeting).toBe('Hello Alice');
+
+        await expect(client.fail()).rejects.toThrowError('Something went wrong');
+    });
+});

--- a/src/webview/webview-logger.ts
+++ b/src/webview/webview-logger.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface WebviewVsCodeApi {
+    postMessage(message: unknown): void;
+}
+
+export class WebviewLogger {
+    constructor(
+        private readonly tag: string,
+        private readonly vscodeApi?: WebviewVsCodeApi,
+    ) {}
+
+    public info(message: string, details?: unknown): void {
+        console.info(`[${this.tag}] ${message}`, details ?? '');
+        this.post('info', message, details);
+    }
+
+    public warn(message: string, details?: unknown): void {
+        console.warn(`[${this.tag}] ${message}`, details ?? '');
+        this.post('warn', message, details);
+    }
+
+    public error(message: string, error?: unknown): void {
+        console.error(`[${this.tag}] ${message}`, error ?? '');
+        this.post('error', message, error);
+    }
+
+    private post(level: 'info' | 'warn' | 'error', message: string, details?: unknown): void {
+        if (!this.vscodeApi) {
+            return;
+        }
+        const detailStr =
+            details instanceof Error
+                ? details.stack || details.message
+                : details !== undefined
+                  ? String(details)
+                  : undefined;
+
+        this.vscodeApi.postMessage({
+            type: 'logMessage',
+            payload: {
+                level,
+                message: `[${this.tag}] ${message}`,
+                details: detailStr,
+            },
+        });
+    }
+}


### PR DESCRIPTION
Introduce a type-safe RPC dispatcher and proxy client using Zod schemas for all webview host interactions. This establishes strict runtime payload validation across the log graph view and commit details custom editor, while providing structured log forwarding from webview components to the extension output channel.