### PR TITLE
uri: store custom scheme parameters in URI fragments

### DIFF
--- a/src/commands/absorb.ts
+++ b/src/commands/absorb.ts
@@ -5,11 +5,12 @@
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getFsPathFromUri } from '../uri-utils';
 import { collectResourceStates, extractRevisions, showJjError, withDelayedProgress } from './command-utils';
 
 export async function absorbCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
-    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+    const paths = resourceStates.map((r) => getFsPathFromUri(r.resourceUri));
 
     const fromRevision = extractRevisions(args)[0];
 

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -11,6 +11,7 @@ import type { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
+import { getFsPathFromUri, getUriParams } from '../uri-utils';
 import { getJjViewConfig } from '../utils/config-utils';
 import { formatCommitDescription } from '../utils/format-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
@@ -84,7 +85,7 @@ export function collectResourceStates(args: unknown[]): JjResourceState[] {
     // De-duplicate by fsPath
     const unique = new Map<string, JjResourceState>();
     for (const state of resourceStates) {
-        unique.set(state.resourceUri.fsPath, state);
+        unique.set(getFsPathFromUri(state.resourceUri), state);
     }
 
     return Array.from(unique.values());
@@ -514,7 +515,7 @@ export function resolveRepository(
         if (activeEditor) {
             const docUri = activeEditor.document.uri;
             if (docUri.scheme === 'jj-commit') {
-                const query = new URLSearchParams(docUri.query);
+                const query = getUriParams(docUri);
                 const repoRoot = query.get('repoRoot');
                 if (repoRoot) {
                     uri = vscode.Uri.file(decodeURIComponent(repoRoot));

--- a/src/commands/compare-all-files-with-revision.ts
+++ b/src/commands/compare-all-files-with-revision.ts
@@ -5,7 +5,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from '../jj-service';
-import { encodeJjViewQuery } from '../uri-utils';
+import { createRevisionUri } from '../uri-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 import { extractRevision, promptForRevision, RevisionQuery, showJjError, withDelayedProgress } from './command-utils';
 
@@ -48,18 +48,9 @@ export async function compareAllFilesWithRevisionCommand(
                     const leftPath = entry.oldPath || entry.path;
                     const rightPath = entry.path;
 
-                    const leftUri = vscode.Uri.file(path.join(jj.workspaceRoot, leftPath)).with({
-                        scheme: 'jj-view',
-                        query: isAdded
-                            ? encodeJjViewQuery({ mode: 'revision', revision: 'none' })
-                            : encodeJjViewQuery({ mode: 'revision', revision: rev }),
-                    });
-
+                    const leftUri = createRevisionUri(jj.workspaceRoot, leftPath, isAdded ? 'none' : rev);
                     const rightUri = isDeleted
-                        ? vscode.Uri.file(path.join(jj.workspaceRoot, rightPath)).with({
-                              scheme: 'jj-view',
-                              query: encodeJjViewQuery({ mode: 'revision', revision: 'none' }),
-                          })
+                        ? createRevisionUri(jj.workspaceRoot, rightPath, 'none')
                         : vscode.Uri.file(path.join(jj.workspaceRoot, rightPath));
 
                     resources.push([leftUri, rightUri]);

--- a/src/commands/compare-file-with-revision.ts
+++ b/src/commands/compare-file-with-revision.ts
@@ -5,7 +5,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from '../jj-service';
-import { encodeJjViewQuery } from '../uri-utils';
+import { createRevisionUri } from '../uri-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 import { extractFileUri, promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
@@ -32,10 +32,7 @@ export async function compareFileWithRevisionCommand(
             return;
         }
 
-        const leftUri = fileUri.with({
-            scheme: 'jj-view',
-            query: encodeJjViewQuery({ mode: 'revision', revision }),
-        });
+        const leftUri = createRevisionUri(jj.workspaceRoot, fileUri.fsPath, revision);
 
         const title = `${path.basename(fileUri.fsPath)} (${revision} ↔ Working Copy)`;
         await vscode.commands.executeCommand('vscode.diff', leftUri, fileUri, title);

--- a/src/commands/discard-change.ts
+++ b/src/commands/discard-change.ts
@@ -56,32 +56,39 @@ export async function discardChangeCommand(
         const originalDoc = await vscode.workspace.openTextDocument(originalUri);
         const modifiedDoc = await vscode.workspace.openTextDocument(uri);
 
+        const getSafeRange = (
+            doc: vscode.TextDocument,
+            startLine1Based: number,
+            endLine1Based: number,
+        ): vscode.Range => {
+            const lineCount = doc.lineCount;
+            if (lineCount === 0) {
+                return new vscode.Range(0, 0, 0, 0);
+            }
+            const startLine = Math.max(0, Math.min(startLine1Based - 1, lineCount - 1));
+            const endLine = Math.max(0, Math.min(endLine1Based - 1, lineCount - 1));
+
+            const startPos = new vscode.Position(startLine, 0);
+            const endLineObj = doc.lineAt(endLine);
+            const endPos = endLineObj.rangeIncludingLineBreak.end;
+
+            return new vscode.Range(startPos, endPos);
+        };
+
         // Calculate Original Range
         let originalTextStr = '';
         if (change.originalEndLineNumber >= change.originalStartLineNumber) {
-            const startLine = change.originalStartLineNumber - 1;
-            const endLine = change.originalEndLineNumber - 1;
-
-            const startPos = new vscode.Position(startLine, 0);
-            const endLineObj = originalDoc.lineAt(endLine);
-            const endPos = endLineObj.rangeIncludingLineBreak.end;
-
-            originalTextStr = originalDoc.getText(new vscode.Range(startPos, endPos));
+            originalTextStr = originalDoc.getText(
+                getSafeRange(originalDoc, change.originalStartLineNumber, change.originalEndLineNumber),
+            );
         }
 
         // Calculate Modified Range
         let modifiedRange: vscode.Range;
         if (change.modifiedEndLineNumber >= change.modifiedStartLineNumber) {
-            const startLine = change.modifiedStartLineNumber - 1;
-            const endLine = change.modifiedEndLineNumber - 1;
-
-            const startPos = new vscode.Position(startLine, 0);
-            const endLineObj = modifiedDoc.lineAt(endLine);
-            const endPos = endLineObj.rangeIncludingLineBreak.end;
-
-            modifiedRange = new vscode.Range(startPos, endPos);
+            modifiedRange = getSafeRange(modifiedDoc, change.modifiedStartLineNumber, change.modifiedEndLineNumber);
         } else {
-            const insertLine = Math.min(change.modifiedStartLineNumber, modifiedDoc.lineCount);
+            const insertLine = Math.max(0, Math.min(change.modifiedStartLineNumber, modifiedDoc.lineCount));
             modifiedRange = new vscode.Range(insertLine, 0, insertLine, 0);
         }
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -4,17 +4,18 @@
  */
 import * as vscode from 'vscode';
 import type { JjResourceState } from '../scm-resource-state';
+import { toFileUri } from '../uri-utils';
 import { extractFileUri } from './command-utils';
 
 // Opens the file on disk (working copy version).
 // Extracts the file URI from command arguments (or active text editor),
-// converts the scheme to 'file', and strips query parameters.
+// converts the scheme to 'file', and strips query/fragment parameters.
 export async function openFileCommand(...args: unknown[]) {
     const resourceUri = extractFileUri(args);
     if (!resourceUri) {
         return;
     }
-    const uri = resourceUri.with({ scheme: 'file', query: '' });
+    const uri = toFileUri(resourceUri);
     await vscode.commands.executeCommand('vscode.open', uri);
 }
 

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -4,6 +4,7 @@
  */
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getFsPathFromUri } from '../uri-utils';
 import { collectResourceStates, showJjError, withDelayedProgress } from './command-utils';
 
 export async function restoreCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
@@ -17,7 +18,7 @@ export async function restoreCommand(scmProvider: JjScmProvider, jj: JjService, 
     for (const state of resourceStates) {
         const rev = state.revision || '@';
         const list = statesByRevision.get(rev) || [];
-        list.push(state.resourceUri.fsPath);
+        list.push(getFsPathFromUri(state.resourceUri));
         statesByRevision.set(rev, list);
     }
 

--- a/src/commands/squash-files.ts
+++ b/src/commands/squash-files.ts
@@ -5,6 +5,7 @@
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
+import { getFsPathFromUri } from '../uri-utils';
 import {
     collectResourceStates,
     extractRevision,
@@ -19,7 +20,7 @@ import {
  */
 export async function squashFilesIntoParentCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
-    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+    const paths = resourceStates.map((r) => getFsPathFromUri(r.resourceUri));
 
     if (paths.length === 0) {
         return;
@@ -43,7 +44,7 @@ export async function squashFilesIntoParentCommand(scmProvider: JjScmProvider, j
  */
 export async function squashFilesIntoAncestorCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
-    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+    const paths = resourceStates.map((r) => getFsPathFromUri(r.resourceUri));
 
     if (paths.length === 0) {
         return;
@@ -76,7 +77,7 @@ export async function squashFilesIntoAncestorCommand(scmProvider: JjScmProvider,
  */
 export async function squashFilesIntoChildCommand(scmProvider: JjScmProvider, jj: JjService, args: unknown[]) {
     const resourceStates = collectResourceStates(args);
-    const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+    const paths = resourceStates.map((r) => getFsPathFromUri(r.resourceUri));
 
     if (paths.length === 0) {
         return;

--- a/src/commands/squash-selection.ts
+++ b/src/commands/squash-selection.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
 import type { JjService } from '../jj-service';
-import { getRevisionFromUri } from '../uri-utils';
+import { getFsPathFromUri, getRevisionFromUri } from '../uri-utils';
 import { showJjError } from './command-utils';
 
 interface LineChange {
@@ -67,7 +67,7 @@ export async function squashHunkIntoParentCommand(
     }
 
     const ranges = [{ startLine, endLine }];
-    const relPath = path.relative(jj.workspaceRoot, uri.fsPath);
+    const relPath = path.relative(jj.workspaceRoot, getFsPathFromUri(uri));
     const revision = getRevisionFromUri(uri) || '@';
 
     try {
@@ -100,7 +100,7 @@ export async function squashSelectionIntoParentCommand(
     }
 
     const docUri = editor.document.uri;
-    const fsPath = docUri.fsPath;
+    const fsPath = getFsPathFromUri(docUri);
     const relPath = path.relative(jj.workspaceRoot, fsPath);
 
     const revision = getRevisionFromUri(docUri) || '@';

--- a/src/commands/view-file-at-revision.ts
+++ b/src/commands/view-file-at-revision.ts
@@ -5,7 +5,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from '../jj-service';
-import { encodeJjViewQuery } from '../uri-utils';
+import { createRevisionUri } from '../uri-utils';
 import type { JjLoggerChannel } from '../utils/output-channel';
 import { extractFileUri, promptForRevision, RevisionQuery, showJjError } from './command-utils';
 
@@ -32,10 +32,7 @@ export async function viewFileAtRevisionCommand(
             return;
         }
 
-        const revisionUri = fileUri.with({
-            scheme: 'jj-view',
-            query: encodeJjViewQuery({ mode: 'revision', revision }),
-        });
+        const revisionUri = createRevisionUri(jj.workspaceRoot, fileUri.fsPath, revision);
 
         await vscode.commands.executeCommand('vscode.open', revisionUri);
     } catch (err: unknown) {

--- a/src/jj-commit-details-editor-provider.ts
+++ b/src/jj-commit-details-editor-provider.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import { WebviewToHostMessageSchema } from './common/ipc-schemas';
 import { createWebviewRpcDispatcher } from './common/webview-rpc-dispatcher';
 import { createJjResourceState } from './scm-resource-state';
+import { getUriParams } from './uri-utils';
 import { getJjViewConfig } from './utils/config-utils';
 import { formatCommitTitle } from './utils/jj-utils';
 
@@ -215,8 +216,8 @@ export class JjCommitDetailsEditorProvider implements vscode.CustomEditorProvide
         _openContext: vscode.CustomDocumentOpenContext,
         _token: vscode.CancellationToken,
     ): Promise<JjCommitDocument> {
-        // URI format: jj-commit://commit/Commit:%20<shortId>?changeId=<changeId>&repoRoot=<repoRoot>
-        const urlParams = new URLSearchParams(uri.query);
+        // URI format: jj-commit://commit/Commit:%20<shortId>#changeId=<changeId>&repoRoot=<repoRoot>
+        const urlParams = getUriParams(uri);
         const changeId = urlParams.get('changeId') || '';
         const repoRootPath = urlParams.get('repoRoot');
         const repoRoot = repoRootPath ? vscode.Uri.file(repoRootPath) : undefined;
@@ -509,7 +510,7 @@ export async function openCommitDetails(
         scheme: 'jj-commit',
         authority: 'commit',
         path: `/${title}`,
-        query: `changeId=${changeId}&repoRoot=${encodeURIComponent(workspaceRoot)}`,
+        fragment: `changeId=${changeId}&repoRoot=${encodeURIComponent(workspaceRoot)}`,
     });
 
     await closeOtherCommitDetailsTabs(uri, workspaceRoot);
@@ -534,7 +535,7 @@ export async function closeOtherCommitDetailsTabs(
         }
 
         try {
-            const query = new URLSearchParams(tab.input.uri.query);
+            const query = getUriParams(tab.input.uri);
             const tabRepoRoot = query.get('repoRoot');
             return !tabRepoRoot || tabRepoRoot === workspaceRoot;
         } catch {

--- a/src/jj-decoration-provider.ts
+++ b/src/jj-decoration-provider.ts
@@ -2,6 +2,7 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from './jj-service';
 import type { JjStatusEntry } from './jj-types';
@@ -39,13 +40,7 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         this._onDidChangeFileDecorations.fire(undefined);
     }
 
-    private getScmStatusDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
-        const uriString = uri.toString();
-        const scmStatus = this.scmStatusDecorations.get(uriString);
-        if (!scmStatus) {
-            return undefined;
-        }
-
+    private createFileDecoration(scmStatus: JjStatusEntry): vscode.FileDecoration | undefined {
         const { status, conflicted } = scmStatus;
 
         if (conflicted) {
@@ -88,9 +83,30 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
         }
     }
 
+    private getScmStatusDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
+        if (uri.scheme === 'jj-edit' || uri.scheme === 'jj-view') {
+            const scmStatus = this.scmStatusDecorations.get(uri.toString());
+            if (scmStatus) {
+                return this.createFileDecoration(scmStatus);
+            }
+        }
+
+        const relativePath = this.getWorkspaceRelativePath(uri);
+        if (!relativePath) {
+            return undefined;
+        }
+        const key = relativePath.startsWith('/') ? relativePath : `/${relativePath}`;
+        const scmStatus = this.scmStatusDecorations.get(key) || this.scmStatusDecorations.get(uri.toString());
+        return scmStatus ? this.createFileDecoration(scmStatus) : undefined;
+    }
+
     private getWorkspaceRelativePath(uri: vscode.Uri): string | undefined {
         if (!this.workspaceRoot) {
             return undefined;
+        }
+        if (uri.scheme === 'jj-edit' || uri.scheme === 'jj-view') {
+            const rel = uri.path;
+            return rel.startsWith('/') ? rel.substring(1) : rel;
         }
 
         const normalizedFsPath = uri.fsPath.replace(/\\/g, '/');
@@ -337,16 +353,24 @@ export class JjDecorationProvider implements vscode.FileDecorationProvider {
     private updateScmStatusDecorations(scmStatusDecorations: Map<string, JjStatusEntry>) {
         const changedUris: vscode.Uri[] = [];
 
+        const relativeKeyToUri = (key: string): vscode.Uri => {
+            if (key.startsWith('file:') || key.startsWith('jj-edit:') || key.startsWith('jj-view:')) {
+                return vscode.Uri.parse(key);
+            }
+            const relKey = key.replace(/^[/\\]+/, '');
+            return vscode.Uri.file(path.join(this.workspaceRoot, relKey));
+        };
+
         // Compare old and new SCM status
         for (const [key, newEntry] of scmStatusDecorations.entries()) {
             const oldEntry = this.scmStatusDecorations.get(key);
             if (!oldEntry || oldEntry.status !== newEntry.status || oldEntry.conflicted !== newEntry.conflicted) {
-                changedUris.push(vscode.Uri.parse(key));
+                changedUris.push(relativeKeyToUri(key));
             }
         }
         for (const key of this.scmStatusDecorations.keys()) {
             if (!scmStatusDecorations.has(key)) {
-                changedUris.push(vscode.Uri.parse(key));
+                changedUris.push(relativeKeyToUri(key));
             }
         }
 

--- a/src/jj-edit-fs-provider.ts
+++ b/src/jj-edit-fs-provider.ts
@@ -2,19 +2,22 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as fs from 'node:fs/promises';
 import * as vscode from 'vscode';
+import { getFsPathFromUri } from './uri-utils';
 
 /**
  * Parse a jj-edit URI to extract revision and file path.
- * URI format: jj-edit:///path/to/file?revision=<changeId>
+ * URI format: jj-edit:///relative/path#root=<repoRoot>&revision=<changeId>
  */
 function parseEditUri(uri: vscode.Uri): { revision: string; filePath: string } {
-    const query = new URLSearchParams(uri.query);
-    const revision = query.get('revision');
+    const params = new URLSearchParams(uri.fragment);
+    const revision = params.get('revision');
     if (!revision) {
         throw vscode.FileSystemError.Unavailable('Missing revision in jj-edit URI');
     }
-    return { revision, filePath: uri.fsPath };
+    const filePath = getFsPathFromUri(uri);
+    return { revision, filePath };
 }
 
 /**
@@ -87,23 +90,30 @@ export class JjEditFileSystemProvider implements vscode.FileSystemProvider {
         const repo = this._repositoryManager.getRepositoryForUri(uri);
         if (!repo) {
             this._repositoryManager.outputChannel.info(
-                `[JjEditFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${uri.fsPath})`,
+                `[JjEditFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${filePath})`,
             );
-            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${uri.fsPath}`);
+            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${filePath}`);
+        }
+        if (revision === '@') {
+            try {
+                return await fs.readFile(filePath);
+            } catch {
+                // Fallback to jj file show if disk file is missing/unreadable
+            }
         }
         const content = await repo.jj.getFileContent(filePath, revision);
         return Buffer.from(content, 'utf8');
     }
 
     async writeFile(uri: vscode.Uri, content: Uint8Array): Promise<void> {
+        const { revision, filePath } = parseEditUri(uri);
         const repo = this._repositoryManager.getRepositoryForUri(uri);
         if (!repo) {
             this._repositoryManager.outputChannel.info(
-                `[JjEditFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${uri.fsPath})`,
+                `[JjEditFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${filePath})`,
             );
-            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${uri.fsPath}`);
+            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${filePath}`);
         }
-        const { revision, filePath } = parseEditUri(uri);
         const text = Buffer.from(content).toString('utf8');
         const repoRoot = repo.rootUri.fsPath;
         const batchKey = `${repoRoot}\u0000${revision}`;
@@ -147,7 +157,13 @@ export class JjEditFileSystemProvider implements vscode.FileSystemProvider {
                     filesMap.set(req.filePath, req.content);
                 }
 
-                await repo.jj.setFilesContent(revision, filesMap);
+                if (revision === '@') {
+                    for (const [filePath, contentStr] of filesMap.entries()) {
+                        await fs.writeFile(filePath, contentStr);
+                    }
+                } else {
+                    await repo.jj.setFilesContent(revision, filesMap);
+                }
 
                 // Notify VS Code and resolve all promises
                 const changeEvents: vscode.FileChangeEvent[] = [];

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -13,6 +13,7 @@ import { JjContextKey } from './jj-context-keys';
 import type { JjRepository } from './jj-repository';
 import type { JjService } from './jj-service';
 import { type JjLogEntry, TOGGLEABLE_COMMIT_ACTIONS, type ToggleableCommitAction } from './jj-types';
+import { getUriParams } from './uri-utils';
 import { getJjViewConfig } from './utils/config-utils';
 import { canAbsorbCommit } from './utils/jj-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
@@ -286,7 +287,7 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
                                     let isForCurrentRepo = true;
                                     if (this._repo) {
                                         try {
-                                            const query = new URLSearchParams(tab.input.uri.query);
+                                            const query = getUriParams(tab.input.uri);
                                             const repoRoot = query.get('repoRoot');
                                             if (repoRoot && repoRoot !== this._repo.rootUri.fsPath) {
                                                 isForCurrentRepo = false;

--- a/src/jj-merge-provider.ts
+++ b/src/jj-merge-provider.ts
@@ -4,6 +4,7 @@
  */
 import * as vscode from 'vscode';
 import type { JjService } from './jj-service';
+import { getUriParams } from './uri-utils';
 
 /**
  * Content provider for merge editor inputs.
@@ -19,7 +20,7 @@ export class JjMergeContentProvider implements vscode.TextDocumentContentProvide
     constructor(private jjService: JjService) {}
 
     async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
-        const query = new URLSearchParams(uri.query);
+        const query = getUriParams(uri);
         const fsPath = query.get('path');
         const part = query.get('part'); // 'base', 'left', 'right'
 

--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -11,6 +11,7 @@ import type { CodeForgeRegistry } from './code-forge-registry';
 import type { JjProcessTracker } from './jj-process-tracker';
 import { JjRepository } from './jj-repository';
 import { JjService, NO_OP_LOGGER } from './jj-service';
+import { getFsPathFromUri, getUriParams } from './uri-utils';
 import { CoalescingQueue } from './utils/coalescing-queue';
 import { getJjViewConfig } from './utils/config-utils';
 import { type JjLoggerChannel, JjOutputChannel } from './utils/output-channel';
@@ -901,19 +902,18 @@ export class JjRepositoryManager implements vscode.Disposable {
     }
 
     private getPathForUri(uri: vscode.Uri): string {
-        let rawPath = uri.fsPath;
         if (uri.scheme === 'jj-commit') {
             try {
-                const query = new URLSearchParams(uri.query);
+                const query = getUriParams(uri);
                 const repoRoot = query.get('repoRoot');
                 if (repoRoot) {
-                    rawPath = decodeURIComponent(repoRoot);
+                    return decodeURIComponent(repoRoot);
                 }
             } catch {
                 // Ignore parsing errors
             }
         }
-        return rawPath;
+        return getFsPathFromUri(uri);
     }
 
     private async isUriInWorkspaceFolder(uri: vscode.Uri): Promise<boolean> {

--- a/src/jj-scm-provider.ts
+++ b/src/jj-scm-provider.ts
@@ -20,6 +20,14 @@ import { JjService } from './jj-service';
 import type { JjLogEntry, JjStatusEntry } from './jj-types';
 import type { JjViewFileSystemProvider } from './jj-view-fs-provider';
 import { createJjResourceState, type JjResourceState } from './scm-resource-state';
+import {
+    encodeJjViewQuery,
+    getFsPathFromUri,
+    getRepoRelativePath,
+    getRevisionFromUri,
+    getUriParams,
+    toFileUri,
+} from './uri-utils';
 import { getJjViewConfig } from './utils/config-utils';
 import { canAbsorbCommit, canSquashCommit, formatDisplayChangeId, isMutableCommit } from './utils/jj-utils';
 import type { JjLoggerChannel } from './utils/output-channel';
@@ -110,7 +118,7 @@ export class JjScmProvider implements vscode.Disposable {
         this.disposables.push(
             vscode.workspace.onDidSaveTextDocument(async (doc) => {
                 if (doc.uri.scheme === 'jj-merge-output') {
-                    const query = new URLSearchParams(doc.uri.query);
+                    const query = getUriParams(doc.uri);
                     const fsPath = query.get('path');
                     if (fsPath) {
                         try {
@@ -373,7 +381,8 @@ export class JjScmProvider implements vscode.Disposable {
                     hasChild,
                 });
                 decorationMap.set(state.resourceUri.toString(), c);
-                this._workingCopyStatuses.set(state.resourceUri.fsPath, c);
+                decorationMap.set(getRepoRelativePath(state.resourceUri, this.jj.workspaceRoot), c);
+                this._workingCopyStatuses.set(getRepoRelativePath(state.resourceUri, this.jj.workspaceRoot), c);
                 return state;
             });
 
@@ -385,6 +394,7 @@ export class JjScmProvider implements vscode.Disposable {
                     inConflictGroup: true,
                 });
                 decorationMap.set(state.resourceUri.toString(), entry);
+                decorationMap.set(getRepoRelativePath(state.resourceUri, this.jj.workspaceRoot), entry);
                 return state;
             });
 
@@ -530,7 +540,7 @@ export class JjScmProvider implements vscode.Disposable {
     }
 
     async restore(resourceStates: vscode.SourceControlResourceState[]) {
-        const paths = resourceStates.map((r) => r.resourceUri.fsPath);
+        const paths = resourceStates.map((r) => getFsPathFromUri(r.resourceUri));
         await this.jj.restore(paths);
         await this.repo.refresh();
     }
@@ -556,32 +566,33 @@ export class JjScmProvider implements vscode.Disposable {
         const uri = r.resourceUri;
 
         try {
-            const encodedPath = encodeURIComponent(uri.fsPath);
+            const fsPath = getFsPathFromUri(uri);
+            const encodedPath = encodeURIComponent(fsPath);
 
             // Create virtual URIs for each part - use relative path so VS Code doesn't try to read root
-            const relativePath = vscode.workspace.asRelativePath(uri);
+            const relativePath = vscode.workspace.asRelativePath(toFileUri(uri));
             const virtualPath = path.posix.join('/', relativePath); // Ensure specific path format
 
             const baseUri = uri.with({
                 scheme: 'jj-merge-output',
                 authority: 'jj-merge',
                 path: virtualPath,
-                query: `path=${encodedPath}&part=base`,
+                fragment: `path=${encodedPath}&part=base`,
             });
             const leftUri = uri.with({
                 scheme: 'jj-merge-output',
                 authority: 'jj-merge',
                 path: virtualPath,
-                query: `path=${encodedPath}&part=left`,
+                fragment: `path=${encodedPath}&part=left`,
             });
             const rightUri = uri.with({
                 scheme: 'jj-merge-output',
                 authority: 'jj-merge',
                 path: virtualPath,
-                query: `path=${encodedPath}&part=right`,
+                fragment: `path=${encodedPath}&part=right`,
             });
             // Output is the real file
-            const outputUri = uri;
+            const outputUri = toFileUri(uri);
             const args = {
                 base: baseUri, // base is a plain URI, not an object
                 input1: { uri: leftUri, title: 'Side 1' },
@@ -608,20 +619,22 @@ export class JjScmProvider implements vscode.Disposable {
     }
 
     provideOriginalResource(uri: vscode.Uri): vscode.ProviderResult<vscode.Uri> {
-        const statusEntry = this._workingCopyStatuses.get(uri.fsPath);
+        const relativePath = getRepoRelativePath(uri, this.jj.workspaceRoot);
+        const statusEntry = this._workingCopyStatuses.get(relativePath);
         if (!statusEntry || statusEntry.status === 'added') {
             return undefined;
         }
 
-        const query = new URLSearchParams(uri.query);
-        const revision = query.get('jj-revision') || '@';
+        const revision = getRevisionFromUri(uri) || '@';
 
-        let originalUri = uri;
-        if (statusEntry.oldPath) {
-            originalUri = vscode.Uri.file(path.join(this.jj.workspaceRoot, statusEntry.oldPath));
-        }
+        const leftPath = statusEntry.oldPath || statusEntry.path;
+        const relPath = leftPath.startsWith('/') ? leftPath : `/${leftPath}`;
 
-        return originalUri.with({ scheme: 'jj-view', query: `base=${revision}&side=left` });
+        return vscode.Uri.from({
+            scheme: 'jj-view',
+            path: relPath,
+            fragment: encodeJjViewQuery({ mode: 'diff', root: this.jj.workspaceRoot, base: revision, side: 'left' }),
+        });
     }
 
     get sourceControl(): vscode.SourceControl {

--- a/src/jj-view-fs-provider.ts
+++ b/src/jj-view-fs-provider.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as vscode from 'vscode';
-import { decodeJjViewQuery } from './uri-utils';
+import { decodeJjViewQuery, getFsPathFromUri } from './uri-utils';
 
 /**
  * A FileSystemProvider that provides read-only access to "original" file content
  * for diff views and gutter decorations.
  *
- * Uses the jj-view scheme: jj-view:///path/to/file?base=<revision>&side=<left|right>
+ * Uses the jj-view scheme: jj-view:///relative/path#root=<repoRoot>&base=<revision>&side=<left|right>
  */
 export class JjViewFileSystemProvider implements vscode.FileSystemProvider {
     private _onDidChangeFile = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
@@ -58,27 +58,27 @@ export class JjViewFileSystemProvider implements vscode.FileSystemProvider {
 
     async readFile(uri: vscode.Uri): Promise<Uint8Array> {
         this._knownUris.add(uri.toString());
+        const filePath = getFsPathFromUri(uri);
         const repo = this._repositoryManager.getRepositoryForUri(uri);
         if (!repo) {
             this._repositoryManager.outputChannel.info(
-                `[JjViewFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${uri.fsPath})`,
+                `[JjViewFileSystemProvider] No Jujutsu repository resolved for URI: ${uri.toString()} (scheme: ${uri.scheme}, fsPath: ${filePath})`,
             );
-            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${uri.fsPath}`);
+            throw vscode.FileSystemError.Unavailable(`No Jujutsu repository found for: ${filePath}`);
         }
 
         try {
-            const query = decodeJjViewQuery(uri.query);
+            const query = decodeJjViewQuery(uri);
 
             if (query.mode === 'revision') {
                 try {
-                    const content = await repo.jj.getFileContent(uri.fsPath, query.revision);
+                    const content = await repo.jj.getFileContent(filePath, query.revision);
                     return Buffer.from(content, 'utf8');
                 } catch {
                     return new Uint8Array();
                 }
             }
 
-            const filePath = uri.fsPath;
             const cacheKey = `${query.base}|${filePath}`;
 
             let content = this._cache.get(cacheKey);

--- a/src/scm-resource-state.ts
+++ b/src/scm-resource-state.ts
@@ -5,7 +5,7 @@
 import type * as vscode from 'vscode';
 import { ScmContextValue } from './jj-context-keys';
 import type { JjStatusEntry } from './jj-types';
-import { createDiffUris } from './uri-utils';
+import { createDiffUris, toFileUri } from './uri-utils';
 
 export interface JjResourceState extends vscode.SourceControlResourceState {
     leftUri?: vscode.Uri;
@@ -54,7 +54,7 @@ export function createJjResourceState(
               : {
                     command: 'vscode.open',
                     title: 'Open File',
-                    arguments: [resourceUri.with({ query: '' })],
+                    arguments: [toFileUri(resourceUri)],
                 };
 
     const flags: string[] = [];

--- a/src/test/commands/compare-all-files-with-revision.test.ts
+++ b/src/test/commands/compare-all-files-with-revision.test.ts
@@ -67,34 +67,23 @@ describe('compareAllFilesWithRevisionCommand', () => {
         const simplified = resourceTuples.map((t) => ({
             path: path.basename(t[0].fsPath),
             leftScheme: t[1].scheme,
-            leftQuery: t[1].query,
+            leftFragment: t[1].fragment,
             rightScheme: t[2].scheme,
-            rightQuery: t[2].query,
+            rightFragment: t[2].fragment,
         }));
         simplified.sort((a, b) => a.path.localeCompare(b.path));
 
-        expect(simplified).toEqual([
-            {
-                path: 'file1.txt',
-                leftScheme: 'jj-view',
-                leftQuery: `revision=${parentId}`,
-                rightScheme: 'file',
-                rightQuery: '',
-            },
-            {
-                path: 'file2.txt',
-                leftScheme: 'jj-view',
-                leftQuery: `revision=${parentId}`,
-                rightScheme: 'jj-view',
-                rightQuery: 'revision=none',
-            },
-            {
-                path: 'file3.txt',
-                leftScheme: 'jj-view',
-                leftQuery: 'revision=none',
-                rightScheme: 'file',
-                rightQuery: '',
-            },
-        ]);
+        expect(simplified[0].leftScheme).toBe('jj-view');
+        expect(simplified[0].leftFragment).toContain(`revision=${parentId}`);
+        expect(simplified[0].rightScheme).toBe('file');
+
+        expect(simplified[1].leftScheme).toBe('jj-view');
+        expect(simplified[1].leftFragment).toContain(`revision=${parentId}`);
+        expect(simplified[1].rightScheme).toBe('jj-view');
+        expect(simplified[1].rightFragment).toContain('revision=none');
+
+        expect(simplified[2].leftScheme).toBe('jj-view');
+        expect(simplified[2].leftFragment).toContain('revision=none');
+        expect(simplified[2].rightScheme).toBe('file');
     });
 });

--- a/src/test/commands/compare-file-with-revision.test.ts
+++ b/src/test/commands/compare-file-with-revision.test.ts
@@ -61,21 +61,17 @@ describe('compareFileWithRevisionCommand', () => {
                   call[0],
                   {
                       scheme: (call[1] as vscode.Uri).scheme,
-                      query: (call[1] as vscode.Uri).query,
+                      fragment: (call[1] as vscode.Uri).fragment,
                   },
                   call[2],
                   call[3],
               ]
             : null;
 
-        expect(simplifiedCall).toEqual([
-            'vscode.diff',
-            {
-                scheme: 'jj-view',
-                query: 'revision=main',
-            },
-            fileUri,
-            'file1.txt (main ↔ Working Copy)',
-        ]);
+        expect(simplifiedCall?.[0]).toBe('vscode.diff');
+        expect(simplifiedCall?.[1].scheme).toBe('jj-view');
+        expect(simplifiedCall?.[1].fragment).toContain('revision=main');
+        expect(simplifiedCall?.[2]).toEqual(fileUri);
+        expect(simplifiedCall?.[3]).toBe('file1.txt (main ↔ Working Copy)');
     });
 });

--- a/src/test/commands/details.test.ts
+++ b/src/test/commands/details.test.ts
@@ -40,7 +40,7 @@ describe('showDetailsCommand', () => {
             'vscode.openWith',
             expect.objectContaining({
                 scheme: 'jj-commit',
-                query: expect.stringContaining(`changeId=${changeId}`),
+                fragment: expect.stringContaining(`changeId=${changeId}`),
             }),
             'jj-view.commitDetailsEditor',
         );
@@ -61,7 +61,7 @@ describe('showDetailsCommand', () => {
             'vscode.openWith',
             expect.objectContaining({
                 scheme: 'jj-commit',
-                query: expect.stringContaining(`changeId=${changeId}`),
+                fragment: expect.stringContaining(`changeId=${changeId}`),
             }),
             'jj-view.commitDetailsEditor',
         );
@@ -75,7 +75,7 @@ describe('showDetailsCommand', () => {
             'vscode.openWith',
             expect.objectContaining({
                 scheme: 'jj-commit',
-                query: expect.stringContaining(`changeId=${changeId}`),
+                fragment: expect.stringContaining(`changeId=${changeId}`),
             }),
             'jj-view.commitDetailsEditor',
         );

--- a/src/test/commands/discard-change.test.ts
+++ b/src/test/commands/discard-change.test.ts
@@ -105,7 +105,7 @@ describe('discardChangeCommand', () => {
         repo = new TestRepo();
         repo.init();
         scmProvider = createMock<JjScmProvider>({
-            provideOriginalResource: (uri: vscode.Uri) => uri.with({ scheme: 'jj-view', query: 'base=@&side=left' }),
+            provideOriginalResource: (uri: vscode.Uri) => uri.with({ scheme: 'jj-view', fragment: 'base=@&side=left' }),
         });
         mockDocuments.clear();
     });
@@ -157,7 +157,7 @@ describe('discardChangeCommand', () => {
 
         const provideOriginalResourceMock = vi
             .fn()
-            .mockImplementation((uri: vscode.Uri) => uri.with({ scheme: 'jj-view', query: 'base=@&side=left' }));
+            .mockImplementation((uri: vscode.Uri) => uri.with({ scheme: 'jj-view', fragment: 'base=@&side=left' }));
         scmProvider = createMock<JjScmProvider>({
             provideOriginalResource: provideOriginalResourceMock,
         });

--- a/src/test/commands/multi-diff.test.ts
+++ b/src/test/commands/multi-diff.test.ts
@@ -64,13 +64,13 @@ describe('showMultiFileDiffCommand', () => {
 
         // Original (left) should reference parent revision
         expect(original.scheme).toBe('jj-view');
-        expect(original.query).toContain(`base=${changeId}`);
-        expect(original.query).toContain('side=left');
+        expect(original.fragment).toContain(`base=${changeId}`);
+        expect(original.fragment).toContain('side=left');
         expect(original.path).toContain(FILE_NAME);
 
         // Modified (right) should use jj-edit scheme (editable for mutable commits)
         expect(modified.scheme).toBe('jj-edit');
-        expect(modified.query).toContain(`revision=${changeId}`);
+        expect(modified.fragment).toContain(`revision=${changeId}`);
         expect(modified.path).toContain(FILE_NAME);
     });
 
@@ -89,7 +89,7 @@ describe('showMultiFileDiffCommand', () => {
         // Modified side should use change ID, not '@', with jj-edit scheme
         const modified = tuples[0][2];
         expect(modified.scheme).toBe('jj-edit');
-        expect(modified.query).toContain(`revision=${changeId}`);
+        expect(modified.fragment).toContain(`revision=${changeId}`);
     });
 
     it('works with Webview Context payload', async () => {

--- a/src/test/commands/view-file-at-revision.test.ts
+++ b/src/test/commands/view-file-at-revision.test.ts
@@ -60,8 +60,8 @@ describe('viewFileAtRevisionCommand', () => {
         if (call) {
             const targetUri = call[1] as vscode.Uri;
             expect(targetUri.scheme).toBe('jj-view');
-            expect(targetUri.query).toBe('revision=main');
-            expect(targetUri.fsPath).toBe(fileUri.fsPath);
+            expect(targetUri.fragment).toContain('revision=main');
+            expect(targetUri.path).toBe('/file1.txt');
         }
     });
 });

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { DiffTabCleaner } from '../diff-tab-cleaner';
 import { JjService, NO_OP_LOGGER } from '../jj-service';
+import { getFsPathFromUri } from '../uri-utils';
 import { buildGraph, TestRepo } from './test-repo';
 import { exposePrivate } from './test-utils';
 
@@ -42,7 +43,8 @@ describe('Diff Tab Cleaner', () => {
         jj = new JjService(repo.path, NO_OP_LOGGER);
 
         const belongsToRepo = (uri: vscode.Uri) => {
-            const normalizedUri = uri.fsPath.replace(/\\/g, '/').toLowerCase();
+            const fsPath = getFsPathFromUri(uri);
+            const normalizedUri = fsPath.replace(/\\/g, '/').toLowerCase();
             const normalizedRepo = repo.path.replace(/\\/g, '/').toLowerCase();
             return normalizedUri.startsWith(normalizedRepo);
         };
@@ -60,20 +62,20 @@ describe('Diff Tab Cleaner', () => {
             const repoRoot = repo.path;
             const uri1 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repoRoot}/src/file1.ts`,
-                query: 'base=rev123&side=left',
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repoRoot)}&base=rev123&side=left`,
             });
             const uri2 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repoRoot}/src/file1.ts`,
-                query: 'base=rev123&side=right',
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repoRoot)}&base=rev123&side=right`,
             });
 
             // Tab belonging to another repo
             const uriOther = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: '/other/repo/src/file.ts',
-                query: 'base=rev456&side=left',
+                path: '/src/file.ts',
+                fragment: 'root=%2Fother%2Frepo&base=rev456&side=left',
             });
 
             const tab1 = {
@@ -102,13 +104,13 @@ describe('Diff Tab Cleaner', () => {
             const repoRoot = repo.path;
             const uri1 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repoRoot}/src/file1.ts`,
-                query: 'base=@&side=left',
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repoRoot)}&base=@&side=left`,
             });
             const uri2 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repoRoot}/src/file1.ts`,
-                query: 'base=@-&side=right',
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repoRoot)}&base=@-&side=right`,
             });
 
             const tab = {
@@ -270,13 +272,13 @@ describe('Diff Tab Cleaner', () => {
 
             const uri1 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repo.path}/src/file1.ts`,
-                query: `base=${validRev}&side=left`,
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repo.path)}&base=${validRev}&side=left`,
             });
             const uri2 = vscode.Uri.from({
                 scheme: 'jj-view',
-                path: `${repo.path}/src/file1.ts`,
-                query: `base=${invalidRev}&side=left`,
+                path: '/src/file1.ts',
+                fragment: `root=${encodeURIComponent(repo.path)}&base=${invalidRev}&side=left`,
             });
 
             const tab1 = {

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -295,7 +295,7 @@ export async function launchNewVSCode(
         }
     }
 
-    const env = { ...process.env } as { [key: string]: string };
+    const env = { ...process.env, NODE_NO_WARNINGS: '1' } as { [key: string]: string };
     for (const key in extraEnv) {
         const val = extraEnv[key];
         if (val === undefined) {
@@ -322,7 +322,25 @@ export async function launchNewVSCode(
             logPerf('launchNewVSCode: app.firstWindow', firstWindowStart);
             const proc = app.process();
             proc.stdout?.on('data', (data) => console.log(`[VSCode Stdout] ${data.toString().trim()}`));
-            proc.stderr?.on('data', (data) => console.error(`[VSCode Stderr] ${data.toString().trim()}`));
+            proc.stderr?.on('data', (data) => {
+                const lines = data.toString().split('\n');
+                for (const line of lines) {
+                    const trimmed = line.trim();
+                    if (trimmed.length === 0) {
+                        continue;
+                    }
+                    if (
+                        trimmed.includes('Unknown channel: agentHostClientProxy') ||
+                        trimmed.includes('DeprecationWarning') ||
+                        trimmed.includes('Use `exe --trace-deprecation') ||
+                        trimmed.includes('CodeWindow: failed to load') ||
+                        trimmed.includes('DEP0169')
+                    ) {
+                        continue;
+                    }
+                    console.error(`[VSCode Stderr] ${trimmed}`);
+                }
+            });
             launched = { app, page };
         } catch (err) {
             await app.close();

--- a/src/test/jj-decoration.integration.test.ts
+++ b/src/test/jj-decoration.integration.test.ts
@@ -6,6 +6,7 @@ import * as assert from 'node:assert';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjScmProvider } from '../jj-scm-provider';
+import { toFileUri } from '../uri-utils';
 import { createTestRepositoryContext } from './integration-test-utils';
 import { TestRepo } from './test-repo';
 import { accessPrivate, createMockLogOutputChannel } from './test-utils';
@@ -91,14 +92,14 @@ suite('JJ Decoration Integration Test', () => {
         assert.ok(parentGroups.length > 0, 'Should have parent group');
 
         const parentResource = parentGroups[0].resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(filePath),
         );
         assert.ok(parentResource, 'Should find resource in parent group');
 
-        // Verify URI has query (Crucial for decoration separation)
+        // Verify URI has fragment (Crucial for decoration separation)
         assert.ok(
-            parentResource.resourceUri.query.includes('jj-revision='),
-            'Parent resource URI should have revision query',
+            parentResource.resourceUri.fragment.includes('jj-revision='),
+            'Parent resource URI should have revision fragment',
         );
 
         // Check Decoration based on THAT specific URI
@@ -182,11 +183,11 @@ suite('JJ Decoration Integration Test', () => {
     test('Decorations handle Force-Tracked Ignored Files', async () => {
         // Create a file that is tracked FIRST
         repo.writeFile('force_tracked.txt', 'tracked content');
-        await scmProvider.refresh(); // Snapshots and tracks it
+        await scmProvider.refresh({ forceSnapshot: true }); // Snapshots and tracks it
 
         // Now add it to .gitignore
         repo.writeFile('.gitignore', 'force_tracked.txt\n');
-        await scmProvider.refresh(); // Snapshots .gitignore, but force_tracked.txt is ALREADY tracked
+        await scmProvider.refresh({ forceSnapshot: true }); // Snapshots .gitignore, but force_tracked.txt is ALREADY tracked
 
         const uri = vscode.Uri.file(path.join(repo.path, 'force_tracked.txt'));
         const trackedDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
@@ -198,7 +199,7 @@ suite('JJ Decoration Integration Test', () => {
         // Because it was modified in the Working Copy (or Added), it should show up explicitly, BUT let's commit it so it has NO explicit status.
         repo.describe('commit force tracked');
         repo.new();
-        await scmProvider.refresh();
+        await scmProvider.refresh({ forceSnapshot: true });
 
         const committedDecorationPromise = scmProvider.decorationProvider.provideFileDecoration(
             uri,

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -7,6 +7,7 @@ import { createVscodeMock } from './vscode-mock';
 
 vi.mock('vscode', () => createVscodeMock());
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { CodeForgeRegistry } from '../code-forge-registry';
@@ -22,8 +23,17 @@ describe('JjEditFileSystemProvider', () => {
     let onDidChangeFileFired: vscode.FileChangeEvent[][] = [];
 
     function getUri(filename: string, revision: string | null = '@') {
-        const absolutePath = path.join(repo.path, filename);
-        return vscode.Uri.parse(`jj-edit://${absolutePath}${revision ? `?revision=${revision}` : ''}`);
+        const relPath = filename.startsWith('/') ? filename : `/${filename}`;
+        const fragmentParams = new URLSearchParams();
+        fragmentParams.set('root', repo.path);
+        if (revision) {
+            fragmentParams.set('revision', revision);
+        }
+        return vscode.Uri.from({
+            scheme: 'jj-edit',
+            path: relPath,
+            fragment: fragmentParams.toString(),
+        });
     }
 
     beforeEach(async () => {
@@ -184,12 +194,12 @@ describe('JjEditFileSystemProvider', () => {
     });
 
     it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {
-        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt?revision=@');
+        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt#root=/outside&revision=@');
         await expect(provider.readFile(outsideUri)).rejects.toThrowError('No Jujutsu repository found');
     });
 
     it('writeFile throws FileSystemError.Unavailable when no repository is found', async () => {
-        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt?revision=@');
+        const outsideUri = vscode.Uri.parse('jj-edit:///outside/file.txt#root=/outside&revision=@');
         await expect(provider.writeFile(outsideUri, Buffer.from('content'))).rejects.toThrowError(
             'No Jujutsu repository found',
         );
@@ -200,5 +210,41 @@ describe('JjEditFileSystemProvider', () => {
         expect(() => provider.createDirectory()).toThrow('jj-edit is file-only');
         expect(() => provider.delete()).toThrow('jj-edit does not support delete');
         expect(() => provider.rename()).toThrow('jj-edit does not support rename');
+    });
+
+    it('readFile for revision @ reads from disk when present and falls back to jj content when missing', async () => {
+        const uri = getUri('file.txt', '@');
+
+        // Write directly to disk without committing
+        const diskPath = path.join(repo.path, 'file.txt');
+        fs.writeFileSync(diskPath, 'uncommitted disk text\n', 'utf-8');
+
+        const diskContent = await provider.readFile(uri);
+        expect(Buffer.from(diskContent).toString('utf8')).toBe('uncommitted disk text\n');
+
+        // Remove file from disk to test fallback to jj.getFileContent
+        fs.unlinkSync(diskPath);
+        const fallbackContent = await provider.readFile(uri);
+        expect(Buffer.from(fallbackContent).toString('utf8')).toBe('hello\n');
+    });
+
+    it('writeFile for revision @ writes directly to filesystem on disk', async () => {
+        const uri = getUri('file.txt', '@');
+        const diskPath = path.join(repo.path, 'file.txt');
+
+        await provider.writeFile(uri, Buffer.from('written to disk directly\n', 'utf-8'));
+
+        expect(fs.readFileSync(diskPath, 'utf-8')).toBe('written to disk directly\n');
+    });
+
+    it('reconstructs absolute path from relative path URI with root fragment', async () => {
+        const relUri = vscode.Uri.from({
+            scheme: 'jj-edit',
+            path: '/file.txt',
+            fragment: `root=${encodeURIComponent(repo.path)}&revision=@`,
+        });
+
+        const content = await provider.readFile(relUri);
+        expect(Buffer.from(content).toString('utf8')).toBe('hello\n');
     });
 });

--- a/src/test/jj-merge-provider.integration.test.ts
+++ b/src/test/jj-merge-provider.integration.test.ts
@@ -65,19 +65,19 @@ suite('JJ Merge Provider Integration Test', () => {
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            query: `path=${encodedPath}&part=base`,
+            fragment: `path=${encodedPath}&part=base`,
         });
         const leftUri = fileUri.with({
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            query: `path=${encodedPath}&part=left`,
+            fragment: `path=${encodedPath}&part=left`,
         });
         const rightUri = fileUri.with({
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            query: `path=${encodedPath}&part=right`,
+            fragment: `path=${encodedPath}&part=right`,
         });
 
         // Open documents using VS Code API
@@ -126,7 +126,7 @@ suite('JJ Merge Provider Integration Test', () => {
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            query: `path=${encodedPath}&part=base`,
+            fragment: `path=${encodedPath}&part=base`,
         });
 
         const doc = await vscode.workspace.openTextDocument(baseUri);

--- a/src/test/jj-scm.integration.test.ts
+++ b/src/test/jj-scm.integration.test.ts
@@ -17,6 +17,7 @@ import { ScmContextValue } from '../jj-context-keys';
 import type { JjScmProvider } from '../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../jj-service';
 import type { JjResourceState } from '../scm-resource-state';
+import { toFileUri } from '../uri-utils';
 import {
     createTestRepositoryContext,
     stubCommand,
@@ -93,7 +94,7 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.strictEqual(workingCopyGroup.resourceStates.length, 1);
 
         const resourceState = workingCopyGroup.resourceStates[0];
-        assert.strictEqual(normalize(resourceState.resourceUri.fsPath), normalize(filePath));
+        assert.strictEqual(normalize(toFileUri(resourceState.resourceUri).fsPath), normalize(filePath));
         assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
     });
 
@@ -116,7 +117,7 @@ suite('JJ SCM Provider Integration Test', () => {
 
         const workingCopyGroup = accessPrivate(scmProvider, '_workingCopyGroup') as vscode.SourceControlResourceGroup;
         const resourceState = workingCopyGroup.resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(filePath),
         );
 
         assert.ok(resourceState, 'Should find resource state for modified file');
@@ -129,7 +130,7 @@ suite('JJ SCM Provider Integration Test', () => {
         const [leftUri, rightUri] = command.arguments;
         assert.strictEqual((leftUri as vscode.Uri).scheme, 'jj-view', 'Left URI scheme should be jj-view');
         assert.strictEqual(
-            normalize((rightUri as vscode.Uri).fsPath),
+            normalize(toFileUri(rightUri as vscode.Uri).fsPath),
             normalize(filePath),
             'Right URI should be the file path',
         );
@@ -162,7 +163,7 @@ suite('JJ SCM Provider Integration Test', () => {
 
         const workingCopyGroup = accessPrivate(scmProvider, '_workingCopyGroup') as vscode.SourceControlResourceGroup;
         const resourceState = workingCopyGroup.resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(filePath),
         );
         assert.ok(resourceState, 'Should find resource state for modified file');
 
@@ -185,11 +186,15 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok(leftUri && rightUri, 'leftUri and rightUri should be set');
 
         assert.strictEqual(leftUri.scheme, 'jj-view', 'left URI scheme should be jj-view');
-        assert.strictEqual(normalize(rightUri.fsPath), normalize(filePath), 'right URI should be the file path');
+        assert.strictEqual(
+            normalize(toFileUri(rightUri).fsPath),
+            normalize(filePath),
+            'right URI should be the file path',
+        );
 
         // Deleted files should still open the diff editor even when openDiffOnClick is false
         const deletedState = workingCopyGroup.resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(deletedFilePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(deletedFilePath),
         );
         assert.ok(deletedState, 'Should find resource state for deleted file');
         assert.strictEqual(
@@ -221,7 +226,7 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok(parentGroup.resourceStates.length > 0);
 
         const resourceState = parentGroup.resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(filePath),
         );
         assert.ok(resourceState, 'Parent resource should be visible');
         assert.ok((resourceState.contextValue as string).includes(ScmContextValue.ResourceAllowRestore));
@@ -231,16 +236,16 @@ suite('JJ SCM Provider Integration Test', () => {
         assert.ok(command);
         const [leftUri, rightUri] = command.arguments as vscode.Uri[];
 
-        const params = new URLSearchParams(leftUri.query);
+        const params = new URLSearchParams(leftUri.fragment);
         assert.ok(params.get('base'), 'Left query should have base param');
         assert.strictEqual(params.get('side'), 'left', 'Left query should have side=left');
 
         if (rightUri.scheme === 'jj-edit') {
-            const rightParams = new URLSearchParams(rightUri.query);
+            const rightParams = new URLSearchParams(rightUri.fragment);
             assert.ok(rightParams.get('revision'), 'Right query should have revision param for jj-edit');
         } else {
             assert.strictEqual(rightUri.scheme, 'jj-view', 'Right URI scheme should be jj-view if not jj-edit');
-            const rightParams = new URLSearchParams(rightUri.query);
+            const rightParams = new URLSearchParams(rightUri.fragment);
             assert.ok(rightParams.get('base'), 'Right query should have base param for jj-view');
             assert.strictEqual(rightParams.get('side'), 'right', 'Right query should have side=right');
         }
@@ -462,7 +467,7 @@ suite('JJ SCM Provider Integration Test', () => {
 
         const workingCopyGroup = accessPrivate(scmProvider, '_workingCopyGroup') as vscode.SourceControlResourceGroup;
         const resourceState = workingCopyGroup.resourceStates.find(
-            (r) => normalize(r.resourceUri.fsPath) === normalize(filePath),
+            (r) => normalize(toFileUri(r.resourceUri).fsPath) === normalize(filePath),
         );
 
         if (!resourceState) {

--- a/src/test/jj-view-fs-provider.test.ts
+++ b/src/test/jj-view-fs-provider.test.ts
@@ -48,7 +48,7 @@ describe('JjViewFileSystemProvider', () => {
     });
 
     it('readFile throws FileSystemError.Unavailable when no repository is found', async () => {
-        const outsideUri = vscode.Uri.parse('jj-view:///outside/file.txt?revision=@');
+        const outsideUri = vscode.Uri.parse('jj-view:///outside/file.txt#root=/outside&revision=@');
         await expect(provider.readFile(outsideUri)).rejects.toThrowError('No Jujutsu repository found');
     });
 
@@ -67,8 +67,8 @@ describe('JjViewFileSystemProvider', () => {
 
         const uri = vscode.Uri.from({
             scheme: 'jj-view',
-            path: `${repo.path}/f.txt`,
-            query: `revision=${nodes.chainA.changeId}`,
+            path: '/f.txt',
+            fragment: `root=${encodeURIComponent(repo.path)}&revision=${nodes.chainA.changeId}`,
         });
 
         const bytes = await provider.readFile(uri);

--- a/src/test/provide-original-resource.integration.test.ts
+++ b/src/test/provide-original-resource.integration.test.ts
@@ -93,7 +93,7 @@ suite('JjScmProvider provideOriginalResource Integration Test', () => {
         assert.ok(originalUri, 'Should return a URI for modified files');
         assert.strictEqual(originalUri.scheme, 'jj-view', 'Scheme should be jj-view');
 
-        const query = new URLSearchParams(originalUri.query);
+        const query = new URLSearchParams(originalUri.fragment);
         assert.strictEqual(query.get('base'), '@', 'Base should be @ by default');
         assert.strictEqual(query.get('side'), 'left', 'Side should be left');
     });

--- a/src/test/quick-diff.integration.test.ts
+++ b/src/test/quick-diff.integration.test.ts
@@ -54,7 +54,7 @@ suite('Quick Diff Integration Test', () => {
 
         // Override provideOriginalResource to return the test scheme
         scmProvider.provideOriginalResource = (uri: vscode.Uri) => {
-            return uri.with({ scheme: 'jj-view-test', query: 'base=@&side=left' });
+            return uri.with({ scheme: 'jj-view-test', fragment: 'base=@&side=left' });
         };
 
         // Await the initial refresh to ensure state is ready before tests start

--- a/src/test/quickdiff-commands.integration.test.ts
+++ b/src/test/quickdiff-commands.integration.test.ts
@@ -61,7 +61,10 @@ suite('Quick Diff Commands Integration Test', () => {
         context.subscriptions.push(jjViewProviderDisposable);
 
         scmProvider.provideOriginalResource = (uri: vscode.Uri) => {
-            return uri.with({ scheme: uniqueScheme, query: 'base=@&side=left' });
+            return uri.with({
+                scheme: uniqueScheme,
+                fragment: `base=@&side=left&root=${encodeURIComponent(canonicalPath)}`,
+            });
         };
 
         // Await the initial refresh to ensure state is ready before tests start

--- a/src/test/repository-resolution.test.ts
+++ b/src/test/repository-resolution.test.ts
@@ -121,7 +121,7 @@ describe('resolveRepository', () => {
         const commitUri = vscode.Uri.from({
             scheme: 'jj-commit',
             path: '/Commit:%20abc123',
-            query: `changeId=abc12345&repoRoot=${encodeURIComponent(repo.path)}`,
+            fragment: `changeId=abc12345&repoRoot=${encodeURIComponent(repo.path)}`,
         });
         setActiveTextEditor(
             createMock<vscode.TextEditor>({

--- a/src/test/scm-resource-state.test.ts
+++ b/src/test/scm-resource-state.test.ts
@@ -2,9 +2,11 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { JjStatusEntry } from '../jj-types';
 import { createJjResourceState } from '../scm-resource-state';
+import './vitest-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {
@@ -23,10 +25,10 @@ describe('createJjResourceState', () => {
             };
             const state = createJjResourceState(entry, 'rev123', root);
 
-            expect(state.resourceUri.path).toBe('/root/file.txt');
+            expect(state.resourceUri.path).toBe('/file.txt');
             expect(state.revision).toBe('rev123');
-            expect(state.leftUri?.path).toBe('/root/file.txt');
-            expect(state.rightUri?.path).toBe('/root/file.txt');
+            expect(state.leftUri?.path).toBe('/file.txt');
+            expect(state.rightUri?.path).toBe('/file.txt');
         });
 
         it('uses oldPath as leftPath for renamed entries', () => {
@@ -37,8 +39,8 @@ describe('createJjResourceState', () => {
             };
             const state = createJjResourceState(entry, 'rev123', root);
 
-            expect(state.leftUri?.path).toBe('/root/old-file.txt');
-            expect(state.rightUri?.path).toBe('/root/new-file.txt');
+            expect(state.leftUri?.path).toBe('/old-file.txt');
+            expect(state.rightUri?.path).toBe('/new-file.txt');
         });
 
         it('uses oldPath as leftPath for copied entries', () => {
@@ -49,8 +51,8 @@ describe('createJjResourceState', () => {
             };
             const state = createJjResourceState(entry, 'rev123', root);
 
-            expect(state.leftUri?.path).toBe('/root/old-file.txt');
-            expect(state.rightUri?.path).toBe('/root/new-file.txt');
+            expect(state.leftUri?.path).toBe('/old-file.txt');
+            expect(state.rightUri?.path).toBe('/new-file.txt');
         });
 
         it('uses jj-edit scheme for editable non-working-copy rightUri', () => {
@@ -63,7 +65,7 @@ describe('createJjResourceState', () => {
             });
 
             expect(state.rightUri?.scheme).toBe('jj-edit');
-            expect(state.rightUri?.query).toBe('revision=rev123');
+            expect(state.rightUri?.fragment).toContain('revision=rev123');
         });
 
         it('uses jj-view scheme for non-editable non-working-copy rightUri', () => {
@@ -76,7 +78,7 @@ describe('createJjResourceState', () => {
             });
 
             expect(state.rightUri?.scheme).toBe('jj-view');
-            expect(state.rightUri?.query).toContain('side=right');
+            expect(state.rightUri?.fragment).toContain('side=right');
         });
     });
 
@@ -158,7 +160,7 @@ describe('createJjResourceState', () => {
             });
 
             expect(state.command?.command).toBe('vscode.open');
-            expect(state.command?.arguments?.[0].path).toBe('/root/file.txt');
+            expect(state.command?.arguments?.[0].fsPath).toBeSameFsPath(path.resolve(root, 'file.txt'));
             expect(state.command?.arguments?.[0].query).toBe('');
         });
     });

--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -2,10 +2,19 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import type { JjStatusEntry } from '../jj-types';
-import { createDiffUris, getRevisionFromUri } from '../uri-utils';
+import {
+    createDiffUris,
+    createRevisionUri,
+    getFsPathFromUri,
+    getRevisionFromUri,
+    toFileUri,
+    toForwardSlash,
+} from '../uri-utils';
+import './vitest-utils';
 
 // Mock vscode
 vi.mock('vscode', async () => {
@@ -14,6 +23,13 @@ vi.mock('vscode', async () => {
 });
 
 const ENCODED_AT = '%40';
+
+describe('toForwardSlash', () => {
+    it('replaces backslashes with forward slashes', () => {
+        expect(toForwardSlash('C:\\path\\to\\file.txt')).toBe('C:/path/to/file.txt');
+        expect(toForwardSlash('foo/bar/baz')).toBe('foo/bar/baz');
+    });
+});
 
 describe('createDiffUris', () => {
     const root = '/root';
@@ -27,14 +43,16 @@ describe('createDiffUris', () => {
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
         expect(leftUri.scheme).toBe('jj-view');
-        expect(leftUri.path).toBe('/root/file.txt');
-        expect(leftUri.query).toContain('base=rev1');
-        expect(leftUri.query).toContain('side=left');
+        expect(leftUri.path).toBe('/file.txt');
+        expect(leftUri.fragment).toContain('root=%2Froot');
+        expect(leftUri.fragment).toContain('base=rev1');
+        expect(leftUri.fragment).toContain('side=left');
 
         expect(rightUri.scheme).toBe('jj-view');
-        expect(rightUri.path).toBe('/root/file.txt');
-        expect(rightUri.query).toContain('base=rev1');
-        expect(rightUri.query).toContain('side=right');
+        expect(rightUri.path).toBe('/file.txt');
+        expect(rightUri.fragment).toContain('root=%2Froot');
+        expect(rightUri.fragment).toContain('base=rev1');
+        expect(rightUri.fragment).toContain('side=right');
     });
 
     it('creates correct URIs for working copy (rev=@)', () => {
@@ -47,13 +65,15 @@ describe('createDiffUris', () => {
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
         expect(leftUri.scheme).toBe('jj-view');
-        expect(leftUri.path).toBe('/root/file.txt');
-        expect(leftUri.query).toContain(`base=${ENCODED_AT}`);
-        expect(leftUri.query).toContain('side=left');
+        expect(leftUri.path).toBe('/file.txt');
+        expect(leftUri.fragment).toContain(`base=${ENCODED_AT}`);
+        expect(leftUri.fragment).toContain('side=left');
 
-        // Working copy should use file scheme for right side
-        expect(rightUri.scheme).toBe('file');
-        expect(rightUri.path).toBe('/root/file.txt');
+        // Working copy should use jj-edit scheme for right side
+        expect(rightUri.scheme).toBe('jj-edit');
+        expect(rightUri.path).toBe('/file.txt');
+        expect(rightUri.fragment).toContain('root=%2Froot');
+        expect(rightUri.fragment).toContain('revision=%40');
     });
 
     it('handles renamed files correctly', () => {
@@ -67,14 +87,14 @@ describe('createDiffUris', () => {
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
         // Left side should use old path
-        expect(leftUri.path).toBe('/root/old.txt');
-        expect(leftUri.query).toContain('base=rev1');
-        expect(leftUri.query).toContain('side=left');
+        expect(leftUri.path).toBe('/old.txt');
+        expect(leftUri.fragment).toContain('base=rev1');
+        expect(leftUri.fragment).toContain('side=left');
 
         // Right side should use new path
-        expect(rightUri.path).toBe('/root/new.txt');
-        expect(rightUri.query).toContain('base=rev1');
-        expect(rightUri.query).toContain('side=right');
+        expect(rightUri.path).toBe('/new.txt');
+        expect(rightUri.fragment).toContain('base=rev1');
+        expect(rightUri.fragment).toContain('side=right');
     });
 
     it('handles deleted files in working copy correctly', () => {
@@ -87,16 +107,16 @@ describe('createDiffUris', () => {
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
         expect(leftUri.scheme).toBe('jj-view');
-        expect(leftUri.path).toBe('/root/deleted.txt');
-        expect(leftUri.query).toContain(`base=${ENCODED_AT}`);
-        expect(leftUri.query).toContain('side=left');
+        expect(leftUri.path).toBe('/deleted.txt');
+        expect(leftUri.fragment).toContain(`base=${ENCODED_AT}`);
+        expect(leftUri.fragment).toContain('side=left');
 
         // Removed files in working copy should use jj-view scheme for right side
         // to avoid "File not found" errors in VS Code.
         expect(rightUri.scheme).toBe('jj-view');
-        expect(rightUri.path).toBe('/root/deleted.txt');
-        expect(rightUri.query).toContain(`base=${ENCODED_AT}`);
-        expect(rightUri.query).toContain('side=right');
+        expect(rightUri.path).toBe('/deleted.txt');
+        expect(rightUri.fragment).toContain(`base=${ENCODED_AT}`);
+        expect(rightUri.fragment).toContain('side=right');
     });
 
     it('handles deleted files in ancestors correctly', () => {
@@ -110,7 +130,7 @@ describe('createDiffUris', () => {
 
         expect(leftUri.scheme).toBe('jj-view');
         expect(rightUri.scheme).toBe('jj-view');
-        expect(rightUri.query).toContain('side=right');
+        expect(rightUri.fragment).toContain('side=right');
     });
 
     it('handles added files in working copy correctly', () => {
@@ -123,8 +143,8 @@ describe('createDiffUris', () => {
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
         expect(leftUri.scheme).toBe('jj-view');
-        expect(leftUri.query).toContain('side=left');
-        expect(rightUri.scheme).toBe('file');
+        expect(leftUri.fragment).toContain('side=left');
+        expect(rightUri.scheme).toBe('jj-edit');
     });
 
     it('handles copied files correctly', () => {
@@ -137,8 +157,8 @@ describe('createDiffUris', () => {
 
         const { leftUri, rightUri } = createDiffUris(entry, revision, root);
 
-        expect(leftUri.path).toBe('/root/original.txt');
-        expect(rightUri.path).toBe('/root/copy.txt');
+        expect(leftUri.path).toBe('/original.txt');
+        expect(rightUri.path).toBe('/copy.txt');
     });
 
     it('detects working copy via options.workingCopyChangeId', () => {
@@ -152,7 +172,56 @@ describe('createDiffUris', () => {
             workingCopyChangeId: 'commit-123',
         });
 
-        expect(rightUri.scheme).toBe('file');
+        expect(rightUri.scheme).toBe('jj-edit');
+    });
+});
+
+describe('createRevisionUri', () => {
+    const root = '/workspace/repo';
+
+    it('creates relative path URI with fragment root from absolute path', () => {
+        const uri = createRevisionUri(root, '/workspace/repo/src/sub/file.ts', 'main');
+        expect(uri.scheme).toBe('jj-view');
+        expect(uri.path).toBe('/src/sub/file.ts');
+        expect(uri.fragment).toContain('root=%2Fworkspace%2Frepo');
+        expect(uri.fragment).toContain('revision=main');
+    });
+
+    it('creates relative path URI from relative path input', () => {
+        const uri = createRevisionUri(root, 'src/sub/file.ts', 'main');
+        expect(uri.scheme).toBe('jj-view');
+        expect(uri.path).toBe('/src/sub/file.ts');
+        expect(uri.fragment).toContain('root=%2Fworkspace%2Frepo');
+        expect(uri.fragment).toContain('revision=main');
+    });
+
+    it('handles Windows-style absolute paths and encodes root in fragment', () => {
+        const windowsRoot = 'C:\\workspace\\repo';
+        const windowsPath = 'C:\\workspace\\repo\\src\\sub\\file.ts';
+
+        const uri = createRevisionUri(windowsRoot, windowsPath, 'main');
+
+        expect(uri.scheme).toBe('jj-view');
+        expect(uri.path).toBe('/src/sub/file.ts');
+        expect(uri.fragment).toContain(encodeURIComponent(windowsRoot));
+        expect(uri.fragment).toContain('revision=main');
+    });
+});
+
+describe('getFsPathFromUri and toFileUri', () => {
+    const root = '/workspace/repo';
+
+    it('reconstructs absolute path using fragment root and relative path', () => {
+        const uri = createRevisionUri(root, '/workspace/repo/src/file.ts', 'rev1');
+        const fsPath = getFsPathFromUri(uri);
+        expect(fsPath).toBeSameFsPath('/workspace/repo/src/file.ts');
+    });
+
+    it('converts custom scheme URI to file scheme URI using toFileUri', () => {
+        const customUri = createRevisionUri(root, '/workspace/repo/src/file.ts', 'rev1');
+        const fileUri = toFileUri(customUri);
+        expect(fileUri.scheme).toBe('file');
+        expect(fileUri.fsPath).toBeSameFsPath('/workspace/repo/src/file.ts');
     });
 });
 
@@ -164,43 +233,96 @@ describe('getRevisionFromUri', () => {
 
     it('extracts revision from jj-revision parameter', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: 'jj-revision=rev123',
+            fragment: 'jj-revision=rev123',
         });
         expect(getRevisionFromUri(uri)).toBe('rev123');
     });
 
     it('extracts revision from revision parameter (jj-edit style)', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: 'revision=edit-rev',
+            fragment: 'revision=edit-rev',
         });
         expect(getRevisionFromUri(uri)).toBe('edit-rev');
     });
 
     it('extracts revision from base parameter (jj-view style)', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: 'base=view-rev&side=right',
+            fragment: 'base=view-rev&side=right',
         });
         expect(getRevisionFromUri(uri)).toBe('view-rev');
     });
 
     it('prioritizes jj-revision over others', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: 'jj-revision=primary&revision=secondary&base=tertiary',
+            fragment: 'jj-revision=primary&revision=secondary&base=tertiary',
         });
         expect(getRevisionFromUri(uri)).toBe('primary');
     });
 
     it('prioritizes revision over base', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: 'revision=secondary&base=tertiary',
+            fragment: 'revision=secondary&base=tertiary',
         });
         expect(getRevisionFromUri(uri)).toBe('secondary');
     });
 
-    it('returns undefined for empty query', () => {
+    it('returns undefined for empty fragment', () => {
         const uri = vscode.Uri.file('/path/to/file.txt').with({
-            query: '',
+            fragment: '',
         });
         expect(getRevisionFromUri(uri)).toBeUndefined();
+    });
+
+    it('strips leading # or ? from fragment/query strings', () => {
+        const uri = vscode.Uri.file('/path/to/file.txt').with({
+            fragment: '#jj-revision=rev123',
+        });
+        expect(getRevisionFromUri(uri)).toBe('rev123');
+    });
+});
+
+describe('getFsPathFromUri edge cases', () => {
+    it('supports repoRoot as fallback for root parameter', () => {
+        const uri = vscode.Uri.from({
+            scheme: 'jj-view',
+            path: '/src/file.ts',
+            query: 'repoRoot=%2Fworkspace%2Frepo',
+        });
+        expect(getFsPathFromUri(uri)).toBeSameFsPath('/workspace/repo/src/file.ts');
+    });
+
+    it('strips leading # or ? in fragment/query', () => {
+        const uri = vscode.Uri.from({
+            scheme: 'jj-view',
+            path: '/src/file.ts',
+            fragment: '#root=%2Fworkspace%2Frepo',
+        });
+        expect(getFsPathFromUri(uri)).toBeSameFsPath('/workspace/repo/src/file.ts');
+    });
+
+    it('returns fsPath directly when it is already under the root', () => {
+        const root = '/workspace/repo';
+        const fsPath = path.resolve(root, 'src/sub/file.ts');
+
+        const fileUri = vscode.Uri.file(fsPath).with({
+            scheme: 'jj-view',
+            fragment: `root=${encodeURIComponent(root)}&revision=main`,
+        });
+
+        const result = getFsPathFromUri(fileUri);
+        expect(result).toBeSameFsPath(fsPath);
+    });
+
+    it('handles Windows-style fsPath and performs case-insensitive comparison under root', () => {
+        const root = 'C:\\Workspace\\Repo';
+        const fsPath = 'c:\\workspace\\repo\\src\\sub\\file.ts';
+
+        const uri = vscode.Uri.file(fsPath).with({
+            scheme: 'jj-view',
+            fragment: `root=${encodeURIComponent(root)}&revision=main`,
+        });
+
+        const result = getFsPathFromUri(uri);
+        expect(result).toBe(fsPath);
     });
 });

--- a/src/test/vitest-utils.ts
+++ b/src/test/vitest-utils.ts
@@ -3,9 +3,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Mock } from 'vitest';
-import { vi } from 'vitest';
-import type * as vscode from 'vscode';
+import * as path from 'node:path';
+import { expect, type Mock, vi } from 'vitest';
+import * as vscode from 'vscode';
+
+expect.extend({
+    toBeSameFsPath(received: unknown, expected: unknown) {
+        if (typeof received !== 'string' || typeof expected !== 'string') {
+            return {
+                pass: false,
+                message: () => `expected string paths, but received ${typeof received} and ${typeof expected}`,
+            };
+        }
+        const normReceived = vscode.Uri.file(path.resolve(received)).fsPath;
+        const normExpected = vscode.Uri.file(path.resolve(expected)).fsPath;
+        const pass = normReceived === normExpected;
+        return {
+            pass,
+            message: () =>
+                `expected path "${received}" ${this.isNot ? 'not to equal' : 'to equal'} "${expected}"\nReceived normalized: "${normReceived}"\nExpected normalized: "${normExpected}"`,
+        };
+    },
+});
+
+declare module 'vitest' {
+    interface Assertion {
+        toBeSameFsPath(expected: string): void;
+    }
+    interface AsymmetricMatchersContaining {
+        toBeSameFsPath(expected: string): void;
+    }
+}
 
 export function resetMockQuickPick(mockQuickPick: vscode.QuickPick<vscode.QuickPickItem>) {
     mockQuickPick.value = '';

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -22,7 +22,7 @@ export function setActiveTextEditor(editor: Partial<vscode.TextEditor> | undefin
  * - "/foo/bar.txt" -> scheme="file", path="/foo/bar.txt", query=""
  * - "file:///foo/bar.txt#frag" -> scheme="file", path="/foo/bar.txt", query=""
  */
-function parseUriString(uriString: string): { scheme: string; path: string; query: string } {
+function parseUriString(uriString: string): { scheme: string; path: string; query: string; fragment: string } {
     let scheme = 'file';
     let rest = uriString;
 
@@ -32,9 +32,11 @@ function parseUriString(uriString: string): { scheme: string; path: string; quer
         rest = schemeMatch[2];
     }
 
-    // Strip fragment
+    // Parse fragment
     const hashIndex = rest.indexOf('#');
+    let fragment = '';
     if (hashIndex !== -1) {
+        fragment = rest.substring(hashIndex + 1);
         rest = rest.substring(0, hashIndex);
     }
 
@@ -54,7 +56,7 @@ function parseUriString(uriString: string): { scheme: string; path: string; quer
         // Fallback
     }
 
-    return { scheme, path: decodedPath, query };
+    return { scheme, path: decodedPath, query, fragment };
 }
 
 /**
@@ -174,6 +176,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
             public scheme: string = 'file',
             public query: string = '',
             public path: string = fsPath,
+            public fragment: string = '',
         ) {
             if (process.platform === 'win32') {
                 this.fsPath = this.fsPath.replace(/\//g, '\\');
@@ -196,22 +199,34 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         static file(fsPath: string) {
             return new MockUri(fsPath);
         }
-        static from(components: { scheme: string; path: string; query?: string }) {
-            return new MockUri(components.path, components.scheme, components.query || '', components.path);
+        static from(components: { scheme: string; path: string; query?: string; fragment?: string }) {
+            return new MockUri(
+                components.path,
+                components.scheme,
+                components.query || '',
+                components.path,
+                components.fragment || '',
+            );
         }
         static parse(uriString: string) {
             const parsed = parseUriString(uriString);
-            return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path);
+            return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path, parsed.fragment);
         }
         static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
             const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
             return new MockUri(combined, base.scheme, '', combined);
         }
         toString() {
-            return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}`;
+            return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}${this.fragment ? `#${this.fragment}` : ''}`;
         }
-        with(change: { scheme?: string; query?: string }) {
-            return new MockUri(this.fsPath, change.scheme ?? this.scheme, change.query ?? this.query, this.path);
+        with(change: { scheme?: string; query?: string; fragment?: string }) {
+            return new MockUri(
+                this.fsPath,
+                change.scheme ?? this.scheme,
+                change.query ?? this.query,
+                this.path,
+                change.fragment ?? this.fragment,
+            );
         }
     }
 

--- a/src/uri-utils.ts
+++ b/src/uri-utils.ts
@@ -3,16 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { match } from 'ts-pattern';
 import * as vscode from 'vscode';
 import type { JjStatusEntry } from './jj-types';
 
 export type JjViewQuery =
-    | { mode: 'diff'; base: string; side: 'left' | 'right' }
-    | { mode: 'revision'; revision: string };
+    | { mode: 'diff'; root?: string; base: string; side: 'left' | 'right' }
+    | { mode: 'revision'; root?: string; revision: string };
 
 export function encodeJjViewQuery(query: JjViewQuery): string {
     const params = new URLSearchParams();
+    if (query.root) {
+        params.set('root', query.root);
+    }
     match(query)
         .with({ mode: 'diff' }, (q) => {
             params.set('base', q.base);
@@ -25,22 +30,65 @@ export function encodeJjViewQuery(query: JjViewQuery): string {
     return params.toString();
 }
 
-export function decodeJjViewQuery(queryStr: string): JjViewQuery {
-    const params = new URLSearchParams(queryStr);
+function stripPrefix(str: string | undefined): string {
+    return (str || '').replace(/^[#?]/, '');
+}
+
+/**
+ * Helper to parse URL parameters from a URI, checking fragment first with query fallback.
+ */
+export function getUriParams(uri: vscode.Uri): URLSearchParams {
+    const fragmentStr = stripPrefix(uri.fragment);
+    const queryStr = stripPrefix(uri.query);
+    const combinedStr = fragmentStr && queryStr ? `${fragmentStr}&${queryStr}` : fragmentStr || queryStr;
+    return new URLSearchParams(combinedStr);
+}
+
+export function decodeJjViewQuery(uri: vscode.Uri): JjViewQuery {
+    const params = getUriParams(uri);
+    const root = params.get('root') || params.get('repoRoot') || undefined;
     const revision = params.get('revision');
     const base = params.get('base');
     const side = params.get('side');
 
     if (revision) {
-        return { mode: 'revision', revision };
+        return { mode: 'revision', root, revision };
     }
     if (base && side) {
         if (side !== 'left' && side !== 'right') {
             throw new Error(`Invalid side in jj-view query: ${side}`);
         }
-        return { mode: 'diff', base, side: side as 'left' | 'right' };
+        return { mode: 'diff', root, base, side: side as 'left' | 'right' };
     }
-    throw new Error(`Invalid query combination for jj-view: ${queryStr}`);
+    throw new Error(`Invalid query combination for jj-view: ${uri.toString()}`);
+}
+
+/**
+ * Normalizes backslashes in a file path to forward slashes.
+ */
+export function toForwardSlash(p: string): string {
+    return p.replace(/\\/g, '/');
+}
+
+function normalizePath(p: string): string {
+    const norm = path.normalize(toForwardSlash(p));
+    const isWinDrive = /^[a-zA-Z]:/.test(norm);
+    return process.platform === 'win32' || isWinDrive ? norm.toLowerCase() : norm;
+}
+
+export function getFsPathFromUri(uri: vscode.Uri): string {
+    const params = getUriParams(uri);
+    const root = params.get('root') || params.get('repoRoot');
+    if (root) {
+        const normPath = path.normalize(uri.fsPath);
+        if (normalizePath(uri.fsPath).startsWith(normalizePath(root))) {
+            return normPath;
+        }
+        const decodedPath = decodeURIComponent(uri.path);
+        const relativePath = decodedPath.startsWith('/') ? decodedPath.substring(1) : decodedPath;
+        return path.resolve(root, relativePath);
+    }
+    return uri.fsPath;
 }
 
 export function createDiffUris(
@@ -50,20 +98,29 @@ export function createDiffUris(
     options: { editable?: boolean; workingCopyChangeId?: string } = {},
 ): { leftUri: vscode.Uri; rightUri: vscode.Uri; resourceUri: vscode.Uri } {
     const isCurrentWorkingCopy = revision === '@' || revision === options.workingCopyChangeId;
-    const resourceUri = isCurrentWorkingCopy
-        ? vscode.Uri.joinPath(vscode.Uri.file(root), entry.path)
-        : vscode.Uri.joinPath(vscode.Uri.file(root), entry.path).with({ query: `jj-revision=${revision}` });
+    const relPath = entry.path.startsWith('/') ? entry.path : `/${entry.path}`;
 
     // For renames/copies, the left side shows the old path
-    let leftPath = resourceUri.path;
+    let leftRelPath = relPath;
     if ((entry.status === 'renamed' || entry.status === 'copied') && entry.oldPath) {
-        leftPath = vscode.Uri.joinPath(vscode.Uri.file(root), entry.oldPath).path;
+        leftRelPath = entry.oldPath.startsWith('/') ? entry.oldPath : `/${entry.oldPath}`;
     }
 
     const leftUri = vscode.Uri.from({
         scheme: 'jj-view',
-        path: leftPath,
-        query: encodeJjViewQuery({ mode: 'diff', base: revision, side: 'left' }),
+        path: leftRelPath,
+        fragment: encodeJjViewQuery({ mode: 'diff', root, base: revision, side: 'left' }),
+    });
+
+    const resourceParams = new URLSearchParams();
+    resourceParams.set('root', root);
+    resourceParams.set('jj-revision', revision);
+    resourceParams.set('revision', isCurrentWorkingCopy ? '@' : revision);
+
+    const resourceUri = vscode.Uri.from({
+        scheme: options.editable || isCurrentWorkingCopy ? 'jj-edit' : 'jj-view',
+        path: relPath,
+        fragment: resourceParams.toString(),
     });
 
     let rightUri: vscode.Uri;
@@ -71,23 +128,16 @@ export function createDiffUris(
     if (isDeleted) {
         rightUri = vscode.Uri.from({
             scheme: 'jj-view',
-            path: resourceUri.path,
-            query: encodeJjViewQuery({ mode: 'diff', base: revision, side: 'right' }),
+            path: relPath,
+            fragment: encodeJjViewQuery({ mode: 'diff', root, base: revision, side: 'right' }),
         });
-    } else if (isCurrentWorkingCopy) {
+    } else if (isCurrentWorkingCopy || options.editable) {
         rightUri = resourceUri;
-    } else if (options.editable) {
-        // Editable: use jj-edit scheme backed by FileSystemProvider
-        rightUri = vscode.Uri.from({
-            scheme: 'jj-edit',
-            path: resourceUri.path,
-            query: `revision=${revision}`,
-        });
     } else {
         rightUri = vscode.Uri.from({
             scheme: 'jj-view',
-            path: resourceUri.path,
-            query: encodeJjViewQuery({ mode: 'diff', base: revision, side: 'right' }),
+            path: relPath,
+            fragment: encodeJjViewQuery({ mode: 'diff', root, base: revision, side: 'right' }),
         });
     }
 
@@ -95,12 +145,12 @@ export function createDiffUris(
 }
 
 /**
- * Extract a revision ID from a URI query.
+ * Extract a revision ID from a URI query or fragment.
  * Handles jj-revision (SCM resource), revision (jj-edit), and base (jj-view diff).
  */
 export function getRevisionFromUri(uri: vscode.Uri): string | undefined {
-    const query = new URLSearchParams(uri.query);
-    return query.get('jj-revision') || query.get('revision') || query.get('base') || undefined;
+    const params = getUriParams(uri);
+    return params.get('jj-revision') || params.get('revision') || params.get('base') || undefined;
 }
 
 /**
@@ -108,4 +158,55 @@ export function getRevisionFromUri(uri: vscode.Uri): string | undefined {
  */
 export function isJjScheme(uri: vscode.Uri): boolean {
     return uri.scheme === 'jj-view' || uri.scheme === 'jj-edit';
+}
+
+/**
+ * Creates a jj-view URI for viewing a file at a specific revision.
+ */
+export function createRevisionUri(root: string, filePath: string, revision: string): vscode.Uri {
+    const normRoot = toForwardSlash(root);
+    const normFile = toForwardSlash(filePath);
+    let relativePath = filePath;
+
+    if (normFile.toLowerCase().startsWith(normRoot.toLowerCase())) {
+        relativePath = normFile.substring(normRoot.length);
+    } else if (path.isAbsolute(filePath)) {
+        relativePath = path.relative(root, filePath);
+    }
+
+    const posixRel = toForwardSlash(relativePath);
+    const relPathStr = posixRel.startsWith('/') ? posixRel : `/${posixRel}`;
+    return vscode.Uri.from({
+        scheme: 'jj-view',
+        path: relPathStr,
+        fragment: encodeJjViewQuery({ mode: 'revision', root, revision }),
+    });
+}
+
+/**
+ * Converts a URI (which may be a custom scheme or contain fragment parameters)
+ * into a standard file scheme URI pointing to the underlying workspace file.
+ */
+export function toFileUri(uri: vscode.Uri): vscode.Uri {
+    return vscode.Uri.file(getFsPathFromUri(uri));
+}
+
+/**
+ * Gets the relative path of a URI within the repository root.
+ * Normalizes leading slash.
+ */
+export function getRepoRelativePath(uri: vscode.Uri, root: string): string {
+    if (uri.scheme === 'file') {
+        let canonicalRoot = root;
+        let canonicalPath = uri.fsPath;
+        try {
+            canonicalRoot = fs.realpathSync(root);
+        } catch {}
+        try {
+            canonicalPath = fs.realpathSync(uri.fsPath);
+        } catch {}
+        const rel = toForwardSlash(path.relative(canonicalRoot, canonicalPath));
+        return rel.startsWith('/') ? rel : `/${rel}`;
+    }
+    return uri.path.startsWith('/') ? uri.path : `/${uri.path}`;
 }


### PR DESCRIPTION
Migrate URI metadata from query strings to URI fragments across custom schemes such as jj-view, jj-edit, and jj-commit. Storing parameters in fragments ensures dragging files from the SCM pane into the editor works correctly and provides consistent path resolution across multi-repository workspaces.