### PR TITLE
diff-tab-cleaner: make tab closing non-blocking

### DIFF
--- a/src/diff-tab-cleaner.ts
+++ b/src/diff-tab-cleaner.ts
@@ -43,7 +43,7 @@ export class DiffTabCleaner {
             const invalidRevisions = await this.checkRevisionsValidity(uniqueRevisions);
             const tabsToClose = this.filterTabsToClose(tabToRevisions, invalidRevisions);
 
-            await this.closeTabs(tabsToClose);
+            this.closeTabs(tabsToClose);
         } catch (err) {
             this.outputChannel?.error(`[DiffTabCleaner] Failed to check/close invalid diff editors: ${err}`);
         }
@@ -194,17 +194,13 @@ export class DiffTabCleaner {
     }
 
     /**
-     * Closes the specified tabs.
+     * Closes the specified tabs asynchronously.
      */
-    private async closeTabs(tabs: vscode.Tab[]): Promise<void> {
-        await Promise.all(
-            tabs.map(async (tab) => {
-                try {
-                    await vscode.window.tabGroups.close(tab);
-                } catch (err) {
-                    this.outputChannel?.error(`[DiffTabCleaner] Failed to close tab: ${err}`);
-                }
-            }),
-        );
+    private closeTabs(tabs: vscode.Tab[]): void {
+        tabs.forEach((tab) => {
+            vscode.window.tabGroups.close(tab).then(undefined, (err) => {
+                this.outputChannel?.error(`[DiffTabCleaner] Failed to close tab: ${err}`);
+            });
+        });
     }
 }

--- a/src/test/diff-tab-cleaner.test.ts
+++ b/src/test/diff-tab-cleaner.test.ts
@@ -28,7 +28,7 @@ interface PrivateDiffTabCleaner {
     };
     checkRevisionsValidity(revisions: Set<string>): Promise<Set<string>>;
     filterTabsToClose(tabToRevisions: Map<vscode.Tab, string[]>, invalidRevisions: Set<string>): vscode.Tab[];
-    closeTabs(tabs: vscode.Tab[]): Promise<void>;
+    closeTabs(tabs: vscode.Tab[]): void;
 }
 
 describe('Diff Tab Cleaner', () => {


### PR DESCRIPTION
Dispatch tab closing operations asynchronously without awaiting them. This prevents tab cleanup from blocking the SCM refresh execution path.