### PR TITLE
fix(auth): detached prompt flow to prevent extension deadlocks

### DIFF
--- a/src/code-forge-auth.ts
+++ b/src/code-forge-auth.ts
@@ -29,15 +29,22 @@ export interface AlternativeChoice {
     execute: () => Promise<AuthResult>;
 }
 
-export class CodeForgeAuthManager {
+export class CodeForgeAuthManager implements vscode.Disposable {
     private promptedThisSession = new Set<string>();
     private unavailableProviders = new Set<string>();
     private registeredProviderIds = new Set<string>();
+
+    private readonly _onDidAuthenticate = new vscode.EventEmitter<string>();
+    public readonly onDidAuthenticate: vscode.Event<string> = this._onDidAuthenticate.event;
 
     constructor(
         private readonly context: vscode.ExtensionContext,
         private readonly outputChannel?: JjLoggerChannel,
     ) {}
+
+    public dispose(): void {
+        this._onDidAuthenticate.dispose();
+    }
 
     public registerProvider(providerId: string): void {
         this.registeredProviderIds.add(providerId);
@@ -95,9 +102,14 @@ export class CodeForgeAuthManager {
 
     /**
      * Checks whether an active OAuth session exists for the given provider.
-     * Uses a short timeout (500ms) so callers stay responsive (e.g., UI menus).
+     * Uses a short timeout (2000ms) so callers stay responsive (e.g., UI menus).
      * Also updates the `isProviderUnavailable` cache so subsequent calls are instant.
      */
+    private isProviderUnavailableError(e: unknown): boolean {
+        const errorStr = String(e);
+        return errorStr.includes('not registered') || errorStr.includes('No authentication provider');
+    }
+
     public async hasOAuthSession(providerId: string, scopes: string[]): Promise<boolean> {
         if (this.isProviderUnavailable(providerId)) {
             return false;
@@ -105,26 +117,13 @@ export class CodeForgeAuthManager {
         try {
             const session = await this.withTimeout(
                 Promise.resolve(vscode.authentication.getSession(providerId, scopes, { silent: true })),
-                500,
+                2000,
                 `${providerId} session check timed out`,
             );
-            if (session) {
-                // Only clear the unavailable flag when we actually get a session back.
-                // If getSession returns undefined it could mean "provider registered but
-                // not signed in" OR "provider not registered" — we can't distinguish.
-                this.setProviderUnavailable(providerId, false);
-                return true;
-            }
-            return false;
+            this.setProviderUnavailable(providerId, false);
+            return !!session;
         } catch (e) {
-            const errorStr = String(e);
-            // Treat both "not registered" errors AND timeouts as "provider unavailable".
-            // A timeout means the provider extension is likely missing or not yet activated.
-            const isUnregistered =
-                errorStr.includes('not registered') ||
-                errorStr.includes('No authentication provider') ||
-                errorStr.includes('session check timed out');
-            if (isUnregistered) {
+            if (this.isProviderUnavailableError(e)) {
                 this.setProviderUnavailable(providerId, true);
             }
             return false;
@@ -197,7 +196,7 @@ export class CodeForgeAuthManager {
             );
             const session = await this.withTimeout(
                 silentPromise,
-                1000,
+                5000,
                 `${providerId} authentication silent check timed out`,
             );
             this.setProviderUnavailable(providerId, false);
@@ -206,10 +205,8 @@ export class CodeForgeAuthManager {
             }
         } catch (e) {
             const errorStr = String(e);
-            const isUnregistered =
-                errorStr.includes('not registered') || errorStr.includes('No authentication provider');
 
-            if (isUnregistered) {
+            if (this.isProviderUnavailableError(e)) {
                 this.setProviderUnavailable(providerId, true);
                 this.outputChannel?.info(
                     `[CodeForgeAuthManager] ${providerId} authentication provider is not available in VS Code. Using unauthenticated requests only.`,
@@ -237,6 +234,24 @@ export class CodeForgeAuthManager {
         }
         this.markPromptedThisSession(providerId);
 
+        // Fire and forget the prompt flow so it doesn't block the caller
+        this.executePromptFlow(providerId, options).catch((e) => {
+            this.outputChannel?.error(`[CodeForgeAuthManager] Detached prompt flow failed for ${providerId}: ${e}`);
+        });
+
+        return undefined;
+    }
+
+    private async executePromptFlow(
+        providerId: string,
+        options: {
+            scopes: string[];
+            promptMessage: string;
+            signInLabel?: string;
+            extensionInstaller?: ExtensionInstaller;
+            alternativeChoice?: AlternativeChoice;
+        },
+    ): Promise<void> {
         const signInLabel = options.signInLabel ?? 'Sign In';
         const skipLabel = "Don't Sign In (Skip)";
         const choices = [signInLabel];
@@ -252,27 +267,28 @@ export class CodeForgeAuthManager {
                     options.extensionInstaller &&
                     !vscode.extensions.getExtension(options.extensionInstaller.extensionId)
                 ) {
-                    return this.promptInstallOrPat(options.extensionInstaller, options.alternativeChoice);
+                    await this.promptInstallOrPat(options.extensionInstaller, options.alternativeChoice);
+                    return;
                 }
                 const session = await vscode.authentication.getSession(providerId, options.scopes, {
                     createIfNone: true,
                 });
-                return session?.accessToken;
+                if (session?.accessToken) {
+                    this.setProviderUnavailable(providerId, false);
+                    this._onDidAuthenticate.fire(providerId);
+                }
             } else if (options.alternativeChoice && choice === options.alternativeChoice.label) {
-                const result = await options.alternativeChoice.execute();
-                return result.status === 'success' ? result.token : undefined;
+                await options.alternativeChoice.execute();
             } else if (choice === skipLabel) {
                 await this.setAuthSkipped(providerId, true);
             }
         } catch (e) {
             this.outputChannel?.error(`[CodeForgeAuthManager] Failed to prompt or sign in for ${providerId}: ${e}`);
-            return (await this.handleAuthError(providerId, e, {
+            await this.handleAuthError(providerId, e, {
                 extensionInstaller: options.extensionInstaller,
                 alternativeChoice: options.alternativeChoice,
-            })) as string | undefined;
+            });
         }
-
-        return undefined;
     }
 
     /**
@@ -302,11 +318,13 @@ export class CodeForgeAuthManager {
                 forceNewSession: options.hasOAuth ? true : undefined,
             });
             if (session) {
+                this.setProviderUnavailable(providerId, false);
                 const providerName =
                     options.extensionInstaller?.providerName ||
                     providerId.charAt(0).toUpperCase() + providerId.slice(1);
                 vscode.window.showInformationMessage(`Successfully authenticated with ${providerName}.`);
                 options.clearCache();
+                this._onDidAuthenticate.fire(providerId);
             }
         } catch (e) {
             await this.handleAuthError(providerId, e, {
@@ -506,7 +524,9 @@ export class CodeForgeAuthManager {
         try {
             await this.secrets.store(options.secretTokenKey, token.trim());
             this.outputChannel?.info(`[${options.displayName}Provider] Personal Access Token saved successfully`);
+            this.setProviderUnavailable(options.providerId, false);
             options.clearCache();
+            this._onDidAuthenticate.fire(options.providerId);
             return { status: 'success', token: token.trim() };
         } catch (err) {
             this.outputChannel?.info(

--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -27,7 +27,7 @@ export class CodeForgeService implements vscode.Disposable {
     private _initPromise: Promise<void>;
     private lastRefreshTime: number = 0;
     private lastDetectionTime = 0;
-    private detectPromise: Promise<void> | undefined;
+    private detectPromise: Promise<boolean> | undefined;
 
     private providers = new Map<string, CodeForgeProvider>();
     private activeProviderInstance: CodeForgeProvider | undefined;
@@ -51,7 +51,7 @@ export class CodeForgeService implements vscode.Disposable {
             }),
         );
 
-        this._initPromise = this.detectActiveProvider(true);
+        this._initPromise = this.detectActiveProvider(true).then(() => {});
 
         // Listen for config changes
         this.disposables.push(
@@ -155,14 +155,14 @@ export class CodeForgeService implements vscode.Disposable {
         }
     }
 
-    public async detectActiveProvider(force = false): Promise<void> {
+    public async detectActiveProvider(force = false): Promise<boolean> {
         if (!force && this.activeProviderInstance) {
-            return;
+            return false;
         }
 
         const now = Date.now();
         if (!force && now - this.lastDetectionTime < 30000) {
-            return;
+            return false;
         }
 
         if (this.detectPromise) {
@@ -173,13 +173,13 @@ export class CodeForgeService implements vscode.Disposable {
         this.detectPromise = this.doDetectActiveProvider();
 
         try {
-            await this.detectPromise;
+            return await this.detectPromise;
         } finally {
             this.detectPromise = undefined;
         }
     }
 
-    private async doDetectActiveProvider(): Promise<void> {
+    private async doDetectActiveProvider(): Promise<boolean> {
         try {
             const remotes = await this.jjService.getGitRemotes();
             const repoRoot = await this.jjService.getRepoRoot();
@@ -204,7 +204,8 @@ export class CodeForgeService implements vscode.Disposable {
             }
 
             const prevActive = this.activeProviderInstance;
-            if (prevActive?.id !== detectedProvider?.id) {
+            const changed = prevActive?.id !== detectedProvider?.id;
+            if (changed) {
                 this.activeProviderDisposable?.dispose();
                 prevActive?.deactivate();
 
@@ -222,8 +223,10 @@ export class CodeForgeService implements vscode.Disposable {
                 this._onDidActiveProviderChange.fire(detectedProvider);
                 this._onDidUpdate.fire();
             }
+            return changed;
         } catch (e) {
             this.outputChannel?.error(`[CodeForgeService] Failed to detect active provider: ${e}`);
+            return false;
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,6 +96,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     const codeForgeRegistry = new CodeForgeRegistry();
     context.subscriptions.push(codeForgeRegistry);
     const authManager = new CodeForgeAuthManager(context, outputChannel);
+    context.subscriptions.push(authManager);
 
     context.subscriptions.push(
         codeForgeRegistry.register({
@@ -147,6 +148,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         processTracker,
     );
     context.subscriptions.push(repositoryManager);
+
+    // Listen to authentication successes from AuthManager and re-detect provider to trigger refresh
+    context.subscriptions.push(
+        authManager.onDidAuthenticate(() => {
+            for (const repo of repositoryManager.repositories) {
+                repo.codeForge
+                    .detectActiveProvider(true)
+                    .then((changed) => {
+                        if (!changed) {
+                            repo.codeForge.forceRefresh();
+                        }
+                    })
+                    .catch((e: unknown) => {
+                        outputChannel.error(`Failed to refresh after authentication: ${e}`);
+                    });
+            }
+        }),
+    );
 
     const commentsManager = new CommentsManager(repositoryManager);
     context.subscriptions.push(commentsManager);

--- a/src/jj-log-webview-provider.ts
+++ b/src/jj-log-webview-provider.ts
@@ -397,7 +397,9 @@ export class JjLogWebviewProvider implements vscode.WebviewViewProvider {
             }
 
             // Background fetch code forge status for commits
-            await this.refreshCodeForge();
+            this.refreshCodeForge().catch((e) => {
+                this.outputChannel?.error(`[JjLogWebviewProvider] Background refreshCodeForge failed: ${e}`);
+            });
         }
     }
 

--- a/src/jj-repository.ts
+++ b/src/jj-repository.ts
@@ -171,13 +171,14 @@ export class JjRepository implements vscode.Disposable {
         this._codeForge.dispose();
         await this._watcher.dispose();
 
-        if (this._refreshQueue.currentRun) {
+        const activeRun = this._refreshQueue.currentRun;
+        this._refreshQueue.dispose();
+        if (activeRun) {
             try {
-                await this._refreshQueue.currentRun;
+                await activeRun;
             } catch {
                 // Ignore any error during dispose
             }
         }
-        this._refreshQueue.dispose();
     }
 }

--- a/src/test/code-forge-auth.test.ts
+++ b/src/test/code-forge-auth.test.ts
@@ -33,6 +33,21 @@ vi.mock('vscode', () => ({
         static from = vi.fn();
         dispose() {}
     },
+    EventEmitter: class {
+        private listeners: ((data: unknown) => void)[] = [];
+        event = (listener: (data: unknown) => void) => {
+            this.listeners.push(listener);
+            return { dispose: () => {} };
+        };
+        fire = (data: unknown) => {
+            for (const listener of this.listeners) {
+                listener(data);
+            }
+        };
+        dispose = () => {
+            this.listeners = [];
+        };
+    },
 }));
 
 describe('CodeForgeAuthManager', () => {
@@ -163,11 +178,34 @@ describe('CodeForgeAuthManager', () => {
         expect(authManager.isProviderUnavailable('github')).toBe(true);
     });
 
+    test('getSessionToken silent mode handles session check timed out error without permanently disabling provider', async () => {
+        vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('github session check timed out'));
+        const token = await authManager.getSessionToken('github', {
+            scopes: ['repo'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'test',
+            prompt: false,
+        });
+        expect(token).toBeUndefined();
+        expect(authManager.isProviderUnavailable('github')).toBe(false);
+    });
+
+    test('hasOAuthSession handles session check timed out error without permanently disabling provider', async () => {
+        vi.mocked(vscode.authentication.getSession).mockRejectedValue(new Error('github session check timed out'));
+        const hasSession = await authManager.hasOAuthSession('github', ['repo']);
+        expect(hasSession).toBe(false);
+        expect(authManager.isProviderUnavailable('github')).toBe(false);
+    });
+
     test('getSessionToken prompt mode warning flow choosing OAuth Sign In', async () => {
         vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Sign In' as never);
         vi.mocked(vscode.authentication.getSession)
             .mockResolvedValueOnce(undefined)
             .mockResolvedValueOnce({ accessToken: 'oauth-token' } as never);
+
+        const authEventPromise = new Promise<string>((resolve) => {
+            authManager.onDidAuthenticate(resolve);
+        });
 
         const token = await authManager.getSessionToken('github', {
             scopes: ['repo'],
@@ -177,7 +215,11 @@ describe('CodeForgeAuthManager', () => {
             prompt: true,
         });
 
-        expect(token).toBe('oauth-token');
+        expect(token).toBeUndefined(); // detached prompt returns undefined immediately
+
+        const providerId = await authEventPromise;
+        expect(providerId).toBe('github');
+
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
             'GitHub authentication required',
             'Sign In',
@@ -203,7 +245,11 @@ describe('CodeForgeAuthManager', () => {
             },
         });
 
-        expect(token).toBe('custom-pat-token');
+        expect(token).toBeUndefined(); // detached prompt returns undefined immediately
+
+        // Allow detached prompt flow microtask to run
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
         expect(alternativeExecute).toHaveBeenCalled();
         expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
             'GitLab authentication required',
@@ -211,6 +257,28 @@ describe('CodeForgeAuthManager', () => {
             'Enter PAT',
             "Don't Sign In (Skip)",
         );
+    });
+
+    test('promptForPat fires onDidAuthenticate exactly once', async () => {
+        vi.mocked(vscode.window.showInputBox).mockResolvedValue('pat-token-123');
+        vi.mocked(context.secrets.store).mockResolvedValue(undefined);
+
+        const authEvents: string[] = [];
+        authManager.onDidAuthenticate((providerId) => {
+            authEvents.push(providerId);
+        });
+
+        const result = await authManager.promptForPat({
+            providerId: 'github',
+            displayName: 'GitHub',
+            secretTokenKey: 'github_token',
+            prompt: 'Enter token',
+            placeHolder: 'token...',
+            clearCache: vi.fn(),
+        });
+
+        expect(result.status).toBe('success');
+        expect(authEvents).toEqual(['github']);
     });
 
     test('getSessionToken prompt mode warning flow choosing Skip', async () => {
@@ -233,6 +301,14 @@ describe('CodeForgeAuthManager', () => {
         vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined); // extension not installed
         vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Install GitLab Extension' as never);
 
+        const commandPromise = new Promise<void>((resolve) => {
+            vi.mocked(vscode.commands.executeCommand).mockImplementation(async (command) => {
+                if (command === 'workbench.extensions.search') {
+                    resolve();
+                }
+            });
+        });
+
         const token = await authManager.getSessionToken('gitlab', {
             scopes: ['api'],
             envTokenKey: 'NON_EXISTENT_ENV_KEY',
@@ -247,6 +323,10 @@ describe('CodeForgeAuthManager', () => {
         });
 
         expect(token).toBeUndefined();
+
+        // Wait for the floating prompt flow to trigger the command
+        await commandPromise;
+
         expect(vscode.extensions.getExtension).toHaveBeenCalledWith('gitlab.gitlab-workflow');
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             "GitLab authentication provider is not available. Please install the official 'GitLab Workflow' extension.",
@@ -257,6 +337,37 @@ describe('CodeForgeAuthManager', () => {
             'gitlab.gitlab-workflow',
         );
         expect(vscode.authentication.getSession).not.toHaveBeenCalledWith('gitlab', ['api'], { createIfNone: true });
+    });
+
+    test('getSessionToken prompt mode warning flow choosing OAuth Sign In with missing extension falls back to PAT', async () => {
+        vi.mocked(vscode.window.showWarningMessage).mockResolvedValue('Sign In (OAuth)' as never);
+        vi.mocked(vscode.extensions.getExtension).mockReturnValue(undefined); // extension not installed
+        vi.mocked(vscode.window.showErrorMessage).mockResolvedValue('Enter PAT' as never);
+        const alternativeExecute = vi.fn().mockResolvedValue({ status: 'success', token: 'fallback-pat' });
+
+        const token = await authManager.getSessionToken('gitlab', {
+            scopes: ['api'],
+            envTokenKey: 'NON_EXISTENT_ENV_KEY',
+            promptMessage: 'GitLab authentication required',
+            signInLabel: 'Sign In (OAuth)',
+            prompt: true,
+            extensionInstaller: {
+                extensionId: 'gitlab.gitlab-workflow',
+                extensionName: 'GitLab Workflow',
+                providerName: 'GitLab',
+            },
+            alternativeChoice: {
+                label: 'Enter PAT',
+                execute: alternativeExecute,
+            },
+        });
+
+        expect(token).toBeUndefined();
+
+        // Allow detached prompt flow microtask to run
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        expect(alternativeExecute).toHaveBeenCalled();
     });
 
     test('getSessionToken skip prompt check', async () => {
@@ -338,11 +449,14 @@ describe('CodeForgeAuthManager', () => {
     });
 
     describe('performOAuthSignIn', () => {
-        test('successful sign-in calls clearCache and shows information message', async () => {
+        test('successful sign-in calls clearCache, shows information message, and fires onDidAuthenticate', async () => {
             vi.mocked(vscode.extensions.getExtension).mockReturnValue({} as never);
             vi.mocked(vscode.authentication.getSession).mockResolvedValue({ accessToken: 'valid-token' } as never);
             vi.mocked(vscode.window.showInformationMessage);
             const clearCache = vi.fn();
+            const authEventPromise = new Promise<string>((resolve) => {
+                authManager.onDidAuthenticate(resolve);
+            });
 
             await authManager.performOAuthSignIn('gitlab', ['api'], {
                 hasOAuth: false,
@@ -362,6 +476,8 @@ describe('CodeForgeAuthManager', () => {
             expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
                 'Successfully authenticated with GitLab.',
             );
+            const providerId = await authEventPromise;
+            expect(providerId).toBe('gitlab');
         });
 
         test('aborts and prompts to install when required extension is missing', async () => {
@@ -561,6 +677,10 @@ describe('CodeForgeAuthManager', () => {
             vi.mocked(vscode.window.showInputBox).mockResolvedValue('my-new-token');
             vi.mocked(context.secrets.store).mockResolvedValue(undefined);
 
+            const authEventPromise = new Promise<string>((resolve) => {
+                authManager.onDidAuthenticate(resolve);
+            });
+
             const result = await authManager.promptForPat({
                 providerId: 'test-provider',
                 displayName: 'TestProvider',
@@ -584,6 +704,10 @@ describe('CodeForgeAuthManager', () => {
             expect(outputChannel.info).toHaveBeenCalledWith(
                 '[TestProviderProvider] Personal Access Token saved successfully',
             );
+
+            const providerId = await authEventPromise;
+            expect(providerId).toBe('test-provider');
+            expect(authManager.isProviderUnavailable('test-provider')).toBe(false);
         });
 
         test('returns cancelled and does not store if input is cancelled (undefined)', async () => {
@@ -639,6 +763,12 @@ describe('CodeForgeAuthManager', () => {
             expect(outputChannel.info).toHaveBeenCalledWith(
                 '[TestProviderProvider] Secrets storage is not available to save PAT: Error: Secret storage write error',
             );
+        });
+    });
+
+    describe('dispose', () => {
+        test('disposes event emitter', () => {
+            expect(() => authManager.dispose()).not.toThrow();
         });
     });
 });

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -464,12 +464,11 @@ export async function triggerRefresh(page: Page) {
 
 export async function hoverAndClick(row: Locator, button: Locator) {
     const start = Date.now();
-    const page = row.page();
     await expect(async () => {
-        await page.mouse.move(0, 0);
         await row.hover();
         // Wait for the button to be visible because VS Code renders inline actions on hover
-        await expect(button).toBeVisible({ timeout: 1000 });
+        await expect(button).toBeVisible({ timeout: 2000 });
+        await button.hover();
         await button.click();
     }, `Failed to click inline action button on row`).toPass({ timeout: 10000 });
     logPerf('hoverAndClick', start);
@@ -521,9 +520,9 @@ export async function clickScmAction(page: Page, rowName: string | RegExp | Loca
     const cls = iconMap[actionTitle];
     let button: Locator;
     if (cls) {
-        button = row.locator('.action-item', { has: page.locator(cls) }).first();
+        button = row.locator(`.action-label${cls}`).first();
     } else {
-        button = row.getByRole('button', { name: new RegExp(actionTitle, 'i') }).first();
+        button = row.getByRole('button', { name: new RegExp(actionTitle.replace(/\.\.\./g, ''), 'i') }).first();
     }
 
     await hoverAndClick(row, button);
@@ -1279,12 +1278,12 @@ export async function pickQuickPickItem(
             await expect(quickInput).not.toBeVisible({ timeout: 5000 });
         } else {
             const item = locateQuickInputItem(page, label).first();
-            await expect(item).toBeVisible({ timeout: 1000 });
+            await expect(item).toBeVisible({ timeout: 5000 });
             await item.click();
-            await expect(item).not.toBeVisible({ timeout: 500 });
+            await expect(item).not.toBeVisible({ timeout: 5000 });
         }
     }, `Failed to pick QuickPick item "${label}"`).toPass({
-        timeout: 5000,
+        timeout: 15000,
         // Add a backoff so we don't spam if the UI is genuinely stuck
         intervals: [100, 250, 500, 1000, 2000],
     });

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -310,7 +310,7 @@ test.describe('SCM Pane E2E', () => {
         // 2. Squash Files into Ancestor
         // We'll squash s.txt from 'source' (WC) into 'base'
         // Hover over s.txt row and click squash into ancestor
-        await clickScmAction(page, /s\.txt/, SCM_ACTIONS.SquashFilesIntoAncestor);
+        await clickScmAction(page, /^s\.txt\b/, SCM_ACTIONS.SquashFilesIntoAncestor);
         // Pick 'base' from quickpick.
         await pickQuickPickItem(page, '(no description)');
 

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -296,6 +296,7 @@ export async function launchNewVSCode(
     }
 
     const env = { ...process.env, NODE_NO_WARNINGS: '1' } as { [key: string]: string };
+    delete env.ELECTRON_RUN_AS_NODE;
     for (const key in extraEnv) {
         const val = extraEnv[key];
         if (val === undefined) {

--- a/src/test/jj-repository-refresh.test.ts
+++ b/src/test/jj-repository-refresh.test.ts
@@ -11,9 +11,15 @@ import { Uri } from '../uri-utils';
 import { TestRepo } from './test-repo';
 import { createMockLogOutputChannel } from './test-utils';
 
+const mockOnDidSaveTextDocument = vi.fn();
+
 vi.mock('vscode', async () => {
     const { createVscodeMock } = await import('./vscode-mock');
-    return createVscodeMock();
+    return createVscodeMock({
+        workspace: {
+            onDidSaveTextDocument: (...args: unknown[]) => mockOnDidSaveTextDocument(...args),
+        },
+    });
 });
 
 describe('JjRepository.refresh error handling', () => {
@@ -21,6 +27,7 @@ describe('JjRepository.refresh error handling', () => {
     let jjRepo: JjRepository;
 
     beforeEach(() => {
+        mockOnDidSaveTextDocument.mockReturnValue({ dispose: () => {} });
         repo = new TestRepo();
         repo.init();
     });
@@ -79,6 +86,32 @@ describe('JjRepository.refresh error handling', () => {
 
         await jjRepo.dispose();
         await expect(refreshPromise).resolves.toBeUndefined();
+        expect(jjRepo.activeRefresh).toBeUndefined();
+    });
+
+    test('dispose() cancels pending background debounce timer immediately', async () => {
+        let saveListener: ((doc: { uri: { scheme: string; fsPath: string } }) => void) | undefined;
+        mockOnDidSaveTextDocument.mockImplementation(
+            (listener: (doc: { uri: { scheme: string; fsPath: string } }) => void) => {
+                saveListener = listener;
+                return { dispose: () => {} };
+            },
+        );
+
+        jjRepo = new JjRepository(
+            Uri.file(repo.path),
+            path.join(repo.path, '.jj', 'repo'),
+            new CodeForgeRegistry(),
+            createMockLogOutputChannel(),
+        );
+
+        // Trigger a background file save event to start a debounce timer
+        saveListener?.({
+            uri: Uri.file(path.join(repo.path, 'file.txt')),
+        });
+        expect(jjRepo.activeRefresh).toBeDefined();
+
+        await jjRepo.dispose();
         expect(jjRepo.activeRefresh).toBeUndefined();
     });
 });

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -178,8 +178,8 @@ suite('Webview Initialization Integration Test', () => {
     });
 
     test('updateRepository does not block on pending CodeForge detection', async () => {
-        let resolveDetection!: () => void;
-        const pendingDetection = new Promise<void>((resolve) => {
+        let resolveDetection!: (value: boolean) => void;
+        const pendingDetection = new Promise<boolean>((resolve) => {
             resolveDetection = resolve;
         });
 
@@ -217,7 +217,7 @@ suite('Webview Initialization Integration Test', () => {
         assert.strictEqual(completed, true, 'updateRepository should complete without awaiting detectActiveProvider');
         assert.strictEqual(unattachedProvider.repository, mockRepo);
 
-        resolveDetection();
+        resolveDetection(false);
     });
 
     test('updateRepository logs and ignores detectActiveProvider errors', async () => {


### PR DESCRIPTION
The background OAuth prompts in CodeForgeAuthManager were blocking the  DebouncingQueue when requiring user interaction. Since these prompts were awaited in the refresh pipeline, this would cause permanent deadlocks of the extension where no other commands could be executed.

This makes the prompting non-blocking by executing it in a floating  promise. When the authentication completes, it now fires an onDidAuthenticate event which extension.ts listens to, in order to trigger a re-detection of the active provider and refresh the Code Forge state without blocking the queue.