### PR TITLE
test(commands): eliminate all vscode usage and imports from src/test/commands

### DIFF
--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -294,8 +294,8 @@ export interface DescriptionFormatContext {
             get<T>(key: string): T | undefined;
         };
         ui?: {
-            setCommitInput?(value: string): void;
-            getCommitInput?(): string | undefined;
+            setScmDescriptionInputValue?(value: string): void;
+            getScmDescriptionInputValue?(): string | undefined;
         };
     };
 }
@@ -313,8 +313,8 @@ export async function maybeFormatDescriptionOnSave(
     const bodyWidthRuler = ctx.host.config.get<number>('commit.bodyWidthRuler') ?? 72;
     description = await formatCommitDescription(description, bodyWidthRuler);
 
-    if (revision === '@' && ctx.host.ui?.setCommitInput) {
-        ctx.host.ui.setCommitInput(description);
+    if (revision === '@' && ctx.host.ui?.setScmDescriptionInputValue) {
+        ctx.host.ui.setScmDescriptionInputValue(description);
     }
     return description;
 }

--- a/src/commands/commit-prompt.ts
+++ b/src/commands/commit-prompt.ts
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { CommandContext } from '../common/command-context';
-import type { JjScmProvider } from '../jj-scm-provider';
 import { maybeFormatDescriptionOnSave } from './command-utils';
 
-export async function commitPromptCommand(ctx: CommandContext, scmProvider?: JjScmProvider): Promise<void> {
+export async function commitPromptCommand(ctx: CommandContext): Promise<void> {
     const { jj } = ctx.repo;
-    const inputBoxValue = scmProvider?.sourceControl.inputBox.value;
+    const inputBoxValue = ctx.host.ui.getScmDescriptionInputValue?.();
     const defaultValue = inputBoxValue || (await jj.getDescription('@'));
 
     const input = await ctx.host.ui.showInputBox({
@@ -24,11 +23,7 @@ export async function commitPromptCommand(ctx: CommandContext, scmProvider?: JjS
     try {
         const message = await maybeFormatDescriptionOnSave(input, ctx);
         await ctx.host.ui.withProgress('Committing...', () => jj.commit(message));
-        if (scmProvider) {
-            await scmProvider.refresh({ reason: 'after commit' });
-        } else {
-            await ctx.repo.refresh();
-        }
+        await ctx.repo.refresh({ reason: 'after commit' });
     } catch (err: unknown) {
         await ctx.host.ui.showError(err, 'Error committing change');
     }

--- a/src/commands/describe-prompt.ts
+++ b/src/commands/describe-prompt.ts
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { CommandContext } from '../common/command-context';
-import type { JjScmProvider } from '../jj-scm-provider';
 import { maybeFormatDescriptionOnSave } from './command-utils';
 
-export async function describePromptCommand(ctx: CommandContext, scmProvider?: JjScmProvider): Promise<void> {
+export async function describePromptCommand(ctx: CommandContext): Promise<void> {
     const { jj } = ctx.repo;
-    const inputBoxValue = scmProvider?.sourceControl.inputBox.value;
+    const inputBoxValue = ctx.host.ui.getScmDescriptionInputValue?.();
     const defaultValue = inputBoxValue || (await jj.getDescription('@'));
 
     const input = await ctx.host.ui.showInputBox({
@@ -24,11 +23,7 @@ export async function describePromptCommand(ctx: CommandContext, scmProvider?: J
     try {
         const description = await maybeFormatDescriptionOnSave(input, ctx);
         await ctx.host.ui.withProgress('Setting description...', () => jj.describe(description));
-        if (scmProvider) {
-            await scmProvider.refresh({ reason: 'after describe' });
-        } else {
-            await ctx.repo.refresh();
-        }
+        await ctx.repo.refresh({ reason: 'after describe' });
     } catch (err: unknown) {
         await ctx.host.ui.showError(err, 'Error setting description');
     }

--- a/src/commands/details.ts
+++ b/src/commands/details.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { CommandContext } from '../common/command-context';
-import { openCommitDetails } from '../jj-commit-details-editor-provider';
 
 export interface ShowDetailsPayload {
     revision?: string;
@@ -12,7 +11,7 @@ export interface ShowDetailsPayload {
 export async function showDetailsCommand(ctx: CommandContext, payload?: ShowDetailsPayload): Promise<void> {
     const {
         repo,
-        host: { ui },
+        host: { ui, nav },
     } = ctx;
     const { jj } = repo;
     const revision = payload?.revision || '@';
@@ -22,7 +21,7 @@ export async function showDetailsCommand(ctx: CommandContext, payload?: ShowDeta
         if (!logEntry) {
             throw new Error(`No log entry found for revision: ${revision}`);
         }
-        await openCommitDetails(
+        await nav.openCommitDetails(
             jj.workspaceRoot,
             logEntry.change_id,
             logEntry.change_id_shortest,

--- a/src/common/host-environment.ts
+++ b/src/common/host-environment.ts
@@ -41,8 +41,8 @@ export interface HostUi {
     }): Promise<string | undefined>;
     withProgress<T>(title: string, task: () => Promise<T>): Promise<T>;
     setStatusBarMessage?(message: string, timeoutMs?: number): void;
-    setCommitInput?(value: string): void;
-    getCommitInput?(): string | undefined;
+    setScmDescriptionInputValue?(value: string): void;
+    getScmDescriptionInputValue?(): string | undefined;
 }
 
 export interface HostConfig {
@@ -55,6 +55,13 @@ export interface HostNavigation {
     openDiff(leftUri: Uri, rightUri: Uri, title: string): Promise<void>;
     openMultiDiff(title: string, resources: { leftUri: Uri; rightUri: Uri; label: string }[]): Promise<void>;
     openMergeEditor(resourceUri: Uri): Promise<void>;
+    openCommitDetails(
+        repoRoot: string,
+        changeId: string,
+        shortestChangeId?: string,
+        isDivergent?: boolean,
+        changeIdOffset?: number,
+    ): Promise<void>;
     openFile(uri: Uri): Promise<void>;
     openFolder(folderUri: Uri, forceNewWindow?: boolean): Promise<void>;
     openExternal(url: string): Promise<void>;

--- a/src/test/absorb.integration.test.ts
+++ b/src/test/absorb.integration.test.ts
@@ -5,20 +5,21 @@
 
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
-import { absorbCommand } from '../../commands/absorb';
-import type { CommentsManager } from '../../comments-manager';
-import type { JjScmProvider } from '../../jj-scm-provider';
-import { createAbsorbPayload } from '../../vscode/payloads/absorb.payload';
-import { VSCodeCommandContext } from '../../vscode/vscode-command-context';
-import { buildGraph, TestRepo } from '../test-repo';
-import { createMock } from '../test-utils';
+import { absorbCommand } from '../commands/absorb';
+import type { CommentsManager } from '../comments-manager';
+import type { JjScmProvider } from '../jj-scm-provider';
+import { createAbsorbPayload } from '../vscode/payloads/absorb.payload';
+import { VSCodeCommandContext } from '../vscode/vscode-command-context';
+import { createTestRepositoryContext, type TestRepositoryContext } from './integration-test-utils';
+import { buildGraph, TestRepo } from './test-repo';
+import { createMock } from './test-utils';
 
 suite('Absorb Integration Test', function () {
     this.timeout(60000);
     let repo: TestRepo;
     let scmProvider: JjScmProvider;
     let outputChannel: vscode.LogOutputChannel;
-    let contextHelper: import('../integration-test-utils').TestRepositoryContext;
+    let contextHelper: TestRepositoryContext;
     let cmdCtx: VSCodeCommandContext;
 
     setup(async () => {
@@ -26,7 +27,6 @@ suite('Absorb Integration Test', function () {
         await repo.init();
 
         outputChannel = vscode.window.createOutputChannel('JJ Test', { log: true });
-        const { createTestRepositoryContext } = await import('../integration-test-utils');
         contextHelper = await createTestRepositoryContext(repo.path, outputChannel);
         scmProvider = contextHelper.scmProvider;
         cmdCtx = new VSCodeCommandContext(scmProvider.repo, scmProvider.outputChannel, createMock<CommentsManager>({}));

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -350,8 +350,8 @@ describe('maybeFormatDescriptionOnSave', () => {
         expect(result).toBe(raw);
     });
 
-    it('formats description and updates ctx.host.ui.setCommitInput when revision is @', async () => {
-        const setCommitInput = vi.fn();
+    it('formats description and updates ctx.host.ui.setScmDescriptionInputValue when revision is @', async () => {
+        const setScmDescriptionInputValue = vi.fn();
         const ctx = {
             repo: jjRepo,
             host: {
@@ -367,7 +367,7 @@ describe('maybeFormatDescriptionOnSave', () => {
                     }),
                 },
                 ui: {
-                    setCommitInput,
+                    setScmDescriptionInputValue,
                 },
             },
         };
@@ -376,11 +376,11 @@ describe('maybeFormatDescriptionOnSave', () => {
         const result = await maybeFormatDescriptionOnSave(raw, ctx, '@');
 
         expect(result).toBe('Title\n\nThis is a long body\nline that should be\nwrapped by prettier.');
-        expect(setCommitInput).toHaveBeenCalledWith(result);
+        expect(setScmDescriptionInputValue).toHaveBeenCalledWith(result);
     });
 
-    it('formats description but does not call setCommitInput when revision is not @', async () => {
-        const setCommitInput = vi.fn();
+    it('formats description but does not call setScmDescriptionInputValue when revision is not @', async () => {
+        const setScmDescriptionInputValue = vi.fn();
         const ctx = {
             repo: jjRepo,
             host: {
@@ -396,7 +396,7 @@ describe('maybeFormatDescriptionOnSave', () => {
                     }),
                 },
                 ui: {
-                    setCommitInput,
+                    setScmDescriptionInputValue,
                 },
             },
         };
@@ -405,6 +405,6 @@ describe('maybeFormatDescriptionOnSave', () => {
         const result = await maybeFormatDescriptionOnSave(raw, ctx, '@-');
 
         expect(result).toBe('Title\n\nThis is a long body\nline that should be\nwrapped by prettier.');
-        expect(setCommitInput).not.toHaveBeenCalled();
+        expect(setScmDescriptionInputValue).not.toHaveBeenCalled();
     });
 });

--- a/src/test/commands/abandon.test.ts
+++ b/src/test/commands/abandon.test.ts
@@ -6,20 +6,15 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { abandonCommand } from '../../commands/abandon';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { Uri } from '../../uri-utils';
-import type { JjLoggerChannel } from '../../utils/output-channel';
-import { createAbandonPayload } from '../../vscode/payloads/abandon.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-import { asMock } from '../vitest-utils';
 
 describe('abandonCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
-    let scmProvider: JjScmProvider;
     let mockJjRepo: JjRepository;
     let ctx: FakeCommandContext;
 
@@ -27,17 +22,6 @@ describe('abandonCommand', () => {
         repo = new TestRepo();
         repo.init();
         jj = new JjService(repo.path, NO_OP_LOGGER);
-
-        scmProvider = createMock<JjScmProvider>({
-            jj,
-            repo: createMock<JjRepository>({
-                jj,
-                rootUri: Uri.file(repo.path),
-                refresh: vi.fn().mockResolvedValue(undefined),
-            }),
-            outputChannel: createMock<JjLoggerChannel>(NO_OP_LOGGER),
-            getSelectedCommitIds: vi.fn().mockReturnValue([]),
-        });
 
         mockJjRepo = createMock<JjRepository>({
             jj,
@@ -52,19 +36,9 @@ describe('abandonCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runAbandon = async (args: unknown[]) => {
-        const payload = createAbandonPayload(args, scmProvider);
-        await abandonCommand(ctx, payload);
-    };
-
     const expectChangeAbandoned = (changeId: string) => {
         const visibleIds = repo.getLog('all()', 'change_id');
         expect(visibleIds).not.toContain(changeId);
-    };
-
-    const expectChangeVisible = (changeId: string) => {
-        const visibleIds = repo.getLog('all()', 'change_id');
-        expect(visibleIds).toContain(changeId);
     };
 
     test('abandons specified commit', async () => {
@@ -72,7 +46,7 @@ describe('abandonCommand', () => {
         const c1 = repo.getChangeId('@');
         repo.new();
 
-        await runAbandon([{ commitId: c1 }]);
+        await abandonCommand(ctx, { revisions: [c1] });
 
         expectChangeAbandoned(c1);
 
@@ -80,17 +54,7 @@ describe('abandonCommand', () => {
         expect(parents).not.toContain(c1);
     });
 
-    test('abandons working copy when triggered from resource group header', async () => {
-        repo.new();
-        const c1 = repo.getChangeId('@');
-        const scmGroup = { id: 'jj.group.workingCopy', label: 'Working Copy', resourceStates: [] };
-
-        await runAbandon([scmGroup]);
-
-        expectChangeAbandoned(c1);
-    });
-
-    test('abandons working copy and IGNORES selection when triggered from resource group header', async () => {
+    test('abandons multiple commits', async () => {
         const graph = await buildGraph(repo, [
             { label: 'C1' },
             { label: 'C2', parents: ['C1'], isCurrentWorkingCopy: true },
@@ -98,82 +62,20 @@ describe('abandonCommand', () => {
         const c1 = graph.C1.changeId;
         const c2 = graph.C2.changeId;
 
-        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([c1]);
-        const scmGroup = { id: 'jj.group.workingCopy', label: 'Working Copy', resourceStates: [] };
-
-        await runAbandon([scmGroup]);
-
-        expectChangeAbandoned(c2);
-        expectChangeVisible(c1);
-    });
-
-    test('abandons clicked commit if not in selection', async () => {
-        repo.new();
-        const c1 = repo.getChangeId('@');
-
-        await runAbandon([{ commitId: c1 }]);
-
-        expectChangeAbandoned(c1);
-    });
-
-    test('abandons clicked commit AND selection if clicked is part of selection', async () => {
-        const graph = await buildGraph(repo, [
-            { label: 'C1' },
-            { label: 'C2', parents: ['C1'], isCurrentWorkingCopy: true },
-        ]);
-        const c1 = graph.C1.changeId;
-        const c2 = graph.C2.changeId;
-
-        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([c1, c2]);
-        const arg = { commitId: c1 };
-
-        await runAbandon([arg]);
+        await abandonCommand(ctx, { revisions: [c1, c2] });
 
         expectChangeAbandoned(c1);
         expectChangeAbandoned(c2);
     });
 
-    test('abandons only clicked commit if clicked is NOT in selection', async () => {
-        const graph = await buildGraph(repo, [
-            { label: 'C1' },
-            { label: 'C2', parents: ['C1'], isCurrentWorkingCopy: true },
-        ]);
-        const c1 = graph.C1.changeId;
-        const c2 = graph.C2.changeId;
-
-        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([c1]);
-        const arg = { commitId: c2 };
-
-        await runAbandon([arg]);
-
-        expectChangeAbandoned(c2);
-        expectChangeVisible(c1);
-
-        const parents = repo.getParents('@');
-        expect(parents).toContain(c1);
-    });
-
-    test('falls back to selection if no click argument', async () => {
-        repo.new();
-        const c1 = repo.getChangeId('@');
-
-        repo.new();
-
-        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([c1]);
-
-        await runAbandon([]);
-
-        expectChangeAbandoned(c1);
-    });
-
-    test('prompts for input if no selection and no click arg', async () => {
+    test('prompts for input if no revisions specified', async () => {
         repo.new();
         const c1 = repo.getChangeId('@');
         repo.new();
 
         ctx.host.ui.setNextRevisionPromptResponse(c1);
 
-        await runAbandon([]);
+        await abandonCommand(ctx, {});
 
         expectChangeAbandoned(c1);
     });
@@ -186,7 +88,7 @@ describe('abandonCommand', () => {
         ]);
         const mergeChangeId = graph.merge.changeId;
 
-        await runAbandon([{ commitId: mergeChangeId }]);
+        await abandonCommand(ctx, { revisions: [mergeChangeId] });
 
         expectChangeAbandoned(mergeChangeId);
     });

--- a/src/test/commands/absorb.test.ts
+++ b/src/test/commands/absorb.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { absorbCommand } from '../../commands/absorb';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createAbsorbPayload } from '../../vscode/payloads/absorb.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -35,11 +34,6 @@ describe('absorbCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runAbsorb = async (args: unknown[]) => {
-        const payload = createAbsorbPayload(args);
-        await absorbCommand(ctx, payload);
-    };
-
     it('should absorb working copy changes', async () => {
         const fileName = 'file.txt';
         await buildGraph(repo, [
@@ -53,7 +47,7 @@ describe('absorbCommand', () => {
             },
         ]);
 
-        await runAbsorb([]);
+        await absorbCommand(ctx, {});
 
         expect(mockJjRepo.refresh).toHaveBeenCalledTimes(1);
         expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after absorb' });
@@ -82,9 +76,7 @@ describe('absorbCommand', () => {
         ]);
 
         const commitBId = ids.B.commitId;
-        const arg = { commitId: commitBId };
-
-        await runAbsorb([arg]);
+        await absorbCommand(ctx, { fromRevision: commitBId });
 
         expect(mockJjRepo.refresh).toHaveBeenCalledTimes(1);
         expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after absorb' });

--- a/src/test/commands/bookmark-advance-upload.test.ts
+++ b/src/test/commands/bookmark-advance-upload.test.ts
@@ -8,7 +8,6 @@ import type { CodeForgeService } from '../../code-forge-service';
 import { advanceBookmarkAndUploadCommand } from '../../commands/bookmark-advance-upload';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createAdvanceBookmarkAndUploadPayload } from '../../vscode/payloads/bookmark-advance-upload.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -60,8 +59,7 @@ describe('advanceBookmarkAndUploadCommand', () => {
         await jj.new({ message: 'child' });
         const [child] = await jj.getLog({ revision: '@' });
 
-        const payload = createAdvanceBookmarkAndUploadPayload([child.change_id]);
-        await advanceBookmarkAndUploadCommand(ctx, payload);
+        await advanceBookmarkAndUploadCommand(ctx, { revision: child.change_id });
 
         const [childLog] = await jj.getLog({ revision: '@' });
         expect(childLog.bookmarks).toEqual(

--- a/src/test/commands/bookmark-advance.test.ts
+++ b/src/test/commands/bookmark-advance.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { advanceBookmarkCommand } from '../../commands/bookmark-advance';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createAdvanceBookmarkPayload } from '../../vscode/payloads/bookmark-advance.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -33,17 +32,12 @@ describe('advanceBookmarkCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runAdvanceBookmark = async (args: unknown[]) => {
-        const payload = createAdvanceBookmarkPayload(args);
-        return await advanceBookmarkCommand(ctx, payload);
-    };
-
     test('advances bookmark with revision argument directly', async () => {
         repo.bookmark('test-bookmark', '@');
         await jj.new({ message: 'child' });
         const [child] = await jj.getLog({ revision: '@' });
 
-        await runAdvanceBookmark([child.change_id]);
+        await advanceBookmarkCommand(ctx, { revision: child.change_id });
 
         const [childLog] = await jj.getLog({ revision: '@' });
         expect(childLog.bookmarks).toEqual(
@@ -58,7 +52,7 @@ describe('advanceBookmarkCommand', () => {
 
         ctx.host.ui.setNextRevisionPromptResponse(child.commit_id);
 
-        await runAdvanceBookmark([]);
+        await advanceBookmarkCommand(ctx, {});
 
         const [childLog] = await jj.getLog({ revision: '@' });
         expect(childLog.bookmarks).toEqual(

--- a/src/test/commands/bookmark.test.ts
+++ b/src/test/commands/bookmark.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { setBookmarkCommand } from '../../commands/bookmark';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createSetBookmarkPayload } from '../../vscode/payloads/bookmark.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -33,18 +32,13 @@ describe('setBookmarkCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runSetBookmark = async (args: unknown[]) => {
-        const payload = createSetBookmarkPayload(args);
-        await setBookmarkCommand(ctx, payload);
-    };
-
     test('sets bookmark when selected from list', async () => {
         repo.bookmark('feature-a', '@');
 
         ctx.host.ui.setNextSelectOrCreateResponse('feature-a');
 
         const commitId = repo.getChangeId('@');
-        await runSetBookmark([{ commitId }]);
+        await setBookmarkCommand(ctx, { revision: commitId });
 
         const bookmarks = repo.getBookmarks('@');
         expect(bookmarks).toContain('feature-a');
@@ -54,7 +48,7 @@ describe('setBookmarkCommand', () => {
         ctx.host.ui.setNextSelectOrCreateResponse('new-feature');
 
         const commitId = repo.getChangeId('@');
-        await runSetBookmark([{ commitId }]);
+        await setBookmarkCommand(ctx, { revision: commitId });
 
         const bookmarks = repo.getBookmarks('@');
         expect(bookmarks).toContain('new-feature');

--- a/src/test/commands/commit-prompt.test.ts
+++ b/src/test/commands/commit-prompt.test.ts
@@ -4,19 +4,16 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
 import { commitPromptCommand } from '../../commands/commit-prompt';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
-import { createMock, createMockLogOutputChannel } from '../test-utils';
+import { createMock } from '../test-utils';
 
 describe('commitPromptCommand', () => {
     let repo: TestRepo;
     let jj: JjService;
-    let scmProvider: JjScmProvider;
     let mockJjRepo: JjRepository;
     let ctx: FakeCommandContext;
 
@@ -25,17 +22,6 @@ describe('commitPromptCommand', () => {
         repo.init();
         jj = new JjService(repo.path, NO_OP_LOGGER);
         mockJjRepo = createMock<JjRepository>({ jj, refresh: vi.fn().mockResolvedValue(undefined) });
-        scmProvider = createMock<JjScmProvider>({
-            refresh: vi.fn().mockResolvedValue(undefined),
-            outputChannel: createMockLogOutputChannel({
-                appendLine: vi.fn(),
-            }),
-            sourceControl: createMock<vscode.SourceControl>({
-                inputBox: createMock<vscode.SourceControlInputBox>({
-                    value: '',
-                }),
-            }),
-        });
         ctx = new FakeCommandContext(mockJjRepo);
     });
 
@@ -44,55 +30,55 @@ describe('commitPromptCommand', () => {
     });
 
     test('prompts if input box is empty and commits with user input', async () => {
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         repo.new(undefined, 'initial');
         await jj.describe('existing description', '@');
 
         ctx.host.ui.setNextInputBoxResponse('new description');
 
-        await commitPromptCommand(ctx, scmProvider);
+        await commitPromptCommand(ctx);
 
         const parentId = repo.getParents('@')[0];
         const parentDesc = repo.getDescription(parentId);
         expect(parentDesc.trim()).toBe('new description');
 
-        expect(scmProvider.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
+        expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
     });
 
     test('does nothing if user cancels prompt', async () => {
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         await jj.describe('existing', '@');
 
         ctx.host.ui.setNextInputBoxResponse(undefined);
 
-        await commitPromptCommand(ctx, scmProvider);
+        await commitPromptCommand(ctx);
 
         const desc = repo.getDescription('@');
         expect(desc.trim()).toBe('existing');
 
-        expect(scmProvider.refresh).not.toHaveBeenCalled();
+        expect(mockJjRepo.refresh).not.toHaveBeenCalled();
     });
 
     test('shows prompt even when input box has text', async () => {
         repo.new(undefined, 'initial');
-        scmProvider.sourceControl.inputBox.value = 'feat: quick commit';
+        ctx.host.ui.setScmDescriptionInputValue('feat: quick commit');
 
         ctx.host.ui.setNextInputBoxResponse('feat: quick commit');
 
-        await commitPromptCommand(ctx, scmProvider);
+        await commitPromptCommand(ctx);
 
         const parentId = repo.getParents('@')[0];
         const parentDesc = repo.getDescription(parentId);
         expect(parentDesc.trim()).toBe('feat: quick commit');
 
-        expect(scmProvider.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
+        expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
     });
 
     test('commits with blank message when prompt is cleared', async () => {
         repo.new(undefined, 'initial');
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         await jj.describe('existing description', '@');
 
@@ -100,7 +86,7 @@ describe('commitPromptCommand', () => {
 
         ctx.host.ui.setNextInputBoxResponse('');
 
-        await commitPromptCommand(ctx, scmProvider);
+        await commitPromptCommand(ctx);
 
         const afterChangeId = repo.getChangeId('@');
         expect(afterChangeId).not.toBe(beforeChangeId);
@@ -112,14 +98,14 @@ describe('commitPromptCommand', () => {
         const currentDesc = repo.getDescription('@');
         expect(currentDesc.trim()).toBe('');
 
-        expect(scmProvider.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
+        expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after commit' });
     });
 
     test('handles errors during commit and displays error to user', async () => {
         ctx.host.ui.setNextInputBoxResponse('failing commit');
         vi.spyOn(jj, 'commit').mockRejectedValue(new Error('Commit failed'));
 
-        await commitPromptCommand(ctx, scmProvider);
+        await commitPromptCommand(ctx);
 
         expect(ctx.host.ui.errorMessages[0].prefix).toBe('Error committing change');
     });

--- a/src/test/commands/compare-all-files-with-revision.test.ts
+++ b/src/test/commands/compare-all-files-with-revision.test.ts
@@ -8,7 +8,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { compareAllFilesWithRevisionCommand } from '../../commands/compare-all-files-with-revision';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createCompareAllFilesWithRevisionPayload } from '../../vscode/payloads/compare-all-files-with-revision.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -31,7 +30,7 @@ describe('compareAllFilesWithRevisionCommand', () => {
         vi.clearAllMocks();
     });
 
-    it('opens vscode.changes with expected file list', async () => {
+    it('opens multi-diff with expected file list', async () => {
         const ids = await buildGraph(repo, [
             { label: 'v1', files: { 'file1.txt': 'v1\n', 'file2.txt': 'v1\n' } },
             { label: 'v2', parents: ['v1'], files: { 'file1.txt': 'v2\n' } },
@@ -43,8 +42,7 @@ describe('compareAllFilesWithRevisionCommand', () => {
         repo.deleteFile('file2.txt');
         repo.writeFile('file3.txt', 'unique added file\n');
 
-        const payload = createCompareAllFilesWithRevisionPayload([parentId]);
-        await compareAllFilesWithRevisionCommand(ctx, payload);
+        await compareAllFilesWithRevisionCommand(ctx, { revision: parentId });
 
         expect(ctx.host.nav.multiDiffsOpened).toHaveLength(1);
         const multiDiff = ctx.host.nav.multiDiffsOpened[0];
@@ -77,8 +75,7 @@ describe('compareAllFilesWithRevisionCommand', () => {
         const ids = await buildGraph(repo, [{ label: 'v1', files: { 'file1.txt': 'v1\n' } }]);
         const parentId = ids.v1.changeId;
 
-        const payload = createCompareAllFilesWithRevisionPayload([parentId]);
-        await compareAllFilesWithRevisionCommand(ctx, payload);
+        await compareAllFilesWithRevisionCommand(ctx, { revision: parentId });
 
         expect(ctx.host.ui.infoMessages).toContain(`No differences found between ${parentId} and working copy.`);
         expect(ctx.host.nav.multiDiffsOpened).toHaveLength(0);

--- a/src/test/commands/describe-prompt.test.ts
+++ b/src/test/commands/describe-prompt.test.ts
@@ -4,19 +4,16 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
 import { describePromptCommand } from '../../commands/describe-prompt';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
-import { createMock, createMockLogOutputChannel } from '../test-utils';
+import { createMock } from '../test-utils';
 
 describe('describePromptCommand', () => {
     let repo: TestRepo;
     let jj: JjService;
-    let scmProvider: JjScmProvider;
     let mockJjRepo: JjRepository;
     let ctx: FakeCommandContext;
 
@@ -25,18 +22,6 @@ describe('describePromptCommand', () => {
         repo.init();
         jj = new JjService(repo.path, NO_OP_LOGGER);
         mockJjRepo = createMock<JjRepository>({ jj, refresh: vi.fn().mockResolvedValue(undefined) });
-
-        scmProvider = createMock<JjScmProvider>({
-            refresh: vi.fn().mockResolvedValue(undefined),
-            outputChannel: createMockLogOutputChannel({
-                appendLine: vi.fn(),
-            }),
-            sourceControl: createMock<vscode.SourceControl>({
-                inputBox: createMock<vscode.SourceControlInputBox>({
-                    value: '',
-                }),
-            }),
-        });
         ctx = new FakeCommandContext(mockJjRepo);
     });
 
@@ -45,40 +30,41 @@ describe('describePromptCommand', () => {
     });
 
     test('prompts if input box is empty and sets description with user input', async () => {
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         repo.new(undefined, 'initial');
         await jj.describe('existing description', '@');
 
         ctx.host.ui.setNextInputBoxResponse('new description');
 
-        await describePromptCommand(ctx, scmProvider);
+        await describePromptCommand(ctx);
 
         const currentDesc = repo.getDescription('@');
         expect(currentDesc.trim()).toBe('new description');
+        expect(mockJjRepo.refresh).toHaveBeenCalledWith({ reason: 'after describe' });
     });
 
     test('does nothing if user cancels prompt', async () => {
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         await jj.describe('existing', '@');
 
         ctx.host.ui.setNextInputBoxResponse(undefined);
 
-        await describePromptCommand(ctx, scmProvider);
+        await describePromptCommand(ctx);
 
         const desc = repo.getDescription('@');
         expect(desc.trim()).toBe('existing');
-        expect(scmProvider.refresh).not.toHaveBeenCalled();
+        expect(mockJjRepo.refresh).not.toHaveBeenCalled();
     });
 
     test('shows prompt even when input box has text', async () => {
         repo.new(undefined, 'initial');
-        scmProvider.sourceControl.inputBox.value = 'feat: quick describe';
+        ctx.host.ui.setScmDescriptionInputValue('feat: quick describe');
 
         ctx.host.ui.setNextInputBoxResponse('feat: quick describe updated');
 
-        await describePromptCommand(ctx, scmProvider);
+        await describePromptCommand(ctx);
 
         const currentDesc = repo.getDescription('@');
         expect(currentDesc.trim()).toBe('feat: quick describe updated');
@@ -86,13 +72,13 @@ describe('describePromptCommand', () => {
 
     test('sets blank description when prompt is cleared', async () => {
         repo.new(undefined, 'initial');
-        scmProvider.sourceControl.inputBox.value = '';
+        ctx.host.ui.setScmDescriptionInputValue('');
 
         await jj.describe('existing description', '@');
 
         ctx.host.ui.setNextInputBoxResponse('');
 
-        await describePromptCommand(ctx, scmProvider);
+        await describePromptCommand(ctx);
 
         const currentDesc = repo.getDescription('@');
         expect(currentDesc.trim()).toBe('');
@@ -102,7 +88,7 @@ describe('describePromptCommand', () => {
         ctx.host.ui.setNextInputBoxResponse('failing describe');
         vi.spyOn(jj, 'describe').mockRejectedValue(new Error('Describe failed'));
 
-        await describePromptCommand(ctx, scmProvider);
+        await describePromptCommand(ctx);
 
         expect(ctx.host.ui.errorMessages[0].prefix).toBe('Error setting description');
     });

--- a/src/test/commands/describe.test.ts
+++ b/src/test/commands/describe.test.ts
@@ -4,21 +4,17 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
 import { setDescriptionCommand } from '../../commands/describe';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createSetDescriptionPayload } from '../../vscode/payloads/describe.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
-import { createMock, createMockLogOutputChannel } from '../test-utils';
+import { createMock } from '../test-utils';
 
 describe('setDescriptionCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
     let mockJjRepo: JjRepository;
-    let scmProvider: JjScmProvider;
     let ctx: FakeCommandContext;
 
     beforeEach(() => {
@@ -29,13 +25,6 @@ describe('setDescriptionCommand', () => {
             jj,
             refresh: vi.fn().mockResolvedValue(undefined),
         });
-        scmProvider = createMock<JjScmProvider>({
-            refresh: vi.fn(),
-            sourceControl: createMock<vscode.SourceControl>({
-                inputBox: createMock<vscode.SourceControlInputBox>({ value: '' }),
-            }),
-            outputChannel: createMockLogOutputChannel({ appendLine: vi.fn() }),
-        });
         ctx = new FakeCommandContext(mockJjRepo);
     });
 
@@ -43,29 +32,15 @@ describe('setDescriptionCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runSetDescription = async (args: unknown[]) => {
-        const payload = createSetDescriptionPayload(args, scmProvider);
-        return await setDescriptionCommand(ctx, payload);
-    };
-
-    test('updates description from string argument', async () => {
-        const result = await runSetDescription(['new description']);
+    test('updates description from description payload', async () => {
+        const result = await setDescriptionCommand(ctx, { description: 'new description' });
         expect(result).toBe('new description');
         const description = repo.getDescription('@');
         expect(description.trim()).toBe('new description');
     });
 
-    test('updates description from input box when message is omitted', async () => {
-        scmProvider.sourceControl.inputBox.value = 'from input box';
-        const result = await runSetDescription([]);
-        expect(result).toBe('from input box');
-        const description = repo.getDescription('@');
-        expect(description.trim()).toBe('from input box');
-    });
-
-    test('allows empty descriptions when invoked from input box', async () => {
-        scmProvider.sourceControl.inputBox.value = '   ';
-        const result = await runSetDescription([]);
+    test('updates description with empty string when empty message is provided', async () => {
+        const result = await setDescriptionCommand(ctx, { description: '   ' });
         expect(result).toBe('');
         const description = repo.getDescription('@');
         expect(description.trim()).toBe('');
@@ -73,7 +48,7 @@ describe('setDescriptionCommand', () => {
 
     test('updates description for specific revision', async () => {
         repo.new([], 'child');
-        const result = await runSetDescription(['updated parent', '@-']);
+        const result = await setDescriptionCommand(ctx, { description: 'updated parent', revision: '@-' });
         expect(result).toBe('updated parent');
         const description = repo.getDescription('@-');
         expect(description.trim()).toBe('updated parent');
@@ -83,9 +58,8 @@ describe('setDescriptionCommand', () => {
         repo.new([], 'child');
         jj.describe('parent description', '@-');
         jj.describe('working copy description', '@');
-        scmProvider.sourceControl.inputBox.value = 'fallback description';
 
-        const result = await runSetDescription(['   ', '@-']);
+        const result = await setDescriptionCommand(ctx, { description: '   ', revision: '@-' });
         expect(result).toBe('');
         const description = repo.getDescription('@-');
         expect(description.trim()).toBe('');
@@ -94,7 +68,7 @@ describe('setDescriptionCommand', () => {
     });
 
     test('returns false on jj describe failure', async () => {
-        const result = await runSetDescription(['description', 'invalid_rev']);
+        const result = await setDescriptionCommand(ctx, { description: 'description', revision: 'invalid_rev' });
         expect(result).toBe(false);
     });
 
@@ -113,7 +87,7 @@ describe('setDescriptionCommand', () => {
         const longMsg = 'Title\n\nThis is a very long line in the body that will be wrapped by the formatter.';
         await setDescriptionCommand(ctx, { description: longMsg, revision: '@' });
 
-        expect(ctx.host.ui.getCommitInput()).toBe(
+        expect(ctx.host.ui.getScmDescriptionInputValue()).toBe(
             'Title\n\nThis is a very long\nline in the body\nthat will be wrapped\nby the formatter.',
         );
     });

--- a/src/test/commands/details.test.ts
+++ b/src/test/commands/details.test.ts
@@ -4,20 +4,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import * as vscode from 'vscode';
 import { showDetailsCommand } from '../../commands/details';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import type { JjResourceState } from '../../scm-resource-state';
-import { createShowDetailsPayload } from '../../vscode/payloads/details.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-
-vi.mock('vscode', async () => {
-    const { createVscodeMock } = await import('../vscode-mock');
-    return createVscodeMock();
-});
 
 describe('showDetailsCommand', () => {
     let repo: TestRepo;
@@ -38,55 +30,32 @@ describe('showDetailsCommand', () => {
         vi.clearAllMocks();
     });
 
-    test('calls vscode.openWith for the extracted revision', async () => {
+    test('calls nav.openCommitDetails for the specified revision', async () => {
         const changeId = repo.getChangeId('@');
-        const payload = createShowDetailsPayload([changeId]);
-        await showDetailsCommand(ctx, payload);
+        await showDetailsCommand(ctx, { revision: changeId });
 
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-            'vscode.openWith',
-            expect.objectContaining({
-                scheme: 'jj-commit',
-                fragment: expect.stringContaining(`changeId=${changeId}`),
-            }),
-            'jj-view.commitDetailsEditor',
-        );
-    });
-
-    test('calls vscode.openWith with resource state revision', async () => {
-        const changeId = repo.getChangeId('@');
-        const mockState = createMock<JjResourceState>({ revision: changeId });
-        const mockGroup = createMock<vscode.SourceControlResourceGroup>({
-            id: 'ancestor-0',
-            label: 'Parent',
-            resourceStates: [mockState],
+        expect(ctx.host.nav.commitDetailsOpened).toHaveLength(1);
+        expect(ctx.host.nav.commitDetailsOpened[0]).toMatchObject({
+            repoRoot: repo.path,
+            changeId,
         });
-
-        const payload = createShowDetailsPayload([mockGroup]);
-        await showDetailsCommand(ctx, payload);
-
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-            'vscode.openWith',
-            expect.objectContaining({
-                scheme: 'jj-commit',
-                fragment: expect.stringContaining(`changeId=${changeId}`),
-            }),
-            'jj-view.commitDetailsEditor',
-        );
     });
 
-    test('defaults to @ if no revision extracted', async () => {
+    test('defaults to @ if no revision is specified in payload', async () => {
         const changeId = repo.getChangeId('@');
-        const payload = createShowDetailsPayload([{}]);
-        await showDetailsCommand(ctx, payload);
+        await showDetailsCommand(ctx, {});
 
-        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
-            'vscode.openWith',
-            expect.objectContaining({
-                scheme: 'jj-commit',
-                fragment: expect.stringContaining(`changeId=${changeId}`),
-            }),
-            'jj-view.commitDetailsEditor',
-        );
+        expect(ctx.host.nav.commitDetailsOpened).toHaveLength(1);
+        expect(ctx.host.nav.commitDetailsOpened[0]).toMatchObject({
+            repoRoot: repo.path,
+            changeId,
+        });
+    });
+
+    test('shows error when getLog fails or logEntry is missing', async () => {
+        await showDetailsCommand(ctx, { revision: 'invalid-nonexistent-rev' });
+
+        expect(ctx.host.ui.errorMessages).toHaveLength(1);
+        expect(ctx.host.ui.errorMessages[0].prefix).toBe('Error showing details');
     });
 });

--- a/src/test/commands/duplicate.test.ts
+++ b/src/test/commands/duplicate.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { duplicateCommand } from '../../commands/duplicate';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createDuplicatePayload } from '../../vscode/payloads/duplicate.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -33,16 +32,11 @@ describe('duplicateCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runDuplicate = async (args: unknown[]) => {
-        const payload = createDuplicatePayload(args);
-        await duplicateCommand(ctx, payload);
-    };
-
     test('duplicates specified commit', async () => {
         repo.describe('original');
         const originalChangeId = repo.getChangeId('@');
 
-        await runDuplicate([originalChangeId]);
+        await duplicateCommand(ctx, { revision: originalChangeId });
 
         const logs = repo.getLogOutput('description').split('\n');
         const duplicates = logs.filter((l) => l.includes('original'));

--- a/src/test/commands/edit.test.ts
+++ b/src/test/commands/edit.test.ts
@@ -4,12 +4,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type * as vscode from 'vscode';
 import { editCommand } from '../../commands/edit';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import type { JjResourceState } from '../../scm-resource-state';
-import { createEditPayload } from '../../vscode/payloads/edit.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -35,39 +32,36 @@ describe('editCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runEdit = async (args: unknown[]) => {
-        const payload = createEditPayload(args);
-        await editCommand(ctx, payload);
-    };
-
     test('edits specified commit', async () => {
         const ids = await buildGraph(repo, [
             { label: 'parent', description: 'parent' },
             { label: 'child', parents: ['parent'], description: 'child', isCurrentWorkingCopy: true },
         ]);
 
-        await runEdit([ids.parent.changeId]);
+        await editCommand(ctx, { revision: ids.parent.changeId });
 
         const currentChangeId = repo.getChangeId('@');
         expect(currentChangeId).toBe(ids.parent.changeId);
+        expect(mockJjRepo.refresh).toHaveBeenCalled();
     });
 
-    test('edits from parent resource group header', async () => {
+    test('does nothing if no revision specified', async () => {
         const ids = await buildGraph(repo, [
             { label: 'parent', description: 'parent' },
             { label: 'child', parents: ['parent'], description: 'child', isCurrentWorkingCopy: true },
         ]);
 
-        const mockState = createMock<JjResourceState>({ revision: ids.parent.changeId });
-        const mockParentGroup = createMock<vscode.SourceControlResourceGroup>({
-            id: 'ancestor-0',
-            label: 'Parent: ...',
-            resourceStates: [mockState],
-        });
-
-        await runEdit([mockParentGroup]);
+        await editCommand(ctx, {});
 
         const currentChangeId = repo.getChangeId('@');
-        expect(currentChangeId).toBe(ids.parent.changeId);
+        expect(currentChangeId).toBe(ids.child.changeId);
+    });
+
+    test('handles errors during edit and displays error', async () => {
+        vi.spyOn(jj, 'edit').mockRejectedValue(new Error('Edit failed'));
+
+        await editCommand(ctx, { revision: 'some-rev' });
+
+        expect(ctx.host.ui.errorMessages[0].prefix).toBe('Error editing commit');
     });
 });

--- a/src/test/commands/merge-editor.test.ts
+++ b/src/test/commands/merge-editor.test.ts
@@ -6,8 +6,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { openMergeEditorCommand } from '../../commands/merge-editor';
 import type { JjRepository } from '../../jj-repository';
+import type { JjResourceState } from '../../scm-resource-state';
 import { Uri } from '../../uri-utils';
-import { createOpenMergeEditorPayload } from '../../vscode/payloads/merge-editor.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { createMock } from '../test-utils';
 
@@ -27,33 +27,30 @@ describe('openMergeEditorCommand', () => {
         vi.clearAllMocks();
     });
 
-    test('does nothing if no resources provided', async () => {
-        const payload = createOpenMergeEditorPayload([undefined]);
-        await openMergeEditorCommand(ctx, payload);
+    test('does nothing if no resource states provided', async () => {
+        await openMergeEditorCommand(ctx, { resourceStates: [] });
 
         expect(ctx.host.nav.openMergeEditor).not.toHaveBeenCalled();
     });
 
-    test('calls openMergeEditor with resource states', async () => {
+    test('calls openMergeEditor with resource uri', async () => {
         const resourceUri = Uri.file('/test/foo.txt');
-        const resource = { resourceUri };
-        const payload = createOpenMergeEditorPayload([resource]);
-        await openMergeEditorCommand(ctx, payload);
+        const resourceState = createMock<JjResourceState>({ resourceUri });
+        await openMergeEditorCommand(ctx, { resourceStates: [resourceState] });
 
         expect(ctx.host.nav.openMergeEditor).toHaveBeenCalledWith(resourceUri);
     });
 
     test('handles error', async () => {
         const resourceUri = Uri.file('/test/foo.txt');
-        const resource = { resourceUri };
+        const resourceState = createMock<JjResourceState>({ resourceUri });
         const openMergeEditor = ctx.host.nav.openMergeEditor;
         if (!openMergeEditor) {
             throw new Error('openMergeEditor not defined');
         }
         vi.mocked(openMergeEditor).mockRejectedValue(new Error('boom'));
 
-        const payload = createOpenMergeEditorPayload([resource]);
-        await openMergeEditorCommand(ctx, payload);
+        await openMergeEditorCommand(ctx, { resourceStates: [resourceState] });
 
         expect(ctx.host.ui.errorMessages[0].prefix).toBe('Error opening merge editor');
     });

--- a/src/test/commands/merge.test.ts
+++ b/src/test/commands/merge.test.ts
@@ -6,18 +6,14 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { newMergeChangeCommand } from '../../commands/merge';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createNewMergeChangePayload } from '../../vscode/payloads/merge.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
-import { asMock } from '../vitest-utils';
 
 describe('newMergeChangeCommand', () => {
     let jj: JjService;
     let repo: TestRepo;
-    let scmProvider: JjScmProvider;
     let mockJjRepo: JjRepository;
     let ctx: FakeCommandContext;
 
@@ -28,10 +24,6 @@ describe('newMergeChangeCommand', () => {
         mockJjRepo = createMock<JjRepository>({
             jj,
             refresh: vi.fn().mockResolvedValue(undefined),
-        });
-        scmProvider = createMock<JjScmProvider>({
-            refresh: vi.fn().mockResolvedValue(undefined),
-            getSelectedCommitIds: vi.fn().mockReturnValue([]),
         });
         ctx = new FakeCommandContext(mockJjRepo);
     });
@@ -46,9 +38,7 @@ describe('newMergeChangeCommand', () => {
             { label: 'p2', description: 'p2' },
         ]);
 
-        const args = [{ revision: ids.p1.changeId }, { revision: ids.p2.changeId }];
-        const payload = createNewMergeChangePayload(args, scmProvider);
-        await newMergeChangeCommand(ctx, payload);
+        await newMergeChangeCommand(ctx, { revisions: [ids.p1.changeId, ids.p2.changeId] });
 
         // Verify parent change IDs
         const actualParents = repo.getParents('@');
@@ -58,54 +48,24 @@ describe('newMergeChangeCommand', () => {
         expect(actualParents).toContain(ids.p2.changeId);
     });
 
-    test('falls back to selection if no args', async () => {
-        // Setup 2 commits
-        repo.new();
-        repo.describe('p1');
-        const p1 = repo.getChangeId('@');
-
-        repo.new(['root()']);
-        repo.describe('p2');
-        const p2 = repo.getChangeId('@');
-
-        asMock(scmProvider.getSelectedCommitIds).mockReturnValue([p1, p2]);
-
-        const payload = createNewMergeChangePayload([], scmProvider);
-        await newMergeChangeCommand(ctx, payload);
-
-        expect(mockJjRepo.refresh).toHaveBeenCalled();
-
-        const parents = repo.getParents('@');
-        expect(parents).toContain(p1);
-        expect(parents).toContain(p2);
-    });
-
-    test('ignores valid string array and shows warning', async () => {
-        const args = ['rev1', 'rev2'] as unknown as { revision: string }[];
-
-        ctx.host.ui.setNextInputBoxResponse(undefined);
-
-        const payload = createNewMergeChangePayload(args, scmProvider);
-        await newMergeChangeCommand(ctx, payload);
-
-        expect(ctx.host.ui.errorMessages[0].prefix).toBe('Merge Error');
-        expect((ctx.host.ui.errorMessages[0].error as Error).message).toContain(
-            'Need at least 1 revision to create a change.',
-        );
-    });
-
-    test('handles single parent (no merge) correctly', async () => {
-        // If passed 1 revision, it should just create a new change on top (not a merge)
+    test('creates commit on top of single parent', async () => {
         repo.new();
         const c1 = repo.getChangeId('@');
 
-        const args = [{ revision: c1 }];
-        const payload = createNewMergeChangePayload(args, scmProvider);
-        await newMergeChangeCommand(ctx, payload);
+        await newMergeChangeCommand(ctx, { revisions: [c1] });
 
         expect(mockJjRepo.refresh).toHaveBeenCalled();
 
         const parents = repo.getParents('@');
         expect(parents).toContain(c1);
+    });
+
+    test('shows error if revisions list is empty', async () => {
+        await newMergeChangeCommand(ctx, { revisions: [] });
+
+        expect(ctx.host.ui.errorMessages[0].prefix).toBe('Merge Error');
+        expect((ctx.host.ui.errorMessages[0].error as Error).message).toContain(
+            'Need at least 1 revision to create a change.',
+        );
     });
 });

--- a/src/test/commands/multi-diff.test.ts
+++ b/src/test/commands/multi-diff.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { showMultiFileDiffCommand } from '../../commands/multi-diff';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createShowMultiFileDiffPayload } from '../../vscode/payloads/multi-diff.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -30,14 +29,13 @@ describe('showMultiFileDiffCommand', () => {
         vi.clearAllMocks();
     });
 
-    it('opens vscode.changes with correct 3-tuple URIs using change ID', async () => {
+    it('opens multi-diff with correct 3-tuple URIs using change ID', async () => {
         const FILE_NAME = 'file1.txt';
         repo.writeFile(FILE_NAME, 'content 1');
         repo.describe('test commit description');
         const changeId = repo.getChangeId('@');
 
-        const payload = createShowMultiFileDiffPayload([changeId]);
-        await showMultiFileDiffCommand(ctx, payload);
+        await showMultiFileDiffCommand(ctx, { revision: changeId });
 
         expect(ctx.host.nav.multiDiffsOpened).toHaveLength(1);
         const multiDiff = ctx.host.nav.multiDiffsOpened[0];
@@ -70,8 +68,7 @@ describe('showMultiFileDiffCommand', () => {
         repo.writeFile('file.txt', 'content');
         const changeId = repo.getChangeId('@');
 
-        const payload = createShowMultiFileDiffPayload(['@']);
-        await showMultiFileDiffCommand(ctx, payload);
+        await showMultiFileDiffCommand(ctx, { revision: '@' });
 
         expect(ctx.host.nav.multiDiffsOpened).toHaveLength(1);
         const multiDiff = ctx.host.nav.multiDiffsOpened[0];
@@ -80,19 +77,8 @@ describe('showMultiFileDiffCommand', () => {
         expect(modified.fragment).toContain(`revision=${changeId}`);
     });
 
-    it('works with Webview Context payload', async () => {
-        repo.writeFile('file1.txt', 'A');
-        const commitId = repo.getCommitId('@');
-
-        const payload = createShowMultiFileDiffPayload([{ commitId }]);
-        await showMultiFileDiffCommand(ctx, payload);
-
-        expect(ctx.host.nav.multiDiffsOpened).toHaveLength(1);
-    });
-
     it('shows info message when no changes found', async () => {
-        const payload = createShowMultiFileDiffPayload(['@']);
-        await showMultiFileDiffCommand(ctx, payload);
+        await showMultiFileDiffCommand(ctx, { revision: '@' });
 
         expect(ctx.host.ui.infoMessages[0]).toContain('No changes found in revision');
         expect(ctx.host.nav.multiDiffsOpened).toHaveLength(0);

--- a/src/test/commands/new-after.test.ts
+++ b/src/test/commands/new-after.test.ts
@@ -6,9 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { newAfterCommand } from '../../commands/new-after';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createNewAfterPayload } from '../../vscode/payloads/new-after.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -42,12 +40,7 @@ describe('newAfterCommand', () => {
             { label: 'target', parents: ['root'], description: 'target', isCurrentWorkingCopy: true },
         ]);
 
-        const mockScm = createMock<JjScmProvider>({
-            getSelectedCommitIds: () => [],
-        });
-
-        const payload = createNewAfterPayload([{ commitId: ids.target.commitId }], mockScm);
-        await newAfterCommand(ctx, payload);
+        await newAfterCommand(ctx, { revisions: [ids.target.commitId] });
 
         expect(mockJjRepo.refresh).toHaveBeenCalled();
     });

--- a/src/test/commands/new-before.test.ts
+++ b/src/test/commands/new-before.test.ts
@@ -6,9 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { newBeforeCommand } from '../../commands/new-before';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createNewBeforePayload } from '../../vscode/payloads/new-before.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -42,12 +40,7 @@ describe('newBeforeCommand', () => {
             { label: 'target', parents: ['root'], description: 'target', isCurrentWorkingCopy: true },
         ]);
 
-        const mockScm = createMock<JjScmProvider>({
-            getSelectedCommitIds: () => [],
-        });
-
-        const payload = createNewBeforePayload([{ commitId: ids.target.commitId }], mockScm);
-        await newBeforeCommand(ctx, payload);
+        await newBeforeCommand(ctx, { revisions: [ids.target.commitId] });
 
         expect(mockJjRepo.refresh).toHaveBeenCalled();
     });

--- a/src/test/commands/new.test.ts
+++ b/src/test/commands/new.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { newCommand } from '../../commands/new';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createNewPayload } from '../../vscode/payloads/new.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -33,14 +32,9 @@ describe('newCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runNew = async (args: unknown[] = []) => {
-        const payload = createNewPayload(args);
-        await newCommand(ctx, payload);
-    };
-
     test('creates new empty commit', async () => {
         const beforeChangeId = repo.getChangeId('@');
-        await runNew();
+        await newCommand(ctx);
         const afterChangeId = repo.getChangeId('@');
         const parents = repo.getParents('@');
 

--- a/src/test/commands/rebase.test.ts
+++ b/src/test/commands/rebase.test.ts
@@ -6,9 +6,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { rebaseOntoSelectedCommand } from '../../commands/rebase';
 import type { JjRepository } from '../../jj-repository';
-import type { JjScmProvider } from '../../jj-scm-provider';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { createRebaseOntoSelectedPayload } from '../../vscode/payloads/rebase.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -36,19 +34,17 @@ describe('rebaseOntoSelectedCommand', () => {
         vi.clearAllMocks();
     });
 
-    it('should rebase source commit onto selected destinations', async () => {
+    it('should rebase source commit onto destination', async () => {
         const ids = await buildGraph(repo, [
             { label: 'root', description: 'root' },
             { label: 'dest', parents: ['root'], description: 'dest' },
             { label: 'source', parents: ['root'], description: 'source', isCurrentWorkingCopy: true },
         ]);
 
-        const mockScm = createMock<JjScmProvider>({
-            getSelectedCommitIds: () => [ids.dest.commitId],
+        await rebaseOntoSelectedCommand(ctx, {
+            sourceId: ids.source.commitId,
+            destinations: [ids.dest.commitId],
         });
-
-        const payload = createRebaseOntoSelectedPayload([{ commitId: ids.source.commitId }], mockScm);
-        await rebaseOntoSelectedCommand(ctx, payload);
 
         expect(mockJjRepo.refresh).toHaveBeenCalled();
     });

--- a/src/test/commands/restore.test.ts
+++ b/src/test/commands/restore.test.ts
@@ -9,8 +9,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { restoreCommand } from '../../commands/restore';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { Uri } from '../../uri-utils';
-import { createRestorePayload } from '../../vscode/payloads/restore.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -36,11 +34,6 @@ describe('restoreCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runRestore = async (args: unknown[]) => {
-        const payload = createRestorePayload(args);
-        await restoreCommand(ctx, payload);
-    };
-
     test('restores file content', async () => {
         const fileName = 'restore.txt';
         await buildGraph(repo, [
@@ -54,10 +47,7 @@ describe('restoreCommand', () => {
             },
         ]);
 
-        const fileUri = Uri.file(path.join(repo.path, fileName));
-        const args = [{ resourceUri: fileUri }];
-
-        await runRestore(args);
+        await restoreCommand(ctx, { pathsByRevision: { '@': [fileName] } });
 
         const content = fs.readFileSync(path.join(repo.path, fileName), 'utf-8');
         expect(content).toBe('original');
@@ -81,10 +71,7 @@ describe('restoreCommand', () => {
             },
         ]);
 
-        const fileUri = Uri.file(path.join(repo.path, fileName));
-        const args = [{ resourceUri: fileUri, revision: ids.ancestor.changeId }];
-
-        await runRestore(args);
+        await restoreCommand(ctx, { pathsByRevision: { [ids.ancestor.changeId]: [fileName] } });
 
         const ancestorContent = repo.getFileContent(ids.ancestor.changeId, fileName);
         expect(ancestorContent).toBe('original');
@@ -110,14 +97,12 @@ describe('restoreCommand', () => {
             },
         ]);
 
-        const file1Uri = Uri.file(path.join(repo.path, file1));
-        const file2Uri = Uri.file(path.join(repo.path, file2));
-        const args = [
-            { resourceUri: file1Uri, revision: ids.ancestor.changeId },
-            { resourceUri: file2Uri, revision: ids.child.changeId },
-        ];
-
-        await runRestore(args);
+        await restoreCommand(ctx, {
+            pathsByRevision: {
+                [ids.ancestor.changeId]: [file1],
+                [ids.child.changeId]: [file2],
+            },
+        });
 
         const ancestorContent = repo.getFileContent(ids.ancestor.changeId, file1);
         expect(ancestorContent).toBe('original 1');

--- a/src/test/commands/squash-files.test.ts
+++ b/src/test/commands/squash-files.test.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
     squashFilesIntoAncestorCommand,
@@ -12,12 +11,6 @@ import {
 } from '../../commands/squash-files';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
-import { Uri } from '../../uri-utils';
-import {
-    createSquashFilesIntoAncestorPayload,
-    createSquashFilesIntoChildPayload,
-    createSquashFilesIntoParentPayload,
-} from '../../vscode/payloads/squash-files.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -45,21 +38,6 @@ describe('squash-files commands', () => {
         vi.clearAllMocks();
     });
 
-    const runSquashFilesIntoParent = async (args: unknown[]) => {
-        const payload = createSquashFilesIntoParentPayload(args);
-        await squashFilesIntoParentCommand(ctx, payload);
-    };
-
-    const runSquashFilesIntoAncestor = async (args: unknown[]) => {
-        const payload = createSquashFilesIntoAncestorPayload(args);
-        await squashFilesIntoAncestorCommand(ctx, payload);
-    };
-
-    const runSquashFilesIntoChild = async (args: unknown[]) => {
-        const payload = createSquashFilesIntoChildPayload(args);
-        await squashFilesIntoChildCommand(ctx, payload);
-    };
-
     describe('squashFilesIntoParentCommand', () => {
         test('squashes specific file to parent', async () => {
             const fileName = 'file.txt';
@@ -83,10 +61,7 @@ describe('squash-files commands', () => {
                 },
             ]);
 
-            const fileUri = Uri.file(path.join(repo.path, fileName));
-            const args = [{ resourceUri: fileUri }];
-
-            await runSquashFilesIntoParent(args);
+            await squashFilesIntoParentCommand(ctx, { paths: [fileName] });
 
             const parentContent = repo.getFileContent('@-', fileName);
             expect(parentContent).toBe('child content');
@@ -118,10 +93,7 @@ describe('squash-files commands', () => {
 
             ctx.host.ui.setNextRevisionPromptResponse(ids.grandparent.changeId);
 
-            const fileUri = Uri.file(path.join(repo.path, fileName));
-            const args = [{ resourceUri: fileUri }];
-
-            await runSquashFilesIntoAncestor(args);
+            await squashFilesIntoAncestorCommand(ctx, { paths: [fileName] });
 
             const gpContent = repo.getFileContent(ids.grandparent.changeId, fileName);
             expect(gpContent).toBe('child content');
@@ -147,10 +119,7 @@ describe('squash-files commands', () => {
                 },
             ]);
 
-            const fileUri = Uri.file(path.join(repo.path, fileName));
-            const args = [{ resourceUri: fileUri }, { revision: ids.parent.changeId }];
-
-            await runSquashFilesIntoChild(args);
+            await squashFilesIntoChildCommand(ctx, { paths: [fileName], revision: ids.parent.changeId });
 
             expect(repo.getFileContent(ids.child.changeId, fileName)).toBe('parent modified');
         });
@@ -169,10 +138,7 @@ describe('squash-files commands', () => {
 
             ctx.host.ui.setNextRevisionPromptResponse(ids.child2.changeId);
 
-            const fileUri = Uri.file(path.join(repo.path, fileName));
-            const args = [{ resourceUri: fileUri }, { revision: ids.parent.changeId }];
-
-            await runSquashFilesIntoChild(args);
+            await squashFilesIntoChildCommand(ctx, { paths: [fileName], revision: ids.parent.changeId });
 
             expect(repo.getFileContent(ids.child2.changeId, fileName)).toBe('parent modified');
         });
@@ -181,52 +147,9 @@ describe('squash-files commands', () => {
             const fileName = 'file.txt';
             const ids = await buildGraph(repo, [{ label: 'only', description: 'only', files: { [fileName]: 'mod' } }]);
 
-            const fileUri = Uri.file(path.join(repo.path, fileName));
-            const args = [{ resourceUri: fileUri }, { revision: ids.only.changeId }];
-
-            await runSquashFilesIntoChild(args);
+            await squashFilesIntoChildCommand(ctx, { paths: [fileName], revision: ids.only.changeId });
 
             expect(ctx.host.ui.errorMessages[0].prefix).toBe('Squash Error');
-        });
-    });
-
-    describe('payload creators target revision extraction', () => {
-        test('createSquashFilesIntoAncestorPayload extracts ancestorRevision from object arg', () => {
-            const fileUri = Uri.file(path.join(repo.path, 'file.txt'));
-            const payload = createSquashFilesIntoAncestorPayload([
-                { resourceUri: fileUri },
-                { revision: 'srcRev', ancestorRevision: 'targetAncestor' },
-            ]);
-            expect(payload.revision).toBe('srcRev');
-            expect(payload.ancestorRevision).toBe('targetAncestor');
-        });
-
-        test('createSquashFilesIntoAncestorPayload extracts ancestorRevision from multiple revision args', () => {
-            const fileUri = Uri.file(path.join(repo.path, 'file.txt'));
-            const payload = createSquashFilesIntoAncestorPayload([
-                { resourceUri: fileUri },
-                'srcRev',
-                'targetAncestor',
-            ]);
-            expect(payload.revision).toBe('srcRev');
-            expect(payload.ancestorRevision).toBe('targetAncestor');
-        });
-
-        test('createSquashFilesIntoChildPayload extracts childRevision from object arg', () => {
-            const fileUri = Uri.file(path.join(repo.path, 'file.txt'));
-            const payload = createSquashFilesIntoChildPayload([
-                { resourceUri: fileUri },
-                { revision: 'srcRev', childRevision: 'targetChild' },
-            ]);
-            expect(payload.revision).toBe('srcRev');
-            expect(payload.childRevision).toBe('targetChild');
-        });
-
-        test('createSquashFilesIntoChildPayload extracts childRevision from multiple revision args', () => {
-            const fileUri = Uri.file(path.join(repo.path, 'file.txt'));
-            const payload = createSquashFilesIntoChildPayload([{ resourceUri: fileUri }, 'srcRev', 'targetChild']);
-            expect(payload.revision).toBe('srcRev');
-            expect(payload.childRevision).toBe('targetChild');
         });
     });
 });

--- a/src/test/commands/squash-revision.test.ts
+++ b/src/test/commands/squash-revision.test.ts
@@ -15,10 +15,6 @@ import {
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { Uri } from '../../uri-utils';
-import {
-    createSquashRevisionIntoAncestorPayload,
-    createSquashRevisionIntoParentPayload,
-} from '../../vscode/payloads/squash-revision.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -47,16 +43,6 @@ describe('squashRevisionIntoParentCommand', () => {
         vi.clearAllMocks();
     });
 
-    const runSquashIntoParent = async (args: unknown[]) => {
-        const payload = createSquashRevisionIntoParentPayload(args);
-        await squashRevisionIntoParentCommand(ctx, payload);
-    };
-
-    const runSquashIntoAncestor = async (args: unknown[]) => {
-        const payload = createSquashRevisionIntoAncestorPayload(args);
-        await squashRevisionIntoAncestorCommand(ctx, payload);
-    };
-
     test('squashes all changes to parent (implicit)', async () => {
         const fileName = 'file.txt';
 
@@ -80,7 +66,7 @@ describe('squashRevisionIntoParentCommand', () => {
             },
         ]);
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
 
         const parentContent = repo.getFileContent('@-', fileName);
         expect(parentContent).toBe('child content');
@@ -111,7 +97,7 @@ describe('squashRevisionIntoParentCommand', () => {
             value: p1CommitId,
         });
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
 
         const p1Content = repo.getFileContent(p1ChangeId, fileName);
         expect(p1Content).toBe('child modified');
@@ -130,7 +116,7 @@ describe('squashRevisionIntoParentCommand', () => {
             },
         ]);
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
 
         expect(ctx.host.nav.filesOpened.length).toBeGreaterThan(0);
 
@@ -164,7 +150,7 @@ describe('squashRevisionIntoParentCommand', () => {
             value: p2CommitId,
         });
 
-        await runSquashIntoParent([childChangeId]);
+        await squashRevisionIntoParentCommand(ctx, { revision: childChangeId });
 
         expect(ctx.host.nav.filesOpened.length).toBeGreaterThan(0);
 
@@ -187,7 +173,7 @@ describe('squashRevisionIntoParentCommand', () => {
             },
         ]);
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
 
         expect(ctx.host.nav.filesOpened).toHaveLength(0);
 
@@ -208,7 +194,7 @@ describe('squashRevisionIntoParentCommand', () => {
             },
         ]);
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
 
         expect(ctx.host.nav.filesOpened).toHaveLength(0);
 
@@ -235,7 +221,7 @@ describe('squashRevisionIntoParentCommand', () => {
             value: ids.p1.commitId,
         });
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
         expect(ctx.host.nav.filesOpened).toHaveLength(0);
         expect(repo.getDescription(ids.p1.changeId)).toBe('Child Description');
     });
@@ -259,7 +245,7 @@ describe('squashRevisionIntoParentCommand', () => {
             value: ids.p2.commitId,
         });
 
-        await runSquashIntoParent([]);
+        await squashRevisionIntoParentCommand(ctx, {});
         expect(ctx.host.nav.filesOpened.length).toBeGreaterThan(0);
     });
 
@@ -270,7 +256,7 @@ describe('squashRevisionIntoParentCommand', () => {
             { label: 'wc', parents: ['child'], isCurrentWorkingCopy: true },
         ]);
 
-        await runSquashIntoParent([ids.child.changeId]);
+        await squashRevisionIntoParentCommand(ctx, { revision: ids.child.changeId });
 
         expect(ctx.host.nav.filesOpened).toHaveLength(0);
         expect(repo.getDescription(ids.p.changeId)).toBe('');
@@ -286,7 +272,7 @@ describe('squashRevisionIntoParentCommand', () => {
 
         ctx.host.ui.setNextRevisionPromptResponse(ids.base.changeId);
 
-        await runSquashIntoAncestor([ids.child.changeId]);
+        await squashRevisionIntoAncestorCommand(ctx, { revision: ids.child.changeId });
 
         expect(repo.getFileContent(ids.base.changeId, 'child.txt')).toBe('child');
     });
@@ -363,31 +349,5 @@ describe('squashRevisionIntoParentCommand', () => {
         expect(fs.existsSync(msgPath)).toBe(false);
 
         expect(ctx.host.ui.warningMessages).toContain('Squash message is empty. Aborting.');
-    });
-
-    describe('squash revision payload creators target revision extraction', () => {
-        test('createSquashRevisionIntoParentPayload extracts targetParent from object arg', () => {
-            const payload = createSquashRevisionIntoParentPayload([{ revision: 'rev1', targetParent: 'parent1' }]);
-            expect(payload.revision).toBe('rev1');
-            expect(payload.targetParent).toBe('parent1');
-        });
-
-        test('createSquashRevisionIntoParentPayload extracts targetParent from multiple revision args', () => {
-            const payload = createSquashRevisionIntoParentPayload(['rev1', 'parent1']);
-            expect(payload.revision).toBe('rev1');
-            expect(payload.targetParent).toBe('parent1');
-        });
-
-        test('createSquashRevisionIntoAncestorPayload extracts ancestorRevision from object arg', () => {
-            const payload = createSquashRevisionIntoAncestorPayload([{ revision: 'rev1', ancestorRevision: 'anc1' }]);
-            expect(payload.revision).toBe('rev1');
-            expect(payload.ancestorRevision).toBe('anc1');
-        });
-
-        test('createSquashRevisionIntoAncestorPayload extracts ancestorRevision from multiple revision args', () => {
-            const payload = createSquashRevisionIntoAncestorPayload(['rev1', 'anc1']);
-            expect(payload.revision).toBe('rev1');
-            expect(payload.ancestorRevision).toBe('anc1');
-        });
     });
 });

--- a/src/test/commands/squash-selection.test.ts
+++ b/src/test/commands/squash-selection.test.ts
@@ -9,7 +9,6 @@ import { squashHunkIntoParentCommand, squashSelectionIntoParentCommand } from '.
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { Uri } from '../../uri-utils';
-import { createSquashHunkIntoParentPayload } from '../../vscode/payloads/squash-selection.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -70,23 +69,11 @@ describe('squash-selection commands', () => {
             repo.edit(ids.modified.changeId);
 
             const uri = Uri.file(path.join(repo.path, fileName));
-            const changes = [
-                {
-                    originalStartLineNumber: 2,
-                    originalEndLineNumber: 2,
-                    modifiedStartLineNumber: 2,
-                    modifiedEndLineNumber: 2,
-                },
-                {
-                    originalStartLineNumber: 4,
-                    originalEndLineNumber: 4,
-                    modifiedStartLineNumber: 4,
-                    modifiedEndLineNumber: 4,
-                },
-            ];
 
-            const payload = createSquashHunkIntoParentPayload([uri, changes, 1]);
-            await squashHunkIntoParentCommand(ctx, payload);
+            await squashHunkIntoParentCommand(ctx, {
+                uri,
+                ranges: [{ startLine: 3, endLine: 3 }],
+            });
 
             const parentContent = repo.getFileContent('@-', fileName);
             expect(parentContent).toBe('line1\nline2\nline3\nmodified4\nline5\n');

--- a/src/test/commands/workspace-delete.test.ts
+++ b/src/test/commands/workspace-delete.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { workspaceDeleteCommand } from '../../commands/workspace-delete';
 import type { JjRepository } from '../../jj-repository';
@@ -65,29 +66,29 @@ describe('workspace delete command', () => {
     });
 
     test('deletes the workspace when confirmed', async () => {
-        repo.workspaceAdd('feature');
+        const workspace = repo.workspaceAdd('feature');
         const YES = 'Yes, Delete Workspace';
         ctx.host.ui.setNextWarningResponse(YES);
         const refreshSpy = vi.spyOn(mockJjRepo, 'refresh').mockResolvedValue(undefined);
-        const forgetSpy = vi.spyOn(jj, 'workspaceForget');
 
         await workspaceDeleteCommand(ctx, { workspaceName: 'feature' });
 
         expect(ctx.host.ui.warningMessages[0]).toContain('forget AND delete the directory for workspace "feature"');
-        expect(forgetSpy).toHaveBeenCalledWith('feature');
+        expect(repo.listWorkspaces()).not.toContain('feature');
+        expect(fs.existsSync(workspace.path)).toBe(false);
         expect(refreshSpy).toHaveBeenCalled();
     });
 
     test('does not delete the workspace when not confirmed', async () => {
-        repo.workspaceAdd('feature');
+        const workspace = repo.workspaceAdd('feature');
         ctx.host.ui.setNextWarningResponse(undefined);
         const refreshSpy = vi.spyOn(mockJjRepo, 'refresh').mockResolvedValue(undefined);
-        const forgetSpy = vi.spyOn(jj, 'workspaceForget');
 
         await workspaceDeleteCommand(ctx, { workspaceName: 'feature' });
 
         expect(ctx.host.ui.warningMessages[0]).toContain('forget AND delete the directory for workspace "feature"');
-        expect(forgetSpy).not.toHaveBeenCalled();
+        expect(repo.listWorkspaces()).toContain('feature');
+        expect(fs.existsSync(workspace.path)).toBe(true);
         expect(refreshSpy).not.toHaveBeenCalled();
     });
 });

--- a/src/test/commands/workspace-open.test.ts
+++ b/src/test/commands/workspace-open.test.ts
@@ -8,10 +8,6 @@ import { workspaceOpenInCurrentWindowCommand, workspaceOpenInNewWindowCommand } 
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { Uri } from '../../uri-utils';
-import {
-    createWorkspaceOpenInCurrentWindowPayload,
-    createWorkspaceOpenInNewWindowPayload,
-} from '../../vscode/payloads/workspace-open.payload';
 import { FakeCommandContext } from '../fake-host-environment';
 import { TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
@@ -37,8 +33,7 @@ describe('workspace open commands', () => {
     test('opens the workspace from a context-menu argument in the current window', async () => {
         const workspace = repo.workspaceAdd('feature');
 
-        const payload = createWorkspaceOpenInCurrentWindowPayload([{ workspaceName: 'feature' }]);
-        await workspaceOpenInCurrentWindowCommand(ctx, payload);
+        await workspaceOpenInCurrentWindowCommand(ctx, { workspaceName: 'feature' });
 
         expect(ctx.host.nav.foldersOpened).toEqual([
             {
@@ -51,8 +46,7 @@ describe('workspace open commands', () => {
     test('opens the selected workspace in a new window', async () => {
         const workspace = repo.workspaceAdd('feature');
 
-        const payload = createWorkspaceOpenInNewWindowPayload([{ workspaceName: 'feature' }]);
-        await workspaceOpenInNewWindowCommand(ctx, payload);
+        await workspaceOpenInNewWindowCommand(ctx, { workspaceName: 'feature' });
 
         expect(ctx.host.nav.foldersOpened).toEqual([
             {
@@ -69,8 +63,7 @@ describe('workspace open commands', () => {
             description: workspace.path,
         });
 
-        const payload = createWorkspaceOpenInCurrentWindowPayload([]);
-        await workspaceOpenInCurrentWindowCommand(ctx, payload);
+        await workspaceOpenInCurrentWindowCommand(ctx, {});
 
         expect(ctx.host.nav.foldersOpened).toEqual([
             {
@@ -84,16 +77,14 @@ describe('workspace open commands', () => {
         repo.workspaceAdd('feature');
         ctx.host.ui.setNextQuickPickResponse(undefined);
 
-        const payload = createWorkspaceOpenInCurrentWindowPayload([]);
-        await workspaceOpenInCurrentWindowCommand(ctx, payload);
+        await workspaceOpenInCurrentWindowCommand(ctx, {});
 
         expect(ctx.host.nav.foldersOpened).toHaveLength(0);
         expect(ctx.host.ui.errorMessages).toHaveLength(0);
     });
 
     test('reports an error when the workspace root cannot be resolved', async () => {
-        const payload = createWorkspaceOpenInCurrentWindowPayload([{ workspaceName: 'missing' }]);
-        await workspaceOpenInCurrentWindowCommand(ctx, payload);
+        await workspaceOpenInCurrentWindowCommand(ctx, { workspaceName: 'missing' });
 
         expect(ctx.host.ui.errorMessages[0].prefix).toContain('Failed to open workspace "missing"');
         expect(ctx.host.nav.foldersOpened).toHaveLength(0);
@@ -102,8 +93,7 @@ describe('workspace open commands', () => {
     test('reports an error when workspace names cannot be resolved', async () => {
         repo.dispose();
 
-        const payload = createWorkspaceOpenInCurrentWindowPayload([]);
-        await workspaceOpenInCurrentWindowCommand(ctx, payload);
+        await workspaceOpenInCurrentWindowCommand(ctx, {});
 
         expect(ctx.host.ui.errorMessages[0].prefix).toContain('Failed to resolve workspace');
         expect(ctx.host.nav.foldersOpened).toHaveLength(0);

--- a/src/test/fake-host-environment.ts
+++ b/src/test/fake-host-environment.ts
@@ -37,7 +37,7 @@ export class FakeHostUi implements HostUi {
     public errorMessages: { error: unknown; prefix: string }[] = [];
     public progressTitles: string[] = [];
     public statusBarMessages: { message: string; timeoutMs?: number }[] = [];
-    public commitInput: string | undefined = undefined;
+    public scmDescriptionInputValue: string | undefined = undefined;
 
     get warningResponse(): string | undefined {
         return this.warningResponses[0];
@@ -141,12 +141,12 @@ export class FakeHostUi implements HostUi {
         this.statusBarMessages.push({ message, timeoutMs });
     }
 
-    setCommitInput(value: string): void {
-        this.commitInput = value;
+    setScmDescriptionInputValue(value: string): void {
+        this.scmDescriptionInputValue = value;
     }
 
-    getCommitInput(): string | undefined {
-        return this.commitInput;
+    getScmDescriptionInputValue(): string | undefined {
+        return this.scmDescriptionInputValue;
     }
 }
 
@@ -154,6 +154,13 @@ export class FakeHostNavigation implements HostNavigation {
     public diffsOpened: { leftUri: Uri; rightUri: Uri; title: string }[] = [];
     public multiDiffsOpened: { title: string; resources: { leftUri: Uri; rightUri: Uri; label: string }[] }[] = [];
     public mergeEditorsOpened: Uri[] = [];
+    public commitDetailsOpened: {
+        repoRoot: string;
+        changeId: string;
+        shortestChangeId?: string;
+        isDivergent?: boolean;
+        changeIdOffset?: number;
+    }[] = [];
     public filesOpened: Uri[] = [];
     public foldersOpened: { folderUri: Uri; forceNewWindow?: boolean }[] = [];
     public externalUrlsOpened: string[] = [];
@@ -172,6 +179,16 @@ export class FakeHostNavigation implements HostNavigation {
 
     async openMergeEditor(resourceUri: Uri): Promise<void> {
         this.mergeEditorsOpened.push(resourceUri);
+    }
+
+    async openCommitDetails(
+        repoRoot: string,
+        changeId: string,
+        shortestChangeId?: string,
+        isDivergent?: boolean,
+        changeIdOffset?: number,
+    ): Promise<void> {
+        this.commitDetailsOpened.push({ repoRoot, changeId, shortestChangeId, isDivergent, changeIdOffset });
     }
 
     async openFile(uri: Uri): Promise<void> {

--- a/src/test/host-environment.test.ts
+++ b/src/test/host-environment.test.ts
@@ -65,8 +65,8 @@ describe('FakeHostEnvironment', () => {
             ui.setStatusBarMessage('status', 1000);
             expect(ui.statusBarMessages).toEqual([{ message: 'status', timeoutMs: 1000 }]);
 
-            ui.setCommitInput('my commit msg');
-            expect(ui.getCommitInput()).toBe('my commit msg');
+            ui.setScmDescriptionInputValue('my commit msg');
+            expect(ui.getScmDescriptionInputValue()).toBe('my commit msg');
         });
     });
 
@@ -105,6 +105,17 @@ describe('FakeHostEnvironment', () => {
 
             await nav.closeTab(leftUri);
             expect(nav.closedTabs).toContain(leftUri);
+
+            await nav.openCommitDetails('/root', 'change123', 'c12', false, 0);
+            expect(nav.commitDetailsOpened).toEqual([
+                {
+                    repoRoot: '/root',
+                    changeId: 'change123',
+                    shortestChangeId: 'c12',
+                    isDivergent: false,
+                    changeIdOffset: 0,
+                },
+            ]);
         });
     });
 

--- a/src/test/index-lock-error.test.ts
+++ b/src/test/index-lock-error.test.ts
@@ -6,13 +6,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, describe, expect, type Mock, test, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { JjService } from '../../jj-service';
-import { showJjError } from '../../vscode/vscode-ui-helpers';
-import { TestRepo } from '../test-repo';
-import { createMockLogOutputChannel } from '../test-utils';
+import { JjService } from '../jj-service';
+import { showJjError } from '../vscode/vscode-ui-helpers';
+import { TestRepo } from './test-repo';
+import { createMockLogOutputChannel } from './test-utils';
 
 vi.mock('vscode', async () => {
-    const { createVscodeMock } = await import('../vscode-mock');
+    const { createVscodeMock } = await import('./vscode-mock');
     return createVscodeMock({
         // Overrides
         window: { showErrorMessage: vi.fn() },

--- a/src/test/vscode-payloads.test.ts
+++ b/src/test/vscode-payloads.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type * as vscode from 'vscode';
+import type { JjScmProvider } from '../jj-scm-provider';
+import type { JjResourceState } from '../scm-resource-state';
+import { Uri } from '../uri-utils';
+import { createAbandonPayload } from '../vscode/payloads/abandon.payload';
+import { createAbsorbPayload } from '../vscode/payloads/absorb.payload';
+import { createSetBookmarkPayload } from '../vscode/payloads/bookmark.payload';
+import { createAdvanceBookmarkPayload } from '../vscode/payloads/bookmark-advance.payload';
+import { createAdvanceBookmarkAndUploadPayload } from '../vscode/payloads/bookmark-advance-upload.payload';
+import { createCommitPayload } from '../vscode/payloads/commit.payload';
+import { createCompareAllFilesWithRevisionPayload } from '../vscode/payloads/compare-all-files-with-revision.payload';
+import { createSetDescriptionPayload } from '../vscode/payloads/describe.payload';
+import { createShowDetailsPayload } from '../vscode/payloads/details.payload';
+import { createDuplicatePayload } from '../vscode/payloads/duplicate.payload';
+import { createEditPayload } from '../vscode/payloads/edit.payload';
+import { createNewMergeChangePayload } from '../vscode/payloads/merge.payload';
+import { createOpenMergeEditorPayload } from '../vscode/payloads/merge-editor.payload';
+import { createShowMultiFileDiffPayload } from '../vscode/payloads/multi-diff.payload';
+import { createNewPayload } from '../vscode/payloads/new.payload';
+import { createNewAfterPayload } from '../vscode/payloads/new-after.payload';
+import { createNewBeforePayload } from '../vscode/payloads/new-before.payload';
+import { createRebaseOntoSelectedPayload } from '../vscode/payloads/rebase.payload';
+import { createRestorePayload } from '../vscode/payloads/restore.payload';
+import {
+    createSquashFilesIntoAncestorPayload,
+    createSquashFilesIntoChildPayload,
+    createSquashFilesIntoParentPayload,
+} from '../vscode/payloads/squash-files.payload';
+import {
+    createSquashRevisionIntoAncestorPayload,
+    createSquashRevisionIntoParentPayload,
+} from '../vscode/payloads/squash-revision.payload';
+import {
+    createSquashHunkIntoParentPayload,
+    createSquashSelectionIntoParentPayload,
+} from '../vscode/payloads/squash-selection.payload';
+import {
+    createWorkspaceOpenInCurrentWindowPayload,
+    createWorkspaceOpenInNewWindowPayload,
+} from '../vscode/payloads/workspace-open.payload';
+import { createMock } from './test-utils';
+
+describe('vscode payloads', () => {
+    describe('abandon payload', () => {
+        it('extracts working copy when resource group is working copy', () => {
+            const scmGroup = { id: 'jj.group.workingCopy', label: 'Working Copy', resourceStates: [] };
+            const payload = createAbandonPayload([scmGroup]);
+            expect(payload.revisions).toEqual(['@']);
+        });
+
+        it('extracts multiple revisions from args', () => {
+            const payload = createAbandonPayload(['rev1', 'rev2']);
+            expect(payload.revisions).toEqual(['rev1', 'rev2']);
+        });
+
+        it('falls back to selected revisions from scmProvider', () => {
+            const scmProvider = createMock<JjScmProvider>({
+                getSelectedCommitIds: vi.fn().mockReturnValue(['sel1', 'sel2']),
+            });
+            const payload = createAbandonPayload([], scmProvider);
+            expect(payload.revisions).toEqual(['sel1', 'sel2']);
+        });
+    });
+
+    describe('absorb payload', () => {
+        it('extracts fromRevision from commitId object', () => {
+            const payload = createAbsorbPayload([{ commitId: 'c123' }]);
+            expect(payload.fromRevision).toBe('c123');
+        });
+    });
+
+    describe('bookmark advance payloads', () => {
+        it('createAdvanceBookmarkPayload extracts revision', () => {
+            const payload = createAdvanceBookmarkPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+
+        it('createAdvanceBookmarkAndUploadPayload extracts revision', () => {
+            const payload = createAdvanceBookmarkAndUploadPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('bookmark payload', () => {
+        it('extracts revision and name', () => {
+            const payload = createSetBookmarkPayload([{ commitId: 'rev1', name: 'bm1' }]);
+            expect(payload.name).toBe('bm1');
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('commit payload', () => {
+        it('extracts description from scmProvider input box', () => {
+            const scmProvider = createMock<JjScmProvider>({
+                sourceControl: createMock<vscode.SourceControl>({
+                    inputBox: createMock<vscode.SourceControlInputBox>({ value: 'commit msg' }),
+                }),
+            });
+            const payload = createCommitPayload([], scmProvider);
+            expect(payload.description).toBe('commit msg');
+        });
+    });
+
+    describe('describe payload', () => {
+        it('extracts description from string arg or scmProvider', () => {
+            const payload = createSetDescriptionPayload(['my desc', 'rev1']);
+            expect(payload.description).toBe('my desc');
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('details payload', () => {
+        it('extracts revision from string arg', () => {
+            const payload = createShowDetailsPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('duplicate payload', () => {
+        it('extracts revision', () => {
+            const payload = createDuplicatePayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('edit payload', () => {
+        it('extracts revision', () => {
+            const payload = createEditPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('merge editor payload', () => {
+        it('extracts uri from resource state', () => {
+            const uri = Uri.file('/test/file.txt');
+            const resourceState = createMock<JjResourceState>({ resourceUri: uri });
+            const payload = createOpenMergeEditorPayload([resourceState]);
+            expect(payload.resourceStates[0].resourceUri.fsPath).toBe(uri.fsPath);
+        });
+    });
+
+    describe('merge payload', () => {
+        it('extracts revisions array', () => {
+            const payload = createNewMergeChangePayload([{ revision: 'r1' }, { revision: 'r2' }]);
+            expect(payload.revisions).toEqual(['r1', 'r2']);
+        });
+    });
+
+    describe('multi diff payload', () => {
+        it('extracts revision', () => {
+            const payload = createShowMultiFileDiffPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('new payloads', () => {
+        it('createNewPayload returns payload', () => {
+            const payload = createNewPayload(['file.txt']);
+            expect(payload).toBeDefined();
+        });
+
+        it('createNewAfterPayload extracts revision', () => {
+            const payload = createNewAfterPayload([{ commitId: 'c1' }]);
+            expect(payload.revisions).toEqual(['c1']);
+        });
+
+        it('createNewBeforePayload extracts revision', () => {
+            const payload = createNewBeforePayload([{ commitId: 'c1' }]);
+            expect(payload.revisions).toEqual(['c1']);
+        });
+    });
+
+    describe('rebase payload', () => {
+        it('extracts source and destination revisions', () => {
+            const scmProvider = createMock<JjScmProvider>({
+                getSelectedCommitIds: vi.fn().mockReturnValue(['dest1']),
+            });
+            const payload = createRebaseOntoSelectedPayload([{ commitId: 'src1' }], scmProvider);
+            expect(payload.sourceId).toBe('src1');
+            expect(payload.destinations).toEqual(['dest1']);
+        });
+    });
+
+    describe('restore payload', () => {
+        it('extracts paths grouped by revision', () => {
+            const uri = Uri.file('/path/to/file.txt');
+            const payload = createRestorePayload([{ resourceUri: uri, revision: 'r1' }]);
+            expect(payload.pathsByRevision.r1).toBeDefined();
+        });
+    });
+
+    describe('compare all files with revision payload', () => {
+        it('extracts revision', () => {
+            const payload = createCompareAllFilesWithRevisionPayload(['rev1']);
+            expect(payload.revision).toBe('rev1');
+        });
+    });
+
+    describe('squash files payloads', () => {
+        it('createSquashFilesIntoParentPayload extracts paths and revision', () => {
+            const uri = Uri.file('/test/file.txt');
+            const payload = createSquashFilesIntoParentPayload([{ resourceUri: uri }, 'rev1']);
+            expect(payload.paths).toEqual([uri.fsPath]);
+            expect(payload.revision).toBe('rev1');
+        });
+
+        it('createSquashFilesIntoAncestorPayload extracts ancestorRevision from object arg', () => {
+            const uri = Uri.file('/test/file.txt');
+            const payload = createSquashFilesIntoAncestorPayload([
+                { resourceUri: uri },
+                { revision: 'srcRev', ancestorRevision: 'targetAncestor' },
+            ]);
+            expect(payload.revision).toBe('srcRev');
+            expect(payload.ancestorRevision).toBe('targetAncestor');
+        });
+
+        it('createSquashFilesIntoAncestorPayload extracts ancestorRevision from multiple revision args', () => {
+            const uri = Uri.file('/test/file.txt');
+            const payload = createSquashFilesIntoAncestorPayload([{ resourceUri: uri }, 'srcRev', 'targetAncestor']);
+            expect(payload.revision).toBe('srcRev');
+            expect(payload.ancestorRevision).toBe('targetAncestor');
+        });
+
+        it('createSquashFilesIntoChildPayload extracts childRevision from object arg', () => {
+            const uri = Uri.file('/test/file.txt');
+            const payload = createSquashFilesIntoChildPayload([
+                { resourceUri: uri },
+                { revision: 'srcRev', childRevision: 'targetChild' },
+            ]);
+            expect(payload.revision).toBe('srcRev');
+            expect(payload.childRevision).toBe('targetChild');
+        });
+
+        it('createSquashFilesIntoChildPayload extracts childRevision from multiple revision args', () => {
+            const uri = Uri.file('/test/file.txt');
+            const payload = createSquashFilesIntoChildPayload([{ resourceUri: uri }, 'srcRev', 'targetChild']);
+            expect(payload.revision).toBe('srcRev');
+            expect(payload.childRevision).toBe('targetChild');
+        });
+    });
+
+    describe('squash revision payloads', () => {
+        it('createSquashRevisionIntoParentPayload extracts targetParent from object arg', () => {
+            const payload = createSquashRevisionIntoParentPayload([{ revision: 'rev1', targetParent: 'parent1' }]);
+            expect(payload.revision).toBe('rev1');
+            expect(payload.targetParent).toBe('parent1');
+        });
+
+        it('createSquashRevisionIntoParentPayload extracts targetParent from multiple revision args', () => {
+            const payload = createSquashRevisionIntoParentPayload(['rev1', 'parent1']);
+            expect(payload.revision).toBe('rev1');
+            expect(payload.targetParent).toBe('parent1');
+        });
+
+        it('createSquashRevisionIntoAncestorPayload extracts ancestorRevision from object arg', () => {
+            const payload = createSquashRevisionIntoAncestorPayload([{ revision: 'rev1', ancestorRevision: 'anc1' }]);
+            expect(payload.revision).toBe('rev1');
+            expect(payload.ancestorRevision).toBe('anc1');
+        });
+
+        it('createSquashRevisionIntoAncestorPayload extracts ancestorRevision from multiple revision args', () => {
+            const payload = createSquashRevisionIntoAncestorPayload(['rev1', 'anc1']);
+            expect(payload.revision).toBe('rev1');
+            expect(payload.ancestorRevision).toBe('anc1');
+        });
+    });
+
+    describe('squash selection payloads', () => {
+        it('createSquashHunkIntoParentPayload extracts uri and ranges', () => {
+            const uri = Uri.file('/test/file.txt');
+            const changes = [
+                {
+                    originalStartLineNumber: 2,
+                    originalEndLineNumber: 2,
+                    modifiedStartLineNumber: 2,
+                    modifiedEndLineNumber: 2,
+                },
+            ];
+            const payload = createSquashHunkIntoParentPayload([uri, changes, 0]);
+            expect(payload.uri?.fsPath).toBe(uri.fsPath);
+            expect(payload.ranges).toEqual([{ startLine: 1, endLine: 1 }]);
+        });
+
+        it('createSquashSelectionIntoParentPayload extracts ranges from selections', () => {
+            const uri = Uri.file('/test/file.txt');
+            const editor = createMock<vscode.TextEditor>({
+                document: createMock<vscode.TextDocument>({ uri }),
+                selections: [
+                    createMock<vscode.Selection>({
+                        start: createMock<vscode.Position>({ line: 0 }),
+                        end: createMock<vscode.Position>({ line: 2 }),
+                    }),
+                ],
+            });
+            const payload = createSquashSelectionIntoParentPayload(editor);
+            expect(payload.uri?.fsPath).toBe(uri.fsPath);
+            expect(payload.ranges).toEqual([{ startLine: 0, endLine: 2 }]);
+        });
+    });
+
+    describe('workspace open payloads', () => {
+        it('createWorkspaceOpenInCurrentWindowPayload extracts workspaceName', () => {
+            const payload = createWorkspaceOpenInCurrentWindowPayload([{ workspaceName: 'ws1' }]);
+            expect(payload.workspaceName).toBe('ws1');
+        });
+
+        it('createWorkspaceOpenInNewWindowPayload extracts workspaceName', () => {
+            const payload = createWorkspaceOpenInNewWindowPayload([{ workspaceName: 'ws1' }]);
+            expect(payload.workspaceName).toBe('ws1');
+        });
+    });
+});

--- a/src/vscode/register-commands.ts
+++ b/src/vscode/register-commands.ts
@@ -205,12 +205,8 @@ export function registerCommands(options: RegisterCommandsOptions): void {
         registerCommandWithPayload('jj-view.new', createNewPayload, newCommand),
         registerCommandWithPayload('jj-view.newMergeChange', createNewMergeChangePayload, newMergeChangeCommand),
         registerCommandWithPayload('jj-view.commit', createCommitPayload, commitCommand),
-        registerCommand('jj-view.commitPrompt', (ctx) =>
-            commitPromptCommand(ctx, scmProviders.get(ctx.repo.rootUri.fsPath)),
-        ),
-        registerCommand('jj-view.describePrompt', (ctx) =>
-            describePromptCommand(ctx, scmProviders.get(ctx.repo.rootUri.fsPath)),
-        ),
+        registerCommand('jj-view.commitPrompt', commitPromptCommand),
+        registerCommand('jj-view.describePrompt', describePromptCommand),
     );
 
     // focusDescriptionInput doesn't need repo context — it just focuses the SCM view

--- a/src/vscode/vscode-host-environment.ts
+++ b/src/vscode/vscode-host-environment.ts
@@ -18,6 +18,7 @@ import type {
     HostUi,
     HostViews,
 } from '../common/host-environment';
+import { openCommitDetails } from '../jj-commit-details-editor-provider';
 import type { JjRepository } from '../jj-repository';
 import { getFsPathFromUri, toFileUri, type Uri } from '../uri-utils';
 import { getJjViewConfig } from '../utils/config-utils';
@@ -131,13 +132,13 @@ export class VsCodeHostUi implements HostUi {
         }
     }
 
-    setCommitInput(value: string): void {
+    setScmDescriptionInputValue(value: string): void {
         if (this.sourceControl) {
             this.sourceControl.inputBox.value = value;
         }
     }
 
-    getCommitInput(): string | undefined {
+    getScmDescriptionInputValue(): string | undefined {
         return this.sourceControl?.inputBox.value;
     }
 }
@@ -193,6 +194,16 @@ export class VsCodeHostNavigation implements HostNavigation {
             output: outputUri,
         };
         await vscode.commands.executeCommand('_open.mergeEditor', args);
+    }
+
+    async openCommitDetails(
+        repoRoot: string,
+        changeId: string,
+        shortestChangeId?: string,
+        isDivergent?: boolean,
+        changeIdOffset?: number,
+    ): Promise<void> {
+        await openCommitDetails(repoRoot, changeId, shortestChangeId, isDivergent, changeIdOffset);
     }
 
     async openFile(uri: Uri): Promise<void> {


### PR DESCRIPTION


- Refactor all command unit tests in src/test/commands/ to execute pure command handlers with typed payloads and FakeCommandContext directly.
- Add openCommitDetails method to HostNavigation (VsCodeHostNavigation, FakeHostNavigation) to decouple showDetailsCommand from vscode.
- Rename commit input methods to getScmDescriptionInputValue / setScmDescriptionInputValue across HostUi implementations.
- Move absorb.integration.test.ts and index-lock-error.test.ts to src/test/ to maintain unit test purity in src/test/commands/.
- Add isolated unit tests in src/test/vscode-payloads.test.ts for all VS Code command argument extractors.