### PR TITLE
e2e: reset extension state and dismiss quick input during teardown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ export interface Api {
     commentsManager: CommentsManager;
     commentsProvider: VsCodeCommentsProvider;
     registerCodeForgeProvider(factory: CodeForgeProviderFactory): vscode.Disposable;
+    resetState(): Promise<void>;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<Api> {
@@ -537,6 +538,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         commentsManager,
         commentsProvider,
         registerCodeForgeProvider: (factory: CodeForgeProviderFactory) => codeForgeRegistry.register(factory),
+        resetState: async () => {
+            await authManager.resetAllChoices();
+            try {
+                await authManager.secrets.delete('gitlab_token');
+                await authManager.secrets.delete('github_token');
+            } catch {}
+            for (const key of context.globalState?.keys?.() ?? []) {
+                await context.globalState.update(key, undefined);
+            }
+            for (const key of context.workspaceState?.keys?.() ?? []) {
+                await context.workspaceState.update(key, undefined);
+            }
+            await repositoryManager.clear();
+        },
     };
 }
 

--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -856,14 +856,31 @@ export function locateQuickInputItem(page: Page, label: string | RegExp): Locato
 }
 
 /**
- * Dismisses any open QuickInput widget by pressing Escape, ensuring it is closed.
+ * Dismisses any open QuickInput widget using the closeQuickOpen command or Escape key.
  */
-export async function dismissQuickInput(page: Page, timeout: number = 2000): Promise<void> {
-    const quickInput = locateQuickInputWidget(page).filter({ visible: true });
-    if (await quickInput.isVisible()) {
-        await page.keyboard.press('Escape');
-        await expect(quickInput).not.toBeVisible({ timeout });
+export async function dismissQuickInput(page: Page, vscode?: VSCodeFixture, timeout: number = 2000): Promise<void> {
+    if (vscode) {
+        try {
+            await vscode.executeCommand('workbench.action.closeQuickOpen');
+        } catch {}
     }
+    const quickInput = locateQuickInputWidget(page).filter({ visible: true });
+    try {
+        await expect(async () => {
+            if (await quickInput.isVisible()) {
+                if (vscode) {
+                    await vscode.executeCommand('workbench.action.closeQuickOpen');
+                } else {
+                    await quickInput
+                        .locator('input.input')
+                        .focus()
+                        .catch(() => {});
+                    await page.keyboard.press('Escape');
+                }
+            }
+            await expect(quickInput).not.toBeVisible({ timeout: 500 });
+        }).toPass({ timeout });
+    } catch {}
 }
 
 /**

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -326,7 +326,7 @@ test.describe('GitHub Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        await dismissQuickInput(page);
+        await dismissQuickInput(page, vscode);
     });
 
     test('Detects PR from fork targeting mainline repo', async ({ vscode }) => {

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -296,7 +296,7 @@ test.describe('GitLab Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        await dismissQuickInput(page);
+        await dismissQuickInput(page, vscode);
     });
 
     test('Shows extension-not-found interstitial when signing in via OAuth without GitLab extension', async ({
@@ -320,7 +320,7 @@ test.describe('GitLab Integration E2E', () => {
         );
 
         await focusSCM(page);
-        await dismissQuickInput(page);
+        await dismissQuickInput(page, vscode);
 
         // Click the Manage Auth button in the Source Control title bar
         const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -1170,6 +1170,10 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
                 const evaluatePromise = this.evaluate(async (vscode, api) => {
                     const evalStart = Date.now();
 
+                    try {
+                        await vscode.commands.executeCommand('workbench.action.closeQuickOpen');
+                    } catch {}
+
                     const hasOpenEditors = vscode.window.tabGroups.all.some((group) => group.tabs.length > 0);
                     if (hasOpenEditors) {
                         try {
@@ -1182,8 +1186,12 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
 
                     const clearStart = Date.now();
                     try {
-                        await api.repositoryManager.clear();
-                        globalThis.logPerf('cleanupAfterTest (eval): repoManager clear', clearStart);
+                        if (typeof api?.resetState === 'function') {
+                            await api.resetState();
+                        } else {
+                            await api?.repositoryManager?.clear();
+                        }
+                        globalThis.logPerf('cleanupAfterTest (eval): resetState', clearStart);
                     } catch {}
 
                     const workspaceFolders = vscode.workspace.workspaceFolders || [];


### PR DESCRIPTION
Ensure test isolation across reused VS Code worker sessions by wiping authentication state, secret storage, global/workspace mementos, and tracked repositories via a new `api.resetState()` lifecycle method. Additionally, dismiss active QuickOpen pickers using workbench commands and retry logic to prevent UI click interception across consecutive test runs.