### PR TITLE
fix(diff): prevent corruption and stale reads during revision diff editing

### DIFF
--- a/scripts/batch-diff.bat
+++ b/scripts/batch-diff.bat
@@ -12,11 +12,55 @@ REM Note: Exits with code 1 to intentionally abort the diffedit operation
 REM       without applying any changes.
 REM
 
-set left=%1
-set right=%2
-set outLeft=%3
-set outRight=%4
+REM 1. Unquote arguments (%~1 strips quotes) passed by JJ CLI / merge-tool
+set "left=%~1"
+set "right=%~2"
+set "outLeft=%~3"
+set "outRight=%~4"
 
-xcopy "%left%" "%outLeft%" /E /H /C /I /Y > nul
-xcopy "%right%" "%outRight%" /E /H /C /I /Y > nul
+REM 2. Normalize forward slashes to Windows backslashes for xcopy and mkdir
+set "left=%left:/=\%"
+set "right=%right:/=\%"
+set "outLeft=%outLeft:/=\%"
+set "outRight=%outRight:/=\%"
+
+REM 3. Copy left (parent) and right (current) trees into cache directories
+call :copy_dir "%left%" "%outLeft%"
+if errorlevel 1 goto :fail
+
+call :copy_dir "%right%" "%outRight%"
+if errorlevel 1 goto :fail
+
+REM 4. Signal successful extraction via .complete sentinel file so _warmDiffCache
+REM    can distinguish an intentional abort (exit 1) from an unexpected script failure.
+echo done > "%outRight%\.complete" 2>nul
 exit /B 1
+
+REM 5. Failure exit path: skip creating .complete so _warmDiffCache knows extraction failed
+:fail
+exit /B 1
+
+REM ============================================================================
+REM Subroutine: :copy_dir
+REM Arguments:  %1 = source directory path, %2 = destination directory path
+REM Returns:    0 on success (or if source doesn't exist), non-zero on failure
+REM ============================================================================
+:copy_dir
+set "src=%~1"
+set "dest=%~2"
+
+REM For root commits or empty diffs, the source folder may not exist on disk.
+REM Treat non-existent source as a successful no-op.
+if not exist "%src%\" exit /B 0
+
+REM Ensure target directory exists before copying
+if not exist "%dest%" mkdir "%dest%" || exit /B 1
+
+REM /E = recursive (including empty), /H = hidden/system files, /C = continue on error,
+REM /I = assume destination is folder, /Y = overwrite without prompt.
+xcopy "%src%\*" "%dest%\" /E /H /C /I /Y > nul 2>&1
+exit /B %ERRORLEVEL%
+
+
+
+

--- a/scripts/batch-diff.sh
+++ b/scripts/batch-diff.sh
@@ -12,24 +12,36 @@
 #       without applying any changes.
 #
 
+# Positional arguments passed by JJ merge-tool configuration
 left=$1
 right=$2
 outLeft=$3
 outRight=$4
 
+# Helper function to safely copy directory contents.
+# Note: Uses "$src/." to copy all contents (including hidden files) without
+# matching "." and ".." which would recursively copy parent directories.
 copy_dir() {
     local src="$1"
     local dest="$2"
     
+    # Non-existent source (e.g. root commit left side) is a successful no-op
     if [ ! -d "$src" ]; then
-        return
+        return 0
     fi
     
-    mkdir -p "$dest"
-    cp -R "$src/"* "$dest/" 2>/dev/null || true
-    cp -R "$src/".* "$dest/" 2>/dev/null || true
+    mkdir -p "$dest" || return 1
+    cp -R "$src/." "$dest/" || return 1
 }
 
-copy_dir "$left" "$outLeft"
-copy_dir "$right" "$outRight"
+# Copy left (parent) and right (current) trees into cache directories.
+# Only create the .complete marker if all copies succeed without error.
+if copy_dir "$left" "$outLeft" && copy_dir "$right" "$outRight"; then
+    touch "$outRight/.complete"
+fi
+
+# Exit 1 intentionally to abort the diffedit operation without applying changes
 exit 1
+
+
+

--- a/src/jj-edit-fs-service.ts
+++ b/src/jj-edit-fs-service.ts
@@ -4,7 +4,9 @@
  */
 
 import * as fs from 'node:fs/promises';
-import { type Event, EventEmitter } from './common/events';
+
+import * as path from 'node:path';
+import { type Disposable, type Event, EventEmitter } from './common/events';
 import type { JjRepository } from './jj-repository';
 import type { JjRepositoryManager } from './jj-repository-manager';
 import { getFsPathFromUri, getUriParams, Uri } from './uri-utils';
@@ -28,11 +30,13 @@ export function parseEditUri(uri: Uri): { revision: string; filePath: string } {
     return { revision, filePath };
 }
 
-export class JjEditFsService {
+export class JjEditFsService implements Disposable {
     private readonly _onDidChangeFile = new EventEmitter<Uri[]>();
     readonly onDidChangeFile: Event<Uri[]> = this._onDidChangeFile.event;
 
     private _pendingWrites = new Map<string, JjEditFsPendingWrite[]>();
+    private _activeWrites = new Map<string, JjEditFsPendingWrite[]>();
+    private _isFlushing = false;
     private _writeTimer: NodeJS.Timeout | undefined;
     private _knownUris = new Set<string>();
 
@@ -40,6 +44,22 @@ export class JjEditFsService {
         private readonly _repositoryManager: JjRepositoryManager,
         public onDidWrite?: (repo: JjRepository) => void,
     ) {}
+
+    dispose(): void {
+        if (this._writeTimer) {
+            clearTimeout(this._writeTimer);
+            this._writeTimer = undefined;
+        }
+        for (const writes of this._pendingWrites.values()) {
+            for (const write of writes) {
+                write.reject(new Error('JjEditFsService disposed'));
+            }
+        }
+        this._pendingWrites.clear();
+        this._activeWrites.clear();
+        this._knownUris.clear();
+        this._onDidChangeFile.dispose();
+    }
 
     invalidateCache(): Uri[] {
         const changedUris: Uri[] = [];
@@ -65,6 +85,20 @@ export class JjEditFsService {
         };
     }
 
+    private getPendingOrActiveContent(repoKey: string, revision: string, filePath: string): string | undefined {
+        const normalizedPath = path.normalize(filePath);
+        const isMatch = (w: JjEditFsPendingWrite) =>
+            w.revision === revision && path.normalize(w.filePath) === normalizedPath;
+
+        const pending = this._pendingWrites.get(repoKey)?.findLast(isMatch);
+        if (pending) {
+            return pending.content;
+        }
+
+        const active = this._activeWrites.get(repoKey)?.findLast(isMatch);
+        return active?.content;
+    }
+
     async readFile(uri: Uri): Promise<Uint8Array> {
         this._knownUris.add(uri.toString());
         const { revision, filePath } = parseEditUri(uri);
@@ -75,6 +109,13 @@ export class JjEditFsService {
             );
             throw new Error(`No Jujutsu repository found for: ${filePath}`);
         }
+
+        const repoKey = repo.rootUri.fsPath;
+        const inMemoryContent = this.getPendingOrActiveContent(repoKey, revision, filePath);
+        if (inMemoryContent !== undefined) {
+            return Buffer.from(inMemoryContent, 'utf8');
+        }
+
         if (revision === '@') {
             try {
                 return await fs.readFile(filePath);
@@ -116,56 +157,85 @@ export class JjEditFsService {
                 clearTimeout(this._writeTimer);
             }
             this._writeTimer = setTimeout(() => {
+                this._writeTimer = undefined;
                 this._flushPendingWrites();
             }, 100);
         });
     }
 
     private async _flushPendingWrites(): Promise<void> {
-        const writesByRepo = new Map(this._pendingWrites);
-        this._pendingWrites.clear();
-        this._writeTimer = undefined;
+        if (this._isFlushing) {
+            return;
+        }
+        this._isFlushing = true;
+        if (this._writeTimer) {
+            clearTimeout(this._writeTimer);
+            this._writeTimer = undefined;
+        }
 
-        for (const [repoKey, writes] of writesByRepo) {
-            const repo = this._repositoryManager.getRepositoryForUri(Uri.file(repoKey));
-            if (!repo) {
-                for (const write of writes) {
-                    write.reject(new Error(`Repository no longer available: ${repoKey}`));
+        try {
+            while (this._pendingWrites.size > 0) {
+                const writesByRepo = new Map(this._pendingWrites);
+                this._pendingWrites.clear();
+                this._activeWrites = writesByRepo;
+
+                for (const [repoKey, writes] of writesByRepo) {
+                    try {
+                        const repo = this._repositoryManager.getRepositoryForUri(Uri.file(repoKey));
+                        if (!repo) {
+                            for (const write of writes) {
+                                write.reject(new Error(`Repository no longer available: ${repoKey}`));
+                            }
+                            continue;
+                        }
+
+                        // Group by revision within this repo
+                        const writesByRevision = new Map<string, JjEditFsPendingWrite[]>();
+                        for (const write of writes) {
+                            const list = writesByRevision.get(write.revision) || [];
+                            list.push(write);
+                            writesByRevision.set(write.revision, list);
+                        }
+
+                        for (const [revision, revWrites] of writesByRevision) {
+                            try {
+                                const filesMap = new Map<string, string>();
+                                for (const w of revWrites) {
+                                    filesMap.set(w.filePath, w.content);
+                                }
+
+                                await repo.jj.setFilesContent(revision, filesMap);
+
+                                this._onDidChangeFile.fire(revWrites.map((w) => w.uri));
+
+                                for (const w of revWrites) {
+                                    w.resolve();
+                                }
+
+                                if (this.onDidWrite) {
+                                    this.onDidWrite(repo);
+                                }
+                            } catch (err: unknown) {
+                                for (const w of revWrites) {
+                                    w.reject(err);
+                                }
+                            }
+                        }
+                    } catch (repoErr: unknown) {
+                        for (const write of writes) {
+                            write.reject(repoErr);
+                        }
+                    }
                 }
-                continue;
             }
-
-            // Group by revision within this repo
-            const writesByRevision = new Map<string, JjEditFsPendingWrite[]>();
-            for (const write of writes) {
-                const list = writesByRevision.get(write.revision) || [];
-                list.push(write);
-                writesByRevision.set(write.revision, list);
-            }
-
-            for (const [revision, revWrites] of writesByRevision) {
-                try {
-                    const filesMap = new Map<string, string>();
-                    for (const w of revWrites) {
-                        filesMap.set(w.filePath, w.content);
-                    }
-
-                    await repo.jj.setFilesContent(revision, filesMap);
-
-                    this._onDidChangeFile.fire(revWrites.map((w) => w.uri));
-
-                    for (const w of revWrites) {
-                        w.resolve();
-                    }
-
-                    if (this.onDidWrite) {
-                        this.onDidWrite(repo);
-                    }
-                } catch (err: unknown) {
-                    for (const w of revWrites) {
-                        w.reject(err);
-                    }
-                }
+        } finally {
+            this._activeWrites.clear();
+            this._isFlushing = false;
+            if (this._pendingWrites.size > 0 && !this._writeTimer) {
+                this._writeTimer = setTimeout(() => {
+                    this._writeTimer = undefined;
+                    this._flushPendingWrites();
+                }, 100);
             }
         }
     }

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -183,20 +183,40 @@ export class JjService {
 
     private async toRepoRelative(filePath: string): Promise<string> {
         const repoRoot = await this.getRepoRoot();
-        let repoReal = repoRoot;
-        let workspaceReal = this.workspaceRoot;
+        const repoReal = await fs.realpath(repoRoot).catch(() => repoRoot);
+        const workspaceReal = await fs.realpath(this.workspaceRoot).catch(() => this.workspaceRoot);
 
+        if (!path.isAbsolute(filePath)) {
+            const repoToWorkspace = path.relative(repoReal, workspaceReal);
+            return path.normalize(path.join(repoToWorkspace, filePath));
+        }
+
+        const rel = path.relative(repoReal, filePath);
+        if (!rel.startsWith('..')) {
+            return path.normalize(rel);
+        }
+
+        const fileReal = await this.resolveRealPath(filePath);
+        return path.normalize(path.relative(repoReal, fileReal));
+    }
+
+    private async resolveRealPath(filePath: string): Promise<string> {
         try {
-            repoReal = await fs.realpath(repoRoot);
-        } catch {}
-        try {
-            workspaceReal = await fs.realpath(this.workspaceRoot);
+            return await fs.realpath(filePath);
         } catch {}
 
-        const relativeToWorkspace = path.isAbsolute(filePath) ? path.relative(this.workspaceRoot, filePath) : filePath;
-
-        const repoToWorkspace = path.relative(repoReal, workspaceReal);
-        return path.normalize(path.join(repoToWorkspace, relativeToWorkspace));
+        let cur = path.dirname(filePath);
+        const tail: string[] = [path.basename(filePath)];
+        while (cur && cur !== path.dirname(cur)) {
+            try {
+                const parentReal = await fs.realpath(cur);
+                return path.join(parentReal, ...tail);
+            } catch {
+                tail.unshift(path.basename(cur));
+                cur = path.dirname(cur);
+            }
+        }
+        return filePath;
     }
 
     private getScriptPath(scriptBaseName: string): string {
@@ -272,6 +292,8 @@ export class JjService {
             'ui.color="never"',
             '--config',
             'ui.paginate="never"',
+            '--config',
+            'ui.diff-instructions=false',
         ];
 
         if (options.useCachedSnapshot) {
@@ -662,8 +684,16 @@ export class JjService {
                     useCachedSnapshot: true,
                     label: `getDiffForRevision ${revision}`,
                 });
-            } catch {
-                // Expected exit 1
+            } catch (err) {
+                // Verify that batch-diff actually ran and wrote the .complete marker
+                const marker = path.join(rightDir, '.complete');
+                const isCompleted = await fs
+                    .access(marker)
+                    .then(() => true)
+                    .catch(() => false);
+                if (!isCompleted) {
+                    throw err;
+                }
             }
 
             return {
@@ -678,6 +708,14 @@ export class JjService {
 
     async clearCache(): Promise<void> {
         await Promise.all([this._diffCache.clear(), this._changesCache.clear()]);
+    }
+
+    /**
+     * Check if a revision is immutable.
+     */
+    async isImmutable(revision: string): Promise<boolean> {
+        const stdout = await this.run('log', ['-r', revision, '-T', 'immutable', '--no-graph']);
+        return stdout.trim() === 'true';
     }
 
     private async runMutation<T>(op: () => Promise<T>): Promise<T> {
@@ -700,14 +738,20 @@ export class JjService {
      * Serialized via a mutation queue to prevent divergent commits.
      */
     async setFilesContent(revision: string, files: Map<string, string>): Promise<void> {
+        if (files.size === 0) {
+            return;
+        }
+
         return this.runMutation(async () => {
             const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jj-batch-edit-'));
             try {
-                const writePromises = Array.from(files.entries()).map(([filePath, content]) => {
-                    const relPath = this.toRelative(filePath);
-                    const safeName = relPath.replace(/[\\/]/g, '_');
-                    const tmpPath = path.join(tempDir, `src_${safeName}`);
-                    return fs.writeFile(tmpPath, content, 'utf8').then(() => ({ relPath, tmpPath }));
+                const writePromises = Array.from(files.entries()).map(async ([filePath, content], idx) => {
+                    const repoRelPath = await this.toRepoRelative(filePath);
+                    const workspaceRelPath = this.toRelative(filePath);
+                    const safeName = repoRelPath.replace(/[\\/]/g, '_');
+                    const tmpPath = path.join(tempDir, `src_${idx}_${safeName}`);
+                    await fs.writeFile(tmpPath, content, 'utf8');
+                    return { repoRelPath, workspaceRelPath, tmpPath };
                 });
 
                 const fileList = await Promise.all(writePromises);
@@ -718,13 +762,13 @@ export class JjService {
                 const argsTemplate = ['$left', '$right'];
                 for (const f of fileList) {
                     argsTemplate.push(f.tmpPath.split(path.sep).join('/'));
-                    argsTemplate.push(f.relPath.split(path.sep).join('/'));
+                    argsTemplate.push(f.repoRelPath.split(path.sep).join('/'));
                 }
                 const toolConfig = this.getToolConfigArgs(toolName, normalizedScriptPath, argsTemplate);
 
                 await this.runInternal(
                     'diffedit',
-                    ['-r', revision, '--tool', toolName, ...toolConfig, ...fileList.map((f) => f.relPath)],
+                    ['-r', revision, '--tool', toolName, ...toolConfig, ...fileList.map((f) => f.workspaceRelPath)],
                     { isMutation: true, label: 'setFilesContent' },
                 );
             } finally {

--- a/src/test/jj-edit-fs-provider.test.ts
+++ b/src/test/jj-edit-fs-provider.test.ts
@@ -251,4 +251,285 @@ describe('VsCodeEditFsProvider', () => {
         const content = await provider.readFile(relUri);
         expect(Buffer.from(content).toString('utf8')).toBe('hello\n');
     });
+
+    function generateLargeFileContent(lineCount = 5500): string {
+        const lines: string[] = [
+            '// Copyright 2026 The Chromium Authors',
+            '// Use of this source code is governed by a BSD-style license that can be',
+            '// found in the LICENSE file.',
+            '',
+            '#include <iostream>',
+            '#include <memory>',
+            '#include <string>',
+            '#include <vector>',
+            '#include <map>',
+            '',
+            'namespace chrome::glic::testing {',
+            '',
+        ];
+
+        let currentClass = 0;
+        while (lines.length < lineCount) {
+            currentClass++;
+            lines.push(`class GlicApiHostHandler_${currentClass} {`);
+            lines.push(' public:');
+            lines.push(`  explicit GlicApiHostHandler_${currentClass}(int id) : id_(id) {}`);
+            lines.push(`  virtual ~GlicApiHostHandler_${currentClass}() = default;`);
+            lines.push('');
+            lines.push(`  int GetHandlerId() const { return id_; }`);
+            lines.push(`  std::string ComputeSignature(const std::string& input) const {`);
+            lines.push(`    return "handler_" + std::to_string(id_) + "_" + input;`);
+            lines.push('  }');
+            lines.push('');
+            lines.push(' protected:');
+            lines.push(`  void HandleMessage(const std::string& type, const std::vector<uint8_t>& payload) {`);
+            lines.push(`    // Processing message type: ${currentClass}`);
+            lines.push('    if (type.empty()) {');
+            lines.push('      return;');
+            lines.push('    }');
+            lines.push('    payload_cache_[type] = payload;');
+            lines.push('  }');
+            lines.push('');
+            lines.push(' private:');
+            lines.push('  int id_;');
+            lines.push('  std::map<std::string, std::vector<uint8_t>> payload_cache_;');
+            lines.push('};');
+            lines.push('');
+        }
+
+        lines.push('} // namespace chrome::glic::testing');
+        return lines.join('\n');
+    }
+
+    it('handles large file editing and saving in non-@ revision with descendants', async () => {
+        const originalContent = generateLargeFileContent(5500);
+        const lines = originalContent.split('\n');
+        lines[1000] = '// MODIFIED LINE AT 1000 IN COMMIT1';
+        const c1Content = lines.join('\n');
+
+        lines[3000] = '// MODIFIED LINE AT 3000 IN COMMIT2';
+        const c2Content = lines.join('\n');
+
+        lines[4000] = '// MODIFIED LINE AT 4000 IN WC';
+        const wcContent = lines.join('\n');
+
+        const filename = 'chrome/browser/glic/host/glic_api_browsertest.cc';
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { [filename]: originalContent } },
+            { label: 'commit1', parents: ['base'], files: { [filename]: c1Content } },
+            { label: 'commit2', parents: ['commit1'], files: { [filename]: c2Content } },
+            { label: 'wc', parents: ['commit2'], isCurrentWorkingCopy: true, files: { [filename]: wcContent } },
+        ]);
+
+        const uri = getUri(filename, ids.commit1.changeId);
+        const readContent = await provider.readFile(uri);
+        expect(Buffer.from(readContent).toString('utf8')).toBe(c1Content);
+
+        // Edit commit1
+        const c1Lines = c1Content.split('\n');
+        c1Lines[500] = '// USER SAVED IN DIFF EDITOR AT 500';
+        const userSaved = c1Lines.join('\n');
+        await provider.writeFile(uri, Buffer.from(userSaved, 'utf8'));
+
+        expect(repo.getFileContent(ids.commit1.changeId, filename)).toBe(userSaved);
+
+        // Verify descendant commit2 and working copy preserved rebased changes
+        const commit2Content = repo.getFileContent(ids.commit2.changeId, filename);
+        const commit2Lines = commit2Content.split('\n');
+        expect(commit2Lines[500]).toBe('// USER SAVED IN DIFF EDITOR AT 500');
+        expect(commit2Lines[1000]).toBe('// MODIFIED LINE AT 1000 IN COMMIT1');
+        expect(commit2Lines[3000]).toBe('// MODIFIED LINE AT 3000 IN COMMIT2');
+
+        const wcSavedContent = repo.getFileContent(ids.wc.changeId, filename);
+        const wcLines = wcSavedContent.split('\n');
+        expect(wcLines[500]).toBe('// USER SAVED IN DIFF EDITOR AT 500');
+        expect(wcLines[1000]).toBe('// MODIFIED LINE AT 1000 IN COMMIT1');
+        expect(wcLines[3000]).toBe('// MODIFIED LINE AT 3000 IN COMMIT2');
+        expect(wcLines[4000]).toBe('// MODIFIED LINE AT 4000 IN WC');
+
+        // Also check read back from provider
+        const reRead = await provider.readFile(uri);
+        expect(Buffer.from(reRead).toString('utf8')).toBe(userSaved);
+    });
+
+    it('exhaustively verifies file content integrity across multi-hunk edits on a large file', async () => {
+        const lineCount = 6000;
+        const baseContent = generateLargeFileContent(lineCount);
+        const filename = 'chrome/browser/glic/host/glic_api_browsertest.cc';
+
+        const c1Lines = baseContent.split('\n');
+        c1Lines[100] = '// INITIAL COMMIT 1 MODIFICATION';
+        const c1Content = c1Lines.join('\n');
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { [filename]: baseContent } },
+            { label: 'commit1', parents: ['base'], files: { [filename]: c1Content } },
+            { label: 'commit2', parents: ['commit1'], files: { [filename]: c1Content } },
+            { label: 'wc', parents: ['commit2'], isCurrentWorkingCopy: true, files: { [filename]: c1Content } },
+        ]);
+
+        const uri = getUri(filename, ids.commit1.changeId);
+
+        // Make multi-line edits in 5 dispersed locations across the 6,000-line file
+        const lines = c1Content.split('\n');
+        lines[15] = '#include <utility> // INJECTED HEADER';
+        lines[850] =
+            '    // INJECTED CONSTRUCTOR LOGIC: line 850 with very long string literal https://example.com/very/long/url/that/could/risk/wrapping/if/pager/was/active';
+        lines[2400] =
+            '  void InjectedCustomMethod_2400() {\n    int count = 42;\n    std::cout << "Custom count: " << count << std::endl;\n  }';
+        lines[4100] = '    payload_cache_["custom_key_4100"] = {0x01, 0x02, 0x03, 0x04};';
+        lines[5800] = '// TRAILING MODIFICATION AT LINE 5800';
+
+        const expectedContent = lines.join('\n');
+        const expectedLines = expectedContent.split('\n');
+
+        // Save via provider
+        await provider.writeFile(uri, Buffer.from(expectedContent, 'utf8'));
+
+        // 1. Check direct readFile from provider
+        const providerRead = await provider.readFile(uri);
+        const providerReadStr = Buffer.from(providerRead).toString('utf8');
+        expect(providerReadStr).toBe(expectedContent);
+
+        // 2. Check repo.getFileContent at commit1
+        const actualContent = repo.getFileContent(ids.commit1.changeId, filename);
+        expect(actualContent).toBe(expectedContent);
+        expect(actualContent.length).toBe(expectedContent.length);
+
+        // 3. Exhaustively verify every line matches with zero wrapping or truncation
+        const actualLines = actualContent.split('\n');
+        expect(actualLines.length).toBe(expectedLines.length);
+        for (let i = 0; i < expectedLines.length; i++) {
+            if (actualLines[i] !== expectedLines[i]) {
+                throw new Error(
+                    `Mismatch at line ${i + 1}:\nExpected: "${expectedLines[i]}"\nActual:   "${actualLines[i]}"`,
+                );
+            }
+        }
+
+        // 4. Verify diff content against base
+        const repository = repoManager.getRepositoryForUri(uri);
+        expect(repository).toBeDefined();
+        if (repository) {
+            const diff = await repository.jj.getDiffContent(ids.commit1.changeId, filename);
+            expect(diff.left).toBe(baseContent);
+            expect(diff.right).toBe(expectedContent);
+
+            // 5. Verify no unintended files were created or modified
+            const changes = await repository.jj.getChanges(ids.commit1.changeId);
+            expect(changes.length).toBe(1);
+            expect(changes[0].path).toBe(filename);
+        }
+    });
+
+    it('returns pending write content when reading before or during flush', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'file.txt': 'initial\n' } },
+            { label: 'commit1', parents: ['base'], files: { 'file.txt': 'commit1\n' } },
+        ]);
+
+        const uri = getUri('file.txt', ids.commit1.changeId);
+
+        // Start write
+        const writePromise = provider.writeFile(uri, Buffer.from('new edited content\n', 'utf8'));
+
+        // Immediately read before write finishes
+        const readImmediately = await provider.readFile(uri);
+        expect(Buffer.from(readImmediately).toString('utf8')).toBe('new edited content\n');
+
+        await writePromise;
+
+        const readAfter = await provider.readFile(uri);
+        expect(Buffer.from(readAfter).toString('utf8')).toBe('new edited content\n');
+    });
+
+    it('handles rapid sequential writes on large file in ancestor revision', async () => {
+        const originalContent = generateLargeFileContent(5500);
+        const filename = 'chrome/browser/glic/host/glic_api_browsertest.cc';
+
+        const lines = originalContent.split('\n');
+        lines[1000] = '// COMMIT 1 MOD';
+        const c1Content = lines.join('\n');
+
+        lines[3000] = '// COMMIT 2 MOD';
+        const c2Content = lines.join('\n');
+
+        lines[4000] = '// WC MOD';
+        const wcContent = lines.join('\n');
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { [filename]: originalContent } },
+            { label: 'commit1', parents: ['base'], files: { [filename]: c1Content } },
+            { label: 'commit2', parents: ['commit1'], files: { [filename]: c2Content } },
+            { label: 'wc', parents: ['commit2'], isCurrentWorkingCopy: true, files: { [filename]: wcContent } },
+        ]);
+
+        const uri = getUri(filename, ids.commit1.changeId);
+
+        // Simulate typing/saving multiple times in rapid succession
+        const c1Lines1 = c1Content.split('\n');
+        c1Lines1[100] = '// EDIT 1';
+        const edit1 = c1Lines1.join('\n');
+
+        const c1Lines2 = c1Content.split('\n');
+        c1Lines2[100] = '// EDIT 1';
+        c1Lines2[200] = '// EDIT 2';
+        const edit2 = c1Lines2.join('\n');
+
+        const p1 = provider.writeFile(uri, Buffer.from(edit1, 'utf8'));
+        // Wait 120ms so first debounce fires and starts diffedit
+        await new Promise((r) => setTimeout(r, 120));
+        // While first diffedit is running, write edit 2
+        const p2 = provider.writeFile(uri, Buffer.from(edit2, 'utf8'));
+
+        await Promise.all([p1, p2]);
+
+        const finalContent = repo.getFileContent(ids.commit1.changeId, filename);
+        expect(finalContent).toBe(edit2);
+    });
+
+    it('cancels pending timers and rejects pending writes on dispose', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'file.txt': 'initial\n' } },
+            { label: 'commit1', parents: ['base'], files: { 'file.txt': 'commit1\n' } },
+        ]);
+
+        const uri = getUri('file.txt', ids.commit1.changeId);
+        const writePromise = provider.writeFile(uri, Buffer.from('unflushed edit\n', 'utf8'));
+
+        // Dispose immediately while debounce timer is active
+        provider.dispose();
+
+        await expect(writePromise).rejects.toThrow('JjEditFsService disposed');
+    });
+
+    it('handles reading and writing in a subfolder workspace', async () => {
+        const subDir = path.join(repo.path, 'nested', 'pkg');
+        fs.mkdirSync(subDir, { recursive: true });
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'nested/pkg/file.txt': 'sub initial\n' } },
+            { label: 'commit1', parents: ['base'], files: { 'nested/pkg/file.txt': 'sub commit1\n' } },
+        ]);
+
+        const fragmentParams = new URLSearchParams();
+        fragmentParams.set('root', subDir);
+        fragmentParams.set('revision', ids.commit1.changeId);
+
+        const subUri = Uri.from({
+            scheme: 'jj-edit',
+            path: '/file.txt',
+            fragment: fragmentParams.toString(),
+        });
+
+        // Read through provider
+        const readData = await provider.readFile(subUri);
+        expect(Buffer.from(readData).toString('utf8')).toBe('sub commit1\n');
+
+        // Write through provider
+        await provider.writeFile(subUri, Buffer.from('sub updated\n', 'utf8'));
+
+        const savedContent = repo.getFileContent(ids.commit1.changeId, 'nested/pkg/file.txt');
+        expect(savedContent).toBe('sub updated\n');
+    });
 });

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as fs from 'node:fs';
+import * as cp from 'node:child_process';
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import { JjService, NO_OP_LOGGER } from '../jj-service';
@@ -341,9 +344,9 @@ describe('JjService Diff Tests', () => {
         expect(cache.tempDir).toBeDefined();
 
         // Check contents in cache
-        const left = (p: string) => fs.readFileSync(path.join(cache.tempDir, 'left', p), 'utf8');
-        const right = (p: string) => fs.readFileSync(path.join(cache.tempDir, 'right', p), 'utf8');
-        const exists = (dir: 'left' | 'right', p: string) => fs.existsSync(path.join(cache.tempDir, dir, p));
+        const left = (p: string) => fsSync.readFileSync(path.join(cache.tempDir, 'left', p), 'utf8');
+        const right = (p: string) => fsSync.readFileSync(path.join(cache.tempDir, 'right', p), 'utf8');
+        const exists = (dir: 'left' | 'right', p: string) => fsSync.existsSync(path.join(cache.tempDir, dir, p));
 
         expect(left('mod.txt')).toBe('old\n');
         expect(right('mod.txt')).toBe('new\n');
@@ -476,5 +479,217 @@ describe('JjService Diff Tests', () => {
         expect(updatedChanges.length).toBe(2);
         const paths = updatedChanges.map((c) => c.path).sort();
         expect(paths).toEqual(['extra.txt', 'test.txt']);
+    });
+
+    function generateRealisticCppSource(lineCount = 5500): string {
+        const lines: string[] = [
+            '// Copyright 2026 The Chromium Authors',
+            '// Use of this source code is governed by a BSD-style license that can be',
+            '// found in the LICENSE file.',
+            '',
+            '#include <iostream>',
+            '#include <memory>',
+            '#include <string>',
+            '#include <vector>',
+            '#include <map>',
+            '',
+            'namespace chrome::glic::testing {',
+            '',
+        ];
+
+        let currentClass = 0;
+        while (lines.length < lineCount) {
+            currentClass++;
+            lines.push(`class GlicApiHostHandler_${currentClass} {`);
+            lines.push(' public:');
+            lines.push(`  explicit GlicApiHostHandler_${currentClass}(int id) : id_(id) {}`);
+            lines.push(`  virtual ~GlicApiHostHandler_${currentClass}() = default;`);
+            lines.push('');
+            lines.push(`  int GetHandlerId() const { return id_; }`);
+            lines.push(`  std::string ComputeSignature(const std::string& input) const {`);
+            lines.push(`    return "handler_" + std::to_string(id_) + "_" + input;`);
+            lines.push('  }');
+            lines.push('');
+            lines.push(' protected:');
+            lines.push(`  void HandleMessage(const std::string& type, const std::vector<uint8_t>& payload) {`);
+            lines.push(`    // Processing message type: ${currentClass}`);
+            lines.push('    if (type.empty()) {');
+            lines.push('      return;');
+            lines.push('    }');
+            lines.push('    payload_cache_[type] = payload;');
+            lines.push('  }');
+            lines.push('');
+            lines.push(' private:');
+            lines.push('  int id_;');
+            lines.push('  std::map<std::string, std::vector<uint8_t>> payload_cache_;');
+            lines.push('};');
+            lines.push('');
+        }
+
+        lines.push('} // namespace chrome::glic::testing');
+        return lines.join('\n');
+    }
+
+    test('large file diff and setFilesContent', async () => {
+        const originalContent = generateRealisticCppSource(5500);
+        const lines = originalContent.split('\n');
+        lines[1500] = '  // MODIFIED IN CHILD AT 1500: Updated signature algorithm';
+        lines[3500] = '    // MODIFIED IN CHILD AT 3500: Added payload validation check';
+        const modifiedContent = lines.join('\n');
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'large_file.cc': originalContent } },
+            { label: 'child', parents: ['base'], files: { 'large_file.cc': modifiedContent } },
+        ]);
+
+        const diff = await jjService.getDiffContent(ids.child.commitId, 'large_file.cc');
+        expect(diff.left).toBe(originalContent);
+        expect(diff.right).toBe(modifiedContent);
+
+        // Now modify and setFilesContent
+        lines[2500] = '  // MODIFIED VIA SETFILESCONTENT: Injected telemetry handler';
+        const newContent = lines.join('\n');
+        await jjService.setFilesContent(ids.child.changeId, new Map([['large_file.cc', newContent]]));
+
+        const saved = repo.getFileContent(ids.child.changeId, 'large_file.cc');
+        expect(saved).toBe(newContent);
+    });
+
+    test('setFilesContent works in a subfolder workspace', async () => {
+        const subDir = path.join(repo.path, 'subfolder');
+        fsSync.mkdirSync(subDir, { recursive: true });
+
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'subfolder/file.txt': 'initial sub' } },
+            { label: 'child', parents: ['base'], files: { 'subfolder/file.txt': 'mod sub' } },
+        ]);
+
+        const subfolderJjService = new JjService(subDir, NO_OP_LOGGER);
+        await subfolderJjService.setFilesContent(
+            ids.child.changeId,
+            new Map([['file.txt', 'updated from subfolder service']]),
+        );
+
+        const saved = repo.getFileContent(ids.child.changeId, 'subfolder/file.txt');
+        expect(saved).toBe('updated from subfolder service');
+    });
+
+    test('getDiffForRevision throws and does not cache when revision is invalid or diff extraction fails', async () => {
+        await expect(jjService.getDiffForRevision('non-existent-rev-12345')).rejects.toThrow();
+
+        // Ensure invalid cache entry was not stored
+        const invalidCache = await jjService.getDiffForRevision('non-existent-rev-12345').catch(() => null);
+        expect(invalidCache).toBeNull();
+    });
+
+    test('setFilesContent handles file paths with potential temp slug collisions', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'a/b_c.txt': 'initial 1', 'a_b/c.txt': 'initial 2' } },
+            { label: 'child', parents: ['base'], files: { 'a/b_c.txt': 'child 1', 'a_b/c.txt': 'child 2' } },
+        ]);
+
+        const filesToEdit = new Map([
+            ['a/b_c.txt', 'updated a/b_c'],
+            ['a_b/c.txt', 'updated a_b/c'],
+        ]);
+
+        await jjService.setFilesContent(ids.child.changeId, filesToEdit);
+
+        expect(repo.getFileContent(ids.child.changeId, 'a/b_c.txt')).toBe('updated a/b_c');
+        expect(repo.getFileContent(ids.child.changeId, 'a_b/c.txt')).toBe('updated a_b/c');
+    });
+
+    test('setFilesContent with empty map is a no-op', async () => {
+        const ids = await buildGraph(repo, [{ label: 'base', files: { 'file.txt': 'hello' } }]);
+
+        await expect(jjService.setFilesContent(ids.base.changeId, new Map())).resolves.toBeUndefined();
+    });
+
+    test('mutation automatically invalidates diff and changes cache', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'file.txt': 'initial' } },
+            { label: 'child', parents: ['base'], files: { 'file.txt': 'child v1' } },
+        ]);
+
+        // 1. Warm diff cache
+        const cache1 = await jjService.getDiffForRevision(ids.child.changeId);
+        const rightFile1 = path.join(cache1.tempDir, 'right', 'file.txt');
+        expect(await fs.readFile(rightFile1, 'utf8')).toBe('child v1');
+
+        // 2. Perform a mutation via setFilesContent
+        await jjService.setFilesContent(ids.child.changeId, new Map([['file.txt', 'child v2']]));
+
+        // 3. Next getDiffForRevision should return new cache with updated content
+        const cache2 = await jjService.getDiffForRevision(ids.child.changeId);
+        const rightFile2 = path.join(cache2.tempDir, 'right', 'file.txt');
+        expect(await fs.readFile(rightFile2, 'utf8')).toBe('child v2');
+    });
+
+    test('batch-diff script does not create .complete marker when copy fails', async () => {
+        const scriptPath = path.resolve(__dirname, '../../scripts/batch-diff.sh');
+        if (process.platform === 'win32') {
+            return; // Unix shell script test
+        }
+
+        const tempBase = await fs.mkdtemp(path.join(os.tmpdir(), 'batch-diff-test-'));
+        try {
+            const leftDir = path.join(tempBase, 'left');
+            const rightDir = path.join(tempBase, 'right');
+            const outLeft = path.join(tempBase, 'outLeft');
+            const outRight = path.join(tempBase, 'outRight');
+
+            await fs.mkdir(leftDir, { recursive: true });
+            await fs.mkdir(rightDir, { recursive: true });
+            await fs.writeFile(path.join(rightDir, 'test.txt'), 'content');
+
+            // Make outRight a read-only file (not directory) so mkdir/cp fails
+            await fs.writeFile(outRight, 'blocker', { mode: 0o444 });
+
+            const result = cp.spawnSync('bash', [scriptPath, leftDir, rightDir, outLeft, outRight]);
+            expect(result.status).toBe(1);
+
+            // .complete marker should NOT exist
+            const completeMarker = path.join(outRight, '.complete');
+            await expect(fs.access(completeMarker)).rejects.toThrow();
+        } finally {
+            await fs.rm(tempBase, { recursive: true, force: true }).catch(() => {});
+        }
+    });
+
+    test('batch-diff script successfully copies clean directory structure and writes .complete marker', async () => {
+        const scriptPath = path.resolve(__dirname, '../../scripts/batch-diff.sh');
+        if (process.platform === 'win32') {
+            return; // Unix shell script test
+        }
+
+        const tempBase = await fs.mkdtemp(path.join(os.tmpdir(), 'batch-diff-success-'));
+        try {
+            const leftDir = path.join(tempBase, 'left');
+            const rightDir = path.join(tempBase, 'right');
+            const outLeft = path.join(tempBase, 'outLeft');
+            const outRight = path.join(tempBase, 'outRight');
+
+            await fs.mkdir(path.join(leftDir, 'nested'), { recursive: true });
+            await fs.mkdir(path.join(rightDir, 'nested'), { recursive: true });
+            await fs.writeFile(path.join(leftDir, 'nested', 'left.txt'), 'left content');
+            await fs.writeFile(path.join(rightDir, 'nested', 'right.txt'), 'right content');
+
+            const result = cp.spawnSync('bash', [scriptPath, leftDir, rightDir, outLeft, outRight]);
+            expect(result.status).toBe(1); // Exits 1 intentionally
+
+            // .complete marker must exist
+            const completeMarker = path.join(outRight, '.complete');
+            await expect(fs.access(completeMarker)).resolves.toBeUndefined();
+
+            // Content must match
+            expect(await fs.readFile(path.join(outLeft, 'nested', 'left.txt'), 'utf8')).toBe('left content');
+            expect(await fs.readFile(path.join(outRight, 'nested', 'right.txt'), 'utf8')).toBe('right content');
+
+            // Must NOT have copied parent directory contents
+            expect(await fs.access(path.join(outRight, 'right')).catch(() => false)).toBe(false);
+            expect(await fs.access(path.join(outRight, 'left')).catch(() => false)).toBe(false);
+        } finally {
+            await fs.rm(tempBase, { recursive: true, force: true }).catch(() => {});
+        }
     });
 });

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -5,6 +5,8 @@
 import { vi } from 'vitest';
 import type * as vscode from 'vscode';
 
+import { Uri } from '../uri-utils';
+
 let activeTextEditorState: unknown;
 
 /**
@@ -12,51 +14,6 @@ let activeTextEditorState: unknown;
  */
 export function setActiveTextEditor(editor: Partial<vscode.TextEditor> | undefined): void {
     activeTextEditorState = editor;
-}
-
-/**
- * Helper to parse a URI string into components for MockUri.
- * Example inputs:
- * - "jj-edit:///foo/bar.txt?revision=@" -> scheme="jj-edit", path="/foo/bar.txt", query="revision=@"
- * - "jj-edit://foo/bar.txt?revision=@" -> scheme="jj-edit", path="foo/bar.txt", query="revision=@"
- * - "/foo/bar.txt" -> scheme="file", path="/foo/bar.txt", query=""
- * - "file:///foo/bar.txt#frag" -> scheme="file", path="/foo/bar.txt", query=""
- */
-function parseUriString(uriString: string): { scheme: string; path: string; query: string; fragment: string } {
-    let scheme = 'file';
-    let rest = uriString;
-
-    const schemeMatch = uriString.match(/^([a-zA-Z0-9.+-]+):\/\/(.*)$/);
-    if (schemeMatch) {
-        scheme = schemeMatch[1];
-        rest = schemeMatch[2];
-    }
-
-    // Parse fragment
-    const hashIndex = rest.indexOf('#');
-    let fragment = '';
-    if (hashIndex !== -1) {
-        fragment = rest.substring(hashIndex + 1);
-        rest = rest.substring(0, hashIndex);
-    }
-
-    // Parse query
-    const queryIndex = rest.indexOf('?');
-    let query = '';
-    let pathPart = rest;
-    if (queryIndex !== -1) {
-        pathPart = rest.substring(0, queryIndex);
-        query = rest.substring(queryIndex + 1);
-    }
-
-    let decodedPath = pathPart;
-    try {
-        decodedPath = decodeURIComponent(pathPart);
-    } catch {
-        // Fallback
-    }
-
-    return { scheme, path: decodedPath, query, fragment };
 }
 
 /**
@@ -170,66 +127,6 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         }
     }
 
-    class MockUri {
-        constructor(
-            public fsPath: string,
-            public scheme: string = 'file',
-            public query: string = '',
-            public path: string = fsPath,
-            public fragment: string = '',
-        ) {
-            if (process.platform === 'win32') {
-                this.fsPath = this.fsPath.replace(/\//g, '\\');
-                // Strip leading backslash if it precedes a drive letter (e.g., \C:\... -> C:\...)
-                if (/^\\[a-zA-Z]:\\/.test(this.fsPath)) {
-                    this.fsPath = this.fsPath.substring(1);
-                }
-                if (/^[a-zA-Z]:\\/.test(this.fsPath)) {
-                    this.fsPath = this.fsPath[0].toLowerCase() + this.fsPath.substring(1);
-                }
-                // For VS Code URIs on Windows, path should always use forward slashes.
-                // If it has a drive letter, it starts with a slash (e.g. /c:/...).
-                let normalizedPath = this.fsPath.replace(/\\/g, '/');
-                if (/^[a-zA-Z]:\//.test(normalizedPath)) {
-                    normalizedPath = `/${normalizedPath}`;
-                }
-                this.path = normalizedPath;
-            }
-        }
-        static file(fsPath: string) {
-            return new MockUri(fsPath);
-        }
-        static from(components: { scheme: string; path: string; query?: string; fragment?: string }) {
-            return new MockUri(
-                components.path,
-                components.scheme,
-                components.query || '',
-                components.path,
-                components.fragment || '',
-            );
-        }
-        static parse(uriString: string) {
-            const parsed = parseUriString(uriString);
-            return new MockUri(parsed.path, parsed.scheme, parsed.query, parsed.path, parsed.fragment);
-        }
-        static joinPath(base: { path: string; scheme: string }, ...paths: string[]) {
-            const combined = [base.path, ...paths].join('/').replace(/\/+/g, '/');
-            return new MockUri(combined, base.scheme, '', combined);
-        }
-        toString() {
-            return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}${this.fragment ? `#${this.fragment}` : ''}`;
-        }
-        with(change: { scheme?: string; query?: string; fragment?: string }) {
-            return new MockUri(
-                this.fsPath,
-                change.scheme ?? this.scheme,
-                change.query ?? this.query,
-                this.path,
-                change.fragment ?? this.fragment,
-            );
-        }
-    }
-
     enum CommentThreadCollapsibleState {
         Collapsed = 0,
         Expanded = 1,
@@ -298,9 +195,9 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         ) {}
     }
 
-    let mockWorkspaceFolders: { uri: MockUri; name: string; index: number }[] = [
+    let mockWorkspaceFolders: { uri: Uri; name: string; index: number }[] = [
         {
-            uri: new MockUri('/root'),
+            uri: Uri.file('/root'),
             name: 'mock-folder',
             index: 0,
         },
@@ -337,7 +234,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
         },
         FileSystemError,
 
-        Uri: MockUri,
+        Uri,
         TabInputTextDiff: class MockTabInputTextDiff {
             constructor(
                 public original: unknown,
@@ -421,7 +318,7 @@ export function createVscodeMock(overrides: Record<string, unknown> = {}): Recor
                     (
                         start: number,
                         deleteCount: number | undefined | null,
-                        ...workspaceFoldersToAdd: { uri: MockUri; name?: string }[]
+                        ...workspaceFoldersToAdd: { uri: Uri; name?: string }[]
                     ) => {
                         const added = workspaceFoldersToAdd.map((f, i) => ({
                             uri: f.uri,

--- a/src/vscode/providers/vscode-edit-fs-provider.ts
+++ b/src/vscode/providers/vscode-edit-fs-provider.ts
@@ -23,7 +23,7 @@ export class VsCodeEditFsProvider implements vscode.FileSystemProvider, vscode.D
             this.service.onDidChangeFile((uris) => {
                 const events: vscode.FileChangeEvent[] = uris.map((uri) => ({
                     type: vscode.FileChangeType.Changed,
-                    uri: uri as unknown as vscode.Uri,
+                    uri: vscode.Uri.parse(uri.toString()),
                 }));
                 this._onDidChangeFile.fire(events);
             }),
@@ -89,6 +89,7 @@ export class VsCodeEditFsProvider implements vscode.FileSystemProvider, vscode.D
     }
 
     dispose(): void {
+        this.service.dispose();
         this._onDidChangeFile.dispose();
         for (const d of this._disposables) {
             d.dispose();


### PR DESCRIPTION


Resolve file corruption and synchronization mismatches when saving editable diffs on ancestor commits and large files. Ensure pending in-memory writes are returned during active flushes, serialize batch edit flushes to eliminate race conditions, and fix directory copying in diff extraction scripts to prevent recursive parent inclusion. Distinguish repository-relative target paths from workspace-relative filter arguments, verify diff extraction completion with sentinel markers, and exhaustively validate multi-hunk edits on multi-thousand line files.

Speculative changes to address #443