### PR TITLE
logging: unify logging interfaces under canonical LoggerChannel

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -12,6 +12,7 @@ This document outlines the coding standards, testing strategies, and architectur
 - **Forbidden**: disabling the `any` type check for a line or block. `// @ts-ignore` or `// eslint-disable-line` are not allowed.
 - **Forbidden**: `as unknown as Type` double casting. Use `createMock` utility or proper type narrowing instead.
 - **Early Returns**: Always prefer early returns / guard clauses to avoid deeply nested blocks of conditional logic. Check error or mismatch conditions first, return early, and keep the primary execution path unindented.
+- **No Omnibus Union Parameters**: Avoid polymorphic argument unions (e.g. `param: TypeA | TypeB`, `optionsOrAction?: Options | string`, or `messageOrError: string | Error`) that change parameter semantics based on runtime type checks. Instead, use explicit, separate parameters, dedicated method names, or a clean options object. Every parameter in a function signature must have a single, unambiguous purpose.
 - **Imports**: All imports (static or dynamic) should be placed at the top of the file. Avoid inline/local dynamic `await import(...)` statements inside functions, classes, or test cases unless strictly necessary (e.g., to break circular dependencies or for conditional loading).
 ### Target Environment
 

--- a/docs/plans/host-abstractions-and-standalone-plan.md
+++ b/docs/plans/host-abstractions-and-standalone-plan.md
@@ -83,7 +83,7 @@ Consolidate all environment capabilities into canonical, reusable interfaces loc
    - View registry: `registerWebviewProvider`, `registerEditorProvider`, `registerFileSystemProvider`, `registerDecorationProvider`.
 10. **`AppContext` & `RepoContext`**:
     - `AppContext`: Global application state (`host: HostEnvironment`, `repositoryManager: JjRepositoryManager`, `codeForgeRegistry: CodeForgeRegistry`, `authManager: CodeForgeAuthManager`, `processTracker: JjProcessTracker`).
-    - `RepoContext`: Repository-scoped execution context passed to commands, containing `{ repo: JjRepository; host: HostEnvironment; log: JjLoggerChannel; comments?: CommentsManager }` with convenience accessors `ui`, `nav`, `config`, `documents`.
+    - `RepoContext`: Repository-scoped execution context passed to commands, containing `{ repo: JjRepository; host: HostEnvironment; log: LoggerChannel; comments?: CommentsManager }` with convenience accessors `ui`, `nav`, `config`, `documents`.
 
 #### Migration Steps for Phase 1:
 - Replace `CommandContext` with `RepoContext` across all command signatures in `src/commands/*.ts`.

--- a/src/change-detection-manager.ts
+++ b/src/change-detection-manager.ts
@@ -11,7 +11,7 @@ import { DirectoryWatcher } from './directory-watcher';
 import type { JjService } from './jj-service';
 import { Poller } from './poller';
 import { getJjViewConfig } from './utils/config-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export class ChangeDetectionManager implements vscode.Disposable {
     private _disposed = false;
@@ -63,7 +63,7 @@ export class ChangeDetectionManager implements vscode.Disposable {
     constructor(
         private workspaceRoot: string,
         private jj: JjService,
-        private outputChannel: JjLoggerChannel,
+        private outputChannel: LoggerChannel,
         private triggerRefresh: (event: { forceSnapshot: boolean; reason: string }) => Promise<void>,
         private readonly watcherBackend?: BackendType,
     ) {

--- a/src/code-forge-auth.ts
+++ b/src/code-forge-auth.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import type { AuthManageItem } from './code-forge-provider';
 import { type Disposable, type Event, EventEmitter } from './common/events';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export type AuthToken = string;
 
@@ -40,7 +40,7 @@ export class CodeForgeAuthManager implements Disposable {
 
     constructor(
         private readonly context: vscode.ExtensionContext,
-        private readonly outputChannel?: JjLoggerChannel,
+        private readonly outputChannel?: LoggerChannel,
     ) {}
 
     public dispose(): void {

--- a/src/code-forge-provider-factory.ts
+++ b/src/code-forge-provider-factory.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { CodeForgeProvider } from './code-forge-provider';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export interface CodeForgeProviderFactory {
     readonly id: string;
-    create(outputChannel?: JjLoggerChannel): CodeForgeProvider;
+    create(outputChannel?: LoggerChannel): CodeForgeProvider;
 }

--- a/src/code-forge-service.ts
+++ b/src/code-forge-service.ts
@@ -10,7 +10,7 @@ import { type Disposable, disposeSafely, type Event, EventEmitter } from './comm
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo, CommitParent, JjLogEntry } from './jj-types';
 import { getJjViewConfig } from './utils/config-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 import { TimerBucket } from './utils/timer-bucket';
 
 export class CodeForgeService implements Disposable {
@@ -38,7 +38,7 @@ export class CodeForgeService implements Disposable {
         public readonly workspaceRoot: string,
         private jjService: JjService,
         private registry: CodeForgeRegistry,
-        private outputChannel?: JjLoggerChannel,
+        private outputChannel?: LoggerChannel,
     ) {
         for (const factory of this.registry.getFactories()) {
             this.providers.set(factory.id, factory.create(this.outputChannel));

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -285,12 +285,7 @@ export function extractFileUri(args: unknown[]): Uri | undefined {
     return extractUriFromArgs(args);
 }
 
-export function getErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-    return String(error);
-}
+export { getErrorMessage, toError } from '../utils/error-utils';
 
 export const RevisionQuery = {
     Parents: 'parents(@)',

--- a/src/common/command-context.ts
+++ b/src/common/command-context.ts
@@ -4,7 +4,7 @@
  */
 import type { CommentsManager } from '../comments-manager';
 import type { JjRepository } from '../jj-repository';
-import type { JjLoggerChannel } from '../utils/output-channel';
+import type { LoggerChannel } from '../utils/output-channel';
 import type { HostEnvironment } from './host-environment';
 
 export interface CommandServices {
@@ -14,6 +14,6 @@ export interface CommandServices {
 export interface CommandContext {
     readonly repo: JjRepository;
     readonly host: HostEnvironment;
-    readonly log: JjLoggerChannel;
+    readonly log: LoggerChannel;
     readonly services?: CommandServices;
 }

--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -4,6 +4,9 @@
  */
 import { z } from 'zod';
 
+import { toError } from '../utils/error-utils';
+import type { LoggerChannel } from '../utils/output-channel';
+
 export type DiscriminatedMessage<K extends string = 'type'> = {
     [P in K]: string;
 };
@@ -12,15 +15,9 @@ export type MessageHandlerMap<TMessage extends DiscriminatedMessage<K>, K extend
     [V in TMessage[K]]?: (message: Extract<TMessage, Record<K, V>>) => unknown | Promise<unknown>;
 };
 
-export interface LoggerLike {
-    info?(message: string, ...args: unknown[]): void;
-    warn?(message: string, ...args: unknown[]): void;
-    error(message: string, ...args: unknown[]): void;
-}
-
 export interface WebviewRpcDispatcherOptions<K extends string = 'type'> {
     discriminatorKey?: K;
-    logger?: LoggerLike;
+    logger?: LoggerChannel;
     messenger?: WebviewPostMessageLike;
     onError?: (error: unknown, rawMessage: unknown) => void;
 }
@@ -62,6 +59,13 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
         return new Promise((resolve, reject) => {
             this.pendingRequests.set(requestId, { resolve, reject });
         });
+    }
+
+    public dispose(): void {
+        for (const pending of this.pendingRequests.values()) {
+            pending.reject(new Error('WebviewRpcDispatcher disposed'));
+        }
+        this.pendingRequests.clear();
     }
 
     private handleRpcResponse(rawMessage: unknown): boolean {
@@ -143,15 +147,15 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
                 }
                 return true;
             } catch (err) {
-                const errorMessage = err instanceof Error ? err.message : String(err);
-                this.options?.logger?.error(`Webview RPC handler error (${String(typeValue)})`, err);
+                const error = toError(err);
+                this.options?.logger?.error(`Webview RPC handler error (${String(typeValue)})`, error);
                 this.options?.onError?.(err, rawMessage);
 
                 if (requestId && this.options?.messenger) {
                     this.options.messenger.postMessage({
                         type: '__rpc_response__',
                         requestId,
-                        error: errorMessage,
+                        error: error.message,
                     });
                 }
                 return false;

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -5,18 +5,19 @@
 
 import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
-import { WebviewToHostMessageSchema } from '../common/ipc-schemas';
+import { type WebviewToHostMessage, WebviewToHostMessageSchema } from '../common/ipc-schemas';
 import {
     createWebviewRpcDispatcher,
-    type LoggerLike,
     type WebviewPostMessageLike,
     type WebviewRpcDispatcher,
 } from '../common/webview-rpc-dispatcher';
 import type { JjRepository } from '../jj-repository';
 import type { JjLogEntry, JjStatusEntry, WebviewPayload } from '../jj-types';
+import { toError } from '../utils/error-utils';
+import type { LoggerChannel } from '../utils/output-channel';
 
 export interface CommitDetailsControllerOptions {
-    logger?: LoggerLike;
+    logger?: LoggerChannel;
     onEditRecorded?: (edit: { undo: () => void; redo: () => void; label: string }) => void;
     openDiff?: (payload: { file: JjStatusEntry; changeId: string; isImmutable?: boolean }) => Promise<void> | void;
 }
@@ -26,8 +27,8 @@ export class CommitDetailsController implements Disposable {
     private readonly _disposables: Disposable[] = [];
     private readonly _messengers = new Set<WebviewPostMessageLike>();
     private _loadVersion = 0;
-    private readonly _logger?: LoggerLike;
-    private readonly _dispatcher: WebviewRpcDispatcher<import('../common/ipc-schemas').WebviewToHostMessage>;
+    private readonly _logger?: LoggerChannel;
+    private readonly _dispatcher: WebviewRpcDispatcher<WebviewToHostMessage>;
 
     private _logEntry?: JjLogEntry;
     private _changes?: readonly JjStatusEntry[];
@@ -178,7 +179,7 @@ export class CommitDetailsController implements Disposable {
 
             return log;
         } catch (err) {
-            this._logger?.error(`[CommitDetailsController] Failed to load commit ${this.changeId}: ${err}`);
+            this._logger?.error(`[CommitDetailsController] Failed to load commit ${this.changeId}`, toError(err));
             return undefined;
         }
     }
@@ -287,7 +288,7 @@ export class CommitDetailsController implements Disposable {
             });
             return true;
         } catch (err) {
-            this._logger?.error(`[CommitDetailsController] Failed to save commit ${this.changeId}: ${err}`);
+            this._logger?.error(`[CommitDetailsController] Failed to save commit ${this.changeId}`, toError(err));
             this.broadcast({ type: 'saveFailed' });
             await this._host.ui.showError(err, 'Failed to save commit description');
             return false;
@@ -302,12 +303,12 @@ export class CommitDetailsController implements Disposable {
             try {
                 messenger.postMessage(message);
             } catch (e) {
-                this._logger?.error(`[CommitDetailsController] Failed to post message: ${e}`);
+                this._logger?.error('[CommitDetailsController] Failed to post message', toError(e));
             }
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<import('../common/ipc-schemas').WebviewToHostMessage> {
+    private _createRpcDispatcher(): WebviewRpcDispatcher<WebviewToHostMessage> {
         return createWebviewRpcDispatcher(
             WebviewToHostMessageSchema,
             {
@@ -358,5 +359,6 @@ export class CommitDetailsController implements Disposable {
         this._messengers.clear();
         this._onDidUpdate.dispose();
         this._onDidClose.dispose();
+        this._dispatcher.dispose();
     }
 }

--- a/src/controllers/log-view-controller.ts
+++ b/src/controllers/log-view-controller.ts
@@ -5,10 +5,9 @@
 
 import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
-import { WebviewToHostMessageSchema } from '../common/ipc-schemas';
+import { type WebviewToHostMessage, WebviewToHostMessageSchema } from '../common/ipc-schemas';
 import {
     createWebviewRpcDispatcher,
-    type LoggerLike,
     type WebviewPostMessageLike,
     type WebviewRpcDispatcher,
 } from '../common/webview-rpc-dispatcher';
@@ -17,11 +16,13 @@ import type { JjRepository } from '../jj-repository';
 import type { JjService } from '../jj-service';
 import { type JjLogEntry, TOGGLEABLE_COMMIT_ACTIONS, type ToggleableCommitAction } from '../jj-types';
 import { CoalescingQueue } from '../utils/coalescing-queue';
+import { toError } from '../utils/error-utils';
 import { canAbsorbCommit } from '../utils/jj-utils';
+import type { LoggerChannel } from '../utils/output-channel';
 
 export interface LogViewControllerOptions {
     messenger?: WebviewPostMessageLike;
-    logger?: LoggerLike;
+    logger?: LoggerChannel;
     onSelectionChange?: (commitIds: string[]) => void;
     closeCommitDetailsTabs?: (predicate: (repoRoot?: string) => boolean) => Promise<void> | void;
 }
@@ -32,8 +33,8 @@ export class LogViewController implements Disposable {
     private readonly _disposables: Disposable[] = [];
     private _codeForgeDisposable: Disposable | undefined;
     private _messenger?: WebviewPostMessageLike;
-    private readonly _logger?: LoggerLike;
-    private readonly _dispatcher: WebviewRpcDispatcher<import('../common/ipc-schemas').WebviewToHostMessage>;
+    private readonly _logger?: LoggerChannel;
+    private readonly _dispatcher: WebviewRpcDispatcher<WebviewToHostMessage>;
     private readonly _refreshQueue: CoalescingQueue;
 
     private _commits: readonly JjLogEntry[] = [];
@@ -149,12 +150,12 @@ export class LogViewController implements Disposable {
         const cf = repo.codeForge;
         this._codeForgeDisposable = cf.onDidUpdate(() => {
             this.refreshCodeForge().catch((e) => {
-                this._logger?.error(`[LogViewController] CodeForge update failed: ${e}`);
+                this._logger?.error('[LogViewController] CodeForge update failed', toError(e));
             });
         });
 
         cf.detectActiveProvider(true).catch((e) => {
-            this._logger?.error(`Code forge detection failed: ${e}`);
+            this._logger?.error('Code forge detection failed', toError(e));
         });
     }
 
@@ -207,12 +208,12 @@ export class LogViewController implements Disposable {
 
             this.setCommits(commits);
         } catch (e) {
-            this._logger?.error(`[LogViewController] Failed to fetch log: ${e}`);
+            this._logger?.error('[LogViewController] Failed to fetch log', toError(e));
             return;
         }
 
         this.refreshCodeForge().catch((e) => {
-            this._logger?.error(`[LogViewController] Background refreshCodeForge failed: ${e}`);
+            this._logger?.error('[LogViewController] Background refreshCodeForge failed', toError(e));
         });
     }
 
@@ -358,7 +359,7 @@ export class LogViewController implements Disposable {
                 this.setCommits(this._commits);
             }
         } catch (e) {
-            this._logger?.error(`[LogViewController] CodeForge refresh failed: ${e}`);
+            this._logger?.error('[LogViewController] CodeForge refresh failed', toError(e));
         }
     }
 
@@ -383,7 +384,7 @@ export class LogViewController implements Disposable {
             try {
                 this._messenger.postMessage(message);
             } catch (e) {
-                this._logger?.error(`[LogViewController] Failed to post message: ${e}`);
+                this._logger?.error('[LogViewController] Failed to post message', toError(e));
             }
         }
     }
@@ -408,7 +409,7 @@ export class LogViewController implements Disposable {
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<import('../common/ipc-schemas').WebviewToHostMessage> {
+    private _createRpcDispatcher(): WebviewRpcDispatcher<WebviewToHostMessage> {
         return createWebviewRpcDispatcher(
             WebviewToHostMessageSchema,
             {
@@ -427,7 +428,7 @@ export class LogViewController implements Disposable {
                             this._logger?.error(`[LogViewController] Blocked insecure scheme: ${parsed.protocol}`);
                         }
                     } catch (e) {
-                        this._logger?.error(`[LogViewController] Invalid URL: ${msg.payload.url}, ${e}`);
+                        this._logger?.error(`[LogViewController] Invalid URL: ${msg.payload.url}`, toError(e));
                     }
                 },
                 newChild: async (msg) => {
@@ -601,5 +602,6 @@ export class LogViewController implements Disposable {
         this._disposables.length = 0;
         this._onDidUpdateCommits.dispose();
         this._onDidChangeSelection.dispose();
+        this._dispatcher.dispose();
     }
 }

--- a/src/controllers/process-monitor-controller.ts
+++ b/src/controllers/process-monitor-controller.ts
@@ -8,7 +8,6 @@ import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
 import {
     createWebviewRpcDispatcher,
-    type LoggerLike,
     type WebviewPostMessageLike,
     type WebviewRpcDispatcher,
 } from '../common/webview-rpc-dispatcher';
@@ -19,6 +18,7 @@ import {
     type JjProcessTracker,
 } from '../jj-process-tracker';
 import { CoalescingQueue } from '../utils/coalescing-queue';
+import type { LoggerChannel } from '../utils/output-channel';
 
 export const ProcessMonitorToHostMessageSchema = z.discriminatedUnion('command', [
     z.object({ command: z.literal('killProcess'), id: z.number() }),
@@ -30,14 +30,14 @@ export type ProcessMonitorToHostMessage = z.infer<typeof ProcessMonitorToHostMes
 
 export interface ProcessMonitorControllerOptions {
     messenger?: WebviewPostMessageLike;
-    logger?: LoggerLike;
+    logger?: LoggerChannel;
 }
 
 export class ProcessMonitorController implements Disposable {
     private _disposed = false;
     private readonly _disposables: Disposable[] = [];
     private _messenger?: WebviewPostMessageLike;
-    private readonly _logger?: LoggerLike;
+    private readonly _logger?: LoggerChannel;
     private readonly _updateQueue: CoalescingQueue;
     private readonly _dispatcher: WebviewRpcDispatcher<ProcessMonitorToHostMessage, 'command'>;
 

--- a/src/diff-tab-cleaner.ts
+++ b/src/diff-tab-cleaner.ts
@@ -9,7 +9,8 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 import type { JjService } from './jj-service';
 import { getRevisionFromUri, isJjScheme, type Uri } from './uri-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import { toError } from './utils/error-utils';
+import type { LoggerChannel } from './utils/output-channel';
 
 interface CollectedTabs {
     uniqueRevisions: Set<string>;
@@ -23,7 +24,7 @@ export class DiffTabCleaner {
     constructor(
         private readonly jj: JjService,
         private readonly belongsToRepo: (uri: Uri) => boolean,
-        private readonly outputChannel?: JjLoggerChannel,
+        private readonly outputChannel?: LoggerChannel,
     ) {}
 
     /**
@@ -45,7 +46,7 @@ export class DiffTabCleaner {
 
             this.closeTabs(tabsToClose);
         } catch (err) {
-            this.outputChannel?.error(`[DiffTabCleaner] Failed to check/close invalid diff editors: ${err}`);
+            this.outputChannel?.error('[DiffTabCleaner] Failed to check/close invalid diff editors', toError(err));
         }
     }
 
@@ -199,7 +200,7 @@ export class DiffTabCleaner {
     private closeTabs(tabs: vscode.Tab[]): void {
         tabs.forEach((tab) => {
             vscode.window.tabGroups.close(tab).then(undefined, (err) => {
-                this.outputChannel?.error(`[DiffTabCleaner] Failed to close tab: ${err}`);
+                this.outputChannel?.error('[DiffTabCleaner] Failed to close tab', toError(err));
             });
         });
     }

--- a/src/directory-watcher.ts
+++ b/src/directory-watcher.ts
@@ -7,7 +7,8 @@ import { type AsyncSubscription, type BackendType, type Event, subscribe } from 
 import * as vscode from 'vscode';
 import { Uri } from './uri-utils';
 import { isWatchmanAvailable } from './utils/binary-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import { toError } from './utils/error-utils';
+import type { LoggerChannel } from './utils/output-channel';
 
 export type DirectoryWatcherCallback = (events: Event[]) => void;
 
@@ -21,7 +22,7 @@ export class DirectoryWatcher implements vscode.Disposable {
     constructor(
         private readonly path: string,
         private readonly callback: DirectoryWatcherCallback,
-        private readonly outputChannel: JjLoggerChannel,
+        private readonly outputChannel: LoggerChannel,
         private readonly name: string = 'DirectoryWatcher',
         backend?: BackendType,
     ) {
@@ -64,7 +65,7 @@ export class DirectoryWatcher implements vscode.Disposable {
                     this.path,
                     (err, events) => {
                         if (err) {
-                            this.log(`[${this.name}] Error: ${err}`);
+                            this.logError(`[${this.name}] Error`, err);
                             return;
                         }
                         if (events.length > 0) {
@@ -83,7 +84,7 @@ export class DirectoryWatcher implements vscode.Disposable {
                 this._subscription = sub;
                 this.log(`[${this.name}] Started.`);
             } catch (err) {
-                this.log(`[${this.name}] Failed to start: ${err}`);
+                this.logError(`[${this.name}] Failed to start`, err);
                 const errorMessage = err instanceof Error ? err.message : String(err);
                 if (
                     errorMessage.includes('inotify_add_watch') ||
@@ -121,7 +122,7 @@ export class DirectoryWatcher implements vscode.Disposable {
             try {
                 await this._subscription.unsubscribe();
             } catch (err) {
-                this.log(`[${this.name}] Failed to unsubscribe: ${err}`);
+                this.logError(`[${this.name}] Failed to unsubscribe`, err);
             }
             this._subscription = undefined;
         }
@@ -141,6 +142,17 @@ export class DirectoryWatcher implements vscode.Disposable {
         }
         try {
             this.outputChannel.info(message);
+        } catch {
+            // Ignore errors if channel is closed/disposed
+        }
+    }
+
+    private logError(message: string, err?: unknown) {
+        if (this._disposed) {
+            return;
+        }
+        try {
+            this.outputChannel.error(message, err !== undefined ? toError(err) : undefined);
         } catch {
             // Ignore errors if channel is closed/disposed
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,8 @@ import { JjViewFsService } from './jj-view-fs-service';
 import { getUriParams } from './uri-utils';
 import { resolveJjBinary } from './utils/binary-utils';
 import { getJjViewConfig } from './utils/config-utils';
-import { type JjLoggerChannel, JjOutputChannel } from './utils/output-channel';
+import { toError } from './utils/error-utils';
+import { type LoggerChannel, OutputChannel } from './utils/output-channel';
 import { VsCodeCommentsProvider } from './vscode/providers/vscode-comments-provider';
 import { VsCodeCommitDetailsEditorProvider } from './vscode/providers/vscode-commit-details-editor-provider';
 import { VsCodeEditFsProvider } from './vscode/providers/vscode-edit-fs-provider';
@@ -52,7 +53,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     const folders = vscode.workspace.workspaceFolders || [];
     const workspaceRoot = folders.length > 0 ? folders[0].uri.fsPath : '';
     const realOutputChannel = vscode.window.createOutputChannel('JJ View', { log: true });
-    const outputChannel = new JjOutputChannel(realOutputChannel);
+    const outputChannel = new OutputChannel(realOutputChannel);
     context.subscriptions.push(realOutputChannel);
 
     // Get preferred binary path configuration
@@ -172,7 +173,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                         }
                     })
                     .catch((e: unknown) => {
-                        outputChannel.error(`Failed to refresh after authentication: ${e}`);
+                        outputChannel.error('Failed to refresh after authentication', toError(e));
                     });
             }
         }),
@@ -434,7 +435,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     // SCM Discovery Lifecycle integration
     repositoryManager.onDidOpenRepository((repo) => {
         const repoPrefix = path.basename(repo.rootUri.fsPath);
-        const repoOutputChannel = new JjOutputChannel(realOutputChannel, repoPrefix);
+        const repoOutputChannel = new OutputChannel(realOutputChannel, repoPrefix);
         const scmProvider = new VsCodeScmProvider(
             context,
             repo,
@@ -469,14 +470,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             repositoryManager.focusedRepository?.rootUri.fsPath === repo.rootUri.fsPath
         ) {
             logWebviewProvider.updateRepository(repo).catch((err) => {
-                outputChannel.error(`[Extension] Failed to update webview repository: ${err}`);
+                outputChannel.error('[Extension] Failed to update webview repository', toError(err));
             });
         }
 
         // Fire and forget: check if we should warn about git colocation
-        checkGitColocation(repo.jj).catch((e) =>
-            outputChannel.error(`[Extension] Colocation check failed for ${repoPrefix}: ${e}`),
-        );
+        checkGitColocation(repo.jj).catch((e) => {
+            outputChannel.error(`[Extension] Colocation check failed for ${repoPrefix}`, toError(e));
+        });
     });
 
     repositoryManager.onDidCloseRepository(async (repo) => {
@@ -493,7 +494,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         focusedRepoActiveProviderSub?.dispose();
         if (repo) {
             logWebviewProvider.updateRepository(repo).catch((err) => {
-                outputChannel.error(`[Extension] Failed to update webview repository: ${err}`);
+                outputChannel.error('[Extension] Failed to update webview repository', toError(err));
             });
             const scm = scmProviders.get(repo.rootUri.fsPath);
             if (scm) {
@@ -573,7 +574,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 export function handleTerminalExecution(
     commandLine: string,
     codeForgeService: CodeForgeService,
-    outputChannel: JjLoggerChannel,
+    outputChannel: LoggerChannel,
     scmProvider: VsCodeScmProvider,
 ): boolean {
     const cmd = commandLine.trim();

--- a/src/gerrit-provider.ts
+++ b/src/gerrit-provider.ts
@@ -21,7 +21,7 @@ import { getGerritAuthHeader, resolveGitRoot } from './utils/gerrit-credential-u
 import { detectGerritHost } from './utils/gerrit-host-detection';
 import { resolveGerritChangeKey, stripGerritTrailers } from './utils/gerrit-utils';
 import { convertJjChangeIdToHex } from './utils/jj-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export const GerritFileSchema = z.object({
     status: z.string().optional(),
@@ -111,7 +111,7 @@ export class GerritProvider implements CodeForgeProvider {
     private _onDidUpdate = new EventEmitter<void>();
     public readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
 
-    constructor(private outputChannel?: JjLoggerChannel) {}
+    constructor(private outputChannel?: LoggerChannel) {}
 
     public async detect(repoRoot: string, remotes: GitRemote[]): Promise<boolean> {
         const binaryPath = getJjViewConfig<string>('binaryPath', 'jj') || 'jj';

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -17,7 +17,7 @@ import { type Event, EventEmitter } from './common/events';
 import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export const GitHubPrNodeSchema = z.object({
     id: z.string(),
@@ -169,7 +169,7 @@ export class GitHubProvider implements CodeForgeProvider {
 
     constructor(
         private readonly authManager: CodeForgeAuthManager,
-        private outputChannel?: JjLoggerChannel,
+        private outputChannel?: LoggerChannel,
     ) {
         this.authManager.registerProvider(this.id);
     }

--- a/src/gitlab-provider.ts
+++ b/src/gitlab-provider.ts
@@ -17,7 +17,7 @@ import type { CodeForgeChangeInfo } from './jj-types';
 import { chunkArray } from './utils/array-utils';
 import { getJjViewConfig } from './utils/config-utils';
 import { fetchWithTimeout } from './utils/fetch-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 const GITLAB_EXTENSION_ID = 'gitlab.gitlab-workflow';
 
@@ -107,7 +107,7 @@ export class GitLabProvider implements CodeForgeProvider {
 
     constructor(
         private readonly authManager: CodeForgeAuthManager,
-        private outputChannel?: JjLoggerChannel,
+        private outputChannel?: LoggerChannel,
     ) {
         this.authManager.registerProvider(this.id);
     }

--- a/src/jj-repository-manager.ts
+++ b/src/jj-repository-manager.ts
@@ -15,7 +15,8 @@ import { JjService, NO_OP_LOGGER } from './jj-service';
 import { getFsPathFromUri, getUriParams, Uri } from './uri-utils';
 import { CoalescingQueue } from './utils/coalescing-queue';
 import { getJjViewConfig } from './utils/config-utils';
-import { type JjLoggerChannel, JjOutputChannel } from './utils/output-channel';
+import { toError } from './utils/error-utils';
+import { type LoggerChannel, OutputChannel } from './utils/output-channel';
 
 interface DetectedRepoInfo {
     rootPath: string;
@@ -59,7 +60,7 @@ export class JjRepositoryManager implements vscode.Disposable {
 
     constructor(
         private readonly _codeForgeRegistry: CodeForgeRegistry,
-        private readonly _outputChannel: JjLoggerChannel,
+        private readonly _outputChannel: LoggerChannel,
         private readonly _workspaceState: vscode.Memento,
         initialBinaryPath?: string,
         private readonly _processTracker?: JjProcessTracker,
@@ -82,7 +83,8 @@ export class JjRepositoryManager implements vscode.Disposable {
                     })
                     .catch((err) => {
                         this._outputChannel.error(
-                            `[RepositoryManager] Error checking open editor URI at start: ${err}`,
+                            '[RepositoryManager] Error checking open editor URI at start',
+                            toError(err),
                         );
                     });
             }
@@ -121,7 +123,7 @@ export class JjRepositoryManager implements vscode.Disposable {
                     this.tryAutoSwitch(uri);
                 }
             } catch (err) {
-                this._outputChannel.error(`[RepositoryManager] Error checking active tab URI: ${err}`);
+                this._outputChannel.error('[RepositoryManager] Error checking active tab URI', toError(err));
             }
         };
 
@@ -132,7 +134,7 @@ export class JjRepositoryManager implements vscode.Disposable {
                 this._normalizedWorkspaceFolders = undefined;
                 this._realNormalizedPathCache.clear();
                 this.scanForRepositories().catch((err) => {
-                    this._outputChannel.error(`[RepositoryManager] Error scanning on workspace change: ${err}`);
+                    this._outputChannel.error('[RepositoryManager] Error scanning on workspace change', toError(err));
                 });
             }),
         );
@@ -154,7 +156,7 @@ export class JjRepositoryManager implements vscode.Disposable {
         return this._workspaceState;
     }
 
-    get outputChannel(): JjLoggerChannel {
+    get outputChannel(): LoggerChannel {
         return this._outputChannel;
     }
 
@@ -171,7 +173,8 @@ export class JjRepositoryManager implements vscode.Disposable {
             repo.jj.binaryPath = binPath;
             repo.refresh({ reason: 'binary path set' }).catch((err) => {
                 this._outputChannel.error(
-                    `[RepositoryManager] Failed to refresh repo ${repo.rootUri.fsPath} on binary path change: ${err}`,
+                    `[RepositoryManager] Failed to refresh repo ${repo.rootUri.fsPath} on binary path change`,
+                    toError(err),
                 );
             });
         }
@@ -238,7 +241,10 @@ export class JjRepositoryManager implements vscode.Disposable {
                 const repo = await this.createRepository(item.rootPath, item.storePath);
                 loaded.push(repo);
             } catch (err) {
-                this._outputChannel.error(`[RepositoryManager] Failed to restore cached repo ${item.rootPath}: ${err}`);
+                this._outputChannel.error(
+                    `[RepositoryManager] Failed to restore cached repo ${item.rootPath}`,
+                    toError(err),
+                );
             }
         }
 
@@ -421,7 +427,8 @@ export class JjRepositoryManager implements vscode.Disposable {
                     newRepos.push(repo);
                 } catch (err) {
                     this._outputChannel.error(
-                        `[RepositoryManager] Error creating repository for ${info.rootPath}: ${err}`,
+                        `[RepositoryManager] Error creating repository for ${info.rootPath}`,
+                        toError(err),
                     );
                 }
             }
@@ -715,7 +722,7 @@ export class JjRepositoryManager implements vscode.Disposable {
     private async createRepository(rootPath: string, storePath?: string): Promise<JjRepository> {
         const resolvedStorePath = storePath ?? (await this.resolveStorePath(path.join(rootPath, '.jj', 'repo')));
         const repoPrefix = path.basename(rootPath);
-        const repoOutputChannel = new JjOutputChannel(this._outputChannel, repoPrefix);
+        const repoOutputChannel = new OutputChannel(this._outputChannel, repoPrefix);
         return new JjRepository(
             Uri.file(rootPath),
             resolvedStorePath,

--- a/src/jj-repository.ts
+++ b/src/jj-repository.ts
@@ -14,7 +14,7 @@ import { JjService } from './jj-service';
 import type { Uri } from './uri-utils';
 import { getJjViewConfig } from './utils/config-utils';
 import { DebouncingQueue } from './utils/debouncing-queue';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 interface RefreshPayload {
     forceSnapshot: boolean;
@@ -34,40 +34,15 @@ export class JjRepository implements Disposable {
         public readonly rootUri: Uri,
         public readonly storePath: string,
         registry: CodeForgeRegistry,
-        outputChannel: JjLoggerChannel,
+        outputChannel: LoggerChannel,
         binaryPath?: string,
         processTracker?: JjProcessTracker,
     ) {
-        this._jj = new JjService(
-            rootUri.fsPath,
-            {
-                info: (msg) => {
-                    try {
-                        outputChannel.info(msg);
-                    } catch {}
-                },
-                warn: (msg) => {
-                    try {
-                        outputChannel.warn(msg);
-                    } catch {}
-                },
-                error: (msg) => {
-                    try {
-                        outputChannel.error(msg);
-                    } catch {}
-                },
-                debug: (msg) => {
-                    try {
-                        outputChannel.debug(msg);
-                    } catch {}
-                },
-            },
-            {
-                binaryPath,
-                getConfig: getJjViewConfig,
-                processTracker,
-            },
-        );
+        this._jj = new JjService(rootUri.fsPath, outputChannel, {
+            binaryPath,
+            getConfig: getJjViewConfig,
+            processTracker,
+        });
         this._codeForge = new CodeForgeService(rootUri.fsPath, this._jj, registry, outputChannel);
 
         this._refreshQueue = new DebouncingQueue<RefreshPayload>(

--- a/src/jj-service.ts
+++ b/src/jj-service.ts
@@ -30,6 +30,10 @@ import type { JjBookmark, JjLogEntry, JjStatusEntry, JjWorkspace } from './jj-ty
 import type { SelectionRange } from './patch-helper';
 import * as PatchHelper from './patch-helper';
 import { AsyncCache } from './utils/async-cache';
+import { getErrorMessage } from './utils/error-utils';
+import { type LoggerChannel, NO_OP_LOGGER } from './utils/output-channel';
+
+export { NO_OP_LOGGER };
 
 export interface JjLogOptions {
     revision?: string;
@@ -46,20 +50,6 @@ const UPLOAD_TIMEOUT_MS = 6 * ONE_MINUTE;
 
 const IS_WINDOWS = process.platform === 'win32';
 const NO_OP_EDITOR = IS_WINDOWS ? 'cmd.exe /c exit 0' : 'true';
-
-export type JjServiceLogger = {
-    info(message: string): void;
-    warn(message: string): void;
-    error(message: string): void;
-    debug(message: string): void;
-};
-
-export const NO_OP_LOGGER: JjServiceLogger = {
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-};
 
 export type JjServiceConfigProvider<S = never> = <T>(key: string, defaultValue?: T, scope?: S) => T | undefined;
 
@@ -87,16 +77,12 @@ export class JjService {
 
     constructor(
         public readonly workspaceRoot: string,
-        public readonly logger: JjServiceLogger,
-        options?: string | JjServiceOptions,
+        public readonly logger: LoggerChannel = NO_OP_LOGGER,
+        options?: JjServiceOptions,
     ) {
-        if (typeof options === 'string') {
-            this.binaryPath = options;
-        } else {
-            this.binaryPath = options?.binaryPath ?? 'jj';
-            this._getConfig = options?.getConfig;
-            this.processTracker = options?.processTracker;
-        }
+        this.binaryPath = options?.binaryPath ?? 'jj';
+        this._getConfig = options?.getConfig;
+        this.processTracker = options?.processTracker;
     }
 
     private getReadTimeoutMs(): number {
@@ -170,7 +156,7 @@ export class JjService {
     }
 
     static isIndexLockError(error: unknown): boolean {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = getErrorMessage(error);
         return message.includes('index.lock') || message.includes('Could not acquire lock');
     }
 

--- a/src/scm-model.ts
+++ b/src/scm-model.ts
@@ -10,8 +10,9 @@ import type { JjService } from './jj-service';
 import type { CommitParent, JjLogEntry, JjStatusEntry } from './jj-types';
 import { encodeJjViewQuery, getRepoRelativePath, getRevisionFromUri, Uri } from './uri-utils';
 import { getJjViewConfig } from './utils/config-utils';
+import { toError } from './utils/error-utils';
 import { canAbsorbCommit, canSquashCommit, formatDisplayChangeId, isMutableCommit } from './utils/jj-utils';
-import type { JjLoggerChannel } from './utils/output-channel';
+import type { LoggerChannel } from './utils/output-channel';
 
 export interface ScmAncestorEntry {
     entry: JjLogEntry;
@@ -55,7 +56,7 @@ export class ScmModel implements Disposable {
 
     constructor(
         public readonly repo: JjRepository,
-        public readonly outputChannel: JjLoggerChannel,
+        public readonly outputChannel: LoggerChannel,
     ) {
         this.disposables.push(
             this.repo.onDidStatusChange(async (event) => {
@@ -193,7 +194,7 @@ export class ScmModel implements Disposable {
 
             await this._onDidChangeSnapshot.fire(this._snapshot);
         } catch (e: unknown) {
-            this.outputChannel.error(`[${this.repo.rootUri.fsPath}] Error calculating SCM snapshot: ${e}`);
+            this.outputChannel.error(`[${this.repo.rootUri.fsPath}] Error calculating SCM snapshot`, toError(e));
         } finally {
             if (!this._disposed) {
                 const duration = performance.now() - start;

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -277,12 +277,11 @@ test.describe('SCM Pane E2E', () => {
         const repo = new TestRepo();
         repo.init();
         const commits = await buildGraph(repo, [
-            { label: 'base', description: '', files: { 'base.txt': '0' } },
-            { label: 'target', parents: ['base'], description: '', files: { 't.txt': '0' } },
-            { label: 'middle', parents: ['target'], description: 'middle message', files: { 'm.txt': '0' } },
+            { label: 'base', description: 'base commit', files: { 'base.txt': '0' } },
+            { label: 'target', description: '', files: { 't.txt': '0' } },
+            { label: 'middle', description: 'middle message', files: { 'm.txt': '0' } },
             {
                 label: 'source',
-                parents: ['middle'],
                 description: 'source message',
                 files: { 's.txt': '0', 's2.txt': '0' },
                 isCurrentWorkingCopy: true,
@@ -296,8 +295,8 @@ test.describe('SCM Pane E2E', () => {
         // 1. Squash Revision into Ancestor
         // We'll squash 'middle' into 'target'
         await clickScmAction(page, /middle message/, SCM_ACTIONS.SquashRevisionIntoAncestor);
-        // Pick 'target' from quickpick. Since it has no description, it will show '(no description)'
-        await pickQuickPickItem(page, '(no description)');
+        // Pick 'target' by its unique short changeId from quickpick
+        await pickQuickPickItem(page, commits.target.changeId.substring(0, 8));
 
         await expect(async () => {
             const log = repo.log();
@@ -307,12 +306,19 @@ test.describe('SCM Pane E2E', () => {
             expect(targetFiles).toContain('m.txt');
         }).toPass({ timeout: 10000 });
 
+        // Wait for SCM tree to settle: m.txt and t.txt should be in the same group
+        await expectFileInScmGroup(page, /middle message/i, 'm.txt');
+        await expectFileInScmGroup(page, /middle message/i, 't.txt');
+
         // 2. Squash Files into Ancestor
         // We'll squash s.txt from 'source' (WC) into 'base'
         // Hover over s.txt row and click squash into ancestor
         await clickScmAction(page, /^s\.txt\b/, SCM_ACTIONS.SquashFilesIntoAncestor);
-        // Pick 'base' from quickpick.
-        await pickQuickPickItem(page, '(no description)');
+        // Pick 'base' by its unique description / short changeId from quickpick
+        await pickQuickPickItem(page, 'base commit');
+
+        // Wait for SCM tree to show s.txt under base commit group
+        await expectFileInScmGroup(page, /base commit/i, 's.txt');
 
         await expect(async () => {
             const baseFiles = repo.getFiles(commits.base.changeId);

--- a/src/test/fake-host-environment.ts
+++ b/src/test/fake-host-environment.ts
@@ -23,7 +23,7 @@ import type {
 } from '../common/host-environment';
 import type { JjRepository } from '../jj-repository';
 import type { Uri } from '../uri-utils';
-import type { JjLoggerChannel } from '../utils/output-channel';
+import type { LoggerChannel } from '../utils/output-channel';
 
 export class FakeHostUi implements HostUi {
     public inputBoxResponses: (string | undefined)[] = [];
@@ -445,7 +445,7 @@ export class FakeCommandContext implements CommandContext {
     constructor(
         readonly repo: JjRepository,
         readonly host: FakeHostEnvironment = new FakeHostEnvironment(),
-        readonly log: JjLoggerChannel = {
+        readonly log: LoggerChannel = {
             info: () => {},
             warn: () => {},
             error: () => {},
@@ -457,8 +457,6 @@ export class FakeCommandContext implements CommandContext {
             clear: () => {},
             dispose: () => {},
             name: 'test',
-            logLevel: 3,
-            onDidChangeLogLevel: () => ({ dispose: () => {} }),
         },
         readonly comments?: CommentsManager,
     ) {

--- a/src/test/output-channel.test.ts
+++ b/src/test/output-channel.test.ts
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it, vi } from 'vitest';
-import { JjOutputChannel } from '../utils/output-channel';
+import { NO_OP_LOGGER, OutputChannel } from '../utils/output-channel';
 import { createMockLogOutputChannel } from './test-utils';
 
-describe('JjOutputChannel', () => {
+describe('OutputChannel', () => {
     it('should delegate explicit logs correctly', () => {
         const delegate = createMockLogOutputChannel();
-        const outputChannel = new JjOutputChannel(delegate, 'prefix');
+        const outputChannel = new OutputChannel(delegate, 'prefix');
 
         const infoSpy = vi.spyOn(delegate, 'info');
         const warnSpy = vi.spyOn(delegate, 'warn');
         const errorSpy = vi.spyOn(delegate, 'error');
         const debugSpy = vi.spyOn(delegate, 'debug');
+        const traceSpy = vi.spyOn(delegate, 'trace');
 
-        // Explicit logs should delegate correctly
         outputChannel.info('info message');
         expect(infoSpy).toHaveBeenCalledWith('[prefix] info message');
 
@@ -29,10 +29,112 @@ describe('JjOutputChannel', () => {
         outputChannel.debug('debug message');
         expect(debugSpy).toHaveBeenCalledWith('[prefix] debug message');
 
-        // Error object should preserve original instance and custom properties
-        const testError = new Error('some error') as Error & { code: string };
-        testError.code = 'ERR_TEST';
-        outputChannel.error(testError);
+        outputChannel.trace('trace message');
+        expect(traceSpy).toHaveBeenCalledWith('[prefix] trace message');
+
+        const testError = new Error('some error');
+        outputChannel.error(testError.message, testError);
         expect(errorSpy).toHaveBeenCalledWith('[prefix] some error', testError);
+    });
+
+    it('should support nested prefixes and delegates', () => {
+        const delegate = createMockLogOutputChannel();
+        const parent = new OutputChannel(delegate, 'repo1');
+        const child = new OutputChannel(parent, 'sub');
+
+        const infoSpy = vi.spyOn(delegate, 'info');
+        child.info('nested message');
+        expect(infoSpy).toHaveBeenCalledWith('[repo1][sub] nested message');
+    });
+
+    it('should delegate lifecycle and UI methods', () => {
+        const delegate = createMockLogOutputChannel();
+        const outputChannel = new OutputChannel(delegate);
+
+        const showSpy = vi.spyOn(delegate, 'show');
+        const hideSpy = vi.spyOn(delegate, 'hide');
+        const clearSpy = vi.spyOn(delegate, 'clear');
+        const replaceSpy = vi.spyOn(delegate, 'replace');
+        const disposeSpy = vi.spyOn(delegate, 'dispose');
+
+        outputChannel.show(true);
+        expect(showSpy).toHaveBeenCalledWith(true);
+
+        outputChannel.hide();
+        expect(hideSpy).toHaveBeenCalled();
+
+        outputChannel.clear();
+        expect(clearSpy).toHaveBeenCalled();
+
+        outputChannel.replace('new content');
+        expect(replaceSpy).toHaveBeenCalledWith('new content');
+
+        outputChannel.dispose();
+        expect(disposeSpy).toHaveBeenCalled();
+
+        expect(outputChannel.name).toBe('Mock Log Output Channel');
+    });
+
+    it('should format logs without brackets when un-prefixed', () => {
+        const delegate = createMockLogOutputChannel();
+        const outputChannel = new OutputChannel(delegate);
+
+        const infoSpy = vi.spyOn(delegate, 'info');
+        const warnSpy = vi.spyOn(delegate, 'warn');
+        const errorSpy = vi.spyOn(delegate, 'error');
+        const debugSpy = vi.spyOn(delegate, 'debug');
+        const traceSpy = vi.spyOn(delegate, 'trace');
+
+        outputChannel.info('raw info');
+        expect(infoSpy).toHaveBeenCalledWith('raw info');
+
+        outputChannel.warn('raw warn');
+        expect(warnSpy).toHaveBeenCalledWith('raw warn');
+
+        outputChannel.debug('raw debug');
+        expect(debugSpy).toHaveBeenCalledWith('raw debug');
+
+        outputChannel.trace('raw trace');
+        expect(traceSpy).toHaveBeenCalledWith('raw trace');
+
+        const err = new Error('raw error');
+        outputChannel.error('raw error msg', err);
+        expect(errorSpy).toHaveBeenCalledWith('raw error msg', err);
+    });
+
+    it('should not dispose underlying delegate when called on a scoped sub-channel', () => {
+        const delegate = createMockLogOutputChannel();
+        const subChannel = new OutputChannel(delegate, 'repo-scope');
+        const disposeSpy = vi.spyOn(delegate, 'dispose');
+
+        subChannel.dispose();
+        expect(disposeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should safely no-op optional methods when delegate does not implement them', () => {
+        const minimalDelegate = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        };
+        const outputChannel = new OutputChannel(minimalDelegate);
+
+        expect(() => outputChannel.trace('trace')).not.toThrow();
+        expect(() => outputChannel.replace('replace')).not.toThrow();
+        expect(() => outputChannel.clear()).not.toThrow();
+        expect(() => outputChannel.show(false)).not.toThrow();
+        expect(() => outputChannel.hide()).not.toThrow();
+        expect(() => outputChannel.dispose()).not.toThrow();
+        expect(outputChannel.name).toBeUndefined();
+    });
+
+    it('should verify NO_OP_LOGGER provides safe no-op implementations', () => {
+        expect(() => {
+            NO_OP_LOGGER.debug('msg');
+            NO_OP_LOGGER.info('msg');
+            NO_OP_LOGGER.warn('msg');
+            NO_OP_LOGGER.error('msg', new Error('test'));
+        }).not.toThrow();
     });
 });

--- a/src/test/utils/debouncing-queue.test.ts
+++ b/src/test/utils/debouncing-queue.test.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { afterEach, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
-import { DebouncingQueue, type ILogger } from '../../utils/debouncing-queue';
+import { DebouncingQueue } from '../../utils/debouncing-queue';
+import type { LoggerChannel } from '../../utils/output-channel';
 
 describe('DebouncingQueue (Exhaustive)', () => {
     let taskFn: Mock;
@@ -556,7 +557,12 @@ describe('DebouncingQueue (Exhaustive)', () => {
 
         test('routes errors to optional logger when provided', async () => {
             const loggerError = vi.fn();
-            const mockLogger: ILogger = { error: loggerError };
+            const mockLogger: LoggerChannel = {
+                debug: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+                error: loggerError,
+            };
             const error = new Error('Logger test error');
             taskFn.mockRejectedValueOnce(error);
 
@@ -571,6 +577,33 @@ describe('DebouncingQueue (Exhaustive)', () => {
 
             await rejectAssertion;
             expect(loggerError).toHaveBeenCalledWith('DebouncingQueue task error:', error);
+            queue.dispose();
+        });
+
+        test('wraps non-Error thrown values into Error instances for logger.error', async () => {
+            const loggerError = vi.fn();
+            const mockLogger: LoggerChannel = {
+                debug: vi.fn(),
+                info: vi.fn(),
+                warn: vi.fn(),
+                error: loggerError,
+            };
+            taskFn.mockRejectedValueOnce('string error message');
+
+            const queue = new DebouncingQueue<string>(taskFn, {
+                getDebounceMillis: () => 100,
+                logger: mockLogger,
+            });
+
+            const p1 = queue.push('error-task');
+            const rejectAssertion = expect(p1).rejects.toBe('string error message');
+            await vi.advanceTimersByTimeAsync(100);
+
+            await rejectAssertion;
+            expect(loggerError).toHaveBeenCalledWith(
+                'DebouncingQueue task error:',
+                expect.objectContaining({ message: 'string error message' }),
+            );
             queue.dispose();
         });
     });

--- a/src/test/utils/error-utils.test.ts
+++ b/src/test/utils/error-utils.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { describe, expect, it } from 'vitest';
+import { getErrorMessage, toError } from '../../utils/error-utils';
+
+describe('error-utils', () => {
+    describe('toError', () => {
+        it('returns an Error instance as-is', () => {
+            const original = new Error('original error');
+            expect(toError(original)).toBe(original);
+        });
+
+        it('wraps a string into an Error instance', () => {
+            const result = toError('something went wrong');
+            expect(result).toBeInstanceOf(Error);
+            expect(result.message).toBe('something went wrong');
+        });
+
+        it('wraps numbers, objects, and null/undefined into Error instances', () => {
+            expect(toError(404).message).toBe('404');
+            expect(toError({ foo: 'bar' }).message).toBe('[object Object]');
+            expect(toError(null).message).toBe('null');
+            expect(toError(undefined).message).toBe('undefined');
+        });
+    });
+
+    describe('getErrorMessage', () => {
+        it('returns message property from Error instances', () => {
+            expect(getErrorMessage(new Error('custom message'))).toBe('custom message');
+        });
+
+        it('converts non-Error values to string', () => {
+            expect(getErrorMessage('plain string')).toBe('plain string');
+            expect(getErrorMessage(1234)).toBe('1234');
+            expect(getErrorMessage(null)).toBe('null');
+            expect(getErrorMessage(undefined)).toBe('undefined');
+        });
+    });
+});

--- a/src/test/webview-rpc-dispatcher.test.ts
+++ b/src/test/webview-rpc-dispatcher.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { z } from 'zod';
 import { createWebviewRpcClient, createWebviewRpcDispatcher } from '../common/webview-rpc-dispatcher';
+import type { LoggerChannel } from '../utils/output-channel';
 
 describe('WebviewRpcDispatcher', () => {
     const testSchema = z.discriminatedUnion('type', [
@@ -77,7 +78,8 @@ describe('WebviewRpcDispatcher', () => {
     });
 
     test('automatically dispatches baseline logMessage to logger', async () => {
-        const mockLogger = {
+        const mockLogger: LoggerChannel = {
+            debug: vi.fn(),
             info: vi.fn(),
             warn: vi.fn(),
             error: vi.fn(),
@@ -107,23 +109,83 @@ describe('WebviewRpcDispatcher', () => {
         expect(mockLogger.error).toHaveBeenCalledWith('Failure: Details');
     });
 
+    test('logs error and invokes onError on validation failure for known message types', async () => {
+        const mockLogger: LoggerChannel = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        };
+        const onError = vi.fn();
+
+        const dispatcher = createWebviewRpcDispatcher(testSchema, { ping: vi.fn() }, { logger: mockLogger, onError });
+
+        const invalidMsg = { type: 'count', amount: 'not a number' };
+        const result = await dispatcher.dispatch(invalidMsg);
+
+        expect(result).toBe(false);
+        expect(mockLogger.error).toHaveBeenCalledWith('Webview RPC validation failed', expect.any(Error));
+        expect(onError).toHaveBeenCalledWith(expect.any(Error), invalidMsg);
+    });
+
+    test('logs error and invokes onError when handler throws', async () => {
+        const mockLogger: LoggerChannel = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        };
+        const onError = vi.fn();
+        const handlerError = new Error('Handler crash');
+
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {
+                ping: () => {
+                    throw handlerError;
+                },
+            },
+            { logger: mockLogger, onError },
+        );
+
+        const validMsg = { type: 'ping', value: 'boom' };
+        const result = await dispatcher.dispatch(validMsg);
+
+        expect(result).toBe(false);
+        expect(mockLogger.error).toHaveBeenCalledWith('Webview RPC handler error (ping)', handlerError);
+        expect(onError).toHaveBeenCalledWith(handlerError, validMsg);
+    });
+
+    test('rejects pending requests when dispatcher is disposed', async () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {});
+        const pending = dispatcher.registerPendingRequest('req_123');
+
+        dispatcher.dispose();
+
+        await expect(pending).rejects.toThrowError('WebviewRpcDispatcher disposed');
+    });
+
     test('dispatches custom logMessage handler with raw message', async () => {
         const customLogMessageHandler = vi.fn(async (_message) => {
             await Promise.resolve();
         });
 
+        const schemaWithLog = z.discriminatedUnion('type', [
+            z.object({ type: z.literal('ping'), value: z.string() }),
+            z.object({
+                type: z.literal('logMessage'),
+                payload: z.object({ level: z.enum(['info', 'warn', 'error']), message: z.string() }),
+            }),
+        ]);
+
         const rawLogMessage = {
-            type: 'logMessage',
-            payload: { level: 'info', message: 'custom log message' },
+            type: 'logMessage' as const,
+            payload: { level: 'info' as const, message: 'custom log message' },
         };
 
-        const dispatcher = createWebviewRpcDispatcher(
-            testSchema,
-            {
-                logMessage: customLogMessageHandler,
-            } as never,
-            {},
-        );
+        const dispatcher = createWebviewRpcDispatcher(schemaWithLog, {
+            logMessage: customLogMessageHandler,
+        });
 
         const handled = await dispatcher.dispatch(rawLogMessage);
 
@@ -169,9 +231,9 @@ describe('createWebviewRpcClient', () => {
         };
 
         const client = createWebviewRpcClient(mockWebview, testSchema);
+        const untypedCount = client.count as (payload: Record<string, unknown>) => Promise<unknown>;
 
-        // @ts-expect-error testing invalid payload type at runtime
-        expect(() => client.count({ amount: 'invalid' })).toThrowError(/Invalid RPC message 'count'/);
+        expect(() => untypedCount({ amount: 'invalid' })).toThrowError(/Invalid RPC message 'count'/);
         expect(mockWebview.postMessage).not.toHaveBeenCalled();
     });
 

--- a/src/utils/debouncing-queue.ts
+++ b/src/utils/debouncing-queue.ts
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { toError } from './error-utils';
+import type { LoggerChannel } from './output-channel';
+
 export interface IDisposable {
     dispose(): void;
-}
-
-export interface ILogger {
-    error(error: string | Error, ...args: unknown[]): void;
 }
 
 export interface DebouncingQueueOptions<TPayload> {
@@ -18,8 +17,8 @@ export interface DebouncingQueueOptions<TPayload> {
     getMaxMultiplier?: () => number;
     /** Custom reducer to merge incoming payloads during debouncing */
     mergePayloads?: (accumulated: TPayload, incoming: TPayload) => TPayload;
-    /** Optional logger channel (e.g. JjLoggerChannel) to log task errors */
-    logger?: ILogger;
+    /** Optional logger channel to log task errors */
+    logger?: LoggerChannel;
 }
 
 interface PendingBatch<TPayload> {
@@ -175,7 +174,7 @@ export class DebouncingQueue<TPayload = void> implements IDisposable {
         } catch (err) {
             taskError = err;
             if (this._options?.logger) {
-                this._options.logger.error('DebouncingQueue task error:', err);
+                this._options.logger.error('DebouncingQueue task error:', toError(err));
             } else {
                 console.error('DebouncingQueue task error:', err);
             }

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Normalizes an unknown caught error into a standard Error instance.
+ * If the value is already an Error, it is returned as-is.
+ * Otherwise, a new Error instance is created with String(error) as the message.
+ */
+export function toError(error: unknown): Error {
+    if (error instanceof Error) {
+        return error;
+    }
+    return new Error(String(error));
+}
+
+/**
+ * Extracts a human-readable error message from an unknown error value.
+ */
+export function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return String(error);
+}

--- a/src/utils/gerrit-credential-utils.ts
+++ b/src/utils/gerrit-credential-utils.ts
@@ -7,7 +7,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { fetchWithTimeout } from './fetch-utils';
-import type { JjLoggerChannel } from './output-channel';
+import type { LoggerChannel } from './output-channel';
 
 /**
  * A helper to wrap cp.execFile in a Promise to prevent deep nesting of callbacks.
@@ -147,7 +147,7 @@ export async function getGitCookies(gitDir: string | null, host: string): Promis
 export async function parseCookieFile(
     filePath: string,
     host: string,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<{ name: string; value: string } | null> {
     try {
         const content = await fs.readFile(filePath, 'utf8');
@@ -192,7 +192,7 @@ export async function parseCookieFile(
 /**
  * LUCI Context Authenticator.
  */
-export async function getLuciToken(outputChannel?: JjLoggerChannel): Promise<string | null> {
+export async function getLuciToken(outputChannel?: LoggerChannel): Promise<string | null> {
     if (!process.env.LUCI_CONTEXT) {
         outputChannel?.debug('[GerritAuth] LUCI_CONTEXT environment variable not set');
         return null;
@@ -250,7 +250,7 @@ async function parseExtraHeaderFile(filePath: string): Promise<{ name: string; v
  */
 export async function getSsoAuth(
     host: string,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<{ name: string; value: string } | null> {
     const checkCmd = process.platform === 'win32' ? 'where' : 'which';
     outputChannel?.debug(`[GerritAuth] Checking if git-remote-sso helper exists using ${checkCmd}...`);
@@ -310,7 +310,7 @@ export async function getSsoAuth(
 /**
  * GCE Metadata Authenticator.
  */
-export async function getGceAuth(outputChannel?: JjLoggerChannel): Promise<{ name: string; value: string } | null> {
+export async function getGceAuth(outputChannel?: LoggerChannel): Promise<{ name: string; value: string } | null> {
     try {
         const metadataHost = process.env.GCE_METADATA_HOST || 'http://metadata.google.internal';
         outputChannel?.debug(`[GerritAuth] Probing GCE Metadata server at ${metadataHost}...`);
@@ -355,7 +355,7 @@ export async function getGceAuth(outputChannel?: JjLoggerChannel): Promise<{ nam
 export async function getGitCredential(
     gitDir: string | null,
     host: string,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<{ username?: string; password?: string } | null> {
     const args = gitDir ? [`--git-dir=${gitDir}`, 'credential', 'fill'] : ['credential', 'fill'];
     const options = {
@@ -401,7 +401,7 @@ export async function getGitCredential(
 export async function getGerritAuthHeader(
     gerritHost: string,
     gitDir: string | null,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<{ name: string; value: string } | undefined> {
     let hostname = gerritHost;
     try {

--- a/src/utils/gerrit-host-detection.ts
+++ b/src/utils/gerrit-host-detection.ts
@@ -8,7 +8,7 @@ import * as path from 'node:path';
 import type { GitRemote } from '../code-forge-provider';
 import { getJjViewConfig } from './config-utils';
 import { getGitConfig } from './gerrit-credential-utils';
-import type { JjLoggerChannel } from './output-channel';
+import type { LoggerChannel } from './output-channel';
 
 /**
  * Normalizes a Gerrit host URL by cleaning trailing slashes, prepending protocol,
@@ -33,7 +33,7 @@ export function normalizeHostUrl(hostUrl: string): string {
 /**
  * Resolves the Gerrit host from the configured VS Code setting.
  */
-function getHostFromSettings(outputChannel?: JjLoggerChannel): string | undefined {
+function getHostFromSettings(outputChannel?: LoggerChannel): string | undefined {
     outputChannel?.debug('[GerritDetector] Checking VS Code settings for jj-view.gerrit.host...');
     const settingHost = getJjViewConfig<string>('gerrit.host')?.trim();
     if (settingHost) {
@@ -53,7 +53,7 @@ function getHostFromSettings(outputChannel?: JjLoggerChannel): string | undefine
  */
 async function getHostFromGitConfig(
     gitRoot: string | null,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<string | undefined> {
     if (!gitRoot) {
         outputChannel?.debug('[GerritDetector] Git root is null, skipping git config check');
@@ -86,7 +86,7 @@ async function getHostFromGitConfig(
     return undefined;
 }
 
-async function getHostFromGitReview(repoRoot: string, outputChannel?: JjLoggerChannel): Promise<string | undefined> {
+async function getHostFromGitReview(repoRoot: string, outputChannel?: LoggerChannel): Promise<string | undefined> {
     const gitreviewPath = path.join(repoRoot, '.gitreview');
     outputChannel?.debug(`[GerritDetector] Checking .gitreview file at: ${gitreviewPath}`);
     try {
@@ -197,7 +197,7 @@ export function parseRemoteUrl(url: string): string | undefined {
 async function getHostFromRemotes(
     remotes: GitRemote[],
     probeFn: (host: string) => Promise<boolean>,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<string | undefined> {
     outputChannel?.debug(`[GerritDetector] Scanning ${remotes.length} remotes for Gerrit host candidates`);
     const origin = remotes.find((r) => r.name === 'origin');
@@ -243,7 +243,7 @@ export async function detectGerritHost(
     gitRoot: string | null,
     remotes: GitRemote[],
     probeFn: (host: string) => Promise<boolean>,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
 ): Promise<string | undefined> {
     outputChannel?.debug(`[GerritDetector] Starting host detection for repoRoot=${repoRoot}, gitRoot=${gitRoot}`);
 

--- a/src/utils/output-channel.ts
+++ b/src/utils/output-channel.ts
@@ -2,97 +2,96 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import type * as vscode from 'vscode';
 
-export type JjLoggerChannel = Omit<vscode.LogOutputChannel, 'appendLine' | 'append'>;
+export interface LoggerChannel {
+    readonly name?: string;
+    trace?(message: string): void;
+    debug(message: string): void;
+    info(message: string): void;
+    warn(message: string): void;
+    error(message: string, error?: Error): void;
+    replace?(value: string): void;
+    clear?(): void;
+    show?(preserveFocus?: boolean): void;
+    hide?(): void;
+    dispose?(): void;
+}
 
-export class JjOutputChannel {
-    private readonly delegateChannel: JjLoggerChannel;
+export const NO_OP_LOGGER: LoggerChannel = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+};
+
+export class OutputChannel implements LoggerChannel {
+    private readonly delegateChannel: LoggerChannel;
     private readonly prefixes: string[] = [];
 
-    constructor(delegate: JjLoggerChannel, prefix?: string) {
-        if (delegate instanceof JjOutputChannel) {
+    constructor(delegate: LoggerChannel, prefix?: string) {
+        if (delegate instanceof OutputChannel) {
             this.delegateChannel = delegate.delegateChannel;
             this.prefixes = [...delegate.prefixes];
-            if (prefix) {
-                this.prefixes.push(prefix);
-            }
         } else {
             this.delegateChannel = delegate;
-            if (prefix) {
-                this.prefixes.push(prefix);
-            }
+        }
+        if (prefix) {
+            this.prefixes.push(prefix);
         }
     }
 
-    get name(): string {
+    get name(): string | undefined {
         return this.delegateChannel.name;
-    }
-
-    get logLevel(): vscode.LogLevel {
-        return this.delegateChannel.logLevel;
-    }
-
-    get onDidChangeLogLevel(): vscode.Event<vscode.LogLevel> {
-        return this.delegateChannel.onDidChangeLogLevel;
     }
 
     private formatPrefixes(): string {
         return this.prefixes.length > 0 ? `[${this.prefixes.join('][')}] ` : '';
     }
 
-    trace(message: string, ...args: unknown[]): void {
-        this.delegateChannel.trace(this.formatPrefixes() + message, ...args);
+    trace(message: string): void {
+        this.delegateChannel.trace?.(`${this.formatPrefixes()}${message}`);
     }
 
-    debug(message: string, ...args: unknown[]): void {
-        this.delegateChannel.debug(this.formatPrefixes() + message, ...args);
+    debug(message: string): void {
+        this.delegateChannel.debug(`${this.formatPrefixes()}${message}`);
     }
 
-    info(message: string, ...args: unknown[]): void {
-        this.delegateChannel.info(this.formatPrefixes() + message, ...args);
+    info(message: string): void {
+        this.delegateChannel.info(`${this.formatPrefixes()}${message}`);
     }
 
-    warn(message: string, ...args: unknown[]): void {
-        this.delegateChannel.warn(this.formatPrefixes() + message, ...args);
+    warn(message: string): void {
+        this.delegateChannel.warn(`${this.formatPrefixes()}${message}`);
     }
 
-    error(message: string | Error, ...args: unknown[]): void {
+    error(message: string, error?: Error): void {
         const prefix = this.formatPrefixes();
-        if (typeof message === 'string') {
-            this.delegateChannel.error(prefix + message, ...args);
+        if (error !== undefined) {
+            this.delegateChannel.error(`${prefix}${message}`, error);
         } else {
-            // Pass the prefixed message but forward the original Error object to preserve
-            // stack traces, identity, and any custom properties (e.g. error codes).
-            this.delegateChannel.error(prefix + message.message, message, ...args);
+            this.delegateChannel.error(`${prefix}${message}`);
         }
     }
 
     replace(value: string): void {
-        this.delegateChannel.replace(value);
+        this.delegateChannel.replace?.(value);
     }
 
     clear(): void {
-        this.delegateChannel.clear();
+        this.delegateChannel.clear?.();
     }
 
-    show(preserveFocus?: boolean): void;
-    show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
-    show(columnOrPreserveFocus?: vscode.ViewColumn | boolean, preserveFocus?: boolean): void {
-        if (typeof columnOrPreserveFocus === 'boolean') {
-            this.delegateChannel.show(columnOrPreserveFocus);
-        } else if (columnOrPreserveFocus !== undefined) {
-            this.delegateChannel.show(columnOrPreserveFocus as vscode.ViewColumn, preserveFocus);
-        } else {
-            this.delegateChannel.show();
-        }
+    show(preserveFocus?: boolean): void {
+        this.delegateChannel.show?.(preserveFocus);
     }
 
     hide(): void {
-        this.delegateChannel.hide();
+        this.delegateChannel.hide?.();
     }
 
     dispose(): void {
-        this.delegateChannel.dispose();
+        if (this.prefixes.length === 0) {
+            this.delegateChannel.dispose?.();
+        }
     }
 }

--- a/src/vscode/providers/vscode-edit-fs-provider.ts
+++ b/src/vscode/providers/vscode-edit-fs-provider.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { type JjEditFsService, parseEditUri } from '../../jj-edit-fs-service';
 import type { JjRepository } from '../../jj-repository';
 import type { Uri } from '../../uri-utils';
+import { getErrorMessage } from '../../utils/error-utils';
 
 export { parseEditUri };
 
@@ -60,7 +61,7 @@ export class VsCodeEditFsProvider implements vscode.FileSystemProvider, vscode.D
         try {
             return await this.service.readFile(uri);
         } catch (e: unknown) {
-            throw vscode.FileSystemError.Unavailable(e instanceof Error ? e.message : String(e));
+            throw vscode.FileSystemError.Unavailable(getErrorMessage(e));
         }
     }
 
@@ -68,7 +69,7 @@ export class VsCodeEditFsProvider implements vscode.FileSystemProvider, vscode.D
         try {
             await this.service.writeFile(uri, content);
         } catch (e: unknown) {
-            throw vscode.FileSystemError.Unavailable(e instanceof Error ? e.message : String(e));
+            throw vscode.FileSystemError.Unavailable(getErrorMessage(e));
         }
     }
 

--- a/src/vscode/providers/vscode-log-webview-provider.ts
+++ b/src/vscode/providers/vscode-log-webview-provider.ts
@@ -9,7 +9,7 @@ import { LogViewController } from '../../controllers/log-view-controller';
 import type { JjRepository } from '../../jj-repository';
 import type { JjLogEntry } from '../../jj-types';
 import type { Uri } from '../../uri-utils';
-import type { JjLoggerChannel } from '../../utils/output-channel';
+import type { LoggerChannel } from '../../utils/output-channel';
 import { VsCodeHostEnvironment } from '../vscode-host-environment';
 import { closeCommitDetailsTabs } from '../vscode-ui-helpers';
 import { getWebviewHtml } from '../vscode-webview-html';
@@ -21,14 +21,14 @@ export class VsCodeLogWebviewProvider implements vscode.WebviewViewProvider, vsc
     private _viewDisposables: vscode.Disposable[] = [];
 
     public readonly controller: LogViewController;
-    public readonly outputChannel?: JjLoggerChannel;
+    public readonly outputChannel?: LoggerChannel;
 
     constructor(
         private readonly _extensionUri: Uri,
         initialRepo: JjRepository | undefined,
         onSelectionChange: (commits: string[]) => void,
         context: vscode.ExtensionContext,
-        outputChannel?: JjLoggerChannel,
+        outputChannel?: LoggerChannel,
     ) {
         this.outputChannel = outputChannel;
 

--- a/src/vscode/providers/vscode-scm-provider.ts
+++ b/src/vscode/providers/vscode-scm-provider.ts
@@ -16,7 +16,7 @@ import { ScmModel, type ScmSnapshot } from '../../scm-model';
 import { createJjResourceState, type JjResourceState } from '../../scm-resource-state';
 import { getRepoRelativePath, type Uri } from '../../uri-utils';
 import { getJjViewConfig } from '../../utils/config-utils';
-import type { JjLoggerChannel } from '../../utils/output-channel';
+import type { LoggerChannel } from '../../utils/output-channel';
 import { VsCodeDecorationProvider } from './vscode-decoration-provider';
 import type { VsCodeEditFsProvider } from './vscode-edit-fs-provider';
 import type { VsCodeViewFsProvider } from './vscode-view-fs-provider';
@@ -68,7 +68,7 @@ export class VsCodeScmProvider implements vscode.Disposable {
     constructor(
         public readonly context: vscode.ExtensionContext,
         public readonly repo: JjRepository,
-        public readonly outputChannel: JjLoggerChannel,
+        public readonly outputChannel: LoggerChannel,
         public readonly repositoryManager: JjRepositoryManager,
         public readonly viewFileSystemProvider?: VsCodeViewFsProvider,
         public readonly editProvider?: VsCodeEditFsProvider,

--- a/src/vscode/providers/vscode-view-fs-provider.ts
+++ b/src/vscode/providers/vscode-view-fs-provider.ts
@@ -6,6 +6,7 @@
 import * as vscode from 'vscode';
 import type { JjViewFsService } from '../../jj-view-fs-service';
 import type { Uri } from '../../uri-utils';
+import { getErrorMessage } from '../../utils/error-utils';
 
 /**
  * Thin VS Code FileSystemProvider adapting JjViewFsService to the VS Code FileSystemProvider API.
@@ -18,11 +19,12 @@ export class VsCodeViewFsProvider implements vscode.FileSystemProvider, vscode.D
     constructor(public readonly service: JjViewFsService) {
         this._disposables.push(
             this.service.onDidChangeFile((uris) => {
-                const events: vscode.FileChangeEvent[] = uris.map((uri) => ({
-                    type: vscode.FileChangeType.Changed,
-                    uri: uri as unknown as vscode.Uri,
-                }));
-                this._onDidChangeFile.fire(events);
+                this._onDidChangeFile.fire(
+                    uris.map((uri) => ({
+                        type: vscode.FileChangeType.Changed,
+                        uri: uri as unknown as vscode.Uri,
+                    })),
+                );
             }),
         );
     }
@@ -35,7 +37,7 @@ export class VsCodeViewFsProvider implements vscode.FileSystemProvider, vscode.D
         this.service.invalidateCache();
     }
 
-    async stat(uri: Uri): Promise<vscode.FileStat> {
+    stat(uri: Uri): vscode.FileStat {
         const s = this.service.stat(uri);
         return {
             type: vscode.FileType.File,
@@ -49,7 +51,7 @@ export class VsCodeViewFsProvider implements vscode.FileSystemProvider, vscode.D
         try {
             return await this.service.readFile(uri);
         } catch (e: unknown) {
-            throw vscode.FileSystemError.Unavailable(e instanceof Error ? e.message : String(e));
+            throw vscode.FileSystemError.Unavailable(getErrorMessage(e));
         }
     }
 

--- a/src/vscode/register-commands.ts
+++ b/src/vscode/register-commands.ts
@@ -64,7 +64,7 @@ import type { CommandContext } from '../common/command-context';
 import type { JjRepository } from '../jj-repository';
 import type { JjRepositoryManager } from '../jj-repository-manager';
 import { TOGGLEABLE_COMMIT_ACTIONS } from '../jj-types';
-import type { JjLoggerChannel } from '../utils/output-channel';
+import type { LoggerChannel } from '../utils/output-channel';
 import { createAbandonPayload } from './payloads/abandon.payload';
 import { createAbsorbPayload } from './payloads/absorb.payload';
 import { createSetBookmarkPayload } from './payloads/bookmark.payload';
@@ -130,7 +130,7 @@ export interface RegisterCommandsOptions {
     context: vscode.ExtensionContext;
     repositoryManager: JjRepositoryManager;
     scmProviders: Map<string, VsCodeScmProvider>;
-    outputChannel: JjLoggerChannel;
+    outputChannel: LoggerChannel;
     commentsManager: CommentsManager;
     logWebviewProvider: VsCodeLogWebviewProvider;
 }

--- a/src/vscode/vscode-command-context.ts
+++ b/src/vscode/vscode-command-context.ts
@@ -6,7 +6,7 @@ import type { CommentsManager } from '../comments-manager';
 import type { CommandContext, CommandServices } from '../common/command-context';
 import type { HostEnvironment } from '../common/host-environment';
 import type { JjRepository } from '../jj-repository';
-import type { JjLoggerChannel } from '../utils/output-channel';
+import type { LoggerChannel } from '../utils/output-channel';
 
 export class VSCodeCommandContext implements CommandContext {
     readonly services?: CommandServices;
@@ -14,7 +14,7 @@ export class VSCodeCommandContext implements CommandContext {
     constructor(
         readonly repo: JjRepository,
         readonly host: HostEnvironment,
-        readonly log: JjLoggerChannel,
+        readonly log: LoggerChannel,
         comments?: CommentsManager,
     ) {
         this.services = comments ? { commentsManager: comments } : undefined;

--- a/src/vscode/vscode-host-environment.ts
+++ b/src/vscode/vscode-host-environment.ts
@@ -23,13 +23,14 @@ import type {
 import type { JjRepository } from '../jj-repository';
 import { getFsPathFromUri, toFileUri, type Uri } from '../uri-utils';
 import { getJjViewConfig } from '../utils/config-utils';
-import type { JjLoggerChannel } from '../utils/output-channel';
+import { getErrorMessage } from '../utils/error-utils';
+import type { LoggerChannel } from '../utils/output-channel';
 import { openCommitDetails, promptForRevision, showJjError, withDelayedProgress } from './vscode-ui-helpers';
 
 export class VsCodeHostUi implements HostUi {
     constructor(
         private readonly repo?: JjRepository,
-        private readonly log?: JjLoggerChannel,
+        private readonly log?: LoggerChannel,
         private readonly sourceControl?: { inputBox: { value: string } },
     ) {}
 
@@ -78,7 +79,7 @@ export class VsCodeHostUi implements HostUi {
 
     async showError(error: unknown, prefix: string, extraActions?: string[]): Promise<string | undefined> {
         if (!this.repo || !this.log) {
-            const message = `${prefix}: ${error instanceof Error ? error.message : String(error)}`;
+            const message = `${prefix}: ${getErrorMessage(error)}`;
             return await vscode.window.showErrorMessage(message, ...(extraActions ?? []));
         }
         return await showJjError(error, prefix, this.repo.jj, this.log, extraActions);
@@ -414,7 +415,7 @@ export class VsCodeHostEnvironment implements HostEnvironment {
     constructor(options: {
         context: vscode.ExtensionContext;
         repo?: JjRepository;
-        log?: JjLoggerChannel;
+        log?: LoggerChannel;
         sourceControl?: { inputBox: { value: string } };
     }) {
         this.ui = new VsCodeHostUi(options.repo, options.log, options.sourceControl);

--- a/src/vscode/vscode-ui-helpers.ts
+++ b/src/vscode/vscode-ui-helpers.ts
@@ -6,14 +6,15 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
-import { extractUriFromArgs, getErrorMessage } from '../commands/command-utils';
+import { extractUriFromArgs, getErrorMessage, toError } from '../commands/command-utils';
 import type { JjRepository } from '../jj-repository';
 import type { JjRepositoryManager } from '../jj-repository-manager';
 import { JjService } from '../jj-service';
 import { createCommitDetailsUri, getUriParams, Uri } from '../uri-utils';
 import { getJjViewConfig } from '../utils/config-utils';
 import { formatCommitTitle } from '../utils/jj-utils';
-import type { JjLoggerChannel } from '../utils/output-channel';
+
+import type { LoggerChannel } from '../utils/output-channel';
 import type { VsCodeScmProvider } from './providers/vscode-scm-provider';
 
 function isSourceControlResourceGroup(arg: unknown): arg is vscode.SourceControlResourceGroup {
@@ -30,13 +31,11 @@ export async function promptForRevision(
     const limit = 200;
 
     try {
-        const commitIds = await jj.getLogIds({
+        const ancestors = await jj.getLog({
             revision: revisionQuery,
             limit,
+            omitChanges: true,
         });
-
-        const entries = await Promise.all(commitIds.map((id) => jj.getLog({ revision: id })));
-        const ancestors = entries.map((e) => e[0]).filter(Boolean);
 
         const items: vscode.QuickPickItem[] = ancestors.map((entry) => {
             const shortId = entry.change_id_shortest || entry.change_id.substring(0, 8);
@@ -137,7 +136,7 @@ export async function showJjError(
     error: unknown,
     prefix: string,
     jj?: JjService,
-    outputChannel?: JjLoggerChannel,
+    outputChannel?: LoggerChannel,
     extraActions: string[] = [],
 ): Promise<string | undefined> {
     const message = getErrorMessage(error);
@@ -163,19 +162,19 @@ export async function showJjError(
     if (!process.env.VITEST) {
         console.error(fullMessage, error);
     }
-    outputChannel?.error(`[Error] ${fullMessage}`);
+    outputChannel?.error(fullMessage, error !== undefined ? toError(error) : undefined);
 
     const SHOW_LOG = 'Show Log';
     const selection = await vscode.window.showErrorMessage(fullMessage, SHOW_LOG, ...extraActions);
 
     if (selection === SHOW_LOG) {
-        outputChannel?.show();
+        outputChannel?.show?.();
     } else if (selection === DELETE_LOCK && lockPath) {
         try {
             await fs.unlink(lockPath);
-            outputChannel?.info(`[Info] Deleted lock file at ${lockPath}`);
+            outputChannel?.info(`Deleted lock file at ${lockPath}`);
         } catch (e) {
-            outputChannel?.error(`[Error] Failed to delete lock file: ${getErrorMessage(e)}`);
+            outputChannel?.error(`Failed to delete lock file: ${getErrorMessage(e)}`, toError(e));
             vscode.window.showErrorMessage(`Failed to delete lock file: ${getErrorMessage(e)}`);
         }
     }


### PR DESCRIPTION
Consolidate fragmented logging abstractions into a canonical, host-agnostic LoggerChannel interface and hierarchical OutputChannel wrapper. Remove VS Code dependencies from the logger contract, enforce strict typed parameters across logging methods, and eliminate polymorphic argument unions.