### PR TITLE
squash: restrict ancestor squash and bookmark advance queries to mutable revisions

### DIFF
--- a/src/commands/bookmark-advance.ts
+++ b/src/commands/bookmark-advance.ts
@@ -19,7 +19,7 @@ export async function advanceBookmarkCommand(
     if (!revision) {
         revision = await promptForRevision(ctx.host.ui, ctx.repo.jj, {
             placeHolder: 'Select target revision to advance bookmarks to',
-            revisionQuery: RevisionQuery.ancestorsIncluding('@'),
+            revisionQuery: RevisionQuery.mutableAncestorsIncluding('@'),
         });
     }
 

--- a/src/commands/command-utils.ts
+++ b/src/commands/command-utils.ts
@@ -292,6 +292,8 @@ export const RevisionQuery = {
     All: 'all()',
     ancestorsExcluding: (rev: string) => `ancestors(${rev}) ~ ${rev}`,
     ancestorsIncluding: (rev: string) => `ancestors(${rev})`,
+    mutableAncestorsExcluding: (rev: string) => `(ancestors(${rev}) ~ ${rev}) & mutable()`,
+    mutableAncestorsIncluding: (rev: string) => `ancestors(${rev}) & mutable()`,
     mutable: () => 'mutable()',
     visible: () => 'visible()',
     children: (rev: string) => `children(${rev})`,

--- a/src/commands/squash-files.ts
+++ b/src/commands/squash-files.ts
@@ -60,7 +60,7 @@ export async function squashFilesIntoAncestorCommand(
         if (!selectedAncestorRev) {
             selectedAncestorRev = await promptForRevision(ctx.host.ui, ctx.repo.jj, {
                 placeHolder: 'Select which ancestor to squash into',
-                revisionQuery: RevisionQuery.ancestorsExcluding(revision),
+                revisionQuery: RevisionQuery.mutableAncestorsExcluding(revision),
             });
         }
         if (!selectedAncestorRev) {
@@ -122,7 +122,12 @@ export async function squashFilesIntoChildCommand(
         }
 
         await ctx.host.ui.withProgress('Squashing file(s) into child...', () =>
-            ctx.repo.jj.squashRevision({ paths, revision, intoRevision: targetChild }),
+            ctx.repo.jj.squashRevision({
+                paths,
+                revision,
+                intoRevision: targetChild,
+                useDestinationMessage: true,
+            }),
         );
         await ctx.repo.refresh({ reason: 'after squash file(s) into child' });
     } catch (e: unknown) {

--- a/src/commands/squash-revision.ts
+++ b/src/commands/squash-revision.ts
@@ -106,7 +106,7 @@ export async function squashRevisionIntoAncestorCommand(
         if (!selectedAncestorRev) {
             selectedAncestorRev = await promptForRevision(ctx.host.ui, ctx.repo.jj, {
                 placeHolder: 'Select which ancestor to squash into',
-                revisionQuery: RevisionQuery.ancestorsExcluding(revision),
+                revisionQuery: RevisionQuery.mutableAncestorsExcluding(revision),
             });
         }
         if (!selectedAncestorRev) {

--- a/src/test/command-utils.test.ts
+++ b/src/test/command-utils.test.ts
@@ -15,6 +15,8 @@ describe('RevisionQuery', () => {
     it('generates expected revision query strings', () => {
         expect(RevisionQuery.ancestorsExcluding('@')).toBe('ancestors(@) ~ @');
         expect(RevisionQuery.ancestorsIncluding('@')).toBe('ancestors(@)');
+        expect(RevisionQuery.mutableAncestorsExcluding('@')).toBe('(ancestors(@) ~ @) & mutable()');
+        expect(RevisionQuery.mutableAncestorsIncluding('@')).toBe('ancestors(@) & mutable()');
         expect(RevisionQuery.mutable()).toBe('mutable()');
         expect(RevisionQuery.visible()).toBe('visible()');
         expect(RevisionQuery.children('rev123')).toBe('children(rev123)');

--- a/src/test/commands/bookmark-advance.test.ts
+++ b/src/test/commands/bookmark-advance.test.ts
@@ -8,7 +8,7 @@ import { advanceBookmarkCommand } from '../../commands/bookmark-advance';
 import type { JjRepository } from '../../jj-repository';
 import { JjService, NO_OP_LOGGER } from '../../jj-service';
 import { FakeCommandContext } from '../fake-host-environment';
-import { TestRepo } from '../test-repo';
+import { buildGraph, TestRepo } from '../test-repo';
 import { createMock } from '../test-utils';
 
 describe('advanceBookmarkCommand', () => {
@@ -45,12 +45,16 @@ describe('advanceBookmarkCommand', () => {
         );
     });
 
-    test('prompts for revision if not provided, and advances bookmark', async () => {
-        repo.bookmark('test-bookmark', '@');
-        await jj.new({ message: 'child' });
-        const [child] = await jj.getLog({ revision: '@' });
+    test('prompts for revision if not provided, restricting to mutable ancestors, and advances bookmark', async () => {
+        const ids = await buildGraph(repo, [
+            { label: 'base', files: { 'base.txt': 'base\n' } },
+            { label: 'parent', parents: ['base'], files: { 'p.txt': 'p\n' } },
+            { label: 'child', parents: ['parent'], files: { 'c.txt': 'c\n' }, isCurrentWorkingCopy: true },
+        ]);
+        repo.config('revset-aliases."immutable_heads()"', `commit_id("${ids.base.commitId}")`);
+        repo.bookmark('test-bookmark', ids.parent.changeId);
 
-        ctx.host.ui.setNextRevisionPromptResponse(child.commit_id);
+        ctx.host.ui.setNextRevisionPromptResponse(ids.child.changeId);
 
         await advanceBookmarkCommand(ctx, {});
 
@@ -58,5 +62,12 @@ describe('advanceBookmarkCommand', () => {
         expect(childLog.bookmarks).toEqual(
             expect.arrayContaining([expect.objectContaining({ name: 'test-bookmark' })]),
         );
+
+        // Verify that prompt only presented mutable ancestors including @, not immutable base
+        const quickPick = ctx.host.ui.quickPickCalls[0];
+        const details = quickPick.items.map((i) => i.detail);
+        expect(details).toContain(ids.child.changeId);
+        expect(details).toContain(ids.parent.changeId);
+        expect(details).not.toContain(ids.base.changeId);
     });
 });

--- a/src/test/commands/squash-files.test.ts
+++ b/src/test/commands/squash-files.test.ts
@@ -75,7 +75,13 @@ describe('squash-files commands', () => {
         test('squashes specific file into grandparent', async () => {
             const fileName = 'file.txt';
             const ids = await buildGraph(repo, [
-                { label: 'grandparent', description: 'grandparent', files: { [fileName]: 'grandparent content' } },
+                { label: 'base', description: 'base', files: { 'base.txt': 'base content' } },
+                {
+                    label: 'grandparent',
+                    parents: ['base'],
+                    description: 'grandparent',
+                    files: { [fileName]: 'grandparent content' },
+                },
                 {
                     label: 'parent',
                     parents: ['grandparent'],
@@ -90,6 +96,7 @@ describe('squash-files commands', () => {
                     isCurrentWorkingCopy: true,
                 },
             ]);
+            repo.config('revset-aliases."immutable_heads()"', `commit_id("${ids.base.commitId}")`);
 
             ctx.host.ui.setNextRevisionPromptResponse(ids.grandparent.changeId);
 
@@ -100,6 +107,14 @@ describe('squash-files commands', () => {
 
             const childOtherContent = repo.getFileContent('@', 'other.txt');
             expect(childOtherContent).toBe('other content');
+
+            // Verify that prompt only presented mutable ancestors, not immutable base or source child
+            const quickPick = ctx.host.ui.quickPickCalls[0];
+            const details = quickPick.items.map((i) => i.detail);
+            expect(details).toContain(ids.grandparent.changeId);
+            expect(details).toContain(ids.parent.changeId);
+            expect(details).not.toContain(ids.base.changeId);
+            expect(details).not.toContain(ids.child.changeId);
         });
     });
 
@@ -122,6 +137,7 @@ describe('squash-files commands', () => {
             await squashFilesIntoChildCommand(ctx, { paths: [fileName], revision: ids.parent.changeId });
 
             expect(repo.getFileContent(ids.child.changeId, fileName)).toBe('parent modified');
+            expect(repo.getDescription(ids.child.changeId)).toBe('child');
         });
 
         test('prompts when multiple children exist', async () => {

--- a/src/test/commands/squash-revision.test.ts
+++ b/src/test/commands/squash-revision.test.ts
@@ -269,12 +269,20 @@ describe('squashRevisionIntoParentCommand', () => {
             { label: 'child', parents: ['p'], description: '', files: { 'child.txt': 'child' } },
             { label: 'wc', parents: ['child'], isCurrentWorkingCopy: true },
         ]);
+        repo.config('revset-aliases."immutable_heads()"', `commit_id("${ids.base.commitId}")`);
 
-        ctx.host.ui.setNextRevisionPromptResponse(ids.base.changeId);
+        ctx.host.ui.setNextRevisionPromptResponse(ids.p.changeId);
 
         await squashRevisionIntoAncestorCommand(ctx, { revision: ids.child.changeId });
 
-        expect(repo.getFileContent(ids.base.changeId, 'child.txt')).toBe('child');
+        expect(repo.getFileContent(ids.p.changeId, 'child.txt')).toBe('child');
+
+        // Verify that prompt only presented mutable ancestors (p), not immutable base or source child
+        const quickPick = ctx.host.ui.quickPickCalls[0];
+        const details = quickPick.items.map((i) => i.detail);
+        expect(details).toContain(ids.p.changeId);
+        expect(details).not.toContain(ids.base.changeId);
+        expect(details).not.toContain(ids.child.changeId);
     });
 
     test('completeSquashRevisionCommand completes squash and closes editor', async () => {

--- a/src/test/common/ui-helpers.test.ts
+++ b/src/test/common/ui-helpers.test.ts
@@ -7,6 +7,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CodeForgeRegistry } from '../../code-forge-registry';
+import { RevisionQuery } from '../../commands/command-utils';
 import {
     promptForRevision,
     promptSelectOrCreate,
@@ -147,6 +148,63 @@ describe('ui-helpers', () => {
             });
 
             expect(result).toBe(ids.p1.changeId);
+        });
+
+        it('restricts prompt to mutable ancestors when using mutableAncestorsExcluding', async () => {
+            const ids = await buildGraph(repo, [
+                { label: 'root', files: { 'file0.txt': 'root\n' } },
+                { label: 'p1', parents: ['root'], files: { 'file1.txt': 'p1\n' } },
+                { label: 'c1', parents: ['p1'], files: { 'file2.txt': 'c1\n' }, isCurrentWorkingCopy: true },
+            ]);
+            repo.config('revset-aliases."immutable_heads()"', `commit_id("${ids.root.commitId}")`);
+
+            let quickPickItems: { label: string; detail?: string }[] = [];
+            ui.showQuickPick = vi.fn().mockImplementation((items) => {
+                quickPickItems = items;
+                return Promise.resolve({
+                    label: 'p1',
+                    detail: ids.p1.changeId,
+                });
+            });
+
+            const result = await promptForRevision(ui, jj, {
+                revisionQuery: RevisionQuery.mutableAncestorsExcluding('@'),
+            });
+
+            expect(result).toBe(ids.p1.changeId);
+            // Should contain mutable parent p1, but NOT the working copy c1 (@) or root commit
+            const details = quickPickItems.map((item) => item.detail);
+            expect(details).toContain(ids.p1.changeId);
+            expect(details).not.toContain(ids.c1.changeId);
+            expect(details).not.toContain(ids.root.changeId);
+        });
+
+        it('restricts prompt to mutable ancestors including target when using mutableAncestorsIncluding', async () => {
+            const ids = await buildGraph(repo, [
+                { label: 'root', files: { 'file0.txt': 'root\n' } },
+                { label: 'p1', parents: ['root'], files: { 'file1.txt': 'p1\n' } },
+                { label: 'c1', parents: ['p1'], files: { 'file2.txt': 'c1\n' }, isCurrentWorkingCopy: true },
+            ]);
+            repo.config('revset-aliases."immutable_heads()"', `commit_id("${ids.root.commitId}")`);
+
+            let quickPickItems: { label: string; detail?: string }[] = [];
+            ui.showQuickPick = vi.fn().mockImplementation((items) => {
+                quickPickItems = items;
+                return Promise.resolve({
+                    label: 'c1',
+                    detail: ids.c1.changeId,
+                });
+            });
+
+            const result = await promptForRevision(ui, jj, {
+                revisionQuery: RevisionQuery.mutableAncestorsIncluding('@'),
+            });
+
+            expect(result).toBe(ids.c1.changeId);
+            const details = quickPickItems.map((item) => item.detail);
+            expect(details).toContain(ids.c1.changeId);
+            expect(details).toContain(ids.p1.changeId);
+            expect(details).not.toContain(ids.root.changeId);
         });
     });
 

--- a/src/test/fake-host-environment.ts
+++ b/src/test/fake-host-environment.ts
@@ -43,6 +43,16 @@ export class FakeHostUi implements HostUi {
     public errorMessages: string[] = [];
     public progressTitles: string[] = [];
     public statusBarMessages: { message: string; timeoutMs?: number }[] = [];
+    public quickPickCalls: {
+        items: { label: string; detail?: string; description?: string; value?: unknown }[];
+        options?: {
+            placeHolder?: string;
+            title?: string;
+            matchOnDescription?: boolean;
+            matchOnDetail?: boolean;
+            acceptCustomValue?: boolean;
+        };
+    }[] = [];
 
     get warningResponse(): string | undefined {
         return this.warningResponses[0];
@@ -94,8 +104,8 @@ export class FakeHostUi implements HostUi {
     }
 
     async showQuickPick<T extends { label: string; value?: unknown }>(
-        _items: T[],
-        _options?: {
+        items: T[],
+        options?: {
             placeHolder?: string;
             title?: string;
             matchOnDescription?: boolean;
@@ -103,6 +113,7 @@ export class FakeHostUi implements HostUi {
             acceptCustomValue?: boolean;
         },
     ): Promise<T | undefined> {
+        this.quickPickCalls.push({ items, options });
         return this.quickPickResponses.shift() as T | undefined;
     }
 


### PR DESCRIPTION

Prevent interactive ancestor selection from retrieving immutable or merged commits across repository history when squashing changes or advancing bookmarks. Revision queries now filter for mutable ancestor sets, ensuring prompt selections are limited to workable commits in the current lineage, and file squashes into children preserve destination descriptions.