### PR TITLE
webview: decouple webview applications from vscode runtime using transport-agnostic bridge

### DIFF
--- a/src/test/webview-logger.test.ts
+++ b/src/test/webview-logger.test.ts
@@ -77,4 +77,25 @@ describe('WebviewLogger', () => {
         expect(consoleInfoSpy).toHaveBeenCalledWith('[TestTag] Standalone info message', '');
         consoleInfoSpy.mockRestore();
     });
+
+    test('omits details when details parameter is undefined', () => {
+        const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+        const mockVscodeApi: WebviewVsCodeApi = {
+            postMessage: vi.fn(),
+        };
+
+        const logger = new WebviewLogger('TestTag', mockVscodeApi);
+        logger.info('Simple message');
+
+        expect(mockVscodeApi.postMessage).toHaveBeenCalledWith({
+            type: 'logMessage',
+            payload: {
+                level: 'info',
+                message: '[TestTag] Simple message',
+                details: undefined,
+            },
+        });
+
+        consoleInfoSpy.mockRestore();
+    });
 });

--- a/src/test/webview/bridge.test.ts
+++ b/src/test/webview/bridge.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    getWebviewTransport,
+    MockWebviewTransport,
+    setWebviewTransport,
+    VsCodeWebviewTransport,
+    WebSocketWebviewTransport,
+} from '../../webview/transport';
+
+class MockMessageEvent extends Event {
+    public readonly data: unknown;
+    constructor(type: string, init?: { data?: unknown }) {
+        super(type);
+        this.data = init?.data;
+    }
+}
+
+class MockWebSocket {
+    public static readonly CONNECTING = 0;
+    public static readonly OPEN = 1;
+    public static readonly CLOSING = 2;
+    public static readonly CLOSED = 3;
+
+    public static instance?: MockWebSocket;
+    public readonly url: string;
+    public readyState = 0;
+    public send = vi.fn();
+    public close = vi.fn();
+    public onopen?: (() => void) | null;
+    public onmessage?: ((event: { data: unknown }) => void) | null;
+    public onerror?: ((event: Event) => void) | null;
+    public onclose?: ((event: CloseEvent) => void) | null;
+
+    constructor(url: string) {
+        this.url = url;
+        MockWebSocket.instance = this;
+    }
+}
+
+describe('WebviewTransport', () => {
+    afterEach(() => {
+        setWebviewTransport(undefined);
+        vi.restoreAllMocks();
+    });
+
+    describe('MockWebviewTransport', () => {
+        it('captures sent messages', () => {
+            const transport = new MockWebviewTransport({ test: 123 });
+            expect(transport.getInitialData<{ test: number }>()).toEqual({ test: 123 });
+
+            transport.postMessage({ type: 'testMessage', payload: { foo: 'bar' } });
+            expect(transport.sentMessages).toEqual([{ type: 'testMessage', payload: { foo: 'bar' } }]);
+
+            transport.clear();
+            expect(transport.sentMessages).toEqual([]);
+        });
+
+        it('dispatches messages to registered onMessage listeners', () => {
+            const transport = new MockWebviewTransport();
+            const received: unknown[] = [];
+
+            const unsubscribe = transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            transport.simulateIncomingMessage({ type: 'update', commits: [] });
+            expect(received).toEqual([{ type: 'update', commits: [] }]);
+
+            unsubscribe();
+            transport.simulateIncomingMessage({ type: 'update', commits: ['c1'] });
+            expect(received).toHaveLength(1);
+        });
+
+        it('clears registered handlers on clear()', () => {
+            const transport = new MockWebviewTransport();
+            const received: unknown[] = [];
+
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            transport.clear();
+            transport.simulateIncomingMessage({ type: 'update' });
+            expect(received).toHaveLength(0);
+        });
+
+        it('isolates subscriber errors during dispatch', () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const transport = new MockWebviewTransport();
+            const received: unknown[] = [];
+
+            transport.onMessage(() => {
+                throw new Error('Subscriber 1 threw');
+            });
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            transport.simulateIncomingMessage({ type: 'update' });
+            expect(received).toEqual([{ type: 'update' }]);
+            expect(consoleErrorSpy).toHaveBeenCalled();
+            consoleErrorSpy.mockRestore();
+        });
+
+        it('updates initial data dynamically', () => {
+            const transport = new MockWebviewTransport();
+            expect(transport.getInitialData()).toBeUndefined();
+
+            transport.setInitialData({ user: 'alice' });
+            expect(transport.getInitialData<{ user: string }>()).toEqual({ user: 'alice' });
+        });
+    });
+
+    describe('VsCodeWebviewTransport', () => {
+        let postMessageMock: (message: unknown) => void;
+        let originalWindow: unknown;
+        let mockEventTarget: EventTarget;
+
+        beforeEach(() => {
+            postMessageMock = vi.fn();
+            mockEventTarget = new EventTarget();
+            originalWindow = (globalThis as { window?: unknown }).window;
+
+            (globalThis as { window?: unknown }).window = Object.assign(mockEventTarget, {
+                acquireVsCodeApi: () => ({
+                    postMessage: postMessageMock,
+                }),
+                vscodeInitialData: {
+                    view: 'graph',
+                    payload: { theme: 'dark' },
+                },
+                addEventListener: mockEventTarget.addEventListener.bind(mockEventTarget),
+                removeEventListener: mockEventTarget.removeEventListener.bind(mockEventTarget),
+                dispatchEvent: mockEventTarget.dispatchEvent.bind(mockEventTarget),
+            });
+        });
+
+        afterEach(() => {
+            (globalThis as { window?: unknown }).window = originalWindow;
+        });
+
+        it('sends messages through acquireVsCodeApi postMessage', () => {
+            const transport = new VsCodeWebviewTransport();
+            transport.postMessage({ type: 'webviewLoaded' });
+
+            expect(postMessageMock).toHaveBeenCalledWith({ type: 'webviewLoaded' });
+        });
+
+        it('retrieves initial data from window.vscodeInitialData', () => {
+            const transport = new VsCodeWebviewTransport();
+            expect(transport.getInitialData()).toEqual({
+                view: 'graph',
+                payload: { theme: 'dark' },
+            });
+        });
+
+        it('listens for window message events and cleans up listener on unsubscribe', () => {
+            const transport = new VsCodeWebviewTransport();
+            const received: unknown[] = [];
+
+            const unsubscribe = transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            const target = (globalThis as { window?: EventTarget }).window;
+            target?.dispatchEvent(
+                new MockMessageEvent('message', {
+                    data: { type: 'update', commits: [] },
+                }),
+            );
+
+            expect(received).toEqual([{ type: 'update', commits: [] }]);
+
+            unsubscribe();
+
+            target?.dispatchEvent(
+                new MockMessageEvent('message', {
+                    data: { type: 'update', commits: ['new'] },
+                }),
+            );
+
+            expect(received).toHaveLength(1);
+        });
+
+        it('isolates subscriber errors in message listener', () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const transport = new VsCodeWebviewTransport();
+            const received: unknown[] = [];
+
+            transport.onMessage(() => {
+                throw new Error('VsCode subscriber error');
+            });
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            const target = (globalThis as { window?: EventTarget }).window;
+            target?.dispatchEvent(
+                new MockMessageEvent('message', {
+                    data: { type: 'update' },
+                }),
+            );
+
+            expect(received).toEqual([{ type: 'update' }]);
+            expect(consoleErrorSpy).toHaveBeenCalled();
+            consoleErrorSpy.mockRestore();
+            transport.dispose();
+        });
+
+        it('cleans up listeners on dispose()', () => {
+            const transport = new VsCodeWebviewTransport();
+            const received: unknown[] = [];
+
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            transport.dispose();
+
+            const target = (globalThis as { window?: EventTarget }).window;
+            target?.dispatchEvent(
+                new MockMessageEvent('message', {
+                    data: { type: 'update' },
+                }),
+            );
+
+            expect(received).toHaveLength(0);
+        });
+
+        it('reuses cached acquireVsCodeApi across multiple instances', () => {
+            const transport1 = new VsCodeWebviewTransport();
+            const transport2 = new VsCodeWebviewTransport();
+
+            transport1.postMessage({ msg: 1 });
+            transport2.postMessage({ msg: 2 });
+
+            expect(postMessageMock).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('WebSocketWebviewTransport', () => {
+        let originalWebSocket: typeof WebSocket | undefined;
+
+        beforeEach(() => {
+            originalWebSocket = globalThis.WebSocket;
+            MockWebSocket.instance = undefined;
+            (globalThis as { WebSocket?: unknown }).WebSocket = MockWebSocket;
+        });
+
+        afterEach(() => {
+            globalThis.WebSocket = originalWebSocket as typeof WebSocket;
+        });
+
+        it('queues messages before socket is open and sends on connect', () => {
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc', { initial: true });
+            expect(transport.getInitialData()).toEqual({ initial: true });
+
+            const socket = MockWebSocket.instance;
+            expect(socket).toBeDefined();
+
+            transport.postMessage({ type: 'queued1' });
+            expect(socket?.send).not.toHaveBeenCalled();
+
+            if (socket) {
+                socket.readyState = 1; // OPEN
+                socket.onopen?.();
+            }
+
+            expect(socket?.send).toHaveBeenCalledWith(JSON.stringify({ type: 'queued1' }));
+
+            transport.postMessage({ type: 'immediate' });
+            expect(socket?.send).toHaveBeenCalledWith(JSON.stringify({ type: 'immediate' }));
+
+            transport.dispose();
+            expect(socket?.close).toHaveBeenCalled();
+            expect(socket?.onopen).toBeNull();
+            expect(socket?.onmessage).toBeNull();
+        });
+
+        it('bounds outbound message queue to MAX_QUEUE_SIZE', () => {
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const socket = MockWebSocket.instance;
+            expect(socket).toBeDefined();
+
+            for (let i = 0; i < 110; i++) {
+                transport.postMessage({ seq: i });
+            }
+
+            if (socket) {
+                socket.readyState = 1;
+                socket.onopen?.();
+            }
+
+            expect(socket?.send).toHaveBeenCalledTimes(100);
+            expect(socket?.send).toHaveBeenCalledWith(JSON.stringify({ seq: 10 }));
+            expect(socket?.send).toHaveBeenCalledWith(JSON.stringify({ seq: 109 }));
+            transport.dispose();
+        });
+
+        it('handles postMessage exceptions gracefully when socket throws', () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const socket = MockWebSocket.instance;
+
+            if (socket) {
+                socket.readyState = 1;
+                socket.send.mockImplementation(() => {
+                    throw new Error('Socket send failed');
+                });
+            }
+
+            expect(() => transport.postMessage({ type: 'fail' })).not.toThrow();
+            expect(consoleErrorSpy).toHaveBeenCalled();
+            consoleErrorSpy.mockRestore();
+            transport.dispose();
+        });
+
+        it('parses incoming JSON messages and dispatches to listeners', () => {
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const received: unknown[] = [];
+
+            const unsubscribe = transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            const socket = MockWebSocket.instance;
+            expect(socket).toBeDefined();
+
+            socket?.onmessage?.({
+                data: JSON.stringify({ type: 'update', data: 42 }),
+            });
+
+            expect(received).toEqual([{ type: 'update', data: 42 }]);
+
+            unsubscribe();
+
+            socket?.onmessage?.({
+                data: JSON.stringify({ type: 'update', data: 43 }),
+            });
+
+            expect(received).toHaveLength(1);
+        });
+
+        it('safely handles malformed JSON without crashing listeners', () => {
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const received: unknown[] = [];
+
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            const socket = MockWebSocket.instance;
+            socket?.onmessage?.({
+                data: 'invalid json{',
+            });
+
+            expect(received).toHaveLength(0);
+        });
+
+        it('isolates subscriber errors in WebSocket listener', () => {
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const received: unknown[] = [];
+
+            transport.onMessage(() => {
+                throw new Error('Subscriber error');
+            });
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            const socket = MockWebSocket.instance;
+            socket?.onmessage?.({
+                data: JSON.stringify({ type: 'update' }),
+            });
+
+            expect(received).toEqual([{ type: 'update' }]);
+            expect(consoleErrorSpy).toHaveBeenCalled();
+            consoleErrorSpy.mockRestore();
+        });
+
+        it('reconnects automatically on socket close', () => {
+            vi.useFakeTimers();
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const initialSocket = MockWebSocket.instance;
+            expect(initialSocket).toBeDefined();
+
+            // Simulate connection close
+            initialSocket?.onclose?.({} as CloseEvent);
+
+            // Fast-forward past reconnect timer (1000ms)
+            vi.advanceTimersByTime(1100);
+
+            // A new MockWebSocket should have been instantiated
+            expect(MockWebSocket.instance).not.toBe(initialSocket);
+
+            transport.dispose();
+            vi.useRealTimers();
+        });
+    });
+
+    describe('getWebviewTransport & setWebviewTransport', () => {
+        it('returns custom transport if overridden', () => {
+            const custom = new MockWebviewTransport({ custom: true });
+            setWebviewTransport(custom);
+
+            expect(getWebviewTransport()).toBe(custom);
+        });
+
+        it('disposes previous transport when setWebviewTransport is called', () => {
+            const disposeSpy = vi.fn();
+            const transport = new MockWebviewTransport();
+            transport.dispose = disposeSpy;
+
+            setWebviewTransport(transport);
+            setWebviewTransport(undefined);
+
+            expect(disposeSpy).toHaveBeenCalled();
+        });
+
+        it('returns MockWebviewTransport in headless/node runtime and caches it', () => {
+            const transport1 = getWebviewTransport();
+            const transport2 = getWebviewTransport();
+
+            expect(transport1).toBeInstanceOf(MockWebviewTransport);
+            expect(transport1).toBe(transport2);
+        });
+
+        it('returns VsCodeWebviewTransport when window.acquireVsCodeApi is present', () => {
+            const originalWindow = (globalThis as { window?: unknown }).window;
+            (globalThis as { window?: unknown }).window = {
+                acquireVsCodeApi: () => ({ postMessage: vi.fn() }),
+            };
+
+            setWebviewTransport(undefined);
+            const transport = getWebviewTransport();
+            expect(transport).toBeInstanceOf(VsCodeWebviewTransport);
+
+            (globalThis as { window?: unknown }).window = originalWindow;
+        });
+
+        it('returns WebSocketWebviewTransport in browser runtime with location.host or __JJ_VIEW_WS_URL__', () => {
+            const originalWindow = (globalThis as { window?: unknown }).window;
+            (globalThis as { window?: unknown }).window = {
+                location: {
+                    protocol: 'http:',
+                    host: 'localhost:3000',
+                },
+                __JJ_VIEW_WS_URL__: 'ws://localhost:3000/custom-ws',
+            };
+
+            setWebviewTransport(undefined);
+            const transport = getWebviewTransport();
+            expect(transport).toBeInstanceOf(WebSocketWebviewTransport);
+
+            (globalThis as { window?: unknown }).window = originalWindow;
+        });
+    });
+});

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -14,25 +14,31 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import * as React from 'react';
-import type { ActionPayload, CommitAction, JjLogEntry, JjStatusEntry, WebviewPayload } from '../jj-types';
+import type {
+    ActionPayload,
+    CommitAction,
+    JjLogEntry,
+    JjStatusEntry,
+    WebviewInitialData,
+    WebviewPayload,
+} from '../jj-types';
 import { BookmarkPill } from './components/Bookmark';
 import { CommitDetails } from './components/CommitDetails';
 import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
 import { useDragModifiers } from './hooks/useDragModifiers';
+import { useBridge } from './transport/BridgeContext';
 import { snapToCursorLeft } from './utils/modifiers';
 import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
-
-// Define the vscode API from the global scope (see global.d.ts)
-const vscode = window.acquireVsCodeApi();
 
 type DragItem =
     | { type: 'bookmark'; name: string; remote?: string }
     | (JjLogEntry & { type: 'commit'; changeId: string });
 
 const App: React.FC = () => {
-    // Initial State from Window (injected by provider)
-    const initialData = window.vscodeInitialData;
+    const bridge = useBridge();
+    // Initial State from Bridge
+    const initialData = bridge.getInitialData<WebviewInitialData>();
     const initialView = initialData?.view || 'graph';
 
     const [view] = React.useState<'graph' | 'details'>(initialView);
@@ -44,11 +50,16 @@ const App: React.FC = () => {
     const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>(
         initialData?.payload?.graphLabelAlignment || 'aligned',
     );
-    // Use ref to access latest commits in event listeners without triggering re-effects
+    // Use refs to access latest state in event listeners without triggering re-effects
     const commitsRef = React.useRef(commits);
     React.useEffect(() => {
         commitsRef.current = commits;
     }, [commits]);
+
+    const viewRef = React.useRef(view);
+    React.useEffect(() => {
+        viewRef.current = view;
+    }, [view]);
 
     const [loading, setLoading] = React.useState(
         initialView === 'graph' && !(initialData?.payload?.commits && initialData.payload.commits.length > 0),
@@ -85,7 +96,7 @@ const App: React.FC = () => {
             // Escape to deselect
             if (e.key === 'Escape') {
                 setSelectedCommitIds(new Set());
-                vscode.postMessage({
+                bridge.postMessage({
                     type: 'selectionChange',
                     payload: {
                         commitIds: [],
@@ -100,16 +111,29 @@ const App: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, []);
+    }, [bridge]);
 
     React.useEffect(() => {
-        // Listen for messages from the extension
-        const handleMessage = (event: MessageEvent) => {
-            const message = event.data;
+        // Listen for messages from the host
+        const handleMessage = (rawMessage: unknown) => {
+            if (!rawMessage || typeof rawMessage !== 'object' || !('type' in rawMessage)) {
+                return;
+            }
+            const message = rawMessage as {
+                type: string;
+                commits?: JjLogEntry[];
+                minChangeIdLength?: number;
+                theme?: string;
+                graphLabelAlignment?: string;
+                hiddenActions?: CommitAction[];
+                payload?: { changeId?: string; description?: string; hiddenActions?: CommitAction[] } & WebviewPayload;
+                ids?: string[];
+            };
             switch (message.type) {
                 case 'update':
-                    if (view === 'graph') {
-                        setCommits(message.commits);
+                    if (viewRef.current === 'graph' && message.commits) {
+                        const newCommits = message.commits;
+                        setCommits(newCommits);
                         if (message.minChangeIdLength !== undefined) {
                             setMinChangeIdLength(message.minChangeIdLength);
                         }
@@ -131,14 +155,14 @@ const App: React.FC = () => {
                             }
 
                             const validIds = Array.from(prevIds).filter((id) =>
-                                message.commits.some((c: JjLogEntry) => c.change_id === id),
+                                newCommits.some((c: JjLogEntry) => c.change_id === id),
                             );
 
                             if (validIds.length !== prevIds.size) {
                                 const newIds = new Set(validIds);
-                                const hasImmutable = hasImmutableSelection(newIds, message.commits);
+                                const hasImmutable = hasImmutableSelection(newIds, newCommits);
 
-                                vscode.postMessage({
+                                bridge.postMessage({
                                     type: 'selectionChange',
                                     payload: {
                                         commitIds: validIds,
@@ -153,15 +177,14 @@ const App: React.FC = () => {
                     break;
                 case 'updateDetails':
                     // If we get an update while in details view (e.g. after save)
-                    if (view === 'details') {
-                        setDetailsCommit(message.payload);
+                    if (viewRef.current === 'details') {
+                        setDetailsCommit(message.payload ?? null);
                     }
                     break;
                 case 'saveComplete':
-                    if (view === 'details') {
-                        setDetailsCommit((prev) =>
-                            prev ? { ...prev, description: message.payload.description } : prev,
-                        );
+                    if (viewRef.current === 'details' && message.payload?.description !== undefined) {
+                        const newDesc = message.payload.description;
+                        setDetailsCommit((prev) => (prev ? { ...prev, description: newDesc } : prev));
                     }
                     break;
                 case 'setSelection': {
@@ -171,7 +194,7 @@ const App: React.FC = () => {
                     // Calculate immutability status for the new selection
                     const hasImmutable = hasImmutableSelection(newIds, commitsRef.current);
 
-                    vscode.postMessage({
+                    bridge.postMessage({
                         type: 'selectionChange',
                         payload: {
                             commitIds: Array.from(newIds),
@@ -182,9 +205,9 @@ const App: React.FC = () => {
                 }
                 case 'panelClosed':
                     setSelectedCommitIds((prevIds) => {
-                        if (prevIds.has(message.payload.changeId) && prevIds.size === 1) {
+                        if (message.payload?.changeId && prevIds.has(message.payload.changeId) && prevIds.size === 1) {
                             const clearedIds = new Set<string>();
-                            vscode.postMessage({
+                            bridge.postMessage({
                                 type: 'selectionChange',
                                 payload: {
                                     commitIds: [],
@@ -197,20 +220,22 @@ const App: React.FC = () => {
                     });
                     break;
                 case 'updateHiddenActions':
-                    setHiddenActions(new Set(message.payload.hiddenActions));
+                    if (message.payload?.hiddenActions) {
+                        setHiddenActions(new Set(message.payload.hiddenActions));
+                    }
                     break;
             }
         };
 
-        window.addEventListener('message', handleMessage);
+        const unsubscribe = bridge.onMessage(handleMessage);
 
         // Signal that we are ready
-        vscode.postMessage({ type: 'webviewLoaded' });
+        bridge.postMessage({ type: 'webviewLoaded' });
 
         return () => {
-            window.removeEventListener('message', handleMessage);
+            unsubscribe();
         };
-    }, [view]);
+    }, [bridge]);
 
     const handleGraphAction = (action: string, payload: ActionPayload) => {
         if (action === 'select') {
@@ -222,10 +247,10 @@ const App: React.FC = () => {
             // 2. Update visual selection state
             setSelectedCommitIds(nextSelectedIds);
 
-            // 3. Notify Extension of Selection Change
+            // 3. Notify Host of Selection Change
             const hasImmutable = hasImmutableSelection(nextSelectedIds, commits);
 
-            vscode.postMessage({
+            bridge.postMessage({
                 type: 'selectionChange',
                 payload: {
                     commitIds: Array.from(nextSelectedIds),
@@ -236,19 +261,19 @@ const App: React.FC = () => {
             // 4. Request Details ONLY if the item ends up selected
             // (If we toggled it off, we shouldn't open details)
             if (nextSelectedIds.has(changeId)) {
-                vscode.postMessage({ type: 'getDetails', payload });
+                bridge.postMessage({ type: 'getDetails', payload });
             }
             return;
         }
 
         if (action === 'showComments') {
-            vscode.postMessage({ type: 'showComments', payload });
+            bridge.postMessage({ type: 'showComments', payload });
             return;
         }
 
         if (action === 'contextMenu') {
             // Include current selection in payload for smarter menus
-            vscode.postMessage({
+            bridge.postMessage({
                 type: action,
                 payload: {
                     ...payload,
@@ -258,12 +283,12 @@ const App: React.FC = () => {
             return;
         }
 
-        vscode.postMessage({ type: action, payload });
+        bridge.postMessage({ type: action, payload });
     };
 
     const handleSaveDescription = (description: string) => {
         if (view === 'details' && detailsCommit) {
-            vscode.postMessage({
+            bridge.postMessage({
                 type: 'saveDescription',
                 payload: { changeId: detailsCommit.changeId, description },
             });
@@ -272,7 +297,7 @@ const App: React.FC = () => {
 
     const handleOpenDiff = (file: JjStatusEntry, isImmutable: boolean) => {
         if (view === 'details' && detailsCommit) {
-            vscode.postMessage({
+            bridge.postMessage({
                 type: 'openDiff',
                 payload: { changeId: detailsCommit.changeId, file, isImmutable },
             });
@@ -281,7 +306,7 @@ const App: React.FC = () => {
 
     const handleOpenMultiDiff = () => {
         if (view === 'details' && detailsCommit) {
-            vscode.postMessage({
+            bridge.postMessage({
                 type: 'openMultiDiff',
                 payload: { changeId: detailsCommit.changeId },
             });
@@ -350,8 +375,8 @@ const App: React.FC = () => {
                     });
                 });
 
-                // Send to extension
-                vscode.postMessage({
+                // Send to host
+                bridge.postMessage({
                     type: 'moveBookmark',
                     payload: { bookmark: bookmarkName, targetChangeId },
                 });
@@ -368,7 +393,7 @@ const App: React.FC = () => {
                 }
 
                 const message = activeModifier.buildMessagePayload(sourceChangeId, targetChangeId);
-                vscode.postMessage(message);
+                bridge.postMessage(message);
             }
         } finally {
             resetKeys();
@@ -397,7 +422,7 @@ const App: React.FC = () => {
                 onOpenDiff={handleOpenDiff}
                 onOpenMultiDiff={handleOpenMultiDiff}
                 onDescriptionChange={(description: string, selectionStart: number, selectionEnd: number) => {
-                    vscode.postMessage({
+                    bridge.postMessage({
                         type: 'descriptionChanged',
                         payload: { description, selectionStart, selectionEnd },
                     });
@@ -430,7 +455,7 @@ const App: React.FC = () => {
                         // Only clear if clicking the container itself, not children
                         if (e.target === e.currentTarget) {
                             setSelectedCommitIds(new Set());
-                            vscode.postMessage({
+                            bridge.postMessage({
                                 type: 'selectionChange',
                                 payload: {
                                     commitIds: [],

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import type { JjBookmark, JjStatusEntry } from '../../jj-types';
 import { formatCommitDescription } from '../../utils/format-utils';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
+import { useMessageListener } from '../transport/BridgeContext';
 import { BasePill, BookmarkPill, TagPill } from './Bookmark';
 import { PersonInfo } from './PersonInfo';
 
@@ -114,47 +115,42 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         prevDescriptionRef.current = description;
     }, [description]);
 
-    React.useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            const data = event.data;
-            if (!isWebviewMessage(data)) {
-                return;
-            }
+    useMessageListener((data: unknown) => {
+        if (!isWebviewMessage(data)) {
+            return;
+        }
 
-            if (data.type === 'saveFailed') {
-                setIsSaving(false);
-                if (saveTimeoutRef.current) {
-                    clearTimeout(saveTimeoutRef.current);
-                }
-            } else if (data.type === 'saveComplete') {
-                setIsSaving(false);
-                if (saveTimeoutRef.current) {
-                    clearTimeout(saveTimeoutRef.current);
-                }
-                const savedDescription = data.payload.description;
-                setDraftDescription(savedDescription);
-                if (textareaRef.current) {
-                    textareaRef.current.value = savedDescription;
-                }
-                prevDescriptionRef.current = savedDescription;
-            } else if (data.type === 'updateDescription') {
-                const { description: newDesc, selectionStart, selectionEnd } = data.payload;
-                isApplyingExtensionEdit.current = true;
-                try {
-                    if (textareaRef.current) {
-                        textareaRef.current.value = newDesc;
-                        setDraftDescription(newDesc);
-                        textareaRef.current.focus();
-                        textareaRef.current.setSelectionRange(selectionStart, selectionEnd);
-                    }
-                } finally {
-                    isApplyingExtensionEdit.current = false;
-                }
+        if (data.type === 'saveFailed') {
+            setIsSaving(false);
+            if (saveTimeoutRef.current) {
+                clearTimeout(saveTimeoutRef.current);
             }
-        };
-        window.addEventListener('message', handleMessage);
-        return () => window.removeEventListener('message', handleMessage);
-    }, []);
+        } else if (data.type === 'saveComplete') {
+            setIsSaving(false);
+            if (saveTimeoutRef.current) {
+                clearTimeout(saveTimeoutRef.current);
+            }
+            const savedDescription = data.payload.description;
+            setDraftDescription(savedDescription);
+            if (textareaRef.current) {
+                textareaRef.current.value = savedDescription;
+            }
+            prevDescriptionRef.current = savedDescription;
+        } else if (data.type === 'updateDescription') {
+            const { description: newDesc, selectionStart, selectionEnd } = data.payload;
+            isApplyingExtensionEdit.current = true;
+            try {
+                if (textareaRef.current) {
+                    textareaRef.current.value = newDesc;
+                    setDraftDescription(newDesc);
+                    textareaRef.current.focus();
+                    textareaRef.current.setSelectionRange(selectionStart, selectionEnd);
+                }
+            } finally {
+                isApplyingExtensionEdit.current = false;
+            }
+        }
+    });
 
     const handleSave = async () => {
         setIsSaving(true);

--- a/src/webview/global.d.ts
+++ b/src/webview/global.d.ts
@@ -8,8 +8,14 @@ declare global {
     interface Window {
         vscode: unknown;
         vscodeInitialData?: WebviewInitialData;
+        __jjViewVsCodeApi?: {
+            postMessage: (message: unknown) => void;
+            setState?: (state: unknown) => void;
+            getState?: () => unknown;
+        };
+        __JJ_VIEW_WS_URL__?: string;
         acquireVsCodeApi: () => {
-            postMessage: (message: { type: string; payload?: unknown }) => void;
+            postMessage: (message: unknown) => void;
             setState: (state: unknown) => void;
             getState: () => unknown;
         };

--- a/src/webview/index.tsx
+++ b/src/webview/index.tsx
@@ -5,9 +5,14 @@
 import '@vscode-elements/elements';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { BridgeProvider } from './transport/BridgeContext';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
     const root = createRoot(rootElement);
-    root.render(<App />);
+    root.render(
+        <BridgeProvider>
+            <App />
+        </BridgeProvider>,
+    );
 }

--- a/src/webview/process-monitor/ProcessMonitorApp.tsx
+++ b/src/webview/process-monitor/ProcessMonitorApp.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useBridge } from '../transport/BridgeContext';
 import { getRelativeTimeString } from '../utils/time-utils';
 
 export interface ActiveTask {
@@ -36,13 +37,6 @@ export interface Metrics {
     totalCount: number;
     avgDurationMs: number;
 }
-
-// Acquire VS Code API
-declare function acquireVsCodeApi(): {
-    postMessage(message: unknown): void;
-};
-
-const vscode = typeof acquireVsCodeApi === 'function' ? acquireVsCodeApi() : { postMessage: () => {} };
 
 function ActiveDurationCell({ startPerformanceTime }: { startPerformanceTime: number }) {
     const [elapsedText, setElapsedText] = useState<string>(() => {
@@ -108,6 +102,7 @@ function HistoryTimestampDetail({ timestamp, fullTimestamp }: { timestamp: numbe
 }
 
 export default function ProcessMonitorApp() {
+    const bridge = useBridge();
     const [metrics, setMetrics] = useState<Metrics>({
         activeCount: 0,
         peakConcurrency: 0,
@@ -121,9 +116,17 @@ export default function ProcessMonitorApp() {
     const [copiedId, setCopiedId] = useState<string | null>(null);
 
     useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            const message = event.data;
-            if (message?.type === 'update') {
+        const unsubscribe = bridge.onMessage((data: unknown) => {
+            if (!data || typeof data !== 'object' || !('type' in data)) {
+                return;
+            }
+            const message = data as {
+                type: string;
+                activeTasks?: ActiveTask[];
+                historyTasks?: HistoryTask[];
+                metrics?: Metrics;
+            };
+            if (message.type === 'update') {
                 setActiveTasks(message.activeTasks || []);
                 setHistoryTasks(message.historyTasks || []);
                 setMetrics(
@@ -135,11 +138,11 @@ export default function ProcessMonitorApp() {
                     },
                 );
             }
+        });
+        return () => {
+            unsubscribe();
         };
-
-        window.addEventListener('message', handleMessage);
-        return () => window.removeEventListener('message', handleMessage);
-    }, []);
+    }, [bridge]);
 
     const toggleExpand = (rowKey: string, e: React.SyntheticEvent) => {
         e.stopPropagation();
@@ -163,19 +166,19 @@ export default function ProcessMonitorApp() {
 
     const handleKillProcess = (id: number, e: React.MouseEvent) => {
         e.stopPropagation();
-        vscode.postMessage({ command: 'killProcess', id });
+        bridge.postMessage({ command: 'killProcess', id });
     };
 
     const handleKillAll = () => {
-        vscode.postMessage({ command: 'killAllProcesses' });
+        bridge.postMessage({ command: 'killAllProcesses' });
     };
 
     const handleClearHistory = () => {
-        vscode.postMessage({ command: 'clearHistory' });
+        bridge.postMessage({ command: 'clearHistory' });
     };
 
     const handleHidePanel = () => {
-        vscode.postMessage({ command: 'hidePanel' });
+        bridge.postMessage({ command: 'hidePanel' });
     };
 
     const copyToClipboard = (text: string, key: string, e: React.MouseEvent) => {

--- a/src/webview/process-monitor/index.tsx
+++ b/src/webview/process-monitor/index.tsx
@@ -3,10 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { createRoot } from 'react-dom/client';
+import { BridgeProvider } from '../transport/BridgeContext';
 import ProcessMonitorApp from './ProcessMonitorApp';
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
     const root = createRoot(rootElement);
-    root.render(<ProcessMonitorApp />);
+    root.render(
+        <BridgeProvider>
+            <ProcessMonitorApp />
+        </BridgeProvider>,
+    );
 }

--- a/src/webview/transport/BridgeContext.tsx
+++ b/src/webview/transport/BridgeContext.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as React from 'react';
+import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import { getWebviewTransport } from './registry';
+import type { WebviewTransport } from './types';
+
+const BridgeContext = createContext<WebviewTransport | null>(null);
+
+export interface BridgeProviderProps {
+    transport?: WebviewTransport;
+    children: React.ReactNode;
+}
+
+export const BridgeProvider: React.FC<BridgeProviderProps> = ({ transport, children }) => {
+    const activeTransport = useMemo(() => transport ?? getWebviewTransport(), [transport]);
+
+    return <BridgeContext.Provider value={activeTransport}>{children}</BridgeContext.Provider>;
+};
+
+export function useBridge(): WebviewTransport {
+    const context = useContext(BridgeContext);
+    if (!context) {
+        return getWebviewTransport();
+    }
+    return context;
+}
+
+export function useMessageListener<T = unknown>(handler: (message: T) => void): void {
+    const bridge = useBridge();
+    const handlerRef = useRef(handler);
+    handlerRef.current = handler;
+
+    useEffect(() => {
+        const unsubscribe = bridge.onMessage((msg) => {
+            handlerRef.current(msg as T);
+        });
+        return () => {
+            unsubscribe();
+        };
+    }, [bridge]);
+}

--- a/src/webview/transport/index.ts
+++ b/src/webview/transport/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './BridgeContext';
+export * from './mock-transport';
+export * from './registry';
+export * from './types';
+export * from './vscode-transport';
+export * from './websocket-transport';

--- a/src/webview/transport/mock-transport.ts
+++ b/src/webview/transport/mock-transport.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WebviewTransport } from './types';
+
+/**
+ * In-Memory Mock Transport for unit tests and headless environments.
+ */
+export class MockWebviewTransport implements WebviewTransport {
+    public readonly sentMessages: unknown[] = [];
+    private readonly handlers = new Set<(message: unknown) => void>();
+    private initialData?: unknown;
+
+    constructor(initialData?: unknown) {
+        this.initialData = initialData;
+    }
+
+    public postMessage(message: unknown): void {
+        this.sentMessages.push(message);
+    }
+
+    public onMessage(handler: (message: unknown) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
+    }
+
+    public getInitialData<T>(): T | undefined {
+        return this.initialData as T | undefined;
+    }
+
+    public setInitialData(data: unknown): void {
+        this.initialData = data;
+    }
+
+    public simulateIncomingMessage(message: unknown): void {
+        for (const handler of Array.from(this.handlers)) {
+            try {
+                handler(message);
+            } catch (err) {
+                console.error('[MockWebviewTransport] Error in onMessage subscriber:', err);
+            }
+        }
+    }
+
+    public clear(): void {
+        this.sentMessages.length = 0;
+        this.handlers.clear();
+    }
+
+    public dispose(): void {
+        this.clear();
+    }
+}

--- a/src/webview/transport/registry.ts
+++ b/src/webview/transport/registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MockWebviewTransport } from './mock-transport';
+import type { WebviewTransport } from './types';
+import { VsCodeWebviewTransport } from './vscode-transport';
+
+import { WebSocketWebviewTransport } from './websocket-transport';
+
+let defaultTransport: WebviewTransport | undefined;
+
+/**
+ * Retrieves or creates the default singleton transport for the active runtime.
+ */
+export function getWebviewTransport(): WebviewTransport {
+    if (defaultTransport) {
+        return defaultTransport;
+    }
+
+    if (typeof window !== 'undefined' && typeof window.acquireVsCodeApi === 'function') {
+        defaultTransport = new VsCodeWebviewTransport();
+    } else if (
+        typeof window !== 'undefined' &&
+        (window.__JJ_VIEW_WS_URL__ ||
+            (window.location && typeof window.location.host === 'string' && window.location.host.length > 0))
+    ) {
+        const wsProtocol = window.location?.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = window.__JJ_VIEW_WS_URL__ ?? `${wsProtocol}//${window.location?.host}/ws`;
+        defaultTransport = new WebSocketWebviewTransport(wsUrl);
+    } else {
+        defaultTransport = new MockWebviewTransport();
+    }
+
+    return defaultTransport;
+}
+
+/**
+ * Overrides the default transport singleton (useful for testing or standalone web bootstrapping).
+ */
+export function setWebviewTransport(transport: WebviewTransport | undefined): void {
+    if (defaultTransport && defaultTransport !== transport) {
+        defaultTransport.dispose?.();
+    }
+    defaultTransport = transport;
+}

--- a/src/webview/transport/types.ts
+++ b/src/webview/transport/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type WebviewTransportMessage =
+    | { type: string; payload?: unknown; [key: string]: unknown }
+    | { command: string; [key: string]: unknown };
+
+export interface WebviewTransport {
+    postMessage(message: unknown): void;
+    onMessage(handler: (message: unknown) => void): () => void;
+    getInitialData<T>(): T | undefined;
+    dispose?(): void;
+}

--- a/src/webview/transport/vscode-transport.ts
+++ b/src/webview/transport/vscode-transport.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WebviewTransport } from './types';
+
+/**
+ * VS Code Webview Transport using window.acquireVsCodeApi() and window message events.
+ */
+export class VsCodeWebviewTransport implements WebviewTransport {
+    private readonly vscodeApi: {
+        postMessage: (message: unknown) => void;
+        setState?: (state: unknown) => void;
+        getState?: () => unknown;
+    };
+    private readonly _listeners = new Set<(event: MessageEvent) => void>();
+
+    constructor() {
+        if (typeof window === 'undefined' || typeof window.acquireVsCodeApi !== 'function') {
+            this.vscodeApi = {
+                postMessage: () => {},
+            };
+            return;
+        }
+
+        if (!window.__jjViewVsCodeApi) {
+            window.__jjViewVsCodeApi = window.acquireVsCodeApi();
+        }
+        this.vscodeApi = window.__jjViewVsCodeApi;
+    }
+
+    public postMessage(message: unknown): void {
+        this.vscodeApi.postMessage(message);
+    }
+
+    public onMessage(handler: (message: unknown) => void): () => void {
+        if (typeof window === 'undefined') {
+            return () => {};
+        }
+
+        const listener = (event: MessageEvent) => {
+            try {
+                handler(event.data);
+            } catch (err) {
+                console.error('[VsCodeWebviewTransport] Error in onMessage subscriber:', err);
+            }
+        };
+
+        this._listeners.add(listener);
+        window.addEventListener('message', listener);
+        return () => {
+            this._listeners.delete(listener);
+            window.removeEventListener('message', listener);
+        };
+    }
+
+    public getInitialData<T>(): T | undefined {
+        if (typeof window === 'undefined') {
+            return undefined;
+        }
+        return window.vscodeInitialData as T | undefined;
+    }
+
+    public dispose(): void {
+        if (typeof window !== 'undefined') {
+            for (const listener of this._listeners) {
+                window.removeEventListener('message', listener);
+            }
+        }
+        this._listeners.clear();
+    }
+}

--- a/src/webview/transport/websocket-transport.ts
+++ b/src/webview/transport/websocket-transport.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WebviewTransport } from './types';
+
+/**
+ * WebSocket Transport for self-hosted Web / Browser client.
+ */
+export class WebSocketWebviewTransport implements WebviewTransport {
+    private socket?: WebSocket;
+    private readonly messageQueue: unknown[] = [];
+    private readonly handlers = new Set<(message: unknown) => void>();
+    private initialData?: unknown;
+    private _disposed = false;
+    private reconnectTimer?: ReturnType<typeof setTimeout>;
+    private reconnectAttempts = 0;
+
+    public static readonly MAX_QUEUE_SIZE = 100;
+
+    constructor(
+        private readonly url: string,
+        initialData?: unknown,
+    ) {
+        this.initialData = initialData;
+        this.connect();
+    }
+
+    private connect(): void {
+        if (this._disposed || typeof WebSocket === 'undefined') {
+            return;
+        }
+
+        this.socket = new WebSocket(this.url);
+
+        this.socket.onopen = () => {
+            this.reconnectAttempts = 0;
+            while (this.messageQueue.length > 0) {
+                const msg = this.messageQueue.shift();
+                if (msg === undefined) {
+                    continue;
+                }
+                try {
+                    this.socket?.send(JSON.stringify(msg));
+                } catch (err) {
+                    console.error('[WebSocketWebviewTransport] Failed to send queued message:', err);
+                }
+            }
+        };
+
+        this.socket.onmessage = (event: MessageEvent) => {
+            let data: unknown;
+            try {
+                data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+            } catch {
+                // Ignore malformed message payloads
+                return;
+            }
+
+            for (const handler of Array.from(this.handlers)) {
+                try {
+                    handler(data);
+                } catch (err) {
+                    console.error('[WebSocketWebviewTransport] Error in onMessage subscriber:', err);
+                }
+            }
+        };
+
+        this.socket.onerror = (err) => {
+            console.error('[WebSocketWebviewTransport] WebSocket connection error:', err);
+        };
+
+        this.socket.onclose = () => {
+            if (!this._disposed) {
+                this.scheduleReconnect();
+            }
+        };
+    }
+
+    private scheduleReconnect(): void {
+        if (this._disposed || this.reconnectTimer) {
+            return;
+        }
+
+        const delay = Math.min(1000 * 2 ** this.reconnectAttempts, 5000);
+        this.reconnectAttempts++;
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = undefined;
+            this.connect();
+        }, delay);
+    }
+
+    public postMessage(message: unknown): void {
+        const isSocketOpen =
+            this.socket &&
+            (this.socket.readyState === 1 ||
+                (typeof WebSocket !== 'undefined' && this.socket.readyState === WebSocket.OPEN));
+        if (isSocketOpen) {
+            try {
+                this.socket?.send(JSON.stringify(message));
+            } catch (err) {
+                console.error('[WebSocketWebviewTransport] Failed to send message:', err);
+            }
+            return;
+        }
+
+        if (this.messageQueue.length >= WebSocketWebviewTransport.MAX_QUEUE_SIZE) {
+            this.messageQueue.shift();
+        }
+        this.messageQueue.push(message);
+    }
+
+    public onMessage(handler: (message: unknown) => void): () => void {
+        this.handlers.add(handler);
+        return () => {
+            this.handlers.delete(handler);
+        };
+    }
+
+    public getInitialData<T>(): T | undefined {
+        return this.initialData as T | undefined;
+    }
+
+    public setInitialData(data: unknown): void {
+        this.initialData = data;
+    }
+
+    public dispose(): void {
+        this._disposed = true;
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+        }
+        if (this.socket) {
+            this.socket.onopen = null;
+            this.socket.onmessage = null;
+            this.socket.onerror = null;
+            this.socket.onclose = null;
+            this.socket.close();
+            this.socket = undefined;
+        }
+        this.handlers.clear();
+        this.messageQueue.length = 0;
+    }
+}

--- a/src/webview/webview-logger.ts
+++ b/src/webview/webview-logger.ts
@@ -3,14 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface WebviewVsCodeApi {
+export interface WebviewMessenger {
     postMessage(message: unknown): void;
 }
+
+export type WebviewVsCodeApi = WebviewMessenger;
 
 export class WebviewLogger {
     constructor(
         private readonly tag: string,
-        private readonly vscodeApi?: WebviewVsCodeApi,
+        private readonly messenger?: WebviewMessenger,
     ) {}
 
     public info(message: string, details?: unknown): void {
@@ -29,7 +31,7 @@ export class WebviewLogger {
     }
 
     private post(level: 'info' | 'warn' | 'error', message: string, details?: unknown): void {
-        if (!this.vscodeApi) {
+        if (!this.messenger) {
             return;
         }
         const detailStr =
@@ -39,7 +41,7 @@ export class WebviewLogger {
                   ? String(details)
                   : undefined;
 
-        this.vscodeApi.postMessage({
+        this.messenger.postMessage({
             type: 'logMessage',
             payload: {
                 level,


### PR DESCRIPTION


Abstract the webview communication layer behind a modular transport interface, decoupling frontend React components from direct VS Code runtime globals. Webview applications now interact strictly through a React bridge context that supports VS Code message passing, standalone WebSocket streaming, and in-memory test mocks.