### PR TITLE
ipc: modularize IPC schemas per webview and adopt typed RPC in frontend

### DIFF
--- a/src/common/ipc/commit-details-schemas.ts
+++ b/src/common/ipc/commit-details-schemas.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+import { JjStatusEntrySchema } from '../../jj-schemas';
+import { WebviewPayloadSchema } from './log-view-schemas';
+
+export const CommitDetailsToHostMessageSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('webviewLoaded') }),
+    z.object({
+        type: z.literal('descriptionChanged'),
+        payload: z.object({
+            description: z.string(),
+            selectionStart: z.number().optional(),
+            selectionEnd: z.number().optional(),
+        }),
+    }),
+    z.object({
+        type: z.literal('saveDescription'),
+        payload: z.object({ changeId: z.string(), description: z.string() }),
+    }),
+    z.object({
+        type: z.literal('openDiff'),
+        payload: z.object({
+            file: JjStatusEntrySchema,
+            changeId: z.string(),
+            isImmutable: z.boolean().optional(),
+        }),
+    }),
+    z.object({
+        type: z.literal('openMultiDiff'),
+        payload: z.object({ changeId: z.string() }),
+    }),
+]);
+export type CommitDetailsToHostMessage = z.infer<typeof CommitDetailsToHostMessageSchema>;
+
+export const CommitDetailsHostToWebviewMessageSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('updateDetails'), payload: WebviewPayloadSchema }),
+    z.object({ type: z.literal('saveComplete'), payload: z.object({ description: z.string() }) }),
+    z.object({ type: z.literal('saveFailed') }),
+    z.object({
+        type: z.literal('updateDescription'),
+        payload: z.object({
+            description: z.string(),
+            selectionStart: z.number().optional(),
+            selectionEnd: z.number().optional(),
+        }),
+    }),
+]);
+export type CommitDetailsHostToWebviewMessage = z.infer<typeof CommitDetailsHostToWebviewMessageSchema>;

--- a/src/common/ipc/log-view-schemas.ts
+++ b/src/common/ipc/log-view-schemas.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { z } from 'zod';
-import { JjBookmarkSchema, JjLogEntrySchema, JjStatusEntrySchema } from '../jj-schemas';
+import { JjBookmarkSchema, JjLogEntrySchema, JjStatusEntrySchema } from '../../jj-schemas';
+
+export const CommitActionSchema = z.enum(['newChild', 'edit', 'squash', 'abandon', 'openCodeForge', 'upload']);
+export type CommitAction = z.infer<typeof CommitActionSchema>;
 
 export const ActionPayloadSchema = z.object({
     changeId: z.string(),
@@ -13,6 +16,7 @@ export const ActionPayloadSchema = z.object({
     changeIdShortest: z.string().optional(),
     isDivergent: z.boolean().optional(),
     changeIdOffset: z.number().optional(),
+    selectedCommitIds: z.array(z.string()).optional(),
 });
 export type ActionPayload = z.infer<typeof ActionPayloadSchema>;
 
@@ -21,7 +25,7 @@ export const WebviewPayloadSchema = z.object({
     minChangeIdLength: z.number().optional(),
     theme: z.string().optional(),
     graphLabelAlignment: z.string().optional(),
-    hiddenActions: z.array(z.string()).optional(),
+    hiddenActions: z.array(CommitActionSchema).optional(),
     changeId: z.string().optional(),
     commitId: z.string().optional(),
     description: z.string().optional(),
@@ -51,17 +55,10 @@ export const WebviewPayloadSchema = z.object({
 });
 export type WebviewPayload = z.infer<typeof WebviewPayloadSchema>;
 
-export const WebviewToHostMessageSchema = z.discriminatedUnion('type', [
+export const LogViewToHostMessageSchema = z.discriminatedUnion('type', [
     z.object({ type: z.literal('webviewLoaded') }),
-    z.object({ type: z.literal('newChild'), payload: ActionPayloadSchema }),
-    z.object({ type: z.literal('edit'), payload: ActionPayloadSchema }),
-    z.object({ type: z.literal('squash'), payload: ActionPayloadSchema }),
-    z.object({ type: z.literal('abandon'), payload: ActionPayloadSchema }),
-    z.object({ type: z.literal('select'), payload: ActionPayloadSchema }),
-    z.object({ type: z.literal('undo') }),
-    z.object({ type: z.literal('redo') }),
-    z.object({ type: z.literal('getDetails'), payload: ActionPayloadSchema }),
     z.object({ type: z.literal('new') }),
+    z.object({ type: z.literal('newChild'), payload: ActionPayloadSchema }),
     z.object({
         type: z.literal('newBefore'),
         payload: z.object({ changeIds: z.array(z.string()).optional() }),
@@ -70,6 +67,13 @@ export const WebviewToHostMessageSchema = z.discriminatedUnion('type', [
         type: z.literal('newAfter'),
         payload: z.object({ changeIds: z.array(z.string()).optional() }),
     }),
+    z.object({ type: z.literal('edit'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('squash'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('abandon'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('select'), payload: ActionPayloadSchema }),
+    z.object({ type: z.literal('undo') }),
+    z.object({ type: z.literal('redo') }),
+    z.object({ type: z.literal('getDetails'), payload: ActionPayloadSchema }),
     z.object({
         type: z.literal('resolve'),
         payload: z.object({ path: z.string() }),
@@ -88,7 +92,11 @@ export const WebviewToHostMessageSchema = z.discriminatedUnion('type', [
     }),
     z.object({
         type: z.literal('squashCommit'),
-        payload: z.object({ sourceChangeId: z.string(), targetChangeId: z.string(), mode: z.enum(['into', 'onto']) }),
+        payload: z.object({
+            sourceChangeId: z.string(),
+            targetChangeId: z.string(),
+            mode: z.enum(['into', 'onto']),
+        }),
     }),
     z.object({
         type: z.literal('duplicateCommit'),
@@ -116,41 +124,32 @@ export const WebviewToHostMessageSchema = z.discriminatedUnion('type', [
         payload: z.object({ url: z.string() }),
     }),
     z.object({
-        type: z.literal('saveDescription'),
-        payload: z.object({ changeId: z.string(), description: z.string() }),
+        type: z.literal('contextMenu'),
+        payload: ActionPayloadSchema,
+    }),
+]);
+export type LogViewToHostMessage = z.infer<typeof LogViewToHostMessageSchema>;
+
+export const LogViewHostToWebviewMessageSchema = z.discriminatedUnion('type', [
+    z.object({
+        type: z.literal('update'),
+        commits: z.array(JjLogEntrySchema),
+        minChangeIdLength: z.number().optional(),
+        theme: z.string().optional(),
+        graphLabelAlignment: z.string().optional(),
+        hiddenActions: z.array(CommitActionSchema).optional(),
     }),
     z.object({
-        type: z.literal('descriptionChanged'),
-        payload: z.object({
-            description: z.string(),
-            selectionStart: z.number().optional(),
-            selectionEnd: z.number().optional(),
-        }),
+        type: z.literal('updateHiddenActions'),
+        payload: z.object({ hiddenActions: z.array(CommitActionSchema) }),
     }),
     z.object({
-        type: z.literal('saveFileText'),
-        payload: z.object({ filePath: z.string(), content: z.string() }),
-    }),
-    z.object({
-        type: z.literal('openDiff'),
-        payload: z.object({
-            file: JjStatusEntrySchema,
-            changeId: z.string(),
-            isImmutable: z.boolean().optional(),
-        }),
-    }),
-    z.object({
-        type: z.literal('openMultiDiff'),
+        type: z.literal('panelClosed'),
         payload: z.object({ changeId: z.string() }),
     }),
+    z.object({
+        type: z.literal('setSelection'),
+        ids: z.array(z.string()),
+    }),
 ]);
-export type WebviewToHostMessage = z.infer<typeof WebviewToHostMessageSchema>;
-
-export const HostToWebviewMessageSchema = z.discriminatedUnion('type', [
-    z.object({ type: z.literal('updateData'), payload: WebviewPayloadSchema.optional() }),
-    z.object({ type: z.literal('updateDetails'), payload: WebviewPayloadSchema.optional() }),
-    z.object({ type: z.literal('updateTheme'), payload: z.object({ theme: z.string() }) }),
-    z.object({ type: z.literal('saveComplete'), payload: z.object({ description: z.string() }).optional() }),
-    z.object({ type: z.literal('saveFailed') }),
-]);
-export type HostToWebviewMessage = z.infer<typeof HostToWebviewMessageSchema>;
+export type LogViewHostToWebviewMessage = z.infer<typeof LogViewHostToWebviewMessageSchema>;

--- a/src/common/ipc/process-monitor-schemas.ts
+++ b/src/common/ipc/process-monitor-schemas.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { z } from 'zod';
+
+export const ProcessMonitorToHostMessageSchema = z.discriminatedUnion('command', [
+    z.object({ command: z.literal('killProcess'), id: z.number() }),
+    z.object({ command: z.literal('killAllProcesses') }),
+    z.object({ command: z.literal('clearHistory') }),
+    z.object({ command: z.literal('hidePanel') }),
+]);
+export type ProcessMonitorToHostMessage = z.infer<typeof ProcessMonitorToHostMessageSchema>;
+
+export const ProcessMonitorActiveTaskSchema = z.object({
+    id: z.number(),
+    command: z.string(),
+    args: z.array(z.string()),
+    startPerformanceTime: z.number(),
+    timestamp: z.number(),
+    label: z.string(),
+    pid: z.number(),
+});
+export type ProcessMonitorActiveTask = z.infer<typeof ProcessMonitorActiveTaskSchema>;
+
+export const ProcessMonitorHistoryTaskSchema = z.object({
+    id: z.number(),
+    command: z.string(),
+    args: z.array(z.string()),
+    duration: z.number(),
+    status: z.enum(['running', 'completed', 'failed', 'timed_out', 'cancelled']),
+    label: z.string(),
+    error: z.string(),
+    stdout: z.string(),
+    stderr: z.string(),
+    exitCode: z.number(),
+    timestamp: z.number(),
+});
+export type ProcessMonitorHistoryTask = z.infer<typeof ProcessMonitorHistoryTaskSchema>;
+
+export const ProcessMonitorMetricsSchema = z.object({
+    activeCount: z.number(),
+    peakConcurrency: z.number(),
+    totalCount: z.number(),
+    avgDurationMs: z.number(),
+});
+export type ProcessMonitorMetrics = z.infer<typeof ProcessMonitorMetricsSchema>;
+
+export const ProcessMonitorHostToWebviewMessageSchema = z.discriminatedUnion('type', [
+    z.object({
+        type: z.literal('update'),
+        activeTasks: z.array(ProcessMonitorActiveTaskSchema),
+        historyTasks: z.array(ProcessMonitorHistoryTaskSchema),
+        metrics: ProcessMonitorMetricsSchema,
+    }),
+]);
+export type ProcessMonitorHostToWebviewMessage = z.infer<typeof ProcessMonitorHostToWebviewMessageSchema>;

--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -161,6 +161,14 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
                 return false;
             }
         }
+
+        if (requestId && this.options?.messenger) {
+            this.options.messenger.postMessage({
+                type: '__rpc_response__',
+                requestId,
+                error: `No handler registered for '${String(typeValue)}'`,
+            });
+        }
         return false;
     }
 }

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -5,7 +5,11 @@
 
 import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
-import { type WebviewToHostMessage, WebviewToHostMessageSchema } from '../common/ipc-schemas';
+import {
+    type CommitDetailsHostToWebviewMessage,
+    type CommitDetailsToHostMessage,
+    CommitDetailsToHostMessageSchema,
+} from '../common/ipc/commit-details-schemas';
 import { showJjError } from '../common/ui-helpers';
 import {
     createWebviewRpcDispatcher,
@@ -29,7 +33,7 @@ export class CommitDetailsController implements Disposable {
     private readonly _messengers = new Set<WebviewPostMessageLike>();
     private _loadVersion = 0;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<WebviewToHostMessage>;
+    private readonly _dispatcher: WebviewRpcDispatcher<CommitDetailsToHostMessage>;
 
     private _logEntry?: JjLogEntry;
     private _changes?: readonly JjStatusEntry[];
@@ -296,7 +300,7 @@ export class CommitDetailsController implements Disposable {
         }
     }
 
-    public broadcast(message: unknown): void {
+    public broadcast(message: CommitDetailsHostToWebviewMessage): void {
         if (this._disposed) {
             return;
         }
@@ -309,9 +313,9 @@ export class CommitDetailsController implements Disposable {
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<WebviewToHostMessage> {
+    private _createRpcDispatcher(): WebviewRpcDispatcher<CommitDetailsToHostMessage> {
         return createWebviewRpcDispatcher(
-            WebviewToHostMessageSchema,
+            CommitDetailsToHostMessageSchema,
             {
                 webviewLoaded: async () => {},
                 descriptionChanged: async (msg) => {
@@ -341,7 +345,7 @@ export class CommitDetailsController implements Disposable {
             {
                 logger: this._logger,
                 messenger: {
-                    postMessage: (m) => this.broadcast(m),
+                    postMessage: (m) => this.broadcast(m as CommitDetailsHostToWebviewMessage),
                 },
             },
         );

--- a/src/controllers/log-view-controller.ts
+++ b/src/controllers/log-view-controller.ts
@@ -5,7 +5,11 @@
 
 import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
-import { type WebviewToHostMessage, WebviewToHostMessageSchema } from '../common/ipc-schemas';
+import {
+    type LogViewHostToWebviewMessage,
+    type LogViewToHostMessage,
+    LogViewToHostMessageSchema,
+} from '../common/ipc/log-view-schemas';
 import { showJjError } from '../common/ui-helpers';
 import {
     createWebviewRpcDispatcher,
@@ -36,7 +40,7 @@ export class LogViewController implements Disposable {
     private _codeForgeDisposable: Disposable | undefined;
     private _messenger?: WebviewPostMessageLike;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<WebviewToHostMessage>;
+    private readonly _dispatcher: WebviewRpcDispatcher<LogViewToHostMessage>;
     private readonly _refreshQueue: CoalescingQueue;
 
     private _commits: readonly JjLogEntry[] = [];
@@ -236,11 +240,11 @@ export class LogViewController implements Disposable {
 
         this._postMessage({
             type: 'update',
-            commits: enrichedCommits,
+            commits: [...enrichedCommits],
             minChangeIdLength: this._minChangeIdLength,
             theme: this._theme,
             graphLabelAlignment: this._graphLabelAlignment,
-            hiddenActions: this._hiddenActions,
+            hiddenActions: [...this._hiddenActions],
         });
     }
 
@@ -319,11 +323,11 @@ export class LogViewController implements Disposable {
 
         this._postMessage({
             type: 'update',
-            commits: this._commits,
+            commits: [...this._commits],
             minChangeIdLength: this._minChangeIdLength,
             theme: this._theme,
             graphLabelAlignment: this._graphLabelAlignment,
-            hiddenActions: this._hiddenActions,
+            hiddenActions: [...this._hiddenActions],
         });
     }
 
@@ -381,7 +385,7 @@ export class LogViewController implements Disposable {
         }
     }
 
-    private _postMessage(message: unknown): void {
+    private _postMessage(message: LogViewHostToWebviewMessage): void {
         if (!this._disposed && this._messenger) {
             try {
                 this._messenger.postMessage(message);
@@ -411,9 +415,9 @@ export class LogViewController implements Disposable {
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<WebviewToHostMessage> {
+    private _createRpcDispatcher(): WebviewRpcDispatcher<LogViewToHostMessage> {
         return createWebviewRpcDispatcher(
-            WebviewToHostMessageSchema,
+            LogViewToHostMessageSchema,
             {
                 webviewLoaded: async () => {
                     await this.refresh('webviewLoaded');
@@ -552,6 +556,12 @@ export class LogViewController implements Disposable {
                 showComments: async (msg) => {
                     await this._host.commands.executeCommand('jj-view.showComments', msg.payload.changeId);
                 },
+                setContextKey: async (msg) => {
+                    this._host.commands.setContextKey(msg.payload.key, msg.payload.value);
+                },
+                contextMenu: async (msg) => {
+                    await this._host.commands.executeCommand('jj-view.contextMenu', msg.payload);
+                },
                 selectionChange: async (msg) => {
                     const count = msg.payload.commitIds.length;
                     const hasImmutable = Boolean(msg.payload.hasImmutableSelection);
@@ -594,7 +604,7 @@ export class LogViewController implements Disposable {
             {
                 logger: this._logger,
                 messenger: {
-                    postMessage: (m) => this._postMessage(m),
+                    postMessage: (m) => this._postMessage(m as LogViewHostToWebviewMessage),
                 },
             },
         );

--- a/src/controllers/process-monitor-controller.ts
+++ b/src/controllers/process-monitor-controller.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { z } from 'zod';
 import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
+import {
+    type ProcessMonitorHostToWebviewMessage,
+    type ProcessMonitorToHostMessage,
+    ProcessMonitorToHostMessageSchema,
+} from '../common/ipc/process-monitor-schemas';
 import {
     createWebviewRpcDispatcher,
     type WebviewPostMessageLike,
@@ -19,14 +23,6 @@ import {
 } from '../jj-process-tracker';
 import { CoalescingQueue } from '../utils/coalescing-queue';
 import type { LoggerChannel } from '../utils/output-channel';
-
-export const ProcessMonitorToHostMessageSchema = z.discriminatedUnion('command', [
-    z.object({ command: z.literal('killProcess'), id: z.number() }),
-    z.object({ command: z.literal('killAllProcesses') }),
-    z.object({ command: z.literal('clearHistory') }),
-    z.object({ command: z.literal('hidePanel') }),
-]);
-export type ProcessMonitorToHostMessage = z.infer<typeof ProcessMonitorToHostMessageSchema>;
 
 export interface ProcessMonitorControllerOptions {
     messenger?: WebviewPostMessageLike;
@@ -84,7 +80,7 @@ export class ProcessMonitorController implements Disposable {
                 discriminatorKey: 'command',
                 logger: this._logger,
                 messenger: {
-                    postMessage: (m) => this._postMessage(m),
+                    postMessage: (m) => this._postMessage(m as ProcessMonitorHostToWebviewMessage),
                 },
             },
         );
@@ -175,7 +171,7 @@ export class ProcessMonitorController implements Disposable {
         this._processTracker.clearHistory();
     }
 
-    private _postMessage(message: unknown): void {
+    private _postMessage(message: ProcessMonitorHostToWebviewMessage): void {
         if (!this._disposed && this._messenger) {
             try {
                 this._messenger.postMessage(message);

--- a/src/test/ipc-schemas.test.ts
+++ b/src/test/ipc-schemas.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    CommitDetailsHostToWebviewMessageSchema,
+    CommitDetailsToHostMessageSchema,
+} from '../common/ipc/commit-details-schemas';
+import {
+    CommitActionSchema,
+    LogViewHostToWebviewMessageSchema,
+    LogViewToHostMessageSchema,
+} from '../common/ipc/log-view-schemas';
+import {
+    ProcessMonitorHostToWebviewMessageSchema,
+    ProcessMonitorToHostMessageSchema,
+} from '../common/ipc/process-monitor-schemas';
+
+describe('IPC Schemas Unit Tests', () => {
+    describe('LogView Schemas', () => {
+        it('validates CommitAction enum', () => {
+            const validActions = ['newChild', 'edit', 'squash', 'abandon', 'openCodeForge', 'upload'];
+            for (const action of validActions) {
+                expect(CommitActionSchema.safeParse(action).success).toBe(true);
+            }
+            expect(CommitActionSchema.safeParse('invalidAction').success).toBe(false);
+        });
+
+        it('validates all LogViewToHostMessage variants', () => {
+            expect(LogViewToHostMessageSchema.safeParse({ type: 'webviewLoaded' }).success).toBe(true);
+            expect(LogViewToHostMessageSchema.safeParse({ type: 'new' }).success).toBe(true);
+            expect(LogViewToHostMessageSchema.safeParse({ type: 'undo' }).success).toBe(true);
+            expect(LogViewToHostMessageSchema.safeParse({ type: 'redo' }).success).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'newChild',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'newBefore',
+                    payload: { changeIds: ['a', 'b'] },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'newAfter',
+                    payload: { changeIds: ['c'] },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'edit',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'squash',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'abandon',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'select',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'getDetails',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'resolve',
+                    payload: { path: 'src/index.ts' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'moveBookmark',
+                    payload: { bookmark: 'main', targetChangeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'rebaseCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'revision' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'rebaseCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'source' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'squashCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'into' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'squashCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'onto' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'duplicateCommit',
+                    payload: { sourceChangeId: 'a' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'mergeCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'upload',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'showComments',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'selectionChange',
+                    payload: { commitIds: ['a', 'b'], hasImmutableSelection: false },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'setContextKey',
+                    payload: { key: 'jj.testKey', value: true },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'openCodeForge',
+                    payload: { url: 'https://github.com/foo/bar' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'contextMenu',
+                    payload: { changeId: 'x', selectedCommitIds: ['x', 'y'] },
+                }).success,
+            ).toBe(true);
+        });
+
+        it('rejects invalid LogViewToHostMessage payloads', () => {
+            expect(LogViewToHostMessageSchema.safeParse({ type: 'unknownAction' }).success).toBe(false);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'rebaseCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'invalid_mode' },
+                }).success,
+            ).toBe(false);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'squashCommit',
+                    payload: { sourceChangeId: 'a', targetChangeId: 'b', mode: 'invalid' },
+                }).success,
+            ).toBe(false);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'moveBookmark',
+                    payload: { bookmark: 'main' }, // missing targetChangeId
+                }).success,
+            ).toBe(false);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'resolve',
+                    payload: {}, // missing path
+                }).success,
+            ).toBe(false);
+            expect(
+                LogViewToHostMessageSchema.safeParse({
+                    type: 'selectionChange',
+                    payload: { commitIds: 'not-an-array' },
+                }).success,
+            ).toBe(false);
+        });
+
+        it('validates LogViewHostToWebviewMessage variants', () => {
+            expect(
+                LogViewHostToWebviewMessageSchema.safeParse({
+                    type: 'update',
+                    commits: [],
+                    minChangeIdLength: 3,
+                    theme: 'default',
+                    graphLabelAlignment: 'aligned',
+                    hiddenActions: ['edit', 'abandon'],
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewHostToWebviewMessageSchema.safeParse({
+                    type: 'updateHiddenActions',
+                    payload: { hiddenActions: ['newChild'] },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewHostToWebviewMessageSchema.safeParse({
+                    type: 'panelClosed',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+            expect(
+                LogViewHostToWebviewMessageSchema.safeParse({
+                    type: 'setSelection',
+                    ids: ['kkmpptxz'],
+                }).success,
+            ).toBe(true);
+
+            expect(LogViewHostToWebviewMessageSchema.safeParse({ type: 'unknownHostType' }).success).toBe(false);
+            expect(
+                LogViewHostToWebviewMessageSchema.safeParse({
+                    type: 'setSelection',
+                    ids: 'not-an-array',
+                }).success,
+            ).toBe(false);
+        });
+    });
+
+    describe('CommitDetails Schemas', () => {
+        it('validates all CommitDetailsToHostMessage variants', () => {
+            expect(CommitDetailsToHostMessageSchema.safeParse({ type: 'webviewLoaded' }).success).toBe(true);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'descriptionChanged',
+                    payload: { description: 'Updated description', selectionStart: 0, selectionEnd: 5 },
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'saveDescription',
+                    payload: { changeId: 'kkmpptxz', description: 'New description' },
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'openDiff',
+                    payload: {
+                        file: {
+                            status: 'modified',
+                            path: 'src/index.ts',
+                            conflicted: false,
+                        },
+                        changeId: 'kkmpptxz',
+                        isImmutable: false,
+                    },
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'openMultiDiff',
+                    payload: { changeId: 'kkmpptxz' },
+                }).success,
+            ).toBe(true);
+        });
+
+        it('rejects invalid CommitDetailsToHostMessage payloads', () => {
+            expect(CommitDetailsToHostMessageSchema.safeParse({ type: 'unknownDetailsAction' }).success).toBe(false);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'saveDescription',
+                    payload: { changeId: 'kkmpptxz' }, // missing description
+                }).success,
+            ).toBe(false);
+            expect(
+                CommitDetailsToHostMessageSchema.safeParse({
+                    type: 'openDiff',
+                    payload: { changeId: 'kkmpptxz' }, // missing file
+                }).success,
+            ).toBe(false);
+        });
+
+        it('validates CommitDetailsHostToWebviewMessage variants', () => {
+            expect(
+                CommitDetailsHostToWebviewMessageSchema.safeParse({
+                    type: 'updateDetails',
+                    payload: {
+                        changeId: 'kkmpptxz',
+                        commitId: 'abcdef12',
+                        description: 'Initial commit',
+                    },
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsHostToWebviewMessageSchema.safeParse({
+                    type: 'saveComplete',
+                    payload: { description: 'Saved description' },
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsHostToWebviewMessageSchema.safeParse({
+                    type: 'saveFailed',
+                }).success,
+            ).toBe(true);
+            expect(
+                CommitDetailsHostToWebviewMessageSchema.safeParse({
+                    type: 'updateDescription',
+                    payload: { description: 'Live updated', selectionStart: 2, selectionEnd: 2 },
+                }).success,
+            ).toBe(true);
+
+            expect(CommitDetailsHostToWebviewMessageSchema.safeParse({ type: 'invalidType' }).success).toBe(false);
+        });
+    });
+
+    describe('ProcessMonitor Schemas', () => {
+        it('validates ProcessMonitorToHostMessage variants with command discriminator', () => {
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'killProcess',
+                    id: 1234,
+                }).success,
+            ).toBe(true);
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'killAllProcesses',
+                }).success,
+            ).toBe(true);
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'clearHistory',
+                }).success,
+            ).toBe(true);
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'hidePanel',
+                }).success,
+            ).toBe(true);
+
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'unknownCommand',
+                }).success,
+            ).toBe(false);
+            expect(
+                ProcessMonitorToHostMessageSchema.safeParse({
+                    command: 'killProcess',
+                    id: 'not-a-number',
+                }).success,
+            ).toBe(false);
+        });
+
+        it('validates ProcessMonitorHostToWebviewMessage variants', () => {
+            expect(
+                ProcessMonitorHostToWebviewMessageSchema.safeParse({
+                    type: 'update',
+                    activeTasks: [
+                        {
+                            id: 1,
+                            command: 'jj',
+                            args: ['log'],
+                            startPerformanceTime: 1000,
+                            timestamp: Date.now(),
+                            label: 'Log',
+                            pid: 42,
+                        },
+                    ],
+                    historyTasks: [
+                        {
+                            id: 2,
+                            command: 'jj',
+                            args: ['status'],
+                            duration: 150,
+                            status: 'completed',
+                            label: 'Status',
+                            error: '',
+                            stdout: 'OK',
+                            stderr: '',
+                            exitCode: 0,
+                            timestamp: Date.now(),
+                        },
+                    ],
+                    metrics: {
+                        activeCount: 1,
+                        peakConcurrency: 2,
+                        totalCount: 5,
+                        avgDurationMs: 120,
+                    },
+                }).success,
+            ).toBe(true);
+
+            // Rejects invalid task status
+            expect(
+                ProcessMonitorHostToWebviewMessageSchema.safeParse({
+                    type: 'update',
+                    activeTasks: [],
+                    historyTasks: [
+                        {
+                            id: 2,
+                            command: 'jj',
+                            args: [],
+                            duration: 150,
+                            status: 'invalid_status_enum',
+                            label: 'Status',
+                            error: '',
+                            stdout: '',
+                            stderr: '',
+                            exitCode: 0,
+                            timestamp: Date.now(),
+                        },
+                    ],
+                    metrics: {
+                        activeCount: 0,
+                        peakConcurrency: 0,
+                        totalCount: 0,
+                        avgDurationMs: 0,
+                    },
+                }).success,
+            ).toBe(false);
+        });
+    });
+});

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -14,20 +14,24 @@ import {
     useSensors,
 } from '@dnd-kit/core';
 import * as React from 'react';
-import type {
-    ActionPayload,
-    CommitAction,
-    JjLogEntry,
-    JjStatusEntry,
-    WebviewInitialData,
-    WebviewPayload,
-} from '../jj-types';
+import {
+    CommitDetailsHostToWebviewMessageSchema,
+    type CommitDetailsToHostMessage,
+    CommitDetailsToHostMessageSchema,
+} from '../common/ipc/commit-details-schemas';
+import {
+    type ActionPayload,
+    LogViewHostToWebviewMessageSchema,
+    type LogViewToHostMessage,
+    LogViewToHostMessageSchema,
+} from '../common/ipc/log-view-schemas';
+import type { CommitAction, JjLogEntry, WebviewInitialData, WebviewPayload } from '../jj-types';
 import { BookmarkPill } from './components/Bookmark';
 import { CommitDetails } from './components/CommitDetails';
 import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
 import { useDragModifiers } from './hooks/useDragModifiers';
-import { useBridge } from './transport/BridgeContext';
+import { useBridge, useRpcClient, useRpcDispatcher } from './transport/BridgeContext';
 import { snapToCursorLeft } from './utils/modifiers';
 import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
 
@@ -35,48 +39,104 @@ type DragItem =
     | { type: 'bookmark'; name: string; remote?: string }
     | (JjLogEntry & { type: 'commit'; changeId: string });
 
-const App: React.FC = () => {
-    const bridge = useBridge();
-    // Initial State from Bridge
-    const initialData = bridge.getInitialData<WebviewInitialData>();
-    const initialView = initialData?.view || 'graph';
+interface CommitDetailsViewProps {
+    initialPayload?: WebviewPayload;
+}
 
-    const [view] = React.useState<'graph' | 'details'>(initialView);
-    const [commits, setCommits] = React.useState<JjLogEntry[]>(initialData?.payload?.commits || []);
-    const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>(
-        initialData?.payload?.minChangeIdLength || 1,
+const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ initialPayload }) => {
+    const [detailsCommit, setDetailsCommit] = React.useState<WebviewPayload | null>(initialPayload || null);
+    const rpc = useRpcClient<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
+
+    useRpcDispatcher(CommitDetailsHostToWebviewMessageSchema, {
+        updateDetails: (msg) => {
+            setDetailsCommit(msg.payload);
+        },
+        saveComplete: (msg) => {
+            const newDesc = msg.payload.description;
+            setDetailsCommit((prev) => (prev ? { ...prev, description: newDesc } : prev));
+        },
+        saveFailed: () => {},
+        updateDescription: () => {},
+    });
+
+    React.useEffect(() => {
+        void rpc.webviewLoaded();
+    }, [rpc]);
+
+    if (!detailsCommit) {
+        return (
+            <div style={{ padding: '20px', color: 'var(--vscode-descriptionForeground)' }}>
+                Loading commit details...
+            </div>
+        );
+    }
+
+    return (
+        <CommitDetails
+            changeId={detailsCommit.changeId || ''}
+            commitId={detailsCommit.commitId || ''}
+            description={detailsCommit.description || ''}
+            files={detailsCommit.files || []}
+            isImmutable={detailsCommit.isImmutable || false}
+            isEmpty={detailsCommit.isEmpty}
+            isConflict={detailsCommit.isConflict}
+            author={detailsCommit.author}
+            committer={detailsCommit.committer}
+            bookmarks={detailsCommit.bookmarks}
+            tags={detailsCommit.tags}
+            titleWidthRuler={detailsCommit.titleWidthRuler}
+            bodyWidthRuler={detailsCommit.bodyWidthRuler}
+            minChangeIdLength={detailsCommit.minChangeIdLength}
+            onSave={(description) => {
+                if (detailsCommit.changeId) {
+                    void rpc.saveDescription({ payload: { changeId: detailsCommit.changeId, description } });
+                }
+            }}
+            onOpenDiff={(file, isImmutable) => {
+                if (detailsCommit.changeId) {
+                    void rpc.openDiff({ payload: { changeId: detailsCommit.changeId, file, isImmutable } });
+                }
+            }}
+            onOpenMultiDiff={() => {
+                if (detailsCommit.changeId) {
+                    void rpc.openMultiDiff({ payload: { changeId: detailsCommit.changeId } });
+                }
+            }}
+            onDescriptionChange={(description, selectionStart, selectionEnd) => {
+                void rpc.descriptionChanged({ payload: { description, selectionStart, selectionEnd } });
+            }}
+        />
     );
-    const [theme, setTheme] = React.useState<string>(initialData?.payload?.theme || 'default');
+};
+
+interface LogViewProps {
+    initialPayload?: WebviewPayload;
+}
+
+const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
+    const [commits, setCommits] = React.useState<JjLogEntry[]>(initialPayload?.commits || []);
+    const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>(initialPayload?.minChangeIdLength || 1);
+    const [theme, setTheme] = React.useState<string>(initialPayload?.theme || 'default');
     const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>(
-        initialData?.payload?.graphLabelAlignment || 'aligned',
+        initialPayload?.graphLabelAlignment || 'aligned',
     );
-    // Use refs to access latest state in event listeners without triggering re-effects
+    const [loading, setLoading] = React.useState(!(initialPayload?.commits && initialPayload.commits.length > 0));
+    const [selectedCommitIds, setSelectedCommitIds] = React.useState<Set<string>>(new Set());
+    const [hiddenActions, setHiddenActions] = React.useState<Set<CommitAction>>(
+        new Set(initialPayload?.hiddenActions || []),
+    );
+
     const commitsRef = React.useRef(commits);
     React.useEffect(() => {
         commitsRef.current = commits;
     }, [commits]);
 
-    const viewRef = React.useRef(view);
-    React.useEffect(() => {
-        viewRef.current = view;
-    }, [view]);
-
-    const [loading, setLoading] = React.useState(
-        initialView === 'graph' && !(initialData?.payload?.commits && initialData.payload.commits.length > 0),
-    ); // Only load graph if in graph mode and no initial commits
-    const [selectedCommitIds, setSelectedCommitIds] = React.useState<Set<string>>(new Set());
-    const [hiddenActions, setHiddenActions] = React.useState<Set<CommitAction>>(
-        new Set(initialData?.payload?.hiddenActions || []),
-    );
-
-    // Details State
-    const [detailsCommit, setDetailsCommit] = React.useState<WebviewPayload | null>(initialData?.payload || null);
+    const rpc = useRpcClient<LogViewToHostMessage>(LogViewToHostMessageSchema);
 
     // Drag State
     const [activeDragItem, setActiveDragItem] = React.useState<DragItem | null>(null);
     const { activeModifier, resetKeys } = useDragModifiers();
 
-    // Configure sensors with activation constraint to prevent accidental drags on click
     const sensors = useSensors(
         useSensor(MouseSensor, {
             activationConstraint: {
@@ -91,13 +151,90 @@ const App: React.FC = () => {
         }),
     );
 
+    useRpcDispatcher(LogViewHostToWebviewMessageSchema, {
+        update: (message) => {
+            const newCommits = message.commits;
+            setCommits(newCommits);
+            if (message.minChangeIdLength !== undefined) {
+                setMinChangeIdLength(message.minChangeIdLength);
+            }
+            if (message.theme !== undefined) {
+                setTheme(message.theme);
+            }
+            if (message.graphLabelAlignment !== undefined) {
+                setGraphLabelAlignment(message.graphLabelAlignment);
+            }
+            if (message.hiddenActions !== undefined) {
+                setHiddenActions(new Set(message.hiddenActions as CommitAction[]));
+            }
+            setLoading(false);
+
+            // Validate current selection against new commits list
+            setSelectedCommitIds((prevIds) => {
+                if (prevIds.size === 0) {
+                    return prevIds;
+                }
+
+                const validIds = Array.from(prevIds).filter((id) =>
+                    newCommits.some((c: JjLogEntry) => c.change_id === id),
+                );
+
+                if (validIds.length !== prevIds.size) {
+                    const newIds = new Set(validIds);
+                    const hasImmutable = hasImmutableSelection(newIds, newCommits);
+
+                    void rpc.selectionChange({
+                        payload: {
+                            commitIds: validIds,
+                            hasImmutableSelection: hasImmutable,
+                        },
+                    });
+                    return newIds;
+                }
+                return prevIds;
+            });
+        },
+        updateHiddenActions: (message) => {
+            setHiddenActions(new Set(message.payload.hiddenActions as CommitAction[]));
+        },
+        panelClosed: (message) => {
+            setSelectedCommitIds((prevIds) => {
+                if (message.payload.changeId && prevIds.has(message.payload.changeId) && prevIds.size === 1) {
+                    const clearedIds = new Set<string>();
+                    void rpc.selectionChange({
+                        payload: {
+                            commitIds: [],
+                            hasImmutableSelection: false,
+                        },
+                    });
+                    return clearedIds;
+                }
+                return prevIds;
+            });
+        },
+        setSelection: (message) => {
+            const newIds = new Set<string>(message.ids || []);
+            setSelectedCommitIds(newIds);
+            const hasImmutable = hasImmutableSelection(newIds, commitsRef.current);
+
+            void rpc.selectionChange({
+                payload: {
+                    commitIds: Array.from(newIds),
+                    hasImmutableSelection: hasImmutable,
+                },
+            });
+        },
+    });
+
+    React.useEffect(() => {
+        void rpc.webviewLoaded();
+    }, [rpc]);
+
     React.useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
-            // Escape to deselect
             if (e.key === 'Escape') {
                 setSelectedCommitIds(new Set());
-                bridge.postMessage({
-                    type: 'selectionChange',
+                void rpc.selectionChange({
                     payload: {
                         commitIds: [],
                         hasImmutableSelection: false,
@@ -107,174 +244,38 @@ const App: React.FC = () => {
         };
 
         window.addEventListener('keydown', handleKeyDown);
-
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [bridge]);
-
-    React.useEffect(() => {
-        // Listen for messages from the host
-        const handleMessage = (rawMessage: unknown) => {
-            if (!rawMessage || typeof rawMessage !== 'object' || !('type' in rawMessage)) {
-                return;
-            }
-            const message = rawMessage as {
-                type: string;
-                commits?: JjLogEntry[];
-                minChangeIdLength?: number;
-                theme?: string;
-                graphLabelAlignment?: string;
-                hiddenActions?: CommitAction[];
-                payload?: { changeId?: string; description?: string; hiddenActions?: CommitAction[] } & WebviewPayload;
-                ids?: string[];
-            };
-            switch (message.type) {
-                case 'update':
-                    if (viewRef.current === 'graph' && message.commits) {
-                        const newCommits = message.commits;
-                        setCommits(newCommits);
-                        if (message.minChangeIdLength !== undefined) {
-                            setMinChangeIdLength(message.minChangeIdLength);
-                        }
-                        if (message.theme !== undefined) {
-                            setTheme(message.theme);
-                        }
-                        if (message.graphLabelAlignment !== undefined) {
-                            setGraphLabelAlignment(message.graphLabelAlignment);
-                        }
-                        if (message.hiddenActions !== undefined) {
-                            setHiddenActions(new Set(message.hiddenActions));
-                        }
-                        setLoading(false);
-
-                        // Validate current selection against new commits list
-                        setSelectedCommitIds((prevIds) => {
-                            if (prevIds.size === 0) {
-                                return prevIds;
-                            }
-
-                            const validIds = Array.from(prevIds).filter((id) =>
-                                newCommits.some((c: JjLogEntry) => c.change_id === id),
-                            );
-
-                            if (validIds.length !== prevIds.size) {
-                                const newIds = new Set(validIds);
-                                const hasImmutable = hasImmutableSelection(newIds, newCommits);
-
-                                bridge.postMessage({
-                                    type: 'selectionChange',
-                                    payload: {
-                                        commitIds: validIds,
-                                        hasImmutableSelection: hasImmutable,
-                                    },
-                                });
-                                return newIds;
-                            }
-                            return prevIds;
-                        });
-                    }
-                    break;
-                case 'updateDetails':
-                    // If we get an update while in details view (e.g. after save)
-                    if (viewRef.current === 'details') {
-                        setDetailsCommit(message.payload ?? null);
-                    }
-                    break;
-                case 'saveComplete':
-                    if (viewRef.current === 'details' && message.payload?.description !== undefined) {
-                        const newDesc = message.payload.description;
-                        setDetailsCommit((prev) => (prev ? { ...prev, description: newDesc } : prev));
-                    }
-                    break;
-                case 'setSelection': {
-                    // External request to set selection (e.g. from closing details tab)
-                    const newIds = new Set<string>(message.ids || []);
-                    setSelectedCommitIds(newIds);
-                    // Calculate immutability status for the new selection
-                    const hasImmutable = hasImmutableSelection(newIds, commitsRef.current);
-
-                    bridge.postMessage({
-                        type: 'selectionChange',
-                        payload: {
-                            commitIds: Array.from(newIds),
-                            hasImmutableSelection: hasImmutable,
-                        },
-                    });
-                    break;
-                }
-                case 'panelClosed':
-                    setSelectedCommitIds((prevIds) => {
-                        if (message.payload?.changeId && prevIds.has(message.payload.changeId) && prevIds.size === 1) {
-                            const clearedIds = new Set<string>();
-                            bridge.postMessage({
-                                type: 'selectionChange',
-                                payload: {
-                                    commitIds: [],
-                                    hasImmutableSelection: false,
-                                },
-                            });
-                            return clearedIds;
-                        }
-                        return prevIds;
-                    });
-                    break;
-                case 'updateHiddenActions':
-                    if (message.payload?.hiddenActions) {
-                        setHiddenActions(new Set(message.payload.hiddenActions));
-                    }
-                    break;
-            }
-        };
-
-        const unsubscribe = bridge.onMessage(handleMessage);
-
-        // Signal that we are ready
-        bridge.postMessage({ type: 'webviewLoaded' });
-
-        return () => {
-            unsubscribe();
-        };
-    }, [bridge]);
+    }, [rpc]);
 
     const handleGraphAction = (action: string, payload: ActionPayload) => {
         if (action === 'select') {
             const { changeId, multiSelect } = payload;
-
-            // 1. Calculate new selection state
-            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, !!multiSelect);
-
-            // 2. Update visual selection state
+            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, Boolean(multiSelect));
             setSelectedCommitIds(nextSelectedIds);
 
-            // 3. Notify Host of Selection Change
             const hasImmutable = hasImmutableSelection(nextSelectedIds, commits);
-
-            bridge.postMessage({
-                type: 'selectionChange',
+            void rpc.selectionChange({
                 payload: {
                     commitIds: Array.from(nextSelectedIds),
                     hasImmutableSelection: hasImmutable,
                 },
             });
 
-            // 4. Request Details ONLY if the item ends up selected
-            // (If we toggled it off, we shouldn't open details)
             if (nextSelectedIds.has(changeId)) {
-                bridge.postMessage({ type: 'getDetails', payload });
+                void rpc.getDetails({ payload });
             }
             return;
         }
 
         if (action === 'showComments') {
-            bridge.postMessage({ type: 'showComments', payload });
+            void rpc.showComments({ payload: { changeId: payload.changeId } });
             return;
         }
 
         if (action === 'contextMenu') {
-            // Include current selection in payload for smarter menus
-            bridge.postMessage({
-                type: action,
+            void rpc.contextMenu({
                 payload: {
                     ...payload,
                     selectedCommitIds: Array.from(selectedCommitIds),
@@ -283,33 +284,40 @@ const App: React.FC = () => {
             return;
         }
 
-        bridge.postMessage({ type: action, payload });
-    };
-
-    const handleSaveDescription = (description: string) => {
-        if (view === 'details' && detailsCommit) {
-            bridge.postMessage({
-                type: 'saveDescription',
-                payload: { changeId: detailsCommit.changeId, description },
-            });
+        if (action === 'new') {
+            void rpc.new();
+            return;
         }
-    };
-
-    const handleOpenDiff = (file: JjStatusEntry, isImmutable: boolean) => {
-        if (view === 'details' && detailsCommit) {
-            bridge.postMessage({
-                type: 'openDiff',
-                payload: { changeId: detailsCommit.changeId, file, isImmutable },
-            });
+        if (action === 'newChild') {
+            void rpc.newChild({ payload });
+            return;
         }
-    };
-
-    const handleOpenMultiDiff = () => {
-        if (view === 'details' && detailsCommit) {
-            bridge.postMessage({
-                type: 'openMultiDiff',
-                payload: { changeId: detailsCommit.changeId },
-            });
+        if (action === 'edit') {
+            void rpc.edit({ payload });
+            return;
+        }
+        if (action === 'squash') {
+            void rpc.squash({ payload });
+            return;
+        }
+        if (action === 'abandon') {
+            void rpc.abandon({ payload });
+            return;
+        }
+        if (action === 'undo') {
+            void rpc.undo();
+            return;
+        }
+        if (action === 'redo') {
+            void rpc.redo();
+            return;
+        }
+        if (action === 'upload') {
+            void rpc.upload({ payload });
+            return;
+        }
+        if (action === 'openCodeForge' && payload.url) {
+            void rpc.openCodeForge({ payload: { url: payload.url } });
         }
     };
 
@@ -334,15 +342,11 @@ const App: React.FC = () => {
             const activeType = (active.data.current as DragItem).type;
 
             if (activeType === 'bookmark') {
-                // bookmark-NAME -> NAME
                 const bookmarkName = (active.data.current as DragItem & { type: 'bookmark' }).name;
                 const bookmarkRemote = (active.data.current as DragItem & { type: 'bookmark' }).remote;
-                // commit-ID -> ID
                 const targetChangeId = over.data.current.changeId;
 
-                // Optimistic Update
                 setCommits((prevCommits) => {
-                    // Check if move is actually needed (and find source)
                     const sourceCommit = prevCommits.find((c) =>
                         c.bookmarks?.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote),
                     );
@@ -354,82 +358,53 @@ const App: React.FC = () => {
                     return prevCommits.map((commit) => {
                         let newBookmarks = commit.bookmarks || [];
 
-                        // Remove from source
                         if (newBookmarks.some((b) => b.name === bookmarkName && b.remote === bookmarkRemote)) {
                             newBookmarks = newBookmarks.filter(
                                 (b) => !(b.name === bookmarkName && b.remote === bookmarkRemote),
                             );
                         }
 
-                        // Add to target
                         if (commit.change_id === targetChangeId) {
                             newBookmarks = [...newBookmarks, { name: bookmarkName, remote: bookmarkRemote }];
                         }
 
-                        // Return new object if changed
                         if (newBookmarks !== commit.bookmarks) {
-                            const updated = { ...commit, bookmarks: newBookmarks };
-                            return updated;
+                            return { ...commit, bookmarks: newBookmarks };
                         }
                         return commit;
                     });
                 });
 
-                // Send to host
-                bridge.postMessage({
-                    type: 'moveBookmark',
-                    payload: { bookmark: bookmarkName, targetChangeId },
-                });
-            } else if (activeType === 'commit') {
+                void rpc.moveBookmark({ payload: { bookmark: bookmarkName, targetChangeId } });
+                return;
+            }
+
+            if (activeType === 'commit') {
                 if (over.data.current.type !== 'commit') {
                     return;
                 }
                 const sourceChangeId = (active.data.current as DragItem & { type: 'commit' }).changeId;
                 const targetChangeId = (over.data.current as { changeId?: string }).changeId;
 
-                // Self-target drop safeguard or invalid target
                 if (!targetChangeId || sourceChangeId === targetChangeId) {
                     return;
                 }
 
                 const message = activeModifier.buildMessagePayload(sourceChangeId, targetChangeId);
-                bridge.postMessage(message);
+                if (message.type === 'rebaseCommit') {
+                    void rpc.rebaseCommit({ payload: message.payload });
+                } else if (message.type === 'squashCommit') {
+                    void rpc.squashCommit({ payload: message.payload });
+                } else if (message.type === 'duplicateCommit') {
+                    void rpc.duplicateCommit({ payload: message.payload });
+                } else if (message.type === 'mergeCommit') {
+                    void rpc.mergeCommit({ payload: message.payload });
+                }
             }
         } finally {
             resetKeys();
         }
     };
-
-    // Render
-    if (view === 'details' && detailsCommit) {
-        return (
-            <CommitDetails
-                changeId={detailsCommit.changeId || ''}
-                commitId={detailsCommit.commitId || ''}
-                description={detailsCommit.description || ''}
-                files={detailsCommit.files || []}
-                isImmutable={detailsCommit.isImmutable || false}
-                isEmpty={detailsCommit.isEmpty}
-                isConflict={detailsCommit.isConflict}
-                author={detailsCommit.author}
-                committer={detailsCommit.committer}
-                bookmarks={detailsCommit.bookmarks}
-                tags={detailsCommit.tags}
-                titleWidthRuler={detailsCommit.titleWidthRuler}
-                bodyWidthRuler={detailsCommit.bodyWidthRuler}
-                minChangeIdLength={detailsCommit.minChangeIdLength}
-                onSave={handleSaveDescription}
-                onOpenDiff={handleOpenDiff}
-                onOpenMultiDiff={handleOpenMultiDiff}
-                onDescriptionChange={(description: string, selectionStart: number, selectionEnd: number) => {
-                    bridge.postMessage({
-                        type: 'descriptionChanged',
-                        payload: { description, selectionStart, selectionEnd },
-                    });
-                }}
-            />
-        );
-    }
 
     if (loading) {
         return <div style={{ padding: '20px', color: 'var(--vscode-descriptionForeground)' }}>Loading changes...</div>;
@@ -452,11 +427,9 @@ const App: React.FC = () => {
                 <div
                     style={{ flex: 1, overflow: 'auto', minHeight: '100vh' }}
                     onClick={(e) => {
-                        // Only clear if clicking the container itself, not children
                         if (e.target === e.currentTarget) {
                             setSelectedCommitIds(new Set());
-                            bridge.postMessage({
-                                type: 'selectionChange',
+                            void rpc.selectionChange({
                                 payload: {
                                     commitIds: [],
                                     hasImmutableSelection: false,
@@ -476,10 +449,6 @@ const App: React.FC = () => {
                         activeModifier={activeModifier}
                     />
                 </div>
-                {/*
-                  snapCenterToCursor ensures the preview is always centered on the mouse,
-                  regardless of where the user grabbed the original wide row.
-                */}
                 <DragOverlay
                     dropAnimation={null}
                     modifiers={activeDragItem?.type === 'commit' ? [snapToCursorLeft] : undefined}
@@ -506,6 +475,17 @@ const App: React.FC = () => {
             </DndContext>
         </div>
     );
+};
+
+const App: React.FC = () => {
+    const bridge = useBridge();
+    const initialData = bridge.getInitialData<WebviewInitialData>();
+    const view = initialData?.view || 'graph';
+
+    if (view === 'details') {
+        return <CommitDetailsView initialPayload={initialData?.payload} />;
+    }
+    return <LogView initialPayload={initialData?.payload} />;
 };
 
 export default App;

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -3,14 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as React from 'react';
+import {
+    type CommitDetailsHostToWebviewMessage,
+    CommitDetailsHostToWebviewMessageSchema,
+} from '../../common/ipc/commit-details-schemas';
 import type { JjBookmark, JjStatusEntry } from '../../jj-types';
 import { formatCommitDescription } from '../../utils/format-utils';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
-import { useMessageListener } from '../transport/BridgeContext';
+import { useRpcDispatcher } from '../transport/BridgeContext';
 import { BasePill, BookmarkPill, TagPill } from './Bookmark';
 import { PersonInfo } from './PersonInfo';
 
-interface CommitDetailsProps {
+export interface CommitDetailsProps {
     changeId: string;
     commitId: string;
     description: string;
@@ -29,37 +33,6 @@ interface CommitDetailsProps {
     onOpenDiff: (file: JjStatusEntry, isImmutable: boolean) => void;
     onOpenMultiDiff: () => void;
     onDescriptionChange?: (description: string, selectionStart: number, selectionEnd: number) => void;
-}
-
-interface SaveFailedMessage {
-    type: 'saveFailed';
-}
-
-interface SaveCompleteMessage {
-    type: 'saveComplete';
-    payload: {
-        description: string;
-    };
-}
-
-interface UpdateDescriptionMessage {
-    type: 'updateDescription';
-    payload: {
-        description: string;
-        selectionStart: number;
-        selectionEnd: number;
-    };
-}
-
-type WebviewMessage = SaveFailedMessage | SaveCompleteMessage | UpdateDescriptionMessage;
-
-function isWebviewMessage(data: unknown): data is WebviewMessage {
-    if (typeof data !== 'object' || data === null) {
-        return false;
-    }
-
-    const { type } = data as { type?: unknown };
-    return typeof type === 'string' && ['saveFailed', 'saveComplete', 'updateDescription'].includes(type);
 }
 
 export const CommitDetails: React.FC<CommitDetailsProps> = ({
@@ -101,6 +74,14 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
     const prevDescriptionRef = React.useRef(description);
 
     React.useEffect(() => {
+        return () => {
+            if (saveTimeoutRef.current) {
+                clearTimeout(saveTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    React.useEffect(() => {
         // Synchronize the draft description with the canonical description from the backend.
         // We only overwrite the draft if the user hasn't made any unsaved edits (the draft
         // matches the previous description), or if the only difference is trailing whitespace
@@ -115,41 +96,39 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         prevDescriptionRef.current = description;
     }, [description]);
 
-    useMessageListener((data: unknown) => {
-        if (!isWebviewMessage(data)) {
-            return;
-        }
-
-        if (data.type === 'saveFailed') {
+    useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
+        saveFailed: () => {
             setIsSaving(false);
             if (saveTimeoutRef.current) {
                 clearTimeout(saveTimeoutRef.current);
             }
-        } else if (data.type === 'saveComplete') {
+        },
+        saveComplete: (msg) => {
             setIsSaving(false);
             if (saveTimeoutRef.current) {
                 clearTimeout(saveTimeoutRef.current);
             }
-            const savedDescription = data.payload.description;
+            const savedDescription = msg.payload.description;
             setDraftDescription(savedDescription);
             if (textareaRef.current) {
                 textareaRef.current.value = savedDescription;
             }
             prevDescriptionRef.current = savedDescription;
-        } else if (data.type === 'updateDescription') {
-            const { description: newDesc, selectionStart, selectionEnd } = data.payload;
+        },
+        updateDescription: (msg) => {
+            const { description: newDesc, selectionStart, selectionEnd } = msg.payload;
             isApplyingExtensionEdit.current = true;
             try {
                 if (textareaRef.current) {
                     textareaRef.current.value = newDesc;
                     setDraftDescription(newDesc);
                     textareaRef.current.focus();
-                    textareaRef.current.setSelectionRange(selectionStart, selectionEnd);
+                    textareaRef.current.setSelectionRange(selectionStart ?? 0, selectionEnd ?? 0);
                 }
             } finally {
                 isApplyingExtensionEdit.current = false;
             }
-        }
+        },
     });
 
     const handleSave = async () => {

--- a/src/webview/process-monitor/ProcessMonitorApp.tsx
+++ b/src/webview/process-monitor/ProcessMonitorApp.tsx
@@ -4,39 +4,18 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useBridge } from '../transport/BridgeContext';
+import {
+    type ProcessMonitorActiveTask as ActiveTask,
+    type ProcessMonitorHistoryTask as HistoryTask,
+    type ProcessMonitorMetrics as Metrics,
+    ProcessMonitorHostToWebviewMessageSchema,
+    type ProcessMonitorToHostMessage,
+    ProcessMonitorToHostMessageSchema,
+} from '../../common/ipc/process-monitor-schemas';
+import { useRpcClient, useRpcDispatcher } from '../transport/BridgeContext';
 import { getRelativeTimeString } from '../utils/time-utils';
 
-export interface ActiveTask {
-    id: number;
-    command: string;
-    args: string[];
-    startPerformanceTime: number;
-    timestamp: number;
-    label: string;
-    pid: number;
-}
-
-export interface HistoryTask {
-    id: number;
-    command: string;
-    args: string[];
-    duration: number;
-    status: 'completed' | 'failed' | 'timed_out' | 'cancelled';
-    label: string;
-    error: string;
-    stdout: string;
-    stderr: string;
-    exitCode: number;
-    timestamp: number;
-}
-
-export interface Metrics {
-    activeCount: number;
-    peakConcurrency: number;
-    totalCount: number;
-    avgDurationMs: number;
-}
+export type { ActiveTask, HistoryTask, Metrics };
 
 function ActiveDurationCell({ startPerformanceTime }: { startPerformanceTime: number }) {
     const [elapsedText, setElapsedText] = useState<string>(() => {
@@ -102,7 +81,9 @@ function HistoryTimestampDetail({ timestamp, fullTimestamp }: { timestamp: numbe
 }
 
 export default function ProcessMonitorApp() {
-    const bridge = useBridge();
+    const rpc = useRpcClient<ProcessMonitorToHostMessage, 'command'>(ProcessMonitorToHostMessageSchema, {
+        discriminatorKey: 'command',
+    });
     const [metrics, setMetrics] = useState<Metrics>({
         activeCount: 0,
         peakConcurrency: 0,
@@ -115,34 +96,13 @@ export default function ProcessMonitorApp() {
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
     const [copiedId, setCopiedId] = useState<string | null>(null);
 
-    useEffect(() => {
-        const unsubscribe = bridge.onMessage((data: unknown) => {
-            if (!data || typeof data !== 'object' || !('type' in data)) {
-                return;
-            }
-            const message = data as {
-                type: string;
-                activeTasks?: ActiveTask[];
-                historyTasks?: HistoryTask[];
-                metrics?: Metrics;
-            };
-            if (message.type === 'update') {
-                setActiveTasks(message.activeTasks || []);
-                setHistoryTasks(message.historyTasks || []);
-                setMetrics(
-                    message.metrics || {
-                        activeCount: 0,
-                        peakConcurrency: 0,
-                        totalCount: 0,
-                        avgDurationMs: 0,
-                    },
-                );
-            }
-        });
-        return () => {
-            unsubscribe();
-        };
-    }, [bridge]);
+    useRpcDispatcher(ProcessMonitorHostToWebviewMessageSchema, {
+        update: (msg) => {
+            setActiveTasks(msg.activeTasks);
+            setHistoryTasks(msg.historyTasks);
+            setMetrics(msg.metrics);
+        },
+    });
 
     const toggleExpand = (rowKey: string, e: React.SyntheticEvent) => {
         e.stopPropagation();
@@ -166,19 +126,19 @@ export default function ProcessMonitorApp() {
 
     const handleKillProcess = (id: number, e: React.MouseEvent) => {
         e.stopPropagation();
-        bridge.postMessage({ command: 'killProcess', id });
+        void rpc.killProcess({ id });
     };
 
     const handleKillAll = () => {
-        bridge.postMessage({ command: 'killAllProcesses' });
+        void rpc.killAllProcesses();
     };
 
     const handleClearHistory = () => {
-        bridge.postMessage({ command: 'clearHistory' });
+        void rpc.clearHistory();
     };
 
     const handleHidePanel = () => {
-        bridge.postMessage({ command: 'hidePanel' });
+        void rpc.hidePanel();
     };
 
     const copyToClipboard = (text: string, key: string, e: React.MouseEvent) => {

--- a/src/webview/transport/BridgeContext.tsx
+++ b/src/webview/transport/BridgeContext.tsx
@@ -5,6 +5,16 @@
 
 import type * as React from 'react';
 import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import type { z } from 'zod';
+import {
+    createWebviewRpcClient,
+    createWebviewRpcDispatcher,
+    type DiscriminatedMessage,
+    type MessageHandlerMap,
+    type RpcClientMethods,
+    type WebviewRpcClientOptions,
+    type WebviewRpcDispatcherOptions,
+} from '../../common/webview-rpc-dispatcher';
 import { getWebviewTransport } from './registry';
 import type { WebviewTransport } from './types';
 
@@ -42,4 +52,65 @@ export function useMessageListener<T = unknown>(handler: (message: T) => void): 
             unsubscribe();
         };
     }, [bridge]);
+}
+
+export function useRpcClient<
+    TMessage extends DiscriminatedMessage<K>,
+    K extends string = 'type',
+    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
+>(schema?: z.ZodType<TMessage>, options?: WebviewRpcClientOptions<K, TResponseMsg>): RpcClientMethods<TMessage, K> {
+    const bridge = useBridge();
+    const discriminatorKey = options?.discriminatorKey;
+    const dispatcher = options?.dispatcher;
+
+    return useMemo(
+        () =>
+            createWebviewRpcClient<TMessage, K, TResponseMsg>(bridge, schema, {
+                discriminatorKey,
+                dispatcher,
+            }),
+        [bridge, schema, discriminatorKey, dispatcher],
+    );
+}
+
+export function useRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+    schema: z.ZodType<TMessage>,
+    handlers: MessageHandlerMap<TMessage, K>,
+    options?: WebviewRpcDispatcherOptions<K>,
+): void {
+    const bridge = useBridge();
+    const handlersRef = useRef(handlers);
+    handlersRef.current = handlers;
+
+    const optionsRef = useRef(options);
+    optionsRef.current = options;
+
+    useEffect(() => {
+        const forwardingHandlers: MessageHandlerMap<TMessage, K> = new Proxy({} as MessageHandlerMap<TMessage, K>, {
+            get(_target, prop: string) {
+                const currentHandler = (handlersRef.current as Record<string, unknown>)[prop];
+                if (typeof currentHandler === 'function') {
+                    return (msg: unknown) => (currentHandler as (m: unknown) => unknown)(msg);
+                }
+                return undefined;
+            },
+        });
+
+        const dispatcher = createWebviewRpcDispatcher(schema, forwardingHandlers, {
+            ...optionsRef.current,
+            onError: (err, raw) => optionsRef.current?.onError?.(err, raw),
+            messenger: {
+                postMessage: (m) => bridge.postMessage(m),
+            },
+        });
+
+        const unsubscribe = bridge.onMessage(async (msg) => {
+            await dispatcher.dispatch(msg);
+        });
+
+        return () => {
+            unsubscribe();
+            dispatcher.dispose();
+        };
+    }, [bridge, schema]);
 }


### PR DESCRIPTION
Split the monolithic IPC schema definitions into modular per-webview contracts (log-view-schemas.ts, commit-details-schemas.ts, process-monitor-schemas.ts). Migrated the React webview components (App.tsx, CommitDetails.tsx, ProcessMonitorApp.tsx) and host controllers to consume the modular schemas with typed RPC client and dispatcher hooks.