### PR TITLE
webview: eliminate HTML initial data injection in favor of dedicated entrypoints and RPC hydration

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -64,6 +64,7 @@ async function main() {
     const webviewCtx = await esbuild.context({
         entryPoints: {
             index: 'src/webview/index.tsx',
+            'commit-details': 'src/webview/commit-details/index.tsx',
             'process-monitor': 'src/webview/process-monitor/index.tsx',
         },
         bundle: true,

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -104,6 +104,12 @@ export class CommitDetailsController implements Disposable {
 
     public addMessenger(messenger: WebviewPostMessageLike): Disposable {
         this._messengers.add(messenger);
+        if (this.detailsPayload) {
+            messenger.postMessage({
+                type: 'updateDetails',
+                payload: this.detailsPayload,
+            });
+        }
         return {
             dispose: () => {
                 this._messengers.delete(messenger);
@@ -318,7 +324,14 @@ export class CommitDetailsController implements Disposable {
         return createWebviewRpcDispatcher(
             CommitDetailsToHostMessageSchema,
             {
-                webviewLoaded: async () => {},
+                webviewLoaded: async () => {
+                    if (this.detailsPayload) {
+                        this.broadcast({
+                            type: 'updateDetails',
+                            payload: this.detailsPayload,
+                        });
+                    }
+                },
                 descriptionChanged: async (payload) => {
                     const newText = payload.description;
                     const newSelection = {

--- a/src/jj-types.ts
+++ b/src/jj-types.ts
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { CommitDetailsPayload } from './common/ipc/commit-details-schemas';
-import type {
-    ActionPayload,
-    CommitAction,
-    LogViewPayload,
-    ToggleableCommitAction,
-} from './common/ipc/log-view-schemas';
+import type { ActionPayload, CommitAction, ToggleableCommitAction } from './common/ipc/log-view-schemas';
 import { TOGGLEABLE_COMMIT_ACTIONS } from './common/ipc/log-view-schemas';
 import type {
     CodeForgeChangeInfo,
@@ -37,13 +31,3 @@ export type {
 };
 
 export { TOGGLEABLE_COMMIT_ACTIONS };
-
-export type WebviewInitialData =
-    | {
-          view: 'graph';
-          payload?: LogViewPayload;
-      }
-    | {
-          view: 'details';
-          payload?: CommitDetailsPayload;
-      };

--- a/src/test/e2e/jj-log.spec.ts
+++ b/src/test/e2e/jj-log.spec.ts
@@ -463,4 +463,27 @@ test.describe('JJ Log Pane E2E', () => {
             expect(repo.getCommitId('drag-bookmark')).toBe(initialCommitId);
         }).toPass({ timeout: 10000 });
     });
+
+    test('Escape key clears commit selection', async ({ vscode }) => {
+        const repo = new TestRepo();
+        repo.init();
+        const nodes = await buildGraph(repo, [
+            { label: 'initial', description: 'initial setup', files: { 'file.txt': 'base' } },
+            { label: 'feature', parents: ['initial'], description: 'feature commit', files: { 'file2.txt': 'mod' } },
+        ]);
+
+        const { page } = await vscode.openWorkspace(repo);
+        await focusJJLog(page);
+        const webview = await getLogWebview(page);
+
+        const featureRow = await waitForLogCommitRow(page, { changeId: nodes.feature.changeId });
+        await featureRow.click();
+        await expect(featureRow).toHaveAttribute('data-selected', 'true');
+
+        // Press Escape inside the webview
+        await webview.locator('body').press('Escape');
+
+        // Verify selection is cleared
+        await expect(featureRow).toHaveAttribute('data-selected', 'false');
+    });
 });

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -82,19 +82,16 @@ suite('Webview Initialization Integration Test', () => {
             await d.dispose();
         }
         disposables = [];
-        if (repo) {
-        }
         await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
-    test('resolveWebviewView injects cached commits into HTML', async () => {
+    test('resolveWebviewView sets up webview options and loads script without HTML data injection', async () => {
         // Setup repo with one commit
         repo.new();
         repo.describe('Test Commit 1');
-        const id1 = repo.getChangeId('@');
 
-        // 1. Initial Resolve & Refresh to populate cache
-        const { view: initialView } = createMockWebviewView();
+        // 1. Initial Resolve & Refresh
+        const { view: initialView, webview: initialWebview } = createMockWebviewView();
         provider.resolveWebviewView(
             initialView,
             createMock<vscode.WebviewViewResolveContext>({}),
@@ -102,49 +99,10 @@ suite('Webview Initialization Integration Test', () => {
         );
         await provider.controller.refresh();
 
-        // 2. Simulate Refocus: Create NEW view and resolve it
-        const { view: newView, webview: newWebview } = createMockWebviewView();
-        provider.resolveWebviewView(
-            newView,
-            createMock<vscode.WebviewViewResolveContext>({}),
-            createMock<vscode.CancellationToken>({}),
-        );
-
-        // 3. Verify HTML contains cached data
-        const html = newWebview.html;
-        assert.ok(html.includes('window.vscodeInitialData ='), 'HTML should contain initial data injection');
-        assert.ok(html.includes(id1), 'HTML should contain the commit ID from the cache');
-        assert.ok(html.includes('Test Commit 1'), 'HTML should contain the description from the cache');
-    });
-
-    test('webview.html is updated when view becomes hidden', async () => {
-        // Setup repo with one commit
-        repo.new();
-        repo.describe('Test Commit 2');
-        const id2 = repo.getChangeId('@');
-
-        // Setup View
-        const { view, webview, triggerVisibilityChange } = createMockWebviewView();
-        provider.resolveWebviewView(
-            view,
-            createMock<vscode.WebviewViewResolveContext>({}),
-            createMock<vscode.CancellationToken>({}),
-        );
-
-        // Populate cache
-        await provider.controller.refresh();
-        const htmlBefore = webview.html;
-
-        // Simulate Hiding
-        Object.defineProperty(view, 'visible', { get: () => false });
-        triggerVisibilityChange();
-
-        // Verify HTML updated
-        const htmlAfter = webview.html;
-        assert.notStrictEqual(htmlAfter, htmlBefore, 'HTML should be updated when view becomes hidden');
-        assert.ok(htmlAfter.includes('window.vscodeInitialData ='), 'HTML should contain initial data');
-        assert.ok(htmlAfter.includes(id2), 'HTML should contain the commit ID from the cache');
-        assert.ok(htmlAfter.includes('Test Commit 2'), 'HTML should contain the description from the cache');
+        // 2. Verify HTML is clean and points to webview bundle
+        const html = initialWebview.html;
+        assert.ok(html.includes('dist/webview/index.js'), 'HTML should reference webview bundle');
+        assert.ok(!html.includes('window.vscodeInitialData'), 'HTML should not contain initial data script injection');
     });
 
     test('repository getter returns undefined until updateRepository is called', async () => {

--- a/src/test/webview/bridge.test.ts
+++ b/src/test/webview/bridge.test.ts
@@ -50,8 +50,7 @@ describe('WebviewTransport', () => {
 
     describe('MockWebviewTransport', () => {
         it('captures sent messages', () => {
-            const transport = new MockWebviewTransport({ test: 123 });
-            expect(transport.getInitialData<{ test: number }>()).toEqual({ test: 123 });
+            const transport = new MockWebviewTransport();
 
             transport.postMessage({ type: 'testMessage', payload: { foo: 'bar' } });
             expect(transport.sentMessages).toEqual([{ type: 'testMessage', payload: { foo: 'bar' } }]);
@@ -101,18 +100,10 @@ describe('WebviewTransport', () => {
                 received.push(msg);
             });
 
-            transport.simulateIncomingMessage({ type: 'update' });
-            expect(received).toEqual([{ type: 'update' }]);
+            transport.simulateIncomingMessage({ type: 'test' });
+            expect(received).toEqual([{ type: 'test' }]);
             expect(consoleErrorSpy).toHaveBeenCalled();
             consoleErrorSpy.mockRestore();
-        });
-
-        it('updates initial data dynamically', () => {
-            const transport = new MockWebviewTransport();
-            expect(transport.getInitialData()).toBeUndefined();
-
-            transport.setInitialData({ user: 'alice' });
-            expect(transport.getInitialData<{ user: string }>()).toEqual({ user: 'alice' });
         });
     });
 
@@ -130,10 +121,6 @@ describe('WebviewTransport', () => {
                 acquireVsCodeApi: () => ({
                     postMessage: postMessageMock,
                 }),
-                vscodeInitialData: {
-                    view: 'graph',
-                    payload: { theme: 'dark' },
-                },
                 addEventListener: mockEventTarget.addEventListener.bind(mockEventTarget),
                 removeEventListener: mockEventTarget.removeEventListener.bind(mockEventTarget),
                 dispatchEvent: mockEventTarget.dispatchEvent.bind(mockEventTarget),
@@ -149,14 +136,6 @@ describe('WebviewTransport', () => {
             transport.postMessage({ type: 'webviewLoaded' });
 
             expect(postMessageMock).toHaveBeenCalledWith({ type: 'webviewLoaded' });
-        });
-
-        it('retrieves initial data from window.vscodeInitialData', () => {
-            const transport = new VsCodeWebviewTransport();
-            expect(transport.getInitialData()).toEqual({
-                view: 'graph',
-                payload: { theme: 'dark' },
-            });
         });
 
         it('listens for window message events and cleans up listener on unsubscribe', () => {
@@ -257,8 +236,7 @@ describe('WebviewTransport', () => {
         });
 
         it('queues messages before socket is open and sends on connect', () => {
-            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc', { initial: true });
-            expect(transport.getInitialData()).toEqual({ initial: true });
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
 
             const socket = MockWebSocket.instance;
             expect(socket).toBeDefined();
@@ -406,7 +384,7 @@ describe('WebviewTransport', () => {
 
     describe('getWebviewTransport & setWebviewTransport', () => {
         it('returns custom transport if overridden', () => {
-            const custom = new MockWebviewTransport({ custom: true });
+            const custom = new MockWebviewTransport();
             setWebviewTransport(custom);
 
             expect(getWebviewTransport()).toBe(custom);

--- a/src/vscode/providers/vscode-commit-details-editor-provider.ts
+++ b/src/vscode/providers/vscode-commit-details-editor-provider.ts
@@ -171,24 +171,14 @@ export class VsCodeCommitDetailsEditorProvider
             enableCommandUris: true,
         };
 
+        const messageDisposable = panel.webview.onDidReceiveMessage(async (message: unknown) => {
+            await controller.handleMessage(message);
+        });
         const messengerDisposable = controller.addMessenger(panel.webview);
 
-        panel.webview.html = getWebviewHtml({
-            webview: panel.webview,
-            extensionUri: this._extensionUri,
-            scriptPath: ['dist', 'webview', 'index.js'],
-            title: 'Commit Details',
-            initialData: {
-                view: 'details',
-                payload: controller.detailsPayload,
-            },
-        });
-
         const viewSubscriptions: vscode.Disposable[] = [
+            messageDisposable,
             messengerDisposable,
-            panel.webview.onDidReceiveMessage(async (message: unknown) => {
-                await controller.handleMessage(message);
-            }),
             panel.onDidDispose(() => {
                 messengerDisposable.dispose();
                 for (const d of viewSubscriptions) {
@@ -196,6 +186,13 @@ export class VsCodeCommitDetailsEditorProvider
                 }
             }),
         ];
+
+        panel.webview.html = getWebviewHtml({
+            webview: panel.webview,
+            extensionUri: this._extensionUri,
+            scriptPath: ['dist', 'webview', 'commit-details.js'],
+            title: 'Commit Details',
+        });
     }
 
     public dispose(): void {

--- a/src/vscode/providers/vscode-log-webview-provider.ts
+++ b/src/vscode/providers/vscode-log-webview-provider.ts
@@ -7,7 +7,6 @@ import * as path from 'node:path';
 import type * as vscode from 'vscode';
 import { LogViewController } from '../../controllers/log-view-controller';
 import type { JjRepository } from '../../jj-repository';
-import type { JjLogEntry } from '../../jj-types';
 import type { Uri } from '../../uri-utils';
 import type { LoggerChannel } from '../../utils/output-channel';
 import { VsCodeHostEnvironment } from '../vscode-host-environment';
@@ -92,8 +91,6 @@ export class VsCodeLogWebviewProvider implements vscode.WebviewViewProvider, vsc
                     this.controller.refresh('becameVisible').catch((e) => {
                         this.outputChannel?.error(`[VsCodeLogWebviewProvider] Visibility refresh error: ${e}`);
                     });
-                } else {
-                    webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
                 }
             }),
             webviewView.webview.onDidReceiveMessage(async (message: unknown) => {
@@ -115,16 +112,6 @@ export class VsCodeLogWebviewProvider implements vscode.WebviewViewProvider, vsc
             extensionUri: this._extensionUri,
             scriptPath: ['dist', 'webview', 'index.js'],
             title: 'JJ Log',
-            initialData: {
-                view: 'graph',
-                payload: {
-                    commits: this.controller.commits as JjLogEntry[],
-                    theme: this.controller.theme,
-                    graphLabelAlignment: this.controller.graphLabelAlignment,
-                    hiddenActions: this.controller.hiddenActions as string[],
-                    minChangeIdLength: this.controller.minChangeIdLength,
-                },
-            },
         });
     }
 

--- a/src/vscode/vscode-webview-html.ts
+++ b/src/vscode/vscode-webview-html.ts
@@ -11,18 +11,16 @@ export interface WebviewHtmlOptions {
     extensionUri: Uri;
     scriptPath: readonly string[];
     title: string;
-    initialData?: unknown;
 }
 
 export function getWebviewHtml(options: WebviewHtmlOptions): string {
-    const { webview, extensionUri, scriptPath, title, initialData } = options;
+    const { webview, extensionUri, scriptPath, title } = options;
     const scriptUri = webview.asWebviewUri(Uri.joinPath(extensionUri, ...scriptPath));
     const styleUri = webview.asWebviewUri(Uri.joinPath(extensionUri, 'media', 'main.css'));
     const themesUri = webview.asWebviewUri(Uri.joinPath(extensionUri, 'media', 'themes.generated.css'));
     const codiconsUri = webview.asWebviewUri(Uri.joinPath(extensionUri, 'media', 'codicons', 'codicon.css'));
 
     const nonce = getNonce();
-    const initialDataScript = initialData ? `window.vscodeInitialData = ${JSON.stringify(initialData)};` : '';
 
     return `<!DOCTYPE html>
         <html lang="en">
@@ -37,9 +35,6 @@ export function getWebviewHtml(options: WebviewHtmlOptions): string {
         </head>
         <body>
             <div id="root"></div>
-            <script nonce="${nonce}">
-                ${initialDataScript}
-            </script>
             <script nonce="${nonce}" src="${scriptUri}"></script>
         </body>
         </html>`;

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -15,28 +15,19 @@ import {
 } from '@dnd-kit/core';
 import * as React from 'react';
 import {
-    type CommitDetailsHostToWebviewMessage,
-    CommitDetailsHostToWebviewMessageSchema,
-    type CommitDetailsPayload,
-    type CommitDetailsToHostMessage,
-    CommitDetailsToHostMessageSchema,
-} from '../common/ipc/commit-details-schemas';
-import {
     type ActionPayload,
     type CommitAction,
     type LogViewHostToWebviewMessage,
     LogViewHostToWebviewMessageSchema,
-    type LogViewPayload,
     type LogViewToHostMessage,
     LogViewToHostMessageSchema,
 } from '../common/ipc/log-view-schemas';
-import type { JjLogEntry, WebviewInitialData } from '../jj-types';
+import type { JjLogEntry } from '../jj-types';
 import { BookmarkPill } from './components/Bookmark';
-import { CommitDetails } from './components/CommitDetails';
 import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
 import { useDragModifiers } from './hooks/useDragModifiers';
-import { useBridge, useRpcClient, useRpcDispatcher } from './transport/BridgeContext';
+import { useRpcClient, useRpcDispatcher } from './transport/BridgeContext';
 import { snapToCursorLeft } from './utils/modifiers';
 import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
 
@@ -44,91 +35,14 @@ type DragItem =
     | { type: 'bookmark'; name: string; remote?: string }
     | (JjLogEntry & { type: 'commit'; changeId: string });
 
-interface CommitDetailsViewProps {
-    initialPayload?: CommitDetailsPayload;
-}
-
-const CommitDetailsView: React.FC<CommitDetailsViewProps> = ({ initialPayload }) => {
-    const [detailsCommit, setDetailsCommit] = React.useState<CommitDetailsPayload | null>(initialPayload || null);
-    const rpc = useRpcClient<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
-
-    useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
-        updateDetails: (payload) => {
-            setDetailsCommit(payload);
-        },
-        saveComplete: ({ description }) => {
-            setDetailsCommit((prev) => (prev ? { ...prev, description } : prev));
-        },
-        saveFailed: () => {},
-        updateDescription: () => {},
-    });
-
-    React.useEffect(() => {
-        void rpc.webviewLoaded();
-    }, [rpc]);
-
-    if (!detailsCommit) {
-        return (
-            <div style={{ padding: '20px', color: 'var(--vscode-descriptionForeground)' }}>
-                Loading commit details...
-            </div>
-        );
-    }
-
-    return (
-        <CommitDetails
-            changeId={detailsCommit.changeId || ''}
-            commitId={detailsCommit.commitId || ''}
-            description={detailsCommit.description || ''}
-            files={detailsCommit.files || []}
-            isImmutable={detailsCommit.isImmutable || false}
-            isEmpty={detailsCommit.isEmpty}
-            isConflict={detailsCommit.isConflict}
-            author={detailsCommit.author}
-            committer={detailsCommit.committer}
-            bookmarks={detailsCommit.bookmarks}
-            tags={detailsCommit.tags}
-            titleWidthRuler={detailsCommit.titleWidthRuler}
-            bodyWidthRuler={detailsCommit.bodyWidthRuler}
-            minChangeIdLength={detailsCommit.minChangeIdLength}
-            onSave={(description) => {
-                if (detailsCommit.changeId) {
-                    void rpc.saveDescription({ changeId: detailsCommit.changeId, description });
-                }
-            }}
-            onOpenDiff={(file, isImmutable) => {
-                if (detailsCommit.changeId) {
-                    void rpc.openDiff({ changeId: detailsCommit.changeId, file, isImmutable });
-                }
-            }}
-            onOpenMultiDiff={() => {
-                if (detailsCommit.changeId) {
-                    void rpc.openMultiDiff({ changeId: detailsCommit.changeId });
-                }
-            }}
-            onDescriptionChange={(description, selectionStart, selectionEnd) => {
-                void rpc.descriptionChanged({ description, selectionStart, selectionEnd });
-            }}
-        />
-    );
-};
-
-interface LogViewProps {
-    initialPayload?: LogViewPayload;
-}
-
-const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
-    const [commits, setCommits] = React.useState<JjLogEntry[]>(initialPayload?.commits || []);
-    const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>(initialPayload?.minChangeIdLength || 1);
-    const [theme, setTheme] = React.useState<string>(initialPayload?.theme || 'default');
-    const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>(
-        initialPayload?.graphLabelAlignment || 'aligned',
-    );
-    const [loading, setLoading] = React.useState(!(initialPayload?.commits && initialPayload.commits.length > 0));
+const App: React.FC = () => {
+    const [commits, setCommits] = React.useState<JjLogEntry[]>([]);
+    const [minChangeIdLength, setMinChangeIdLength] = React.useState<number>(1);
+    const [theme, setTheme] = React.useState<string>('default');
+    const [graphLabelAlignment, setGraphLabelAlignment] = React.useState<string>('aligned');
+    const [loading, setLoading] = React.useState<boolean>(true);
     const [selectedCommitIds, setSelectedCommitIds] = React.useState<Set<string>>(new Set());
-    const [hiddenActions, setHiddenActions] = React.useState<Set<CommitAction>>(
-        new Set(initialPayload?.hiddenActions || []),
-    );
+    const [hiddenActions, setHiddenActions] = React.useState<Set<CommitAction>>(new Set());
 
     const commitsRef = React.useRef(commits);
     React.useEffect(() => {
@@ -198,6 +112,7 @@ const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
                     });
                     return newIds;
                 }
+
                 return prevIds;
             });
         },
@@ -206,24 +121,22 @@ const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
         },
         panelClosed: ({ changeId }) => {
             setSelectedCommitIds((prevIds) => {
-                if (changeId && prevIds.has(changeId) && prevIds.size === 1) {
-                    const clearedIds = new Set<string>();
+                if (prevIds.has(changeId) && prevIds.size === 1) {
                     void rpc.selectionChange({
                         commitIds: [],
                         hasImmutableSelection: false,
                     });
-                    return clearedIds;
+                    return new Set();
                 }
                 return prevIds;
             });
         },
         setSelection: ({ ids }) => {
-            const newIds = new Set<string>(ids || []);
+            const newIds = new Set(ids);
             setSelectedCommitIds(newIds);
             const hasImmutable = hasImmutableSelection(newIds, commitsRef.current);
-
             void rpc.selectionChange({
-                commitIds: Array.from(newIds),
+                commitIds: ids,
                 hasImmutableSelection: hasImmutable,
             });
         },
@@ -252,17 +165,19 @@ const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
 
     const handleGraphAction = (action: string, payload: ActionPayload) => {
         if (action === 'select') {
-            const { changeId, multiSelect } = payload;
-            const nextSelectedIds = calculateNextSelection(selectedCommitIds, changeId, Boolean(multiSelect));
-            setSelectedCommitIds(nextSelectedIds);
+            const multiSelect = payload.multiSelect ?? false;
+            const newSelection = calculateNextSelection(selectedCommitIds, payload.changeId, multiSelect);
+            setSelectedCommitIds(newSelection);
 
-            const hasImmutable = hasImmutableSelection(nextSelectedIds, commits);
+            const commitIds = Array.from(newSelection);
+            const hasImmutable = hasImmutableSelection(newSelection, commitsRef.current);
+
             void rpc.selectionChange({
-                commitIds: Array.from(nextSelectedIds),
+                commitIds,
                 hasImmutableSelection: hasImmutable,
             });
 
-            if (nextSelectedIds.has(changeId)) {
+            if (newSelection.has(payload.changeId)) {
                 void rpc.getDetails(payload);
             }
             return;
@@ -470,17 +385,6 @@ const LogView: React.FC<LogViewProps> = ({ initialPayload }) => {
             </DndContext>
         </div>
     );
-};
-
-const App: React.FC = () => {
-    const bridge = useBridge();
-    const initialData = bridge.getInitialData<WebviewInitialData>();
-    const view = initialData?.view || 'graph';
-
-    if (view === 'details') {
-        return <CommitDetailsView initialPayload={initialData?.payload as CommitDetailsPayload | undefined} />;
-    }
-    return <LogView initialPayload={initialData?.payload as LogViewPayload | undefined} />;
 };
 
 export default App;

--- a/src/webview/commit-details/CommitDetailsApp.tsx
+++ b/src/webview/commit-details/CommitDetailsApp.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as React from 'react';
+import {
+    type CommitDetailsHostToWebviewMessage,
+    CommitDetailsHostToWebviewMessageSchema,
+    type CommitDetailsPayload,
+    type CommitDetailsToHostMessage,
+    CommitDetailsToHostMessageSchema,
+} from '../../common/ipc/commit-details-schemas';
+import { CommitDetails } from '../components/CommitDetails';
+import { useRpcClient, useRpcDispatcher } from '../transport/BridgeContext';
+
+export const CommitDetailsApp: React.FC = () => {
+    const [detailsCommit, setDetailsCommit] = React.useState<CommitDetailsPayload | null>(null);
+    const rpc = useRpcClient<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
+
+    useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
+        updateDetails: (payload) => {
+            setDetailsCommit(payload);
+        },
+        saveComplete: ({ description }) => {
+            setDetailsCommit((prev) => (prev ? { ...prev, description } : prev));
+        },
+        saveFailed: () => {},
+        updateDescription: () => {},
+    });
+
+    React.useEffect(() => {
+        void rpc.webviewLoaded();
+    }, [rpc]);
+
+    if (!detailsCommit) {
+        return (
+            <div style={{ padding: '20px', color: 'var(--vscode-descriptionForeground)' }}>
+                Loading commit details...
+            </div>
+        );
+    }
+
+    return (
+        <CommitDetails
+            changeId={detailsCommit.changeId || ''}
+            commitId={detailsCommit.commitId || ''}
+            description={detailsCommit.description || ''}
+            files={detailsCommit.files || []}
+            isImmutable={detailsCommit.isImmutable || false}
+            isEmpty={detailsCommit.isEmpty}
+            isConflict={detailsCommit.isConflict}
+            author={detailsCommit.author}
+            committer={detailsCommit.committer}
+            bookmarks={detailsCommit.bookmarks}
+            tags={detailsCommit.tags}
+            titleWidthRuler={detailsCommit.titleWidthRuler}
+            bodyWidthRuler={detailsCommit.bodyWidthRuler}
+            minChangeIdLength={detailsCommit.minChangeIdLength}
+            onSave={(description) => {
+                if (detailsCommit.changeId) {
+                    void rpc.saveDescription({ changeId: detailsCommit.changeId, description });
+                }
+            }}
+            onOpenDiff={(file, isImmutable) => {
+                if (detailsCommit.changeId) {
+                    void rpc.openDiff({ changeId: detailsCommit.changeId, file, isImmutable });
+                }
+            }}
+            onOpenMultiDiff={() => {
+                if (detailsCommit.changeId) {
+                    void rpc.openMultiDiff({ changeId: detailsCommit.changeId });
+                }
+            }}
+            onDescriptionChange={(description, selectionStart, selectionEnd) => {
+                void rpc.descriptionChanged({ description, selectionStart, selectionEnd });
+            }}
+        />
+    );
+};

--- a/src/webview/commit-details/index.tsx
+++ b/src/webview/commit-details/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import '@vscode-elements/elements';
+import { createRoot } from 'react-dom/client';
+import { BridgeProvider } from '../transport/BridgeContext';
+import { CommitDetailsApp } from './CommitDetailsApp';
+
+const rootElement = document.getElementById('root');
+if (rootElement) {
+    const root = createRoot(rootElement);
+    root.render(
+        <BridgeProvider>
+            <CommitDetailsApp />
+        </BridgeProvider>,
+    );
+}

--- a/src/webview/global.d.ts
+++ b/src/webview/global.d.ts
@@ -2,22 +2,22 @@
  * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { WebviewInitialData } from '../jj-types';
 
 declare global {
     interface Window {
-        vscode: unknown;
-        vscodeInitialData?: WebviewInitialData;
+        vscode?: unknown;
         __jjViewVsCodeApi?: {
             postMessage: (message: unknown) => void;
             setState?: (state: unknown) => void;
             getState?: () => unknown;
         };
         __JJ_VIEW_WS_URL__?: string;
-        acquireVsCodeApi: () => {
+        acquireVsCodeApi?: () => {
             postMessage: (message: unknown) => void;
             setState: (state: unknown) => void;
             getState: () => unknown;
         };
     }
 }
+
+export {};

--- a/src/webview/transport/mock-transport.ts
+++ b/src/webview/transport/mock-transport.ts
@@ -11,11 +11,6 @@ import type { WebviewTransport } from './types';
 export class MockWebviewTransport implements WebviewTransport {
     public readonly sentMessages: unknown[] = [];
     private readonly handlers = new Set<(message: unknown) => void>();
-    private initialData?: unknown;
-
-    constructor(initialData?: unknown) {
-        this.initialData = initialData;
-    }
 
     public postMessage(message: unknown): void {
         this.sentMessages.push(message);
@@ -26,14 +21,6 @@ export class MockWebviewTransport implements WebviewTransport {
         return () => {
             this.handlers.delete(handler);
         };
-    }
-
-    public getInitialData<T>(): T | undefined {
-        return this.initialData as T | undefined;
-    }
-
-    public setInitialData(data: unknown): void {
-        this.initialData = data;
     }
 
     public simulateIncomingMessage(message: unknown): void {

--- a/src/webview/transport/types.ts
+++ b/src/webview/transport/types.ts
@@ -10,6 +10,5 @@ export type WebviewTransportMessage =
 export interface WebviewTransport {
     postMessage(message: unknown): void;
     onMessage(handler: (message: unknown) => void): () => void;
-    getInitialData<T>(): T | undefined;
     dispose?(): void;
 }

--- a/src/webview/transport/vscode-transport.ts
+++ b/src/webview/transport/vscode-transport.ts
@@ -55,13 +55,6 @@ export class VsCodeWebviewTransport implements WebviewTransport {
         };
     }
 
-    public getInitialData<T>(): T | undefined {
-        if (typeof window === 'undefined') {
-            return undefined;
-        }
-        return window.vscodeInitialData as T | undefined;
-    }
-
     public dispose(): void {
         if (typeof window !== 'undefined') {
             for (const listener of this._listeners) {

--- a/src/webview/transport/websocket-transport.ts
+++ b/src/webview/transport/websocket-transport.ts
@@ -12,18 +12,13 @@ export class WebSocketWebviewTransport implements WebviewTransport {
     private socket?: WebSocket;
     private readonly messageQueue: unknown[] = [];
     private readonly handlers = new Set<(message: unknown) => void>();
-    private initialData?: unknown;
     private _disposed = false;
     private reconnectTimer?: ReturnType<typeof setTimeout>;
     private reconnectAttempts = 0;
 
     public static readonly MAX_QUEUE_SIZE = 100;
 
-    constructor(
-        private readonly url: string,
-        initialData?: unknown,
-    ) {
-        this.initialData = initialData;
+    constructor(private readonly url: string) {
         this.connect();
     }
 
@@ -116,14 +111,6 @@ export class WebSocketWebviewTransport implements WebviewTransport {
         return () => {
             this.handlers.delete(handler);
         };
-    }
-
-    public getInitialData<T>(): T | undefined {
-        return this.initialData as T | undefined;
-    }
-
-    public setInitialData(data: unknown): void {
-        this.initialData = data;
     }
 
     public dispose(): void {


### PR DESCRIPTION


Build separate bundles for Log View, Commit Details, and Process Monitor webviews rather than routing through a single monolithic bundle via injected window state. Webview state is loaded reactively over the transport upon receiving the webviewLoaded handshake, removing initial data serialization from HTML templates, providers, and transport interfaces.