### PR TITLE
rpc: introduce bidirectional message queuing and automatic state synchronization

### DIFF
--- a/src/common/ipc/commit-details-schemas.ts
+++ b/src/common/ipc/commit-details-schemas.ts
@@ -73,7 +73,7 @@ export type CommitDetailsPayload = z.infer<typeof CommitDetailsPayloadSchema>;
 
 export const CommitDetailsHostToWebviewMessageSchema = z.discriminatedUnion('type', [
     z.object({
-        type: z.literal('updateDetails'),
+        type: z.literal('update'),
         payload: CommitDetailsPayloadSchema,
     }),
     z.object({

--- a/src/common/ipc/process-monitor-schemas.ts
+++ b/src/common/ipc/process-monitor-schemas.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 
 export const ProcessMonitorToHostMessageSchema = z.discriminatedUnion('command', [
+    z.object({ command: z.literal('webviewLoaded') }),
     z.object({
         command: z.literal('killProcess'),
         payload: z.object({ id: z.number() }),

--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -19,11 +19,41 @@ export type MessageHandlerMap<TMessage extends DiscriminatedMessage<K>, K extend
         : (payload: MessagePayload<Extract<TMessage, { [P in K]: V }>>) => unknown | Promise<unknown>;
 };
 
-export interface WebviewRpcDispatcherOptions<K extends string = 'type'> {
+export type InitialStateMap<TOutbound extends DiscriminatedMessage<'type'>> = string extends TOutbound['type']
+    ? Record<string, unknown>
+    : {
+          [V in TOutbound['type']]?: MessagePayload<Extract<TOutbound, { type: V }>>;
+      };
+
+export type StateValue<TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>> =
+    | TOutbound
+    | InitialStateMap<TOutbound>
+    | MessagePayload<Extract<TOutbound, { type: 'update' }>>
+    | Record<string, unknown>
+    | undefined;
+
+export type StateProvider<TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>> = () =>
+    | StateValue<TOutbound>
+    | StateValue<TOutbound>[];
+
+export type InitialStateValue<TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>> =
+    StateValue<TOutbound>;
+
+export type InitialStateProvider<TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>> =
+    StateProvider<TOutbound>;
+
+export interface WebviewRpcDispatcherOptions<
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+> {
     discriminatorKey?: K;
     logger?: LoggerChannel;
     messenger?: WebviewPostMessageLike;
     onError?: (error: unknown, rawMessage: unknown) => void;
+    getState?: StateProvider<TOutbound>;
+    state?: StateProvider<TOutbound>;
+    getInitialState?: StateProvider<TOutbound>;
+    maxQueueSize?: number;
 }
 
 export const loggerSchema = z.object({
@@ -47,29 +77,195 @@ type PendingPromise = {
     reject: (reason: unknown) => void;
 };
 
-export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> {
+export class WebviewRpcDispatcher<
+    TMessage extends DiscriminatedMessage<K>,
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+> {
     private readonly discriminatorKey: K;
     private readonly pendingRequests = new Map<string, PendingPromise>();
+    private readonly _messengers = new Set<WebviewPostMessageLike>();
+    private readonly _outboundQueue: unknown[] = [];
+    private readonly _maxQueueSize: number;
+    private _disposed = false;
 
     constructor(
         private readonly schema: z.ZodType<TMessage>,
         private readonly handlers: MessageHandlerMap<TMessage, K>,
-        private readonly options?: WebviewRpcDispatcherOptions<K>,
+        private readonly options?: WebviewRpcDispatcherOptions<TOutbound, K>,
     ) {
         this.discriminatorKey = options?.discriminatorKey ?? ('type' as K);
+        this._maxQueueSize = options?.maxQueueSize ?? 100;
+        if (options?.messenger) {
+            this.addMessenger(options.messenger);
+        }
+    }
+
+    public get isDisposed(): boolean {
+        return this._disposed;
+    }
+
+    public get hasMessengers(): boolean {
+        return this._messengers.size > 0;
+    }
+
+    public addMessenger(messenger: WebviewPostMessageLike): { dispose: () => void } {
+        if (this._disposed) {
+            return { dispose: () => {} };
+        }
+
+        this._messengers.add(messenger);
+        this._flushOutboundQueue(messenger);
+        this._sendState(messenger);
+
+        let disposed = false;
+        return {
+            dispose: () => {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                this.removeMessenger(messenger);
+            },
+        };
+    }
+
+    public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
+        this._messengers.clear();
+        if (!messenger || this._disposed) {
+            return;
+        }
+        this.addMessenger(messenger);
+    }
+
+    public removeMessenger(messenger: WebviewPostMessageLike): void {
+        this._messengers.delete(messenger);
+    }
+
+    public broadcast(message: unknown): void {
+        if (this._disposed) {
+            return;
+        }
+
+        if (this._messengers.size === 0) {
+            if (this._maxQueueSize <= 0) {
+                return;
+            }
+            if (this._outboundQueue.length >= this._maxQueueSize) {
+                this._outboundQueue.shift();
+            }
+            this._outboundQueue.push(message);
+            return;
+        }
+
+        this._postToMessengers(message, Array.from(this._messengers));
+    }
+
+    private _postToMessengers(message: unknown, recipients: readonly WebviewPostMessageLike[]): void {
+        for (const messenger of recipients) {
+            try {
+                messenger.postMessage(message);
+            } catch (err) {
+                this.options?.logger?.error('WebviewRpcDispatcher post error', toError(err));
+            }
+        }
+    }
+
+    private _flushOutboundQueue(targetMessenger?: WebviewPostMessageLike): void {
+        if (this._outboundQueue.length === 0) {
+            return;
+        }
+
+        const recipients = targetMessenger ? [targetMessenger] : Array.from(this._messengers);
+        if (recipients.length === 0) {
+            return;
+        }
+
+        const pending = this._outboundQueue.splice(0, this._outboundQueue.length);
+        for (const message of pending) {
+            this._postToMessengers(message, recipients);
+        }
+    }
+
+    private _sendState(targetMessenger?: WebviewPostMessageLike): void {
+        const stateProvider = this.options?.getState ?? this.options?.state ?? this.options?.getInitialState;
+        if (!stateProvider) {
+            return;
+        }
+
+        let stateResult: unknown | undefined;
+        try {
+            stateResult = stateProvider();
+        } catch (err) {
+            this.options?.logger?.error('WebviewRpcDispatcher state provider error', toError(err));
+            return;
+        }
+
+        if (stateResult === undefined || stateResult === null) {
+            return;
+        }
+
+        const recipients = targetMessenger ? [targetMessenger] : Array.from(this._messengers);
+        if (recipients.length === 0) {
+            return;
+        }
+
+        const items = Array.isArray(stateResult) ? stateResult : [stateResult];
+        for (const item of items) {
+            if (item === undefined || item === null) {
+                continue;
+            }
+
+            if (typeof item === 'object' && 'type' in item) {
+                this._postToMessengers(item, recipients);
+                continue;
+            }
+
+            if (typeof item === 'object') {
+                const definedKeys = Object.keys(item).filter((k) => (item as Record<string, unknown>)[k] !== undefined);
+                if (definedKeys.length === 1 && definedKeys[0] === 'update') {
+                    this._postToMessengers(
+                        {
+                            type: 'update',
+                            payload: (item as Record<string, unknown>).update,
+                        },
+                        recipients,
+                    );
+                    continue;
+                }
+
+                this._postToMessengers(
+                    {
+                        type: 'update',
+                        payload: item,
+                    },
+                    recipients,
+                );
+            }
+        }
     }
 
     public registerPendingRequest(requestId: string): Promise<unknown> {
+        if (this._disposed) {
+            return Promise.reject(new Error('WebviewRpcDispatcher is disposed'));
+        }
         return new Promise((resolve, reject) => {
             this.pendingRequests.set(requestId, { resolve, reject });
         });
     }
 
+    public unregisterPendingRequest(requestId: string): void {
+        this.pendingRequests.delete(requestId);
+    }
+
     public dispose(): void {
+        this._disposed = true;
         for (const pending of this.pendingRequests.values()) {
             pending.reject(new Error('WebviewRpcDispatcher disposed'));
         }
         this.pendingRequests.clear();
+        this._messengers.clear();
+        this._outboundQueue.length = 0;
     }
 
     private handleRpcResponse(rawMessage: unknown): boolean {
@@ -77,6 +273,7 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
         if (!responseParse.success) {
             return false;
         }
+
         const { requestId, result, error } = responseParse.data;
         const pending = this.pendingRequests.get(requestId);
         if (pending) {
@@ -86,9 +283,8 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
             } else {
                 pending.resolve(result);
             }
-            return true;
         }
-        return false;
+        return true;
     }
 
     private async handleLogMessage(rawMessage: unknown): Promise<boolean> {
@@ -109,12 +305,20 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
 
         const customHandler = (this.handlers as Record<string, unknown>).logMessage;
         if (typeof customHandler === 'function') {
-            await (customHandler as (msg: unknown) => Promise<void>)(rawMessage);
+            try {
+                await (customHandler as (msg: unknown) => Promise<void>)(logMsgParse.data.payload);
+            } catch (err) {
+                this.options?.logger?.error('WebviewRpcDispatcher logMessage handler error', toError(err));
+            }
         }
         return true;
     }
 
     public async dispatch(rawMessage: unknown): Promise<boolean> {
+        if (this._disposed) {
+            return false;
+        }
+
         if (this.handleRpcResponse(rawMessage)) {
             return true;
         }
@@ -123,67 +327,108 @@ export class WebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ex
             return true;
         }
 
+        const rawTypeValue = (rawMessage as Record<string, unknown>)?.[this.discriminatorKey];
+        if (rawTypeValue === 'webviewLoaded') {
+            this._flushOutboundQueue();
+            this._sendState();
+            const customLoadedHandler = this.handlers['webviewLoaded' as TMessage[K]] as (() => unknown) | undefined;
+            if (typeof customLoadedHandler === 'function') {
+                try {
+                    await customLoadedHandler();
+                } catch (err) {
+                    this.options?.logger?.error('WebviewRpcDispatcher webviewLoaded handler error', toError(err));
+                }
+            }
+            const requestId = (rawMessage as Record<string, unknown>)?.requestId as string | undefined;
+            if (requestId) {
+                this._sendRpcSuccessResponse(requestId, undefined);
+            }
+            return true;
+        }
+
         const parseResult = this.schema.safeParse(rawMessage);
+        const requestId = (rawMessage as Record<string, unknown>)?.requestId as string | undefined;
+
         if (!parseResult.success) {
-            const isUnknownDiscriminator = parseResult.error.issues.some((issue) => issue.code === 'invalid_union');
+            const isUnknownDiscriminator = parseResult.error.issues.some(
+                (issue) =>
+                    issue.code === 'invalid_union' ||
+                    (issue as { code: string }).code === 'invalid_union_discriminator',
+            );
             if (isUnknownDiscriminator) {
                 return false;
             }
+
             this.options?.logger?.error('Webview RPC validation failed', parseResult.error);
-            this.options?.onError?.(parseResult.error, rawMessage);
+            try {
+                this.options?.onError?.(parseResult.error, rawMessage);
+            } catch (e) {
+                this.options?.logger?.error('WebviewRpcDispatcher onError callback failed', toError(e));
+            }
+            this._sendRpcErrorResponse(requestId, `Validation failed: ${parseResult.error.message}`);
             return false;
         }
 
         const message = parseResult.data;
         const typeValue = message[this.discriminatorKey] as TMessage[K];
         const handler = this.handlers[typeValue] as ((payload?: unknown) => unknown | Promise<unknown>) | undefined;
-        const requestId = (rawMessage as Record<string, unknown>)?.requestId as string | undefined;
 
-        if (typeof handler === 'function') {
+        if (typeof handler !== 'function') {
+            this._sendRpcErrorResponse(requestId, `No handler registered for '${String(typeValue)}'`);
+            return false;
+        }
+
+        try {
+            const payload = (message as { payload?: unknown }).payload;
+            const result = await (payload !== undefined ? handler(payload) : handler());
+            this._sendRpcSuccessResponse(requestId, result);
+            return true;
+        } catch (err) {
+            const error = toError(err);
+            this.options?.logger?.error(`Webview RPC handler error (${String(typeValue)})`, error);
             try {
-                const payload = (message as { payload?: unknown }).payload;
-                const result = await (payload !== undefined ? handler(payload) : handler());
-                if (requestId && this.options?.messenger) {
-                    this.options.messenger.postMessage({
-                        type: '__rpc_response__',
-                        requestId,
-                        result,
-                    });
-                }
-                return true;
-            } catch (err) {
-                const error = toError(err);
-                this.options?.logger?.error(`Webview RPC handler error (${String(typeValue)})`, error);
                 this.options?.onError?.(err, rawMessage);
-
-                if (requestId && this.options?.messenger) {
-                    this.options.messenger.postMessage({
-                        type: '__rpc_response__',
-                        requestId,
-                        error: error.message,
-                    });
-                }
-                return false;
+            } catch (e) {
+                this.options?.logger?.error('WebviewRpcDispatcher onError callback failed', toError(e));
             }
+            this._sendRpcErrorResponse(requestId, error.message);
+            return false;
         }
+    }
 
-        if (requestId && this.options?.messenger) {
-            this.options.messenger.postMessage({
-                type: '__rpc_response__',
-                requestId,
-                error: `No handler registered for '${String(typeValue)}'`,
-            });
+    private _sendRpcSuccessResponse(requestId: string | undefined, result: unknown): void {
+        if (!requestId) {
+            return;
         }
-        return false;
+        this.broadcast({
+            type: '__rpc_response__',
+            requestId,
+            result,
+        });
+    }
+
+    private _sendRpcErrorResponse(requestId: string | undefined, error: string): void {
+        if (!requestId) {
+            return;
+        }
+        this.broadcast({
+            type: '__rpc_response__',
+            requestId,
+            error,
+        });
     }
 }
 
-export function createWebviewRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+export function createWebviewRpcDispatcher<
+    TMessage extends DiscriminatedMessage<K>,
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+>(
     schema: z.ZodType<TMessage>,
     handlers: MessageHandlerMap<TMessage, K>,
-    options?: WebviewRpcDispatcherOptions<K>,
-): WebviewRpcDispatcher<TMessage, K> {
-    return new WebviewRpcDispatcher<TMessage, K>(schema, handlers, options);
+    options?: WebviewRpcDispatcherOptions<TOutbound, K>,
+): WebviewRpcDispatcher<TMessage, TOutbound, K> {
+    return new WebviewRpcDispatcher<TMessage, TOutbound, K>(schema, handlers, options);
 }
 
 export type RpcClientMethods<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
@@ -198,32 +443,32 @@ export interface WebviewPostMessageLike {
 
 export interface WebviewRpcPendingRequestRegisterable {
     registerPendingRequest(requestId: string): Promise<unknown>;
+    unregisterPendingRequest?(requestId: string): void;
 }
 
-export interface WebviewRpcClientOptions<
-    K extends string = 'type',
-    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
-> {
+export interface WebviewRpcClientOptions<K extends string = 'type'> {
     discriminatorKey?: K;
-    dispatcher?: WebviewRpcDispatcher<TResponseMsg, K> | WebviewRpcPendingRequestRegisterable;
+    dispatcher?: WebviewRpcPendingRequestRegisterable;
 }
 
-export function createWebviewRpcClient<
-    TMessage extends DiscriminatedMessage<K>,
-    K extends string = 'type',
-    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
->(
+let globalRequestIdCounter = 0;
+
+export function createWebviewRpcClient<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
     webview: WebviewPostMessageLike,
     schema?: z.ZodType<TMessage>,
-    options?: WebviewRpcClientOptions<K, TResponseMsg>,
+    options?: WebviewRpcClientOptions<K>,
 ): RpcClientMethods<TMessage, K> {
-    let requestIdCounter = 0;
     const discriminatorKey = options?.discriminatorKey ?? ('type' as K);
 
     return new Proxy({} as RpcClientMethods<TMessage, K>, {
-        get(_target, prop: string) {
+        get(_target, prop: string | symbol) {
+            if (typeof prop === 'symbol' || prop === 'then' || prop === 'toJSON' || prop === 'constructor') {
+                return undefined;
+            }
+
             return (payload?: unknown) => {
-                const requestId = `req_${Date.now()}_${++requestIdCounter}`;
+                const randomToken = Math.random().toString(36).slice(2, 8);
+                const requestId = `req_${Date.now()}_${++globalRequestIdCounter}_${randomToken}`;
                 const message =
                     payload !== undefined
                         ? {
@@ -248,11 +493,18 @@ export function createWebviewRpcClient<
                     pendingPromise = options.dispatcher.registerPendingRequest(requestId);
                 }
 
-                const sendResult = webview.postMessage(message);
-                if (pendingPromise) {
-                    return pendingPromise;
+                try {
+                    const sendResult = webview.postMessage(message);
+                    if (pendingPromise) {
+                        return pendingPromise;
+                    }
+                    return Promise.resolve(sendResult);
+                } catch (err) {
+                    if (options?.dispatcher?.unregisterPendingRequest) {
+                        options.dispatcher.unregisterPendingRequest(requestId);
+                    }
+                    throw err;
                 }
-                return Promise.resolve(sendResult);
             };
         },
     });

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -31,10 +31,9 @@ export interface CommitDetailsControllerOptions {
 export class CommitDetailsController implements Disposable {
     private _disposed = false;
     private readonly _disposables: Disposable[] = [];
-    private readonly _messengers = new Set<WebviewPostMessageLike>();
     private _loadVersion = 0;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<CommitDetailsToHostMessage>;
+    private readonly _dispatcher: WebviewRpcDispatcher<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>;
 
     private _logEntry?: JjLogEntry;
     private _changes?: readonly JjStatusEntry[];
@@ -78,7 +77,7 @@ export class CommitDetailsController implements Disposable {
         return this._persistedDescription;
     }
 
-    public get detailsPayload(): CommitDetailsPayload | undefined {
+    public getState(): CommitDetailsPayload | undefined {
         if (!this._logEntry) {
             return undefined;
         }
@@ -103,17 +102,16 @@ export class CommitDetailsController implements Disposable {
     }
 
     public addMessenger(messenger: WebviewPostMessageLike): Disposable {
-        this._messengers.add(messenger);
-        if (this.detailsPayload) {
-            messenger.postMessage({
-                type: 'updateDetails',
-                payload: this.detailsPayload,
-            });
-        }
+        const sub = this._dispatcher.addMessenger(messenger);
+        let disposed = false;
         return {
             dispose: () => {
-                this._messengers.delete(messenger);
-                if (this._messengers.size === 0) {
+                if (disposed) {
+                    return;
+                }
+                disposed = true;
+                sub.dispose();
+                if (!this._dispatcher.hasMessengers) {
                     this._onDidClose.fire(this.changeId);
                 }
             },
@@ -161,40 +159,32 @@ export class CommitDetailsController implements Disposable {
 
             if (!wasDirty) {
                 this._draftDescription = freshPersisted;
+                this._lastPushedText = freshPersisted;
             }
-
-            this._lastPushedText = freshPersisted;
 
             this._onDidUpdate.fire(log);
 
-            this.broadcast({
-                type: 'updateDetails',
-                payload: {
-                    changeId: this.changeId,
-                    commitId: log.commit_id,
-                    description: (log.description || '').trim(),
-                    files: changes,
-                    isImmutable: log.is_immutable,
-                    author: log.author,
-                    committer: log.committer,
-                    bookmarks: log.bookmarks || [],
-                    tags: log.tags || [],
-                    isEmpty: log.is_empty,
-                    isConflict: log.conflict,
-                    minChangeIdLength: this._host.config.get<number>('minChangeIdLength', 1),
-                    theme: this._host.config.get<string>('logTheme', 'default'),
-                    titleWidthRuler: this._host.config.get<number | undefined>('commit.titleWidthRuler'),
-                    bodyWidthRuler: this._host.config.get<number | undefined>('commit.bodyWidthRuler'),
-                    formatDescriptionOnSave: this._host.config.get<boolean>('commit.formatDescriptionOnSave', false),
-                },
-            });
+            const state = this.getState();
+            if (state) {
+                this.broadcast({
+                    type: 'update',
+                    payload: state,
+                });
+            }
             return log;
-        } finally {
-            // Completed load
+        } catch (err) {
+            this._logger?.error(
+                `[CommitDetailsController] Failed to load commit details for ${this.changeId}`,
+                toError(err),
+            );
+            return undefined;
         }
     }
 
     public updateDraft(newText: string, selection: { start: number; end: number } = { start: 0, end: 0 }): void {
+        if (this._disposed) {
+            return;
+        }
         this._draftDescription = newText;
 
         if (this._debounceTimer) {
@@ -261,6 +251,9 @@ export class CommitDetailsController implements Disposable {
     }
 
     public async save(finalDescription?: string): Promise<boolean> {
+        if (this._disposed) {
+            return false;
+        }
         this.flushDebounce();
 
         const descriptionToSave = finalDescription ?? this._draftDescription ?? this._logEntry?.description ?? '';
@@ -311,27 +304,16 @@ export class CommitDetailsController implements Disposable {
         if (this._disposed) {
             return;
         }
-        for (const messenger of this._messengers) {
-            try {
-                messenger.postMessage(message);
-            } catch (e) {
-                this._logger?.error('[CommitDetailsController] Failed to post message', toError(e));
-            }
-        }
+        this._dispatcher.broadcast(message);
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<CommitDetailsToHostMessage> {
-        return createWebviewRpcDispatcher(
+    private _createRpcDispatcher(): WebviewRpcDispatcher<
+        CommitDetailsToHostMessage,
+        CommitDetailsHostToWebviewMessage
+    > {
+        return createWebviewRpcDispatcher<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>(
             CommitDetailsToHostMessageSchema,
             {
-                webviewLoaded: async () => {
-                    if (this.detailsPayload) {
-                        this.broadcast({
-                            type: 'updateDetails',
-                            payload: this.detailsPayload,
-                        });
-                    }
-                },
                 descriptionChanged: async (payload) => {
                     const newText = payload.description;
                     const newSelection = {
@@ -358,9 +340,7 @@ export class CommitDetailsController implements Disposable {
             },
             {
                 logger: this._logger,
-                messenger: {
-                    postMessage: (m) => this.broadcast(m as CommitDetailsHostToWebviewMessage),
-                },
+                getState: () => this.getState(),
             },
         );
     }
@@ -375,7 +355,6 @@ export class CommitDetailsController implements Disposable {
             d.dispose();
         }
         this._disposables.length = 0;
-        this._messengers.clear();
         this._onDidUpdate.dispose();
         this._onDidClose.dispose();
         this._dispatcher.dispose();

--- a/src/controllers/log-view-controller.ts
+++ b/src/controllers/log-view-controller.ts
@@ -7,6 +7,7 @@ import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
 import {
     type LogViewHostToWebviewMessage,
+    type LogViewPayload,
     type LogViewToHostMessage,
     LogViewToHostMessageSchema,
     TOGGLEABLE_COMMIT_ACTIONS,
@@ -40,9 +41,8 @@ export class LogViewController implements Disposable {
     private _disposed = false;
     private readonly _disposables: Disposable[] = [];
     private _codeForgeDisposable: Disposable | undefined;
-    private _messenger?: WebviewPostMessageLike;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<LogViewToHostMessage>;
+    private readonly _dispatcher: WebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage>;
     private readonly _refreshQueue: CoalescingQueue;
 
     private _commits: readonly JjLogEntry[] = [];
@@ -63,20 +63,23 @@ export class LogViewController implements Disposable {
         private readonly _host: HostEnvironment,
         private readonly _options?: LogViewControllerOptions,
     ) {
-        this._messenger = _options?.messenger;
         this._logger = _options?.logger;
         this._theme = this._host.config.get<string>('logTheme', 'default');
         this._graphLabelAlignment = this._host.config.get<string>('graphLabelAlignment', 'aligned');
         this._minChangeIdLength = this._host.config.get<number>('minChangeIdLength', 1);
-
-        const storedHidden = this._host.storage.get<string[]>(LogViewController.HIDDEN_ACTIONS_STORAGE_KEY, []) ?? [];
-        this.setHiddenActions(storedHidden);
 
         this._refreshQueue = new CoalescingQueue(async () => {
             await this._doRefresh();
         });
 
         this._dispatcher = this._createRpcDispatcher();
+        if (_options?.messenger) {
+            this._dispatcher.setMessenger(_options.messenger);
+        }
+
+        const storedHidden = this._host.storage.get<string[]>(LogViewController.HIDDEN_ACTIONS_STORAGE_KEY, []) ?? [];
+        this.setHiddenActions(storedHidden);
+
         this.bindRepo(this._repo);
 
         if (this._host.config.onDidChangeConfiguration) {
@@ -126,15 +129,27 @@ export class LogViewController implements Disposable {
         return this._minChangeIdLength;
     }
 
+    public getState(): LogViewPayload {
+        return {
+            commits: [...this._commits],
+            minChangeIdLength: this._minChangeIdLength,
+            theme: this._theme,
+            graphLabelAlignment: this._graphLabelAlignment,
+            hiddenActions: [...this._hiddenActions],
+        };
+    }
+
     public get repository(): JjRepository | undefined {
         return this._repo;
     }
 
     public set repository(repo: JjRepository | undefined) {
-        if (this._repo?.rootUri.fsPath === repo?.rootUri.fsPath) {
+        if (this._disposed || this._repo?.rootUri.fsPath === repo?.rootUri.fsPath) {
             return;
         }
         this._repo = repo;
+        this._selectedCommitIds = [];
+        this._updateSelectionContextKeys(this._selectedCommitIds);
         this.bindRepo(repo);
         this.refresh('repoChanged');
     }
@@ -144,7 +159,7 @@ export class LogViewController implements Disposable {
     }
 
     public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
-        this._messenger = messenger;
+        this._dispatcher.setMessenger(messenger);
     }
 
     private bindRepo(repo: JjRepository | undefined): void {
@@ -233,6 +248,7 @@ export class LogViewController implements Disposable {
         }
 
         this._commits = enrichedCommits;
+        this._updateSelectionContextKeys(this._selectedCommitIds);
 
         if (this._disposed) {
             return;
@@ -242,25 +258,41 @@ export class LogViewController implements Disposable {
 
         this._postMessage({
             type: 'update',
-            payload: {
-                commits: [...enrichedCommits],
-                minChangeIdLength: this._minChangeIdLength,
-                theme: this._theme,
-                graphLabelAlignment: this._graphLabelAlignment,
-                hiddenActions: [...this._hiddenActions],
-            },
+            payload: this.getState(),
         });
     }
 
-    public setSelectedCommits(commitIds: readonly string[]): void {
+    private _updateSelectionContextKeys(selectedCommitIds: readonly string[], hasImmutableSelection?: boolean): void {
+        const count = selectedCommitIds.length;
+        const selectedCommits = this._commits.filter((c) => selectedCommitIds.includes(c.change_id));
+        const containsImmutable = hasImmutableSelection ?? selectedCommits.some((c) => c.is_immutable);
+
+        const allowAbandon = count > 0 && !containsImmutable;
+        const allowMerge = count > 1;
+        const allowNewBefore = count > 0 && !containsImmutable;
+
+        let parentMutable = false;
+        if (count === 1 && selectedCommits.length === 1) {
+            parentMutable = canAbsorbCommit(selectedCommits[0]);
+        }
+
+        this._host.commands.setContextKey(JjContextKey.SelectionAllowAbandon, allowAbandon);
+        this._host.commands.setContextKey(JjContextKey.SelectionAllowMerge, allowMerge);
+        this._host.commands.setContextKey(JjContextKey.SelectionAllowNewBefore, allowNewBefore);
+        this._host.commands.setContextKey(JjContextKey.SelectionParentMutable, parentMutable);
+    }
+
+    public setSelectedCommits(commitIds: readonly string[], hasImmutableSelection?: boolean): void {
         if (
             this._selectedCommitIds.length === commitIds.length &&
             this._selectedCommitIds.every((id, idx) => id === commitIds[idx])
         ) {
+            this._updateSelectionContextKeys(this._selectedCommitIds, hasImmutableSelection);
             return;
         }
 
         this._selectedCommitIds = [...commitIds];
+        this._updateSelectionContextKeys(this._selectedCommitIds, hasImmutableSelection);
 
         if (this._disposed) {
             return;
@@ -332,13 +364,20 @@ export class LogViewController implements Disposable {
 
         this._postMessage({
             type: 'update',
-            payload: {
-                commits: [...this._commits],
-                minChangeIdLength: this._minChangeIdLength,
-                theme: this._theme,
-                graphLabelAlignment: this._graphLabelAlignment,
-                hiddenActions: [...this._hiddenActions],
-            },
+            payload: this.getState(),
+        });
+    }
+
+    public setGraphLabelAlignment(alignment: string): void {
+        this._graphLabelAlignment = alignment;
+
+        if (this._disposed) {
+            return;
+        }
+
+        this._postMessage({
+            type: 'update',
+            payload: this.getState(),
         });
     }
 
@@ -376,13 +415,7 @@ export class LogViewController implements Disposable {
 
         this._postMessage({
             type: 'update',
-            payload: {
-                commits: [...this._commits],
-                minChangeIdLength: this._minChangeIdLength,
-                theme: this._theme,
-                graphLabelAlignment: this._graphLabelAlignment,
-                hiddenActions: [...this._hiddenActions],
-            },
+            payload: this.getState(),
         });
     }
 
@@ -441,12 +474,8 @@ export class LogViewController implements Disposable {
     }
 
     private _postMessage(message: LogViewHostToWebviewMessage): void {
-        if (!this._disposed && this._messenger) {
-            try {
-                this._messenger.postMessage(message);
-            } catch (e) {
-                this._logger?.error('[LogViewController] Failed to post message', toError(e));
-            }
+        if (!this._disposed) {
+            this._dispatcher.broadcast(message);
         }
     }
 
@@ -470,8 +499,8 @@ export class LogViewController implements Disposable {
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<LogViewToHostMessage> {
-        return createWebviewRpcDispatcher(
+    private _createRpcDispatcher(): WebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage> {
+        return createWebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage>(
             LogViewToHostMessageSchema,
             {
                 webviewLoaded: async () => {
@@ -540,11 +569,10 @@ export class LogViewController implements Disposable {
                     await this._host.commands.executeCommand('jj-view.newAfter', ...(msg.changeIds || []));
                 },
                 resolve: async (msg) => {
-                    if (this.jj) {
-                        await this.jj.resolve(msg.path);
-                        await this.refresh('resolveComplete');
+                    await this.executeJjMutation('Resolving conflict...', 'Failed to resolve conflict', async (jj) => {
+                        await jj.resolve(msg.path);
                         await this._host.commands.executeCommand('jj-view.refresh');
-                    }
+                    });
                 },
                 moveBookmark: async (msg) => {
                     if (!msg.bookmark || !msg.targetChangeId) {
@@ -597,7 +625,7 @@ export class LogViewController implements Disposable {
                     await this._host.commands.executeCommand('jj-view.showComments', msg.changeId);
                 },
                 setContextKey: async (msg) => {
-                    this._host.commands.setContextKey(msg.key, msg.value);
+                    await this._host.commands.setContextKey(msg.key, msg.value);
                 },
                 contextMenu: async (msg) => {
                     await this._host.commands.executeCommand('jj-view.contextMenu', msg);
@@ -620,32 +648,13 @@ export class LogViewController implements Disposable {
                         }
                     }
 
-                    const allowAbandon = count > 0 && !hasImmutable;
-                    const allowMerge = count > 1;
-                    const allowNewBefore = count > 0 && !hasImmutable;
-
-                    let parentMutable = false;
-                    if (count === 1) {
-                        const selectedCommit = this._commits.find((c) => c.change_id === msg.commitIds[0]);
-                        if (selectedCommit) {
-                            parentMutable = canAbsorbCommit(selectedCommit);
-                        }
-                    }
-
-                    this._host.commands.setContextKey(JjContextKey.SelectionAllowAbandon, allowAbandon);
-                    this._host.commands.setContextKey(JjContextKey.SelectionAllowMerge, allowMerge);
-                    this._host.commands.setContextKey(JjContextKey.SelectionAllowNewBefore, allowNewBefore);
-                    this._host.commands.setContextKey(JjContextKey.SelectionParentMutable, parentMutable);
-
-                    this.setSelectedCommits(msg.commitIds);
+                    this.setSelectedCommits(msg.commitIds, hasImmutable);
                     this._options?.onSelectionChange?.(msg.commitIds);
                 },
             },
             {
                 logger: this._logger,
-                messenger: {
-                    postMessage: (m) => this._postMessage(m as LogViewHostToWebviewMessage),
-                },
+                getState: () => this.getState(),
             },
         );
     }

--- a/src/controllers/process-monitor-controller.ts
+++ b/src/controllers/process-monitor-controller.ts
@@ -7,6 +7,7 @@ import { type Disposable, type Event, EventEmitter } from '../common/events';
 import type { HostEnvironment } from '../common/host-environment';
 import {
     type ProcessMonitorHostToWebviewMessage,
+    type ProcessMonitorPayload,
     type ProcessMonitorToHostMessage,
     ProcessMonitorToHostMessageSchema,
 } from '../common/ipc/process-monitor-schemas';
@@ -22,6 +23,7 @@ import {
     type JjProcessTracker,
 } from '../jj-process-tracker';
 import { CoalescingQueue } from '../utils/coalescing-queue';
+import { toError } from '../utils/error-utils';
 import type { LoggerChannel } from '../utils/output-channel';
 
 export interface ProcessMonitorControllerOptions {
@@ -32,10 +34,13 @@ export interface ProcessMonitorControllerOptions {
 export class ProcessMonitorController implements Disposable {
     private _disposed = false;
     private readonly _disposables: Disposable[] = [];
-    private _messenger?: WebviewPostMessageLike;
     private readonly _logger?: LoggerChannel;
     private readonly _updateQueue: CoalescingQueue;
-    private readonly _dispatcher: WebviewRpcDispatcher<ProcessMonitorToHostMessage, 'command'>;
+    private readonly _dispatcher: WebviewRpcDispatcher<
+        ProcessMonitorToHostMessage,
+        ProcessMonitorHostToWebviewMessage,
+        'command'
+    >;
 
     private readonly _onDidUpdate = new EventEmitter<void>();
     public readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
@@ -45,22 +50,32 @@ export class ProcessMonitorController implements Disposable {
         private readonly _host: HostEnvironment,
         options?: ProcessMonitorControllerOptions,
     ) {
-        this._messenger = options?.messenger;
         this._logger = options?.logger;
 
         this._updateQueue = new CoalescingQueue(async () => {
-            this.updateWebview();
+            try {
+                this.updateWebview();
+            } catch (err) {
+                this._logger?.error('ProcessMonitorController updateWebview error', toError(err));
+            }
         });
 
         this._disposables.push(
             this._processTracker.onDidChangeProcesses(() => {
-                if (!this._disposed) {
-                    this._updateQueue.run();
+                if (this._disposed) {
+                    return;
                 }
+                this._updateQueue.run().catch((err) => {
+                    this._logger?.error('ProcessMonitorController update queue run failed', toError(err));
+                });
             }),
         );
 
-        this._dispatcher = createWebviewRpcDispatcher(
+        this._dispatcher = createWebviewRpcDispatcher<
+            ProcessMonitorToHostMessage,
+            ProcessMonitorHostToWebviewMessage,
+            'command'
+        >(
             ProcessMonitorToHostMessageSchema,
             {
                 killProcess: (payload) => {
@@ -79,11 +94,13 @@ export class ProcessMonitorController implements Disposable {
             {
                 discriminatorKey: 'command',
                 logger: this._logger,
-                messenger: {
-                    postMessage: (m) => this._postMessage(m as ProcessMonitorHostToWebviewMessage),
-                },
+                getState: () => this.getState(),
             },
         );
+
+        if (options?.messenger) {
+            this._dispatcher.setMessenger(options.messenger);
+        }
 
         this.updateWebview();
     }
@@ -100,25 +117,7 @@ export class ProcessMonitorController implements Disposable {
         return this._processTracker.getHistory();
     }
 
-    public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
-        this._messenger = messenger;
-        if (messenger) {
-            this.updateWebview();
-        }
-    }
-
-    public async handleMessage(rawMessage: unknown): Promise<boolean> {
-        if (this._disposed) {
-            return false;
-        }
-        return this._dispatcher.dispatch(rawMessage);
-    }
-
-    public updateWebview(): void {
-        if (this._disposed) {
-            return;
-        }
-
+    public getState(): ProcessMonitorPayload {
         const activeTasks = this._processTracker.getActiveTasks().map((t: JjProcessTask) => ({
             id: t.id,
             command: t.command,
@@ -145,15 +144,33 @@ export class ProcessMonitorController implements Disposable {
 
         const metrics = this._processTracker.getMetrics();
 
-        this._onDidUpdate.fire();
+        return {
+            activeTasks,
+            historyTasks,
+            metrics,
+        };
+    }
 
+    public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
+        this._dispatcher.setMessenger(messenger);
+    }
+
+    public async handleMessage(rawMessage: unknown): Promise<boolean> {
+        if (this._disposed) {
+            return false;
+        }
+        return this._dispatcher.dispatch(rawMessage);
+    }
+
+    public updateWebview(): void {
+        if (this._disposed) {
+            return;
+        }
+
+        this._onDidUpdate.fire();
         this._postMessage({
             type: 'update',
-            payload: {
-                activeTasks,
-                historyTasks,
-                metrics,
-            },
+            payload: this.getState(),
         });
     }
 
@@ -174,13 +191,10 @@ export class ProcessMonitorController implements Disposable {
     }
 
     private _postMessage(message: ProcessMonitorHostToWebviewMessage): void {
-        if (!this._disposed && this._messenger) {
-            try {
-                this._messenger.postMessage(message);
-            } catch (e) {
-                this._logger?.error(`[ProcessMonitorController] Failed to post message: ${e}`);
-            }
+        if (this._disposed) {
+            return;
         }
+        this._dispatcher.broadcast(message);
     }
 
     public dispose(): void {
@@ -190,5 +204,6 @@ export class ProcessMonitorController implements Disposable {
         }
         this._disposables.length = 0;
         this._onDidUpdate.dispose();
+        this._dispatcher.dispose();
     }
 }

--- a/src/test/commit-details-controller.test.ts
+++ b/src/test/commit-details-controller.test.ts
@@ -109,4 +109,49 @@ describe('CommitDetailsController Domain Unit Tests', () => {
         expect(handled).toBe(true);
         expect(controller.draftDescription).toBe('typed from webview');
     });
+
+    test('replays initial state snapshot to newly attached messenger after load', async () => {
+        testRepo.writeFile('file.txt', 'data\n');
+        testRepo.describe('initial commit for replay');
+
+        await controller.load();
+
+        const lateMessages: unknown[] = [];
+        controller.addMessenger({
+            postMessage: (m) => lateMessages.push(m),
+        });
+
+        expect(lateMessages).toHaveLength(1);
+        expect(lateMessages[0]).toEqual(
+            expect.objectContaining({
+                type: 'update',
+                payload: expect.objectContaining({
+                    description: 'initial commit for replay',
+                }),
+            }),
+        );
+    });
+
+    test('fires onDidClose only when the last messenger detaches', async () => {
+        const repo = await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo.path));
+        const testController = new CommitDetailsController('@', repo, fakeHost);
+        const closeListener = vi.fn();
+        testController.onDidClose(closeListener);
+
+        const messenger1 = { postMessage: vi.fn() };
+        const messenger2 = { postMessage: vi.fn() };
+
+        const sub1 = testController.addMessenger(messenger1);
+        const sub2 = testController.addMessenger(messenger2);
+
+        // Disposing first messenger does not fire onDidClose because messenger2 is still attached
+        sub1.dispose();
+        expect(closeListener).not.toHaveBeenCalled();
+
+        // Disposing second messenger fires onDidClose
+        sub2.dispose();
+        expect(closeListener).toHaveBeenCalledTimes(1);
+
+        testController.dispose();
+    });
 });

--- a/src/test/ipc-schemas.test.ts
+++ b/src/test/ipc-schemas.test.ts
@@ -299,7 +299,7 @@ describe('IPC Schemas Unit Tests', () => {
         it('validates CommitDetailsHostToWebviewMessage variants', () => {
             expect(
                 CommitDetailsHostToWebviewMessageSchema.safeParse({
-                    type: 'updateDetails',
+                    type: 'update',
                     payload: {
                         changeId: 'kkmpptxz',
                         commitId: 'abcdef12',

--- a/src/test/log-view-controller.test.ts
+++ b/src/test/log-view-controller.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CodeForgeRegistry } from '../code-forge-registry';
 import { LogViewController } from '../controllers/log-view-controller';
+import { JjContextKey } from '../jj-context-keys';
 import { JjRepositoryManager } from '../jj-repository-manager';
 import type { JjLogEntry } from '../jj-types';
 import { Uri } from '../uri-utils';
@@ -152,5 +153,32 @@ describe('LogViewController Domain Unit Tests', () => {
         await controller.refresh('test');
         expect(controller.commits.length).toBeGreaterThan(0);
         expect(controller.commits[0].description).toContain('feature: add example');
+    });
+
+    test('replays initial snapshot on setMessenger and updates context keys on setCommits', async () => {
+        testRepo.writeFile('example.txt', 'test content\n');
+        testRepo.describe('feature: add example');
+        await controller.refresh('test');
+
+        const newMessages: unknown[] = [];
+        controller.setMessenger({
+            postMessage: (m) => newMessages.push(m),
+        });
+
+        expect(newMessages).toHaveLength(1);
+        expect(newMessages[0]).toEqual(
+            expect.objectContaining({
+                type: 'update',
+                payload: expect.objectContaining({
+                    commits: expect.any(Array),
+                }),
+            }),
+        );
+
+        // Selection context keys update on setCommits
+        const changeId = controller.commits[0].change_id;
+        controller.setSelectedCommits([changeId]);
+        controller.setCommits(controller.commits);
+        expect(fakeHost.commands.contextKeys.get(JjContextKey.SelectionAllowAbandon)).toBe(true);
     });
 });

--- a/src/test/process-monitor-controller.test.ts
+++ b/src/test/process-monitor-controller.test.ts
@@ -77,4 +77,27 @@ describe('ProcessMonitorController Domain Unit Tests', () => {
         controller.cancelAllProcesses();
         expect(cancelAllSpy).toHaveBeenCalled();
     });
+
+    test('replays initial snapshot on setMessenger and responds to webviewLoaded', async () => {
+        const newMessages: unknown[] = [];
+        controller.setMessenger({
+            postMessage: (m) => newMessages.push(m),
+        });
+
+        expect(newMessages).toHaveLength(1);
+        expect(newMessages[0]).toEqual(
+            expect.objectContaining({
+                type: 'update',
+                payload: expect.objectContaining({
+                    activeTasks: expect.any(Array),
+                    historyTasks: expect.any(Array),
+                    metrics: expect.any(Object),
+                }),
+            }),
+        );
+
+        const loadedHandled = await controller.handleMessage({ command: 'webviewLoaded' });
+        expect(loadedHandled).toBe(true);
+        expect(newMessages).toHaveLength(2);
+    });
 });

--- a/src/test/webview-rpc-dispatcher.test.ts
+++ b/src/test/webview-rpc-dispatcher.test.ts
@@ -224,7 +224,229 @@ describe('WebviewRpcDispatcher', () => {
 
         expect(handled).toBe(true);
         expect(customLogMessageHandler).toHaveBeenCalledTimes(1);
-        expect(customLogMessageHandler).toHaveBeenCalledWith(rawLogMessage);
+        expect(customLogMessageHandler).toHaveBeenCalledWith(rawLogMessage.payload);
+    });
+
+    test('buffers outbound messages before messenger attaches and flushes in order on addMessenger', () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {});
+        expect(dispatcher.hasMessengers).toBe(false);
+
+        dispatcher.broadcast({ type: 'queued1' });
+        dispatcher.broadcast({ type: 'queued2' });
+
+        const messenger = {
+            postMessage: vi.fn(),
+        };
+
+        const sub = dispatcher.addMessenger(messenger);
+        expect(dispatcher.hasMessengers).toBe(true);
+        expect(messenger.postMessage).toHaveBeenCalledTimes(2);
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(1, { type: 'queued1' });
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(2, { type: 'queued2' });
+
+        dispatcher.broadcast({ type: 'immediate' });
+        expect(messenger.postMessage).toHaveBeenCalledTimes(3);
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(3, { type: 'immediate' });
+
+        sub.dispose();
+        expect(dispatcher.hasMessengers).toBe(false);
+    });
+
+    test('sends initial state upon messenger attachment and on webviewLoaded handshake', async () => {
+        let currentState = { count: 1 };
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {
+                ping: vi.fn(),
+            },
+            {
+                getInitialState: () => ({ type: 'snapshot', count: currentState.count }),
+            },
+        );
+
+        const messenger = {
+            postMessage: vi.fn(),
+        };
+
+        dispatcher.addMessenger(messenger);
+        expect(messenger.postMessage).toHaveBeenCalledWith({ type: 'snapshot', count: 1 });
+
+        currentState = { count: 2 };
+        await dispatcher.dispatch({ type: 'webviewLoaded' });
+        expect(messenger.postMessage).toHaveBeenCalledWith({ type: 'snapshot', count: 2 });
+    });
+
+    test('supports getState returning state payload directly', () => {
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {},
+            {
+                getState: () => ({
+                    commits: ['c1', 'c2'],
+                    theme: 'dark',
+                }),
+            },
+        );
+
+        const messenger = {
+            postMessage: vi.fn(),
+        };
+
+        dispatcher.addMessenger(messenger);
+        expect(messenger.postMessage).toHaveBeenCalledTimes(1);
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'update',
+            payload: { commits: ['c1', 'c2'], theme: 'dark' },
+        });
+    });
+
+    test('supports getInitialState returning keyed InitialStateMap', () => {
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {},
+            {
+                getInitialState: () => ({
+                    update: { commits: ['c1', 'c2'] },
+                    skipped: undefined,
+                }),
+            },
+        );
+
+        const messenger = {
+            postMessage: vi.fn(),
+        };
+
+        dispatcher.addMessenger(messenger);
+        expect(messenger.postMessage).toHaveBeenCalledTimes(1);
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'update',
+            payload: { commits: ['c1', 'c2'] },
+        });
+    });
+
+    test('supports setMessenger to replace active messenger and flush queues', () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {});
+
+        const messenger1 = { postMessage: vi.fn() };
+        dispatcher.setMessenger(messenger1);
+        expect(dispatcher.hasMessengers).toBe(true);
+
+        dispatcher.broadcast({ type: 'msg1' });
+        expect(messenger1.postMessage).toHaveBeenCalledWith({ type: 'msg1' });
+
+        const messenger2 = { postMessage: vi.fn() };
+        dispatcher.setMessenger(messenger2);
+
+        dispatcher.broadcast({ type: 'msg2' });
+        expect(messenger1.postMessage).not.toHaveBeenCalledWith({ type: 'msg2' });
+        expect(messenger2.postMessage).toHaveBeenCalledWith({ type: 'msg2' });
+
+        dispatcher.setMessenger(undefined);
+        expect(dispatcher.hasMessengers).toBe(false);
+    });
+
+    test('broadcasts to multiple simultaneous messengers and handles selective disposal', () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {});
+        const messengerA = { postMessage: vi.fn() };
+        const messengerB = { postMessage: vi.fn() };
+
+        const subA = dispatcher.addMessenger(messengerA);
+        const subB = dispatcher.addMessenger(messengerB);
+        expect(dispatcher.hasMessengers).toBe(true);
+
+        dispatcher.broadcast({ type: 'multi1' });
+        expect(messengerA.postMessage).toHaveBeenCalledWith({ type: 'multi1' });
+        expect(messengerB.postMessage).toHaveBeenCalledWith({ type: 'multi1' });
+
+        subA.dispose();
+        expect(dispatcher.hasMessengers).toBe(true);
+
+        dispatcher.broadcast({ type: 'multi2' });
+        expect(messengerA.postMessage).not.toHaveBeenCalledWith({ type: 'multi2' });
+        expect(messengerB.postMessage).toHaveBeenCalledWith({ type: 'multi2' });
+
+        subB.dispose();
+        expect(dispatcher.hasMessengers).toBe(false);
+    });
+
+    test('enforces maxQueueSize on outbound message buffer', () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, {}, { maxQueueSize: 2 });
+        dispatcher.broadcast({ type: 'msg1' });
+        dispatcher.broadcast({ type: 'msg2' });
+        dispatcher.broadcast({ type: 'msg3' });
+
+        const messenger = { postMessage: vi.fn() };
+        dispatcher.addMessenger(messenger);
+
+        expect(messenger.postMessage).toHaveBeenCalledTimes(2);
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(1, { type: 'msg2' });
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(2, { type: 'msg3' });
+    });
+
+    test('handles getInitialState returning array of messages or undefined', async () => {
+        let stateMode = 'array';
+        const dispatcher = createWebviewRpcDispatcher(
+            testSchema,
+            {},
+            {
+                getInitialState: () => {
+                    if (stateMode === 'undefined') {
+                        return undefined;
+                    }
+                    return [{ type: 'item1' }, undefined, { type: 'item2' }];
+                },
+            },
+        );
+
+        const messenger = { postMessage: vi.fn() };
+        dispatcher.addMessenger(messenger);
+
+        expect(messenger.postMessage).toHaveBeenCalledTimes(2);
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(1, { type: 'item1' });
+        expect(messenger.postMessage).toHaveBeenNthCalledWith(2, { type: 'item2' });
+
+        messenger.postMessage.mockClear();
+        stateMode = 'undefined';
+        await dispatcher.dispatch({ type: 'webviewLoaded' });
+        expect(messenger.postMessage).not.toHaveBeenCalled();
+    });
+
+    test('sends RPC error response when known command fails payload validation', async () => {
+        const messenger = { postMessage: vi.fn() };
+        const dispatcher = createWebviewRpcDispatcher(testSchema, { count: vi.fn() }, { messenger });
+
+        const result = await dispatcher.dispatch({
+            type: 'count',
+            requestId: 'req_val_err',
+            payload: { amount: 'invalid_type' },
+        });
+
+        expect(result).toBe(false);
+        expect(messenger.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: '__rpc_response__',
+                requestId: 'req_val_err',
+                error: expect.stringContaining('Validation failed'),
+            }),
+        );
+    });
+
+    test('guards against operations after disposal', async () => {
+        const dispatcher = createWebviewRpcDispatcher(testSchema, { ping: vi.fn() });
+        dispatcher.dispose();
+        expect(dispatcher.isDisposed).toBe(true);
+
+        dispatcher.broadcast({ type: 'ping', payload: { value: 'test' } });
+        const handled = await dispatcher.dispatch({ type: 'ping', payload: { value: 'test' } });
+        expect(handled).toBe(false);
+
+        await expect(dispatcher.registerPendingRequest('req_after_dispose')).rejects.toThrowError(
+            'WebviewRpcDispatcher is disposed',
+        );
+
+        const sub = dispatcher.addMessenger({ postMessage: vi.fn() });
+        expect(dispatcher.hasMessengers).toBe(false);
+        sub.dispose();
     });
 });
 
@@ -304,5 +526,37 @@ describe('createWebviewRpcClient', () => {
         expect(greeting).toBe('Hello Alice');
 
         await expect(client.fail()).rejects.toThrowError('Something went wrong');
+    });
+
+    test('ignores then, toJSON, and symbol properties on client proxy', () => {
+        const mockWebview = { postMessage: vi.fn() };
+        const client = createWebviewRpcClient(mockWebview, testSchema);
+        const dynamicClient = client as Record<string | symbol, unknown>;
+
+        expect(dynamicClient.then).toBeUndefined();
+        expect(dynamicClient.toJSON).toBeUndefined();
+        expect(dynamicClient[Symbol.iterator]).toBeUndefined();
+        expect(mockWebview.postMessage).not.toHaveBeenCalled();
+    });
+
+    test('unregisters pending request when webview.postMessage throws synchronously', () => {
+        const unregisterSpy = vi.fn();
+        const mockDispatcher = {
+            registerPendingRequest: vi.fn().mockReturnValue(new Promise(() => {})),
+            unregisterPendingRequest: unregisterSpy,
+        };
+
+        const errorWebview = {
+            postMessage: () => {
+                throw new Error('Transport write failure');
+            },
+        };
+
+        const client = createWebviewRpcClient(errorWebview, testSchema, {
+            dispatcher: mockDispatcher,
+        });
+
+        expect(() => client.ping({ value: 'fail' })).toThrowError('Transport write failure');
+        expect(unregisterSpy).toHaveBeenCalledWith(expect.stringMatching(/^req_/));
     });
 });

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -113,8 +113,8 @@ suite('Webview Visibility Integration Test', () => {
         );
 
         await provider.controller.refresh();
-        assert.strictEqual(sentMessages.length, 1, 'Should have sent initial update message');
-        const initialCommits = sentMessages[0].payload.commits;
+        assert.ok(sentMessages.length >= 1, 'Should have sent initial update message');
+        const initialCommits = sentMessages[sentMessages.length - 1].payload.commits;
         assert.ok(
             initialCommits.some((c: JjLogEntry) => c.description.includes('Initial Commit')),
             'Should contain initial description',

--- a/src/test/webview/bridge.test.ts
+++ b/src/test/webview/bridge.test.ts
@@ -88,6 +88,19 @@ describe('WebviewTransport', () => {
             expect(received).toHaveLength(0);
         });
 
+        it('buffers incoming messages before onMessage is registered and flushes to first subscriber', () => {
+            const transport = new MockWebviewTransport();
+            transport.simulateIncomingMessage({ type: 'early1' });
+            transport.simulateIncomingMessage({ type: 'early2' });
+
+            const received: unknown[] = [];
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            expect(received).toEqual([{ type: 'early1' }, { type: 'early2' }]);
+        });
+
         it('isolates subscriber errors during dispatch', () => {
             const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             const transport = new MockWebviewTransport();
@@ -104,6 +117,15 @@ describe('WebviewTransport', () => {
             expect(received).toEqual([{ type: 'test' }]);
             expect(consoleErrorSpy).toHaveBeenCalled();
             consoleErrorSpy.mockRestore();
+        });
+
+        it('cleans up on dispose()', () => {
+            const transport = new MockWebviewTransport();
+            transport.postMessage({ type: 'queued' });
+            transport.onMessage(() => {});
+            transport.dispose();
+
+            expect(transport.sentMessages).toHaveLength(0);
         });
     });
 
@@ -166,13 +188,32 @@ describe('WebviewTransport', () => {
             expect(received).toHaveLength(1);
         });
 
+        it('buffers window messages before onMessage is registered and flushes to first subscriber', () => {
+            const transport = new VsCodeWebviewTransport();
+
+            const target = (globalThis as { window?: EventTarget }).window;
+            target?.dispatchEvent(
+                new MockMessageEvent('message', {
+                    data: { type: 'early_vscode_msg' },
+                }),
+            );
+
+            const received: unknown[] = [];
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            expect(received).toEqual([{ type: 'early_vscode_msg' }]);
+            transport.dispose();
+        });
+
         it('isolates subscriber errors in message listener', () => {
             const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             const transport = new VsCodeWebviewTransport();
             const received: unknown[] = [];
 
             transport.onMessage(() => {
-                throw new Error('VsCode subscriber error');
+                throw new Error('Subscriber error');
             });
             transport.onMessage((msg) => {
                 received.push(msg);
@@ -181,20 +222,19 @@ describe('WebviewTransport', () => {
             const target = (globalThis as { window?: EventTarget }).window;
             target?.dispatchEvent(
                 new MockMessageEvent('message', {
-                    data: { type: 'update' },
+                    data: { type: 'safe_msg' },
                 }),
             );
 
-            expect(received).toEqual([{ type: 'update' }]);
+            expect(received).toEqual([{ type: 'safe_msg' }]);
             expect(consoleErrorSpy).toHaveBeenCalled();
             consoleErrorSpy.mockRestore();
             transport.dispose();
         });
 
-        it('cleans up listeners on dispose()', () => {
+        it('ignores window messages after dispose()', () => {
             const transport = new VsCodeWebviewTransport();
             const received: unknown[] = [];
-
             transport.onMessage((msg) => {
                 received.push(msg);
             });
@@ -204,13 +244,12 @@ describe('WebviewTransport', () => {
             const target = (globalThis as { window?: EventTarget }).window;
             target?.dispatchEvent(
                 new MockMessageEvent('message', {
-                    data: { type: 'update' },
+                    data: { type: 'post_dispose_msg' },
                 }),
             );
 
             expect(received).toHaveLength(0);
         });
-
         it('reuses cached acquireVsCodeApi across multiple instances', () => {
             const transport1 = new VsCodeWebviewTransport();
             const transport2 = new VsCodeWebviewTransport();
@@ -361,7 +400,6 @@ describe('WebviewTransport', () => {
             expect(consoleErrorSpy).toHaveBeenCalled();
             consoleErrorSpy.mockRestore();
         });
-
         it('reconnects automatically on socket close', () => {
             vi.useFakeTimers();
             const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
@@ -379,6 +417,23 @@ describe('WebviewTransport', () => {
 
             transport.dispose();
             vi.useRealTimers();
+        });
+
+        it('buffers incoming messages before onMessage is registered and flushes on subscribe', () => {
+            const transport = new WebSocketWebviewTransport('ws://localhost:8080/rpc');
+            const socket = MockWebSocket.instance;
+
+            socket?.onmessage?.({
+                data: JSON.stringify({ type: 'early_ws_msg' }),
+            });
+
+            const received: unknown[] = [];
+            transport.onMessage((msg) => {
+                received.push(msg);
+            });
+
+            expect(received).toEqual([{ type: 'early_ws_msg' }]);
+            transport.dispose();
         });
     });
 

--- a/src/vscode/providers/vscode-commit-details-editor-provider.ts
+++ b/src/vscode/providers/vscode-commit-details-editor-provider.ts
@@ -130,7 +130,7 @@ export class VsCodeCommitDetailsEditorProvider
 
         let controller = this._controllers.get(document.changeId);
         if (!controller) {
-            controller = new CommitDetailsController(document.changeId, repo, host, {
+            const newController = new CommitDetailsController(document.changeId, repo, host, {
                 logger: this._repositoryManager.outputChannel,
                 onEditRecorded: (edit) => {
                     this._onDidChangeCustomDocument.fire({
@@ -150,17 +150,20 @@ export class VsCodeCommitDetailsEditorProvider
                     }
                 },
             });
-            this._controllers.set(document.changeId, controller);
-        }
+            this._controllers.set(document.changeId, newController);
+            controller = newController;
 
-        controller.onDidClose(() => {
-            this._controllers.delete(document.changeId);
-            this._onDidClosePanel.fire(document.changeId);
-            controller.dispose();
-        });
+            newController.onDidClose(() => {
+                this._controllers.delete(document.changeId);
+                this._onDidClosePanel.fire(document.changeId);
+                newController.dispose();
+            });
+        }
 
         const log = await controller.load();
         if (!log) {
+            this._controllers.delete(document.changeId);
+            controller.dispose();
             panel.dispose();
             return;
         }
@@ -176,16 +179,12 @@ export class VsCodeCommitDetailsEditorProvider
         });
         const messengerDisposable = controller.addMessenger(panel.webview);
 
-        const viewSubscriptions: vscode.Disposable[] = [
-            messageDisposable,
-            messengerDisposable,
-            panel.onDidDispose(() => {
-                messengerDisposable.dispose();
-                for (const d of viewSubscriptions) {
-                    d.dispose();
-                }
-            }),
-        ];
+        const panelDisposables: vscode.Disposable[] = [messageDisposable, messengerDisposable];
+        panel.onDidDispose(() => {
+            for (const d of panelDisposables) {
+                d.dispose();
+            }
+        });
 
         panel.webview.html = getWebviewHtml({
             webview: panel.webview,

--- a/src/vscode/providers/vscode-process-monitor-provider.ts
+++ b/src/vscode/providers/vscode-process-monitor-provider.ts
@@ -50,7 +50,7 @@ export class VsCodeProcessMonitorProvider implements vscode.WebviewViewProvider,
         webviewView.webview.html = getWebviewHtml({
             webview: webviewView.webview,
             extensionUri: this._extensionUri,
-            scriptPath: ['dist', 'process-monitor', 'index.js'],
+            scriptPath: ['dist', 'webview', 'process-monitor.js'],
             title: 'JJ Process Monitor',
         });
 

--- a/src/webview/commit-details/CommitDetailsApp.tsx
+++ b/src/webview/commit-details/CommitDetailsApp.tsx
@@ -18,7 +18,7 @@ export const CommitDetailsApp: React.FC = () => {
     const rpc = useRpcClient<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
 
     useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
-        updateDetails: (payload) => {
+        update: (payload) => {
             setDetailsCommit(payload);
         },
         saveComplete: ({ description }) => {

--- a/src/webview/process-monitor/ProcessMonitorApp.tsx
+++ b/src/webview/process-monitor/ProcessMonitorApp.tsx
@@ -104,6 +104,10 @@ export default function ProcessMonitorApp() {
         },
     });
 
+    useEffect(() => {
+        void rpc.webviewLoaded();
+    }, [rpc]);
+
     const toggleExpand = (rowKey: string, e: React.SyntheticEvent) => {
         e.stopPropagation();
         setExpandedIds((prev) => {

--- a/src/webview/transport/BridgeContext.tsx
+++ b/src/webview/transport/BridgeContext.tsx
@@ -54,18 +54,17 @@ export function useMessageListener<T = unknown>(handler: (message: T) => void): 
     }, [bridge]);
 }
 
-export function useRpcClient<
-    TMessage extends DiscriminatedMessage<K>,
-    K extends string = 'type',
-    TResponseMsg extends DiscriminatedMessage<K> = DiscriminatedMessage<K>,
->(schema?: z.ZodType<TMessage>, options?: WebviewRpcClientOptions<K, TResponseMsg>): RpcClientMethods<TMessage, K> {
+export function useRpcClient<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+    schema?: z.ZodType<TMessage>,
+    options?: WebviewRpcClientOptions<K>,
+): RpcClientMethods<TMessage, K> {
     const bridge = useBridge();
     const discriminatorKey = options?.discriminatorKey;
     const dispatcher = options?.dispatcher;
 
     return useMemo(
         () =>
-            createWebviewRpcClient<TMessage, K, TResponseMsg>(bridge, schema, {
+            createWebviewRpcClient<TMessage, K>(bridge, schema, {
                 discriminatorKey,
                 dispatcher,
             }),
@@ -73,10 +72,14 @@ export function useRpcClient<
     );
 }
 
-export function useRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+export function useRpcDispatcher<
+    TMessage extends DiscriminatedMessage<K>,
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+>(
     schema: z.ZodType<TMessage>,
     handlers: MessageHandlerMap<TMessage, K>,
-    options?: WebviewRpcDispatcherOptions<K>,
+    options?: WebviewRpcDispatcherOptions<TOutbound, K>,
 ): void {
     const bridge = useBridge();
     const handlersRef = useRef(handlers);
@@ -96,7 +99,7 @@ export function useRpcDispatcher<TMessage extends DiscriminatedMessage<K>, K ext
             },
         });
 
-        const dispatcher = createWebviewRpcDispatcher(schema, forwardingHandlers, {
+        const dispatcher = createWebviewRpcDispatcher<TMessage, TOutbound, K>(schema, forwardingHandlers, {
             ...optionsRef.current,
             onError: (err, raw) => optionsRef.current?.onError?.(err, raw),
             messenger: {

--- a/src/webview/transport/mock-transport.ts
+++ b/src/webview/transport/mock-transport.ts
@@ -7,10 +7,12 @@ import type { WebviewTransport } from './types';
 
 /**
  * In-Memory Mock Transport for unit tests and headless environments.
+ * Buffers early incoming messages until subscribers attach.
  */
 export class MockWebviewTransport implements WebviewTransport {
     public readonly sentMessages: unknown[] = [];
     private readonly handlers = new Set<(message: unknown) => void>();
+    private readonly inboundQueue: unknown[] = [];
 
     public postMessage(message: unknown): void {
         this.sentMessages.push(message);
@@ -18,24 +20,40 @@ export class MockWebviewTransport implements WebviewTransport {
 
     public onMessage(handler: (message: unknown) => void): () => void {
         this.handlers.add(handler);
+
+        const pending = this.inboundQueue.splice(0, this.inboundQueue.length);
+        for (const queued of pending) {
+            this.dispatchSingle(handler, queued);
+        }
+
         return () => {
             this.handlers.delete(handler);
         };
     }
 
     public simulateIncomingMessage(message: unknown): void {
+        if (this.handlers.size === 0) {
+            this.inboundQueue.push(message);
+            return;
+        }
+
         for (const handler of Array.from(this.handlers)) {
-            try {
-                handler(message);
-            } catch (err) {
-                console.error('[MockWebviewTransport] Error in onMessage subscriber:', err);
-            }
+            this.dispatchSingle(handler, message);
+        }
+    }
+
+    private dispatchSingle(handler: (message: unknown) => void, data: unknown): void {
+        try {
+            handler(data);
+        } catch (err) {
+            console.error('[MockWebviewTransport] Error in message subscriber:', err);
         }
     }
 
     public clear(): void {
         this.sentMessages.length = 0;
         this.handlers.clear();
+        this.inboundQueue.length = 0;
     }
 
     public dispose(): void {

--- a/src/webview/transport/vscode-transport.ts
+++ b/src/webview/transport/vscode-transport.ts
@@ -7,6 +7,7 @@ import type { WebviewTransport } from './types';
 
 /**
  * VS Code Webview Transport using window.acquireVsCodeApi() and window message events.
+ * Automatically buffers early inbound messages until handlers subscribe.
  */
 export class VsCodeWebviewTransport implements WebviewTransport {
     private readonly vscodeApi: {
@@ -14,7 +15,9 @@ export class VsCodeWebviewTransport implements WebviewTransport {
         setState?: (state: unknown) => void;
         getState?: () => unknown;
     };
-    private readonly _listeners = new Set<(event: MessageEvent) => void>();
+    private readonly _handlers = new Set<(message: unknown) => void>();
+    private readonly _inboundQueue: unknown[] = [];
+    private readonly _windowListener?: (event: MessageEvent) => void;
 
     constructor() {
         if (typeof window === 'undefined' || typeof window.acquireVsCodeApi !== 'function') {
@@ -28,6 +31,32 @@ export class VsCodeWebviewTransport implements WebviewTransport {
             window.__jjViewVsCodeApi = window.acquireVsCodeApi();
         }
         this.vscodeApi = window.__jjViewVsCodeApi;
+
+        if (typeof window.addEventListener === 'function') {
+            this._windowListener = (event: MessageEvent) => {
+                this._handleIncomingMessage(event.data);
+            };
+            window.addEventListener('message', this._windowListener);
+        }
+    }
+
+    private _handleIncomingMessage(data: unknown): void {
+        if (this._handlers.size === 0) {
+            this._inboundQueue.push(data);
+            return;
+        }
+
+        for (const handler of Array.from(this._handlers)) {
+            this._dispatchSingle(handler, data);
+        }
+    }
+
+    private _dispatchSingle(handler: (message: unknown) => void, data: unknown): void {
+        try {
+            handler(data);
+        } catch (err) {
+            console.error('[VsCodeWebviewTransport] Error in message handler:', err);
+        }
     }
 
     public postMessage(message: unknown): void {
@@ -35,32 +64,23 @@ export class VsCodeWebviewTransport implements WebviewTransport {
     }
 
     public onMessage(handler: (message: unknown) => void): () => void {
-        if (typeof window === 'undefined') {
-            return () => {};
+        this._handlers.add(handler);
+
+        const pending = this._inboundQueue.splice(0, this._inboundQueue.length);
+        for (const queued of pending) {
+            this._dispatchSingle(handler, queued);
         }
 
-        const listener = (event: MessageEvent) => {
-            try {
-                handler(event.data);
-            } catch (err) {
-                console.error('[VsCodeWebviewTransport] Error in onMessage subscriber:', err);
-            }
-        };
-
-        this._listeners.add(listener);
-        window.addEventListener('message', listener);
         return () => {
-            this._listeners.delete(listener);
-            window.removeEventListener('message', listener);
+            this._handlers.delete(handler);
         };
     }
 
     public dispose(): void {
-        if (typeof window !== 'undefined') {
-            for (const listener of this._listeners) {
-                window.removeEventListener('message', listener);
-            }
+        if (typeof window !== 'undefined' && this._windowListener) {
+            window.removeEventListener('message', this._windowListener);
         }
-        this._listeners.clear();
+        this._handlers.clear();
+        this._inboundQueue.length = 0;
     }
 }

--- a/src/webview/transport/websocket-transport.ts
+++ b/src/webview/transport/websocket-transport.ts
@@ -7,10 +7,12 @@ import type { WebviewTransport } from './types';
 
 /**
  * WebSocket Transport for self-hosted Web / Browser client.
+ * Automatically buffers early inbound and outbound messages.
  */
 export class WebSocketWebviewTransport implements WebviewTransport {
     private socket?: WebSocket;
     private readonly messageQueue: unknown[] = [];
+    private readonly inboundQueue: unknown[] = [];
     private readonly handlers = new Set<(message: unknown) => void>();
     private _disposed = false;
     private reconnectTimer?: ReturnType<typeof setTimeout>;
@@ -53,12 +55,13 @@ export class WebSocketWebviewTransport implements WebviewTransport {
                 return;
             }
 
+            if (this.handlers.size === 0) {
+                this.inboundQueue.push(data);
+                return;
+            }
+
             for (const handler of Array.from(this.handlers)) {
-                try {
-                    handler(data);
-                } catch (err) {
-                    console.error('[WebSocketWebviewTransport] Error in onMessage subscriber:', err);
-                }
+                this.dispatchSingle(handler, data);
             }
         };
 
@@ -86,6 +89,14 @@ export class WebSocketWebviewTransport implements WebviewTransport {
         }, delay);
     }
 
+    private dispatchSingle(handler: (message: unknown) => void, data: unknown): void {
+        try {
+            handler(data);
+        } catch (err) {
+            console.error('[WebSocketWebviewTransport] Error in onMessage subscriber:', err);
+        }
+    }
+
     public postMessage(message: unknown): void {
         const isSocketOpen =
             this.socket &&
@@ -96,6 +107,10 @@ export class WebSocketWebviewTransport implements WebviewTransport {
                 this.socket?.send(JSON.stringify(message));
             } catch (err) {
                 console.error('[WebSocketWebviewTransport] Failed to send message:', err);
+                if (this.messageQueue.length >= WebSocketWebviewTransport.MAX_QUEUE_SIZE) {
+                    this.messageQueue.shift();
+                }
+                this.messageQueue.push(message);
             }
             return;
         }
@@ -108,6 +123,12 @@ export class WebSocketWebviewTransport implements WebviewTransport {
 
     public onMessage(handler: (message: unknown) => void): () => void {
         this.handlers.add(handler);
+
+        const pending = this.inboundQueue.splice(0, this.inboundQueue.length);
+        for (const queued of pending) {
+            this.dispatchSingle(handler, queued);
+        }
+
         return () => {
             this.handlers.delete(handler);
         };
@@ -129,5 +150,6 @@ export class WebSocketWebviewTransport implements WebviewTransport {
         }
         this.handlers.clear();
         this.messageQueue.length = 0;
+        this.inboundQueue.length = 0;
     }
 }


### PR DESCRIPTION


Add pre-connection outbound queuing to WebviewRpcDispatcher and inbound event buffering across webview transport implementations to prevent dropped messages during startup. Wire automatic initial state replay and webviewLoaded handshakes across LogViewController, CommitDetailsController, and ProcessMonitorController to eliminate bespoke initialization timing workarounds.