### PR TITLE
rpc: provide typed emitter proxy for host-to-webview message broadcasting

### DIFF
--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -109,6 +109,25 @@ export class WebviewRpcDispatcher<
         return this._messengers.size > 0;
     }
 
+    private _emitter?: RpcEmitterMethods<TOutbound>;
+
+    public get emitter(): RpcEmitterMethods<TOutbound> {
+        if (!this._emitter) {
+            this._emitter = new Proxy({} as RpcEmitterMethods<TOutbound>, {
+                get: (_target, prop: string | symbol) => {
+                    if (typeof prop === 'symbol' || prop === 'then' || prop === 'toJSON' || prop === 'constructor') {
+                        return undefined;
+                    }
+                    return (payload?: unknown) => {
+                        const message = payload !== undefined ? { type: prop, payload } : { type: prop };
+                        this.broadcast(message as TOutbound);
+                    };
+                },
+            });
+        }
+        return this._emitter;
+    }
+
     public addMessenger(messenger: WebviewPostMessageLike): { dispose: () => void } {
         if (this._disposed) {
             return { dispose: () => {} };
@@ -431,10 +450,22 @@ export function createWebviewRpcDispatcher<
     return new WebviewRpcDispatcher<TMessage, TOutbound, K>(schema, handlers, options);
 }
 
+export type ReservedRpcProperties = 'then' | 'toJSON' | 'constructor';
+
 export type RpcClientMethods<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
-    [V in TMessage[K]]: MessagePayload<Extract<TMessage, { [P in K]: V }>> extends undefined
+    [V in Exclude<TMessage[K], ReservedRpcProperties>]: MessagePayload<
+        Extract<TMessage, { [P in K]: V }>
+    > extends undefined
         ? () => Promise<unknown>
         : (payload: MessagePayload<Extract<TMessage, { [P in K]: V }>>) => Promise<unknown>;
+};
+
+export type RpcEmitterMethods<TOutbound extends DiscriminatedMessage<'type'>> = {
+    [V in Exclude<TOutbound['type'], ReservedRpcProperties>]: MessagePayload<
+        Extract<TOutbound, { type: V }>
+    > extends undefined
+        ? () => void
+        : (payload: MessagePayload<Extract<TOutbound, { type: V }>>) => void;
 };
 
 export interface WebviewPostMessageLike {

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -166,10 +166,7 @@ export class CommitDetailsController implements Disposable {
 
             const state = this.getState();
             if (state) {
-                this.broadcast({
-                    type: 'update',
-                    payload: state,
-                });
+                this._dispatcher.emitter.update(state);
             }
             return log;
         } catch (err) {
@@ -236,17 +233,18 @@ export class CommitDetailsController implements Disposable {
     }
 
     public applyUndoRedo(text: string, selection: { start: number; end: number }): void {
+        if (this._disposed) {
+            return;
+        }
+        this.flushDebounce();
         this._lastPushedText = text;
         this._lastPushedSelection = selection;
         this._draftDescription = text;
 
-        this.broadcast({
-            type: 'updateDescription',
-            payload: {
-                description: text,
-                selectionStart: selection.start,
-                selectionEnd: selection.end,
-            },
+        this._dispatcher.emitter.updateDescription({
+            description: text,
+            selectionStart: selection.start,
+            selectionEnd: selection.end,
         });
     }
 
@@ -285,16 +283,13 @@ export class CommitDetailsController implements Disposable {
             this._draftDescription = savedDescription;
             this._persistedDescription = savedDescription;
 
-            this.broadcast({
-                type: 'saveComplete',
-                payload: {
-                    description: savedDescription,
-                },
+            this._dispatcher.emitter.saveComplete({
+                description: savedDescription,
             });
             return true;
         } catch (err) {
             this._logger?.error(`[CommitDetailsController] Failed to save commit ${this.changeId}`, toError(err));
-            this.broadcast({ type: 'saveFailed' });
+            this._dispatcher.emitter.saveFailed();
             await showJjError(this._host.ui, err, 'Failed to save commit description', this.repo?.jj, this._logger);
             return false;
         }

--- a/src/controllers/log-view-controller.ts
+++ b/src/controllers/log-view-controller.ts
@@ -256,10 +256,7 @@ export class LogViewController implements Disposable {
 
         this._onDidUpdateCommits.fire(enrichedCommits);
 
-        this._postMessage({
-            type: 'update',
-            payload: this.getState(),
-        });
+        this._dispatcher.emitter.update(this.getState());
     }
 
     private _updateSelectionContextKeys(selectedCommitIds: readonly string[], hasImmutableSelection?: boolean): void {
@@ -300,10 +297,7 @@ export class LogViewController implements Disposable {
 
         this._onDidChangeSelection.fire(this._selectedCommitIds);
 
-        this._postMessage({
-            type: 'setSelection',
-            payload: { ids: [...commitIds] },
-        });
+        this._dispatcher.emitter.setSelection({ ids: [...commitIds] });
     }
 
     public setHiddenActions(hiddenActions: readonly string[]): void {
@@ -318,10 +312,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._postMessage({
-            type: 'updateHiddenActions',
-            payload: { hiddenActions: [...validActions] },
-        });
+        this._dispatcher.emitter.updateHiddenActions({ hiddenActions: [...validActions] });
     }
 
     public getHiddenActions(): string[] {
@@ -329,22 +320,18 @@ export class LogViewController implements Disposable {
     }
 
     public toggleAction(actionId: string): readonly ToggleableCommitAction[] {
-        if (!(TOGGLEABLE_COMMIT_ACTIONS as readonly string[]).includes(actionId)) {
+        const validAction = actionId as ToggleableCommitAction;
+        if (!TOGGLEABLE_COMMIT_ACTIONS.includes(validAction)) {
             return this._hiddenActions;
         }
 
-        const action = actionId as ToggleableCommitAction;
-        const hiddenSet = new Set(this._hiddenActions);
-        if (hiddenSet.has(action)) {
-            hiddenSet.delete(action);
-        } else {
-            hiddenSet.add(action);
-        }
+        const next = this._hiddenActions.includes(validAction)
+            ? this._hiddenActions.filter((a) => a !== validAction)
+            : [...this._hiddenActions, validAction];
 
-        const newHidden = Array.from(hiddenSet);
-        this.setHiddenActions(newHidden);
-        this._host.storage.update(LogViewController.HIDDEN_ACTIONS_STORAGE_KEY, newHidden);
-        return this._hiddenActions;
+        this.setHiddenActions(next);
+        this._host.storage.update(LogViewController.HIDDEN_ACTIONS_STORAGE_KEY, next);
+        return next;
     }
 
     public updateConfig(config: { theme?: string; graphLabelAlignment?: string; minChangeIdLength?: number }): void {
@@ -362,10 +349,17 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._postMessage({
-            type: 'update',
-            payload: this.getState(),
-        });
+        this._dispatcher.emitter.update(this.getState());
+    }
+
+    public setTheme(theme: string): void {
+        this._theme = theme;
+
+        if (this._disposed) {
+            return;
+        }
+
+        this._dispatcher.emitter.update(this.getState());
     }
 
     public setGraphLabelAlignment(alignment: string): void {
@@ -375,10 +369,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._postMessage({
-            type: 'update',
-            payload: this.getState(),
-        });
+        this._dispatcher.emitter.update(this.getState());
     }
 
     public refreshSettings(): void {
@@ -413,10 +404,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._postMessage({
-            type: 'update',
-            payload: this.getState(),
-        });
+        this._dispatcher.emitter.update(this.getState());
     }
 
     public async refreshCodeForge(): Promise<void> {
@@ -458,10 +446,7 @@ export class LogViewController implements Disposable {
     }
 
     public handlePanelClosed(changeId: string): void {
-        this._postMessage({
-            type: 'panelClosed',
-            payload: { changeId },
-        });
+        this._dispatcher.emitter.panelClosed({ changeId });
     }
 
     private _updateActionContextKeys(): void {
@@ -470,12 +455,6 @@ export class LogViewController implements Disposable {
             const key = `jj.commitActionVisible.${actionId}`;
             const value = !hiddenSet.has(actionId);
             this._host.commands.setContextKey(key, value);
-        }
-    }
-
-    private _postMessage(message: LogViewHostToWebviewMessage): void {
-        if (!this._disposed) {
-            this._dispatcher.broadcast(message);
         }
     }
 

--- a/src/controllers/process-monitor-controller.ts
+++ b/src/controllers/process-monitor-controller.ts
@@ -168,10 +168,7 @@ export class ProcessMonitorController implements Disposable {
         }
 
         this._onDidUpdate.fire();
-        this._postMessage({
-            type: 'update',
-            payload: this.getState(),
-        });
+        this._dispatcher.emitter.update(this.getState());
     }
 
     public getMetrics(): JjProcessMetrics {
@@ -188,13 +185,6 @@ export class ProcessMonitorController implements Disposable {
 
     public clearHistory(): void {
         this._processTracker.clearHistory();
-    }
-
-    private _postMessage(message: ProcessMonitorHostToWebviewMessage): void {
-        if (this._disposed) {
-            return;
-        }
-        this._dispatcher.broadcast(message);
     }
 
     public dispose(): void {

--- a/src/test/webview-rpc-dispatcher.test.ts
+++ b/src/test/webview-rpc-dispatcher.test.ts
@@ -448,6 +448,41 @@ describe('WebviewRpcDispatcher', () => {
         expect(dispatcher.hasMessengers).toBe(false);
         sub.dispose();
     });
+
+    test('supports typed emitter proxy for broadcasting messages', () => {
+        type OutboundEvents =
+            | { type: 'update'; payload: { count: number } }
+            | { type: 'reset' }
+            | { type: 'notify'; payload: { message: string } };
+
+        const dispatcher = createWebviewRpcDispatcher<z.infer<typeof testSchema>, OutboundEvents>(testSchema, {});
+
+        const messenger = { postMessage: vi.fn() };
+        dispatcher.addMessenger(messenger);
+
+        dispatcher.emitter.update({ count: 42 });
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'update',
+            payload: { count: 42 },
+        });
+
+        dispatcher.emitter.reset();
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'reset',
+        });
+
+        dispatcher.emitter.notify({ message: 'hello' });
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'notify',
+            payload: { message: 'hello' },
+        });
+
+        const dynamicEmitter = dispatcher.emitter as Record<string | symbol, unknown>;
+        expect(dynamicEmitter.then).toBeUndefined();
+        expect(dynamicEmitter.toJSON).toBeUndefined();
+        expect(dynamicEmitter.constructor).toBeUndefined();
+        expect(dynamicEmitter[Symbol.iterator]).toBeUndefined();
+    });
 });
 
 describe('createWebviewRpcClient', () => {
@@ -528,13 +563,14 @@ describe('createWebviewRpcClient', () => {
         await expect(client.fail()).rejects.toThrowError('Something went wrong');
     });
 
-    test('ignores then, toJSON, and symbol properties on client proxy', () => {
+    test('ignores then, toJSON, constructor, and symbol properties on client proxy', () => {
         const mockWebview = { postMessage: vi.fn() };
         const client = createWebviewRpcClient(mockWebview, testSchema);
         const dynamicClient = client as Record<string | symbol, unknown>;
 
         expect(dynamicClient.then).toBeUndefined();
         expect(dynamicClient.toJSON).toBeUndefined();
+        expect(dynamicClient.constructor).toBeUndefined();
         expect(dynamicClient[Symbol.iterator]).toBeUndefined();
         expect(mockWebview.postMessage).not.toHaveBeenCalled();
     });


### PR DESCRIPTION


Host controllers previously manually constructed raw wire envelopes `{ type, payload }` and passed them to low-level broadcast or `_postMessage` helpers, bypassing compile-time argument checking and exposing serialization details across controller methods.

Add `RpcEmitterMethods<TOutbound>` and an `emitter` Proxy property to `WebviewRpcDispatcher`. The emitter dynamically maps outbound event names to typed broadcast invocations, enforcing message payload shapes without boilerplate. Migrate `CommitDetailsController`, `LogViewController`, and `ProcessMonitorController` to use `this._dispatcher.emitter` directly, eliminating manual wire envelope assembly and private `_postMessage` dispatchers. Add comprehensive unit tests verifying typed emission, parameterless event dispatch, and symbol filtering on the emitter proxy.