### PR TITLE
rpc: align messaging semantics on sender and receiver

### DIFF
--- a/src/common/webview-rpc-dispatcher.ts
+++ b/src/common/webview-rpc-dispatcher.ts
@@ -13,11 +13,16 @@ export type DiscriminatedMessage<K extends string = 'type'> = {
 
 export type MessagePayload<T> = T extends { payload: infer P } ? P : undefined;
 
-export type MessageHandlerMap<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
+export type RpcReceiverHandlers<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
     [V in TMessage[K]]?: MessagePayload<Extract<TMessage, { [P in K]: V }>> extends undefined
         ? () => unknown | Promise<unknown>
         : (payload: MessagePayload<Extract<TMessage, { [P in K]: V }>>) => unknown | Promise<unknown>;
 };
+
+export type MessageHandlerMap<
+    TMessage extends DiscriminatedMessage<K>,
+    K extends string = 'type',
+> = RpcReceiverHandlers<TMessage, K>;
 
 export type InitialStateMap<TOutbound extends DiscriminatedMessage<'type'>> = string extends TOutbound['type']
     ? Record<string, unknown>
@@ -42,7 +47,7 @@ export type InitialStateValue<TOutbound extends DiscriminatedMessage<'type'> = D
 export type InitialStateProvider<TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>> =
     StateProvider<TOutbound>;
 
-export interface WebviewRpcDispatcherOptions<
+export interface WebviewRpcReceiverOptions<
     TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
     K extends string = 'type',
 > {
@@ -55,6 +60,11 @@ export interface WebviewRpcDispatcherOptions<
     getInitialState?: StateProvider<TOutbound>;
     maxQueueSize?: number;
 }
+
+export type WebviewRpcDispatcherOptions<
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+> = WebviewRpcReceiverOptions<TOutbound, K>;
 
 export const loggerSchema = z.object({
     type: z.literal('logMessage'),
@@ -77,7 +87,7 @@ type PendingPromise = {
     reject: (reason: unknown) => void;
 };
 
-export class WebviewRpcDispatcher<
+export class WebviewRpcReceiver<
     TMessage extends DiscriminatedMessage<K>,
     TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
     K extends string = 'type',
@@ -91,8 +101,8 @@ export class WebviewRpcDispatcher<
 
     constructor(
         private readonly schema: z.ZodType<TMessage>,
-        private readonly handlers: MessageHandlerMap<TMessage, K>,
-        private readonly options?: WebviewRpcDispatcherOptions<TOutbound, K>,
+        private readonly handlers: RpcReceiverHandlers<TMessage, K>,
+        private readonly options?: WebviewRpcReceiverOptions<TOutbound, K>,
     ) {
         this.discriminatorKey = options?.discriminatorKey ?? ('type' as K);
         this._maxQueueSize = options?.maxQueueSize ?? 100;
@@ -109,11 +119,11 @@ export class WebviewRpcDispatcher<
         return this._messengers.size > 0;
     }
 
-    private _emitter?: RpcEmitterMethods<TOutbound>;
+    private _sender?: RpcSenderMethods<TOutbound, 'type', void>;
 
-    public get emitter(): RpcEmitterMethods<TOutbound> {
-        if (!this._emitter) {
-            this._emitter = new Proxy({} as RpcEmitterMethods<TOutbound>, {
+    public get sender(): RpcSenderMethods<TOutbound, 'type', void> {
+        if (!this._sender) {
+            this._sender = new Proxy({} as RpcSenderMethods<TOutbound, 'type', void>, {
                 get: (_target, prop: string | symbol) => {
                     if (typeof prop === 'symbol' || prop === 'then' || prop === 'toJSON' || prop === 'constructor') {
                         return undefined;
@@ -125,7 +135,11 @@ export class WebviewRpcDispatcher<
                 },
             });
         }
-        return this._emitter;
+        return this._sender;
+    }
+
+    public get emitter(): RpcSenderMethods<TOutbound, 'type', void> {
+        return this.sender;
     }
 
     public addMessenger(messenger: WebviewPostMessageLike): { dispose: () => void } {
@@ -438,35 +452,52 @@ export class WebviewRpcDispatcher<
     }
 }
 
-export function createWebviewRpcDispatcher<
+export const WebviewRpcDispatcher = WebviewRpcReceiver;
+export type WebviewRpcDispatcher<
+    TMessage extends DiscriminatedMessage<K>,
+    TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
+    K extends string = 'type',
+> = WebviewRpcReceiver<TMessage, TOutbound, K>;
+
+export function createWebviewRpcReceiver<
     TMessage extends DiscriminatedMessage<K>,
     TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
     K extends string = 'type',
 >(
     schema: z.ZodType<TMessage>,
-    handlers: MessageHandlerMap<TMessage, K>,
-    options?: WebviewRpcDispatcherOptions<TOutbound, K>,
-): WebviewRpcDispatcher<TMessage, TOutbound, K> {
-    return new WebviewRpcDispatcher<TMessage, TOutbound, K>(schema, handlers, options);
+    handlers: RpcReceiverHandlers<TMessage, K>,
+    options?: WebviewRpcReceiverOptions<TOutbound, K>,
+): WebviewRpcReceiver<TMessage, TOutbound, K> {
+    return new WebviewRpcReceiver<TMessage, TOutbound, K>(schema, handlers, options);
 }
+
+export const createWebviewRpcDispatcher = createWebviewRpcReceiver;
 
 export type ReservedRpcProperties = 'then' | 'toJSON' | 'constructor';
 
-export type RpcClientMethods<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = {
+export type RpcSenderMethods<
+    TMessage extends DiscriminatedMessage<K>,
+    K extends string = 'type',
+    TReturn = Promise<unknown>,
+> = {
     [V in Exclude<TMessage[K], ReservedRpcProperties>]: MessagePayload<
         Extract<TMessage, { [P in K]: V }>
     > extends undefined
-        ? () => Promise<unknown>
-        : (payload: MessagePayload<Extract<TMessage, { [P in K]: V }>>) => Promise<unknown>;
+        ? () => TReturn
+        : (payload: MessagePayload<Extract<TMessage, { [P in K]: V }>>) => TReturn;
 };
 
-export type RpcEmitterMethods<TOutbound extends DiscriminatedMessage<'type'>> = {
-    [V in Exclude<TOutbound['type'], ReservedRpcProperties>]: MessagePayload<
-        Extract<TOutbound, { type: V }>
-    > extends undefined
-        ? () => void
-        : (payload: MessagePayload<Extract<TOutbound, { type: V }>>) => void;
-};
+export type RpcClientMethods<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'> = RpcSenderMethods<
+    TMessage,
+    K,
+    Promise<unknown>
+>;
+
+export type RpcEmitterMethods<TOutbound extends DiscriminatedMessage<'type'>> = RpcSenderMethods<
+    TOutbound,
+    'type',
+    void
+>;
 
 export interface WebviewPostMessageLike {
     postMessage(message: unknown): unknown;
@@ -477,21 +508,25 @@ export interface WebviewRpcPendingRequestRegisterable {
     unregisterPendingRequest?(requestId: string): void;
 }
 
-export interface WebviewRpcClientOptions<K extends string = 'type'> {
+export interface WebviewRpcSenderOptions<K extends string = 'type'> {
     discriminatorKey?: K;
     dispatcher?: WebviewRpcPendingRequestRegisterable;
+    receiver?: WebviewRpcPendingRequestRegisterable;
 }
+
+export type WebviewRpcClientOptions<K extends string = 'type'> = WebviewRpcSenderOptions<K>;
 
 let globalRequestIdCounter = 0;
 
-export function createWebviewRpcClient<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+export function createWebviewRpcSender<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
     webview: WebviewPostMessageLike,
     schema?: z.ZodType<TMessage>,
-    options?: WebviewRpcClientOptions<K>,
-): RpcClientMethods<TMessage, K> {
+    options?: WebviewRpcSenderOptions<K>,
+): RpcSenderMethods<TMessage, K, Promise<unknown>> {
     const discriminatorKey = options?.discriminatorKey ?? ('type' as K);
+    const requestRegisterable = options?.receiver ?? options?.dispatcher;
 
-    return new Proxy({} as RpcClientMethods<TMessage, K>, {
+    return new Proxy({} as RpcSenderMethods<TMessage, K, Promise<unknown>>, {
         get(_target, prop: string | symbol) {
             if (typeof prop === 'symbol' || prop === 'then' || prop === 'toJSON' || prop === 'constructor') {
                 return undefined;
@@ -520,8 +555,8 @@ export function createWebviewRpcClient<TMessage extends DiscriminatedMessage<K>,
                 }
 
                 let pendingPromise: Promise<unknown> | undefined;
-                if (options?.dispatcher) {
-                    pendingPromise = options.dispatcher.registerPendingRequest(requestId);
+                if (requestRegisterable) {
+                    pendingPromise = requestRegisterable.registerPendingRequest(requestId);
                 }
 
                 try {
@@ -531,8 +566,8 @@ export function createWebviewRpcClient<TMessage extends DiscriminatedMessage<K>,
                     }
                     return Promise.resolve(sendResult);
                 } catch (err) {
-                    if (options?.dispatcher?.unregisterPendingRequest) {
-                        options.dispatcher.unregisterPendingRequest(requestId);
+                    if (requestRegisterable?.unregisterPendingRequest) {
+                        requestRegisterable.unregisterPendingRequest(requestId);
                     }
                     throw err;
                 }
@@ -540,3 +575,5 @@ export function createWebviewRpcClient<TMessage extends DiscriminatedMessage<K>,
         },
     });
 }
+
+export const createWebviewRpcClient = createWebviewRpcSender;

--- a/src/controllers/commit-details-controller.ts
+++ b/src/controllers/commit-details-controller.ts
@@ -13,9 +13,9 @@ import {
 } from '../common/ipc/commit-details-schemas';
 import { showJjError } from '../common/ui-helpers';
 import {
-    createWebviewRpcDispatcher,
+    createWebviewRpcReceiver,
     type WebviewPostMessageLike,
-    type WebviewRpcDispatcher,
+    type WebviewRpcReceiver,
 } from '../common/webview-rpc-dispatcher';
 import type { JjRepository } from '../jj-repository';
 import type { JjLogEntry, JjStatusEntry } from '../jj-types';
@@ -33,7 +33,7 @@ export class CommitDetailsController implements Disposable {
     private readonly _disposables: Disposable[] = [];
     private _loadVersion = 0;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>;
+    private readonly _receiver: WebviewRpcReceiver<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>;
 
     private _logEntry?: JjLogEntry;
     private _changes?: readonly JjStatusEntry[];
@@ -58,7 +58,7 @@ export class CommitDetailsController implements Disposable {
         private readonly _options?: CommitDetailsControllerOptions,
     ) {
         this._logger = _options?.logger;
-        this._dispatcher = this._createRpcDispatcher();
+        this._receiver = this._createRpcReceiver();
     }
 
     public get logEntry(): JjLogEntry | undefined {
@@ -102,7 +102,7 @@ export class CommitDetailsController implements Disposable {
     }
 
     public addMessenger(messenger: WebviewPostMessageLike): Disposable {
-        const sub = this._dispatcher.addMessenger(messenger);
+        const sub = this._receiver.addMessenger(messenger);
         let disposed = false;
         return {
             dispose: () => {
@@ -111,7 +111,7 @@ export class CommitDetailsController implements Disposable {
                 }
                 disposed = true;
                 sub.dispose();
-                if (!this._dispatcher.hasMessengers) {
+                if (!this._receiver.hasMessengers) {
                     this._onDidClose.fire(this.changeId);
                 }
             },
@@ -122,7 +122,7 @@ export class CommitDetailsController implements Disposable {
         if (this._disposed) {
             return false;
         }
-        return this._dispatcher.dispatch(rawMessage);
+        return this._receiver.dispatch(rawMessage);
     }
 
     public async load(): Promise<JjLogEntry | undefined> {
@@ -166,7 +166,7 @@ export class CommitDetailsController implements Disposable {
 
             const state = this.getState();
             if (state) {
-                this._dispatcher.emitter.update(state);
+                this._receiver.sender.update(state);
             }
             return log;
         } catch (err) {
@@ -241,7 +241,7 @@ export class CommitDetailsController implements Disposable {
         this._lastPushedSelection = selection;
         this._draftDescription = text;
 
-        this._dispatcher.emitter.updateDescription({
+        this._receiver.sender.updateDescription({
             description: text,
             selectionStart: selection.start,
             selectionEnd: selection.end,
@@ -283,30 +283,20 @@ export class CommitDetailsController implements Disposable {
             this._draftDescription = savedDescription;
             this._persistedDescription = savedDescription;
 
-            this._dispatcher.emitter.saveComplete({
+            this._receiver.sender.saveComplete({
                 description: savedDescription,
             });
             return true;
         } catch (err) {
             this._logger?.error(`[CommitDetailsController] Failed to save commit ${this.changeId}`, toError(err));
-            this._dispatcher.emitter.saveFailed();
+            this._receiver.sender.saveFailed();
             await showJjError(this._host.ui, err, 'Failed to save commit description', this.repo?.jj, this._logger);
             return false;
         }
     }
 
-    public broadcast(message: CommitDetailsHostToWebviewMessage): void {
-        if (this._disposed) {
-            return;
-        }
-        this._dispatcher.broadcast(message);
-    }
-
-    private _createRpcDispatcher(): WebviewRpcDispatcher<
-        CommitDetailsToHostMessage,
-        CommitDetailsHostToWebviewMessage
-    > {
-        return createWebviewRpcDispatcher<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>(
+    private _createRpcReceiver(): WebviewRpcReceiver<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage> {
+        return createWebviewRpcReceiver<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>(
             CommitDetailsToHostMessageSchema,
             {
                 descriptionChanged: async (payload) => {
@@ -352,6 +342,6 @@ export class CommitDetailsController implements Disposable {
         this._disposables.length = 0;
         this._onDidUpdate.dispose();
         this._onDidClose.dispose();
-        this._dispatcher.dispose();
+        this._receiver.dispose();
     }
 }

--- a/src/controllers/log-view-controller.ts
+++ b/src/controllers/log-view-controller.ts
@@ -15,9 +15,9 @@ import {
 } from '../common/ipc/log-view-schemas';
 import { showJjError } from '../common/ui-helpers';
 import {
-    createWebviewRpcDispatcher,
+    createWebviewRpcReceiver,
     type WebviewPostMessageLike,
-    type WebviewRpcDispatcher,
+    type WebviewRpcReceiver,
 } from '../common/webview-rpc-dispatcher';
 import { JjContextKey } from '../jj-context-keys';
 import type { JjRepository } from '../jj-repository';
@@ -42,7 +42,7 @@ export class LogViewController implements Disposable {
     private readonly _disposables: Disposable[] = [];
     private _codeForgeDisposable: Disposable | undefined;
     private readonly _logger?: LoggerChannel;
-    private readonly _dispatcher: WebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage>;
+    private readonly _receiver: WebviewRpcReceiver<LogViewToHostMessage, LogViewHostToWebviewMessage>;
     private readonly _refreshQueue: CoalescingQueue;
 
     private _commits: readonly JjLogEntry[] = [];
@@ -72,9 +72,9 @@ export class LogViewController implements Disposable {
             await this._doRefresh();
         });
 
-        this._dispatcher = this._createRpcDispatcher();
+        this._receiver = this._createRpcReceiver();
         if (_options?.messenger) {
-            this._dispatcher.setMessenger(_options.messenger);
+            this._receiver.setMessenger(_options.messenger);
         }
 
         const storedHidden = this._host.storage.get<string[]>(LogViewController.HIDDEN_ACTIONS_STORAGE_KEY, []) ?? [];
@@ -159,7 +159,7 @@ export class LogViewController implements Disposable {
     }
 
     public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
-        this._dispatcher.setMessenger(messenger);
+        this._receiver.setMessenger(messenger);
     }
 
     private bindRepo(repo: JjRepository | undefined): void {
@@ -186,7 +186,7 @@ export class LogViewController implements Disposable {
         if (this._disposed) {
             return false;
         }
-        return this._dispatcher.dispatch(rawMessage);
+        return this._receiver.dispatch(rawMessage);
     }
 
     public async refresh(reason?: string): Promise<void> {
@@ -256,7 +256,7 @@ export class LogViewController implements Disposable {
 
         this._onDidUpdateCommits.fire(enrichedCommits);
 
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     private _updateSelectionContextKeys(selectedCommitIds: readonly string[], hasImmutableSelection?: boolean): void {
@@ -297,7 +297,7 @@ export class LogViewController implements Disposable {
 
         this._onDidChangeSelection.fire(this._selectedCommitIds);
 
-        this._dispatcher.emitter.setSelection({ ids: [...commitIds] });
+        this._receiver.sender.setSelection({ ids: [...commitIds] });
     }
 
     public setHiddenActions(hiddenActions: readonly string[]): void {
@@ -312,7 +312,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._dispatcher.emitter.updateHiddenActions({ hiddenActions: [...validActions] });
+        this._receiver.sender.updateHiddenActions({ hiddenActions: [...validActions] });
     }
 
     public getHiddenActions(): string[] {
@@ -349,7 +349,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     public setTheme(theme: string): void {
@@ -359,7 +359,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     public setGraphLabelAlignment(alignment: string): void {
@@ -369,7 +369,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     public refreshSettings(): void {
@@ -404,7 +404,7 @@ export class LogViewController implements Disposable {
             return;
         }
 
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     public async refreshCodeForge(): Promise<void> {
@@ -446,7 +446,7 @@ export class LogViewController implements Disposable {
     }
 
     public handlePanelClosed(changeId: string): void {
-        this._dispatcher.emitter.panelClosed({ changeId });
+        this._receiver.sender.panelClosed({ changeId });
     }
 
     private _updateActionContextKeys(): void {
@@ -478,8 +478,8 @@ export class LogViewController implements Disposable {
         }
     }
 
-    private _createRpcDispatcher(): WebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage> {
-        return createWebviewRpcDispatcher<LogViewToHostMessage, LogViewHostToWebviewMessage>(
+    private _createRpcReceiver(): WebviewRpcReceiver<LogViewToHostMessage, LogViewHostToWebviewMessage> {
+        return createWebviewRpcReceiver<LogViewToHostMessage, LogViewHostToWebviewMessage>(
             LogViewToHostMessageSchema,
             {
                 webviewLoaded: async () => {
@@ -647,6 +647,6 @@ export class LogViewController implements Disposable {
         this._disposables.length = 0;
         this._onDidUpdateCommits.dispose();
         this._onDidChangeSelection.dispose();
-        this._dispatcher.dispose();
+        this._receiver.dispose();
     }
 }

--- a/src/controllers/process-monitor-controller.ts
+++ b/src/controllers/process-monitor-controller.ts
@@ -12,9 +12,9 @@ import {
     ProcessMonitorToHostMessageSchema,
 } from '../common/ipc/process-monitor-schemas';
 import {
-    createWebviewRpcDispatcher,
+    createWebviewRpcReceiver,
     type WebviewPostMessageLike,
-    type WebviewRpcDispatcher,
+    type WebviewRpcReceiver,
 } from '../common/webview-rpc-dispatcher';
 import {
     getTaskExitCode,
@@ -36,7 +36,7 @@ export class ProcessMonitorController implements Disposable {
     private readonly _disposables: Disposable[] = [];
     private readonly _logger?: LoggerChannel;
     private readonly _updateQueue: CoalescingQueue;
-    private readonly _dispatcher: WebviewRpcDispatcher<
+    private readonly _receiver: WebviewRpcReceiver<
         ProcessMonitorToHostMessage,
         ProcessMonitorHostToWebviewMessage,
         'command'
@@ -71,7 +71,7 @@ export class ProcessMonitorController implements Disposable {
             }),
         );
 
-        this._dispatcher = createWebviewRpcDispatcher<
+        this._receiver = createWebviewRpcReceiver<
             ProcessMonitorToHostMessage,
             ProcessMonitorHostToWebviewMessage,
             'command'
@@ -99,7 +99,7 @@ export class ProcessMonitorController implements Disposable {
         );
 
         if (options?.messenger) {
-            this._dispatcher.setMessenger(options.messenger);
+            this._receiver.setMessenger(options.messenger);
         }
 
         this.updateWebview();
@@ -152,14 +152,14 @@ export class ProcessMonitorController implements Disposable {
     }
 
     public setMessenger(messenger: WebviewPostMessageLike | undefined): void {
-        this._dispatcher.setMessenger(messenger);
+        this._receiver.setMessenger(messenger);
     }
 
     public async handleMessage(rawMessage: unknown): Promise<boolean> {
         if (this._disposed) {
             return false;
         }
-        return this._dispatcher.dispatch(rawMessage);
+        return this._receiver.dispatch(rawMessage);
     }
 
     public updateWebview(): void {
@@ -168,7 +168,7 @@ export class ProcessMonitorController implements Disposable {
         }
 
         this._onDidUpdate.fire();
-        this._dispatcher.emitter.update(this.getState());
+        this._receiver.sender.update(this.getState());
     }
 
     public getMetrics(): JjProcessMetrics {
@@ -194,6 +194,6 @@ export class ProcessMonitorController implements Disposable {
         }
         this._disposables.length = 0;
         this._onDidUpdate.dispose();
-        this._dispatcher.dispose();
+        this._receiver.dispose();
     }
 }

--- a/src/test/webview-rpc-dispatcher.test.ts
+++ b/src/test/webview-rpc-dispatcher.test.ts
@@ -4,10 +4,16 @@
  */
 import { describe, expect, test, vi } from 'vitest';
 import { z } from 'zod';
-import { createWebviewRpcClient, createWebviewRpcDispatcher } from '../common/webview-rpc-dispatcher';
+import {
+    createWebviewRpcClient,
+    createWebviewRpcDispatcher,
+    createWebviewRpcReceiver,
+    createWebviewRpcSender,
+    WebviewRpcReceiver,
+} from '../common/webview-rpc-dispatcher';
 import type { LoggerChannel } from '../utils/output-channel';
 
-describe('WebviewRpcDispatcher', () => {
+describe('WebviewRpcReceiver', () => {
     const testSchema = z.discriminatedUnion('type', [
         z.object({ type: z.literal('ping'), payload: z.object({ value: z.string() }) }),
         z.object({ type: z.literal('count'), payload: z.object({ amount: z.number() }) }),
@@ -449,43 +455,49 @@ describe('WebviewRpcDispatcher', () => {
         sub.dispose();
     });
 
-    test('supports typed emitter proxy for broadcasting messages', () => {
+    test('supports typed sender proxy for broadcasting messages', () => {
         type OutboundEvents =
             | { type: 'update'; payload: { count: number } }
             | { type: 'reset' }
             | { type: 'notify'; payload: { message: string } };
 
-        const dispatcher = createWebviewRpcDispatcher<z.infer<typeof testSchema>, OutboundEvents>(testSchema, {});
+        const receiver = createWebviewRpcReceiver<z.infer<typeof testSchema>, OutboundEvents>(testSchema, {});
 
         const messenger = { postMessage: vi.fn() };
-        dispatcher.addMessenger(messenger);
+        receiver.addMessenger(messenger);
 
-        dispatcher.emitter.update({ count: 42 });
+        receiver.sender.update({ count: 42 });
         expect(messenger.postMessage).toHaveBeenCalledWith({
             type: 'update',
             payload: { count: 42 },
         });
 
-        dispatcher.emitter.reset();
+        receiver.sender.reset();
         expect(messenger.postMessage).toHaveBeenCalledWith({
             type: 'reset',
         });
 
-        dispatcher.emitter.notify({ message: 'hello' });
+        receiver.sender.notify({ message: 'hello' });
         expect(messenger.postMessage).toHaveBeenCalledWith({
             type: 'notify',
             payload: { message: 'hello' },
         });
 
-        const dynamicEmitter = dispatcher.emitter as Record<string | symbol, unknown>;
-        expect(dynamicEmitter.then).toBeUndefined();
-        expect(dynamicEmitter.toJSON).toBeUndefined();
-        expect(dynamicEmitter.constructor).toBeUndefined();
-        expect(dynamicEmitter[Symbol.iterator]).toBeUndefined();
+        // Test alias emitter behaves identically
+        receiver.emitter.reset();
+        expect(messenger.postMessage).toHaveBeenCalledWith({
+            type: 'reset',
+        });
+
+        const dynamicSender = receiver.sender as Record<string | symbol, unknown>;
+        expect(dynamicSender.then).toBeUndefined();
+        expect(dynamicSender.toJSON).toBeUndefined();
+        expect(dynamicSender.constructor).toBeUndefined();
+        expect(dynamicSender[Symbol.iterator]).toBeUndefined();
     });
 });
 
-describe('createWebviewRpcClient', () => {
+describe('createWebviewRpcSender', () => {
     const testSchema = z.discriminatedUnion('type', [
         z.object({ type: z.literal('ping'), payload: z.object({ value: z.string() }) }),
         z.object({ type: z.literal('count'), payload: z.object({ amount: z.number() }) }),
@@ -496,9 +508,9 @@ describe('createWebviewRpcClient', () => {
             postMessage: vi.fn().mockReturnValue(Promise.resolve(true)),
         };
 
-        const client = createWebviewRpcClient(mockWebview, testSchema);
+        const sender = createWebviewRpcSender(mockWebview, testSchema);
 
-        client.ping({ value: 'hello' });
+        sender.ping({ value: 'hello' });
         expect(mockWebview.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: 'ping',
@@ -506,7 +518,7 @@ describe('createWebviewRpcClient', () => {
             }),
         );
 
-        client.count({ amount: 10 });
+        sender.count({ amount: 10 });
         expect(mockWebview.postMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: 'count',
@@ -520,8 +532,8 @@ describe('createWebviewRpcClient', () => {
             postMessage: vi.fn().mockReturnValue(Promise.resolve(true)),
         };
 
-        const client = createWebviewRpcClient(mockWebview, testSchema);
-        const untypedCount = client.count as (payload: Record<string, unknown>) => Promise<unknown>;
+        const sender = createWebviewRpcSender(mockWebview, testSchema);
+        const untypedCount = sender.count as (payload: Record<string, unknown>) => Promise<unknown>;
 
         expect(() => untypedCount({ amount: 'invalid' })).toThrowError(/Invalid RPC message 'count'/);
         expect(mockWebview.postMessage).not.toHaveBeenCalled();
@@ -539,12 +551,12 @@ describe('createWebviewRpcClient', () => {
 
         const messenger = {
             postMessage: vi.fn((msg) => {
-                dispatcher.dispatch(msg);
+                receiver.dispatch(msg);
                 return Promise.resolve(true);
             }),
         };
 
-        const dispatcher = createWebviewRpcDispatcher(
+        const receiver = createWebviewRpcReceiver(
             rpcSchema,
             {
                 greet: async ({ name }) => `Hello ${name}`,
@@ -555,23 +567,23 @@ describe('createWebviewRpcClient', () => {
             { messenger },
         );
 
-        const client = createWebviewRpcClient(messenger, rpcSchema, { dispatcher });
+        const sender = createWebviewRpcSender(messenger, rpcSchema, { dispatcher: receiver });
 
-        const greeting = await client.greet({ name: 'Alice' });
+        const greeting = await sender.greet({ name: 'Alice' });
         expect(greeting).toBe('Hello Alice');
 
-        await expect(client.fail()).rejects.toThrowError('Something went wrong');
+        await expect(sender.fail()).rejects.toThrowError('Something went wrong');
     });
 
     test('ignores then, toJSON, constructor, and symbol properties on client proxy', () => {
         const mockWebview = { postMessage: vi.fn() };
-        const client = createWebviewRpcClient(mockWebview, testSchema);
-        const dynamicClient = client as Record<string | symbol, unknown>;
+        const sender = createWebviewRpcSender(mockWebview, testSchema);
+        const dynamicSender = sender as Record<string | symbol, unknown>;
 
-        expect(dynamicClient.then).toBeUndefined();
-        expect(dynamicClient.toJSON).toBeUndefined();
-        expect(dynamicClient.constructor).toBeUndefined();
-        expect(dynamicClient[Symbol.iterator]).toBeUndefined();
+        expect(dynamicSender.then).toBeUndefined();
+        expect(dynamicSender.toJSON).toBeUndefined();
+        expect(dynamicSender.constructor).toBeUndefined();
+        expect(dynamicSender[Symbol.iterator]).toBeUndefined();
         expect(mockWebview.postMessage).not.toHaveBeenCalled();
     });
 
@@ -588,11 +600,32 @@ describe('createWebviewRpcClient', () => {
             },
         };
 
-        const client = createWebviewRpcClient(errorWebview, testSchema, {
+        const sender = createWebviewRpcSender(errorWebview, testSchema, {
             dispatcher: mockDispatcher,
         });
 
-        expect(() => client.ping({ value: 'fail' })).toThrowError('Transport write failure');
+        expect(() => sender.ping({ value: 'fail' })).toThrowError('Transport write failure');
         expect(unregisterSpy).toHaveBeenCalledWith(expect.stringMatching(/^req_/));
+    });
+
+    test('supports createWebviewRpcClient and createWebviewRpcDispatcher aliases', async () => {
+        const mockWebview = { postMessage: vi.fn().mockReturnValue(Promise.resolve(true)) };
+        const client = createWebviewRpcClient(mockWebview, testSchema);
+        client.ping({ value: 'alias' });
+        expect(mockWebview.postMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'ping',
+                payload: { value: 'alias' },
+            }),
+        );
+
+        const receiverInstance = new WebviewRpcReceiver(testSchema, {});
+        expect(receiverInstance.isDisposed).toBe(false);
+        receiverInstance.dispose();
+        expect(receiverInstance.isDisposed).toBe(true);
+
+        const legacyDispatcher = createWebviewRpcDispatcher(testSchema, {});
+        expect(legacyDispatcher.isDisposed).toBe(false);
+        legacyDispatcher.dispose();
     });
 });

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -27,7 +27,7 @@ import { BookmarkPill } from './components/Bookmark';
 import { CommitDragPreview } from './components/CommitDragPreview';
 import { CommitGraph } from './components/CommitGraph';
 import { useDragModifiers } from './hooks/useDragModifiers';
-import { useRpcClient, useRpcDispatcher } from './transport/BridgeContext';
+import { useRpcReceiver, useRpcSender } from './transport/BridgeContext';
 import { snapToCursorLeft } from './utils/modifiers';
 import { calculateNextSelection, hasImmutableSelection } from './utils/selection-utils';
 
@@ -49,7 +49,7 @@ const App: React.FC = () => {
         commitsRef.current = commits;
     }, [commits]);
 
-    const rpc = useRpcClient<LogViewToHostMessage>(LogViewToHostMessageSchema);
+    const sender = useRpcSender<LogViewToHostMessage>(LogViewToHostMessageSchema);
 
     // Drag State
     const [activeDragItem, setActiveDragItem] = React.useState<DragItem | null>(null);
@@ -69,7 +69,7 @@ const App: React.FC = () => {
         }),
     );
 
-    useRpcDispatcher<LogViewHostToWebviewMessage>(LogViewHostToWebviewMessageSchema, {
+    useRpcReceiver<LogViewHostToWebviewMessage>(LogViewHostToWebviewMessageSchema, {
         update: ({
             commits: newCommits,
             minChangeIdLength: minLen,
@@ -106,7 +106,7 @@ const App: React.FC = () => {
                     const newIds = new Set(validIds);
                     const hasImmutable = hasImmutableSelection(newIds, newCommits);
 
-                    void rpc.selectionChange({
+                    void sender.selectionChange({
                         commitIds: validIds,
                         hasImmutableSelection: hasImmutable,
                     });
@@ -122,7 +122,7 @@ const App: React.FC = () => {
         panelClosed: ({ changeId }) => {
             setSelectedCommitIds((prevIds) => {
                 if (prevIds.has(changeId) && prevIds.size === 1) {
-                    void rpc.selectionChange({
+                    void sender.selectionChange({
                         commitIds: [],
                         hasImmutableSelection: false,
                     });
@@ -135,7 +135,7 @@ const App: React.FC = () => {
             const newIds = new Set(ids);
             setSelectedCommitIds(newIds);
             const hasImmutable = hasImmutableSelection(newIds, commitsRef.current);
-            void rpc.selectionChange({
+            void sender.selectionChange({
                 commitIds: ids,
                 hasImmutableSelection: hasImmutable,
             });
@@ -143,14 +143,14 @@ const App: React.FC = () => {
     });
 
     React.useEffect(() => {
-        void rpc.webviewLoaded();
-    }, [rpc]);
+        void sender.webviewLoaded();
+    }, [sender]);
 
     React.useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 setSelectedCommitIds(new Set());
-                void rpc.selectionChange({
+                void sender.selectionChange({
                     commitIds: [],
                     hasImmutableSelection: false,
                 });
@@ -161,7 +161,7 @@ const App: React.FC = () => {
         return () => {
             window.removeEventListener('keydown', handleKeyDown);
         };
-    }, [rpc]);
+    }, [sender]);
 
     const handleGraphAction = (action: string, payload: ActionPayload) => {
         if (action === 'select') {
@@ -172,24 +172,24 @@ const App: React.FC = () => {
             const commitIds = Array.from(newSelection);
             const hasImmutable = hasImmutableSelection(newSelection, commitsRef.current);
 
-            void rpc.selectionChange({
+            void sender.selectionChange({
                 commitIds,
                 hasImmutableSelection: hasImmutable,
             });
 
             if (newSelection.has(payload.changeId)) {
-                void rpc.getDetails(payload);
+                void sender.getDetails(payload);
             }
             return;
         }
 
         if (action === 'showComments') {
-            void rpc.showComments({ changeId: payload.changeId });
+            void sender.showComments({ changeId: payload.changeId });
             return;
         }
 
         if (action === 'contextMenu') {
-            void rpc.contextMenu({
+            void sender.contextMenu({
                 ...payload,
                 selectedCommitIds: Array.from(selectedCommitIds),
             });
@@ -197,39 +197,39 @@ const App: React.FC = () => {
         }
 
         if (action === 'new') {
-            void rpc.new();
+            void sender.new();
             return;
         }
         if (action === 'newChild') {
-            void rpc.newChild(payload);
+            void sender.newChild(payload);
             return;
         }
         if (action === 'edit') {
-            void rpc.edit(payload);
+            void sender.edit(payload);
             return;
         }
         if (action === 'squash') {
-            void rpc.squash(payload);
+            void sender.squash(payload);
             return;
         }
         if (action === 'abandon') {
-            void rpc.abandon(payload);
+            void sender.abandon(payload);
             return;
         }
         if (action === 'undo') {
-            void rpc.undo();
+            void sender.undo();
             return;
         }
         if (action === 'redo') {
-            void rpc.redo();
+            void sender.redo();
             return;
         }
         if (action === 'upload') {
-            void rpc.upload(payload);
+            void sender.upload(payload);
             return;
         }
         if (action === 'openCodeForge' && payload.url) {
-            void rpc.openCodeForge({ url: payload.url });
+            void sender.openCodeForge({ url: payload.url });
         }
     };
 
@@ -287,7 +287,7 @@ const App: React.FC = () => {
                     });
                 });
 
-                void rpc.moveBookmark({ bookmark: bookmarkName, targetChangeId });
+                void sender.moveBookmark({ bookmark: bookmarkName, targetChangeId });
                 return;
             }
 
@@ -304,13 +304,13 @@ const App: React.FC = () => {
 
                 const message = activeModifier.buildMessagePayload(sourceChangeId, targetChangeId);
                 if (message.type === 'rebaseCommit') {
-                    void rpc.rebaseCommit(message.payload);
+                    void sender.rebaseCommit(message.payload);
                 } else if (message.type === 'squashCommit') {
-                    void rpc.squashCommit(message.payload);
+                    void sender.squashCommit(message.payload);
                 } else if (message.type === 'duplicateCommit') {
-                    void rpc.duplicateCommit(message.payload);
+                    void sender.duplicateCommit(message.payload);
                 } else if (message.type === 'mergeCommit') {
-                    void rpc.mergeCommit(message.payload);
+                    void sender.mergeCommit(message.payload);
                 }
             }
         } finally {
@@ -341,7 +341,7 @@ const App: React.FC = () => {
                     onClick={(e) => {
                         if (e.target === e.currentTarget) {
                             setSelectedCommitIds(new Set());
-                            void rpc.selectionChange({
+                            void sender.selectionChange({
                                 commitIds: [],
                                 hasImmutableSelection: false,
                             });

--- a/src/webview/commit-details/CommitDetailsApp.tsx
+++ b/src/webview/commit-details/CommitDetailsApp.tsx
@@ -11,13 +11,13 @@ import {
     CommitDetailsToHostMessageSchema,
 } from '../../common/ipc/commit-details-schemas';
 import { CommitDetails } from '../components/CommitDetails';
-import { useRpcClient, useRpcDispatcher } from '../transport/BridgeContext';
+import { useRpcReceiver, useRpcSender } from '../transport/BridgeContext';
 
 export const CommitDetailsApp: React.FC = () => {
     const [detailsCommit, setDetailsCommit] = React.useState<CommitDetailsPayload | null>(null);
-    const rpc = useRpcClient<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
+    const sender = useRpcSender<CommitDetailsToHostMessage>(CommitDetailsToHostMessageSchema);
 
-    useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
+    useRpcReceiver<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
         update: (payload) => {
             setDetailsCommit(payload);
         },
@@ -29,8 +29,8 @@ export const CommitDetailsApp: React.FC = () => {
     });
 
     React.useEffect(() => {
-        void rpc.webviewLoaded();
-    }, [rpc]);
+        void sender.webviewLoaded();
+    }, [sender]);
 
     if (!detailsCommit) {
         return (
@@ -58,21 +58,21 @@ export const CommitDetailsApp: React.FC = () => {
             minChangeIdLength={detailsCommit.minChangeIdLength}
             onSave={(description) => {
                 if (detailsCommit.changeId) {
-                    void rpc.saveDescription({ changeId: detailsCommit.changeId, description });
+                    void sender.saveDescription({ changeId: detailsCommit.changeId, description });
                 }
             }}
             onOpenDiff={(file, isImmutable) => {
                 if (detailsCommit.changeId) {
-                    void rpc.openDiff({ changeId: detailsCommit.changeId, file, isImmutable });
+                    void sender.openDiff({ changeId: detailsCommit.changeId, file, isImmutable });
                 }
             }}
             onOpenMultiDiff={() => {
                 if (detailsCommit.changeId) {
-                    void rpc.openMultiDiff({ changeId: detailsCommit.changeId });
+                    void sender.openMultiDiff({ changeId: detailsCommit.changeId });
                 }
             }}
             onDescriptionChange={(description, selectionStart, selectionEnd) => {
-                void rpc.descriptionChanged({ description, selectionStart, selectionEnd });
+                void sender.descriptionChanged({ description, selectionStart, selectionEnd });
             }}
         />
     );

--- a/src/webview/components/CommitDetails.tsx
+++ b/src/webview/components/CommitDetails.tsx
@@ -10,7 +10,7 @@ import {
 import type { JjBookmark, JjStatusEntry } from '../../jj-types';
 import { formatCommitDescription } from '../../utils/format-utils';
 import { formatDisplayChangeId } from '../../utils/jj-utils';
-import { useRpcDispatcher } from '../transport/BridgeContext';
+import { useRpcReceiver } from '../transport/BridgeContext';
 import { BasePill, BookmarkPill, TagPill } from './Bookmark';
 import { PersonInfo } from './PersonInfo';
 
@@ -96,7 +96,7 @@ export const CommitDetails: React.FC<CommitDetailsProps> = ({
         prevDescriptionRef.current = description;
     }, [description]);
 
-    useRpcDispatcher<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
+    useRpcReceiver<CommitDetailsHostToWebviewMessage>(CommitDetailsHostToWebviewMessageSchema, {
         saveFailed: () => {
             setIsSaving(false);
             if (saveTimeoutRef.current) {

--- a/src/webview/process-monitor/ProcessMonitorApp.tsx
+++ b/src/webview/process-monitor/ProcessMonitorApp.tsx
@@ -12,7 +12,7 @@ import {
     type ProcessMonitorToHostMessage,
     ProcessMonitorToHostMessageSchema,
 } from '../../common/ipc/process-monitor-schemas';
-import { useRpcClient, useRpcDispatcher } from '../transport/BridgeContext';
+import { useRpcReceiver, useRpcSender } from '../transport/BridgeContext';
 import { getRelativeTimeString } from '../utils/time-utils';
 
 export type { ActiveTask, HistoryTask, Metrics };
@@ -81,7 +81,7 @@ function HistoryTimestampDetail({ timestamp, fullTimestamp }: { timestamp: numbe
 }
 
 export default function ProcessMonitorApp() {
-    const rpc = useRpcClient<ProcessMonitorToHostMessage, 'command'>(ProcessMonitorToHostMessageSchema, {
+    const sender = useRpcSender<ProcessMonitorToHostMessage, 'command'>(ProcessMonitorToHostMessageSchema, {
         discriminatorKey: 'command',
     });
     const [metrics, setMetrics] = useState<Metrics>({
@@ -96,7 +96,7 @@ export default function ProcessMonitorApp() {
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
     const [copiedId, setCopiedId] = useState<string | null>(null);
 
-    useRpcDispatcher(ProcessMonitorHostToWebviewMessageSchema, {
+    useRpcReceiver(ProcessMonitorHostToWebviewMessageSchema, {
         update: ({ activeTasks: tasks, historyTasks: history, metrics: currentMetrics }) => {
             setActiveTasks(tasks);
             setHistoryTasks(history);
@@ -105,8 +105,8 @@ export default function ProcessMonitorApp() {
     });
 
     useEffect(() => {
-        void rpc.webviewLoaded();
-    }, [rpc]);
+        void sender.webviewLoaded();
+    }, [sender]);
 
     const toggleExpand = (rowKey: string, e: React.SyntheticEvent) => {
         e.stopPropagation();
@@ -130,19 +130,19 @@ export default function ProcessMonitorApp() {
 
     const handleKillProcess = (id: number, e: React.MouseEvent) => {
         e.stopPropagation();
-        void rpc.killProcess({ id });
+        void sender.killProcess({ id });
     };
 
     const handleKillAll = () => {
-        void rpc.killAllProcesses();
+        void sender.killAllProcesses();
     };
 
     const handleClearHistory = () => {
-        void rpc.clearHistory();
+        void sender.clearHistory();
     };
 
     const handleHidePanel = () => {
-        void rpc.hidePanel();
+        void sender.hidePanel();
     };
 
     const copyToClipboard = (text: string, key: string, e: React.MouseEvent) => {

--- a/src/webview/transport/BridgeContext.tsx
+++ b/src/webview/transport/BridgeContext.tsx
@@ -7,13 +7,13 @@ import type * as React from 'react';
 import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 import type { z } from 'zod';
 import {
-    createWebviewRpcClient,
-    createWebviewRpcDispatcher,
+    createWebviewRpcReceiver,
+    createWebviewRpcSender,
     type DiscriminatedMessage,
-    type MessageHandlerMap,
-    type RpcClientMethods,
-    type WebviewRpcClientOptions,
-    type WebviewRpcDispatcherOptions,
+    type RpcReceiverHandlers,
+    type RpcSenderMethods,
+    type WebviewRpcReceiverOptions,
+    type WebviewRpcSenderOptions,
 } from '../../common/webview-rpc-dispatcher';
 import { getWebviewTransport } from './registry';
 import type { WebviewTransport } from './types';
@@ -54,17 +54,17 @@ export function useMessageListener<T = unknown>(handler: (message: T) => void): 
     }, [bridge]);
 }
 
-export function useRpcClient<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
+export function useRpcSender<TMessage extends DiscriminatedMessage<K>, K extends string = 'type'>(
     schema?: z.ZodType<TMessage>,
-    options?: WebviewRpcClientOptions<K>,
-): RpcClientMethods<TMessage, K> {
+    options?: WebviewRpcSenderOptions<K>,
+): RpcSenderMethods<TMessage, K, Promise<unknown>> {
     const bridge = useBridge();
     const discriminatorKey = options?.discriminatorKey;
     const dispatcher = options?.dispatcher;
 
     return useMemo(
         () =>
-            createWebviewRpcClient<TMessage, K>(bridge, schema, {
+            createWebviewRpcSender<TMessage, K>(bridge, schema, {
                 discriminatorKey,
                 dispatcher,
             }),
@@ -72,14 +72,16 @@ export function useRpcClient<TMessage extends DiscriminatedMessage<K>, K extends
     );
 }
 
-export function useRpcDispatcher<
+export const useRpcClient = useRpcSender;
+
+export function useRpcReceiver<
     TMessage extends DiscriminatedMessage<K>,
     TOutbound extends DiscriminatedMessage<'type'> = DiscriminatedMessage<'type'>,
     K extends string = 'type',
 >(
     schema: z.ZodType<TMessage>,
-    handlers: MessageHandlerMap<TMessage, K>,
-    options?: WebviewRpcDispatcherOptions<TOutbound, K>,
+    handlers: RpcReceiverHandlers<TMessage, K>,
+    options?: WebviewRpcReceiverOptions<TOutbound, K>,
 ): void {
     const bridge = useBridge();
     const handlersRef = useRef(handlers);
@@ -89,7 +91,7 @@ export function useRpcDispatcher<
     optionsRef.current = options;
 
     useEffect(() => {
-        const forwardingHandlers: MessageHandlerMap<TMessage, K> = new Proxy({} as MessageHandlerMap<TMessage, K>, {
+        const forwardingHandlers: RpcReceiverHandlers<TMessage, K> = new Proxy({} as RpcReceiverHandlers<TMessage, K>, {
             get(_target, prop: string) {
                 const currentHandler = (handlersRef.current as Record<string, unknown>)[prop];
                 if (typeof currentHandler === 'function') {
@@ -99,7 +101,7 @@ export function useRpcDispatcher<
             },
         });
 
-        const dispatcher = createWebviewRpcDispatcher<TMessage, TOutbound, K>(schema, forwardingHandlers, {
+        const receiver = createWebviewRpcReceiver<TMessage, TOutbound, K>(schema, forwardingHandlers, {
             ...optionsRef.current,
             onError: (err, raw) => optionsRef.current?.onError?.(err, raw),
             messenger: {
@@ -108,12 +110,14 @@ export function useRpcDispatcher<
         });
 
         const unsubscribe = bridge.onMessage(async (msg) => {
-            await dispatcher.dispatch(msg);
+            await receiver.dispatch(msg);
         });
 
         return () => {
             unsubscribe();
-            dispatcher.dispose();
+            receiver.dispose();
         };
     }, [bridge, schema]);
 }
+
+export const useRpcDispatcher = useRpcReceiver;


### PR DESCRIPTION
Standardizes host and webview RPC communication around sender and receiver terminology, replacing the prior mix of dispatcher, client, and emitter identifiers.

- Introduce WebviewRpcReceiver, createWebviewRpcReceiver, and RpcReceiverHandlers for inbound message handling and dispatching.
- Introduce RpcSenderMethods, createWebviewRpcSender, and receiver.sender for typed message broadcasting and request execution.
- Provide useRpcSender and useRpcReceiver React hooks in webview transport while retaining backward-compatible aliases.
- Update CommitDetailsController, LogViewController, and ProcessMonitorController to use WebviewRpcReceiver and sender.
- Remove unused leftover broadcast method on CommitDetailsController.