### PR TITLE
theme: fix semi-transparent orange chart color across VS Code themes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "json.schemas": [
         {
-            "fileMatch": ["src/core/webview/themes.json"],
+            "fileMatch": ["src/core/webview/themes.jsonc"],
             "url": "./src/core/webview/themes.schema.json"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -1241,6 +1241,7 @@
         "adm-zip": "^0.5.16",
         "esbuild": "^0.27.1",
         "handlebars": "^4.7.9",
+        "jsonc-parser": "^3.3.1",
         "npm-run-all": "^4.1.5",
         "ovsx": "^0.10.8",
         "playwright": "^1.58.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5

--- a/src/core/webview/themes.jsonc
+++ b/src/core/webview/themes.jsonc
@@ -3,11 +3,14 @@
         "strategy": "cycle",
         "colors": [
             "var(--vscode-charts-green)",
-            "var(--vscode-charts-orange)",
             "var(--vscode-charts-blue)",
-            "var(--vscode-charts-red)",
-            "var(--vscode-charts-purple)",
             "var(--vscode-charts-yellow)",
+            "var(--vscode-charts-purple)",
+            "var(--vscode-charts-red)",
+            // VS Code's charts.orange fallback delegates to minimapFindMatch / editorFindMatchHighlight,
+            // which has ~33% alpha (#ea5c0055). See: https://github.com/microsoft/vscode/issues/333529
+            // We use --opaque() to strip the alpha channel at build time and guarantee 100% opacity.
+            "--opaque(var(--vscode-charts-orange))",
             "var(--vscode-charts-foreground)"
         ]
     },

--- a/src/core/webview/themes.schema.json
+++ b/src/core/webview/themes.schema.json
@@ -16,6 +16,11 @@
                     "type": "string",
                     "pattern": "^var\\(--[a-zA-Z0-9-]+\\)$",
                     "description": "A VS Code charting color variable (e.g. var(--vscode-charts-green))."
+                },
+                {
+                    "type": "string",
+                    "pattern": "^--opaque\\(var\\(--[a-zA-Z0-9-]+\\)\\)$",
+                    "description": "A CSS custom function polyfill that strips opacity (e.g. --opaque(var(--vscode-charts-orange)))."
                 }
             ]
         },

--- a/tooling/generate-themes.test.ts
+++ b/tooling/generate-themes.test.ts
@@ -3,7 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { describe, expect, it } from 'vitest';
-import { generateThemes, type ThemeJsonConfig } from './generate-themes';
+import { generateThemes, resolveColor, type ThemeJsonConfig } from './generate-themes';
+
+describe('resolveColor', () => {
+    it('should resolve --opaque(var(--variable)) to relative color syntax', () => {
+        expect(resolveColor('--opaque(var(--vscode-charts-orange))')).toBe(
+            'rgb(from var(--vscode-charts-orange) r g b / 1)',
+        );
+    });
+
+    it('should resolve --opaque with whitespace', () => {
+        expect(resolveColor('  --opaque(var(--vscode-charts-blue))  ')).toBe(
+            'rgb(from var(--vscode-charts-blue) r g b / 1)',
+        );
+    });
+
+    it('should leave regular colors unchanged', () => {
+        expect(resolveColor('#ff0000')).toBe('#ff0000');
+        expect(resolveColor('var(--vscode-charts-green)')).toBe('var(--vscode-charts-green)');
+    });
+});
 
 describe('generateThemes', () => {
     it('should generate valid TS and CSS output for a cycle theme', () => {
@@ -53,5 +72,30 @@ describe('generateThemes', () => {
         expect(css).toContain(`.vscode-light .theme-test-clamp {`);
         expect(css).toContain(`--jj-lane-0: #ffffff;`);
         expect(css).toContain(`--jj-lane-1: #eeeeee;`);
+    });
+
+    it('should polyfill --opaque() expressions in colors and lightColors', () => {
+        const mockData: Record<string, ThemeJsonConfig> = {
+            'test-opaque': {
+                strategy: 'cycle',
+                colors: ['var(--vscode-charts-green)', '--opaque(var(--vscode-charts-orange))'],
+                lightColors: ['--opaque(var(--vscode-charts-yellow))'],
+            },
+        };
+
+        const { ts, css } = generateThemes(mockData);
+
+        // Verify TS output preserves count
+        expect(ts).toContain(`'test-opaque': {`);
+        expect(ts).toContain(`count: 2`);
+
+        // Verify CSS output compiles --opaque() to rgb(from ... r g b / 1)
+        expect(css).toContain(`.theme-test-opaque {`);
+        expect(css).toContain(`--jj-lane-0: var(--vscode-charts-green);`);
+        expect(css).toContain(`--jj-lane-1: rgb(from var(--vscode-charts-orange) r g b / 1);`);
+
+        // Verify lightColors compilation
+        expect(css).toContain(`.vscode-light .theme-test-opaque {`);
+        expect(css).toContain(`--jj-lane-0: rgb(from var(--vscode-charts-yellow) r g b / 1);`);
     });
 });

--- a/tooling/generate-themes.ts
+++ b/tooling/generate-themes.ts
@@ -1,12 +1,39 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as parcelWatcher from '@parcel/watcher';
 import Handlebars from 'handlebars';
+import { type ParseError, parse } from 'jsonc-parser';
 
 export interface ThemeJsonConfig {
     strategy: 'cycle' | 'clamp';
     colors: string[];
     lightColors?: string[];
+}
+
+/**
+ * Resolves compile-time color expressions like `--opaque(var(--variable))`
+ * into modern CSS Relative Color Syntax (`rgb(from var(--variable) r g b / 1)`).
+ */
+export function resolveColor(color: string): string {
+    const trimmed = color.trim();
+    const opaqueMatch = /^--opaque\((.+)\)$/.exec(trimmed);
+    if (opaqueMatch) {
+        return `rgb(from ${opaqueMatch[1].trim()} r g b / 1)`;
+    }
+    return trimmed;
+}
+
+function normalizeThemeConfig(config: ThemeJsonConfig): ThemeJsonConfig {
+    return {
+        strategy: config.strategy,
+        colors: config.colors.map(resolveColor),
+        lightColors: config.lightColors ? config.lightColors.map(resolveColor) : undefined,
+    };
 }
 
 const TS_TEMPLATE = `/**
@@ -16,7 +43,7 @@ const TS_TEMPLATE = `/**
 
 /**
  * AUTO-GENERATED FILE. DO NOT EDIT DIRECTLY.
- * Run \`pnpm build:themes\` to update this file from themes.json.
+ * Run \`pnpm build:themes\` to update this file from themes.jsonc.
  */
 
 export interface ThemeConfig {
@@ -57,7 +84,7 @@ const CSS_TEMPLATE = `/**
 
 /**
  * AUTO-GENERATED FILE. DO NOT EDIT DIRECTLY.
- * Run \`pnpm build:themes\` to update this file from themes.json.
+ * Run \`pnpm build:themes\` to update this file from themes.jsonc.
  */
 
 {{#each themes}}
@@ -83,11 +110,14 @@ export function generateThemes(themesData: Record<string, ThemeJsonConfig>): { t
     const tsTemplate = Handlebars.compile(TS_TEMPLATE);
     const cssTemplate = Handlebars.compile(CSS_TEMPLATE);
 
-    const context = { themes: themesData };
+    const normalizedThemes: Record<string, ThemeJsonConfig> = {};
+    for (const [key, theme] of Object.entries(themesData)) {
+        normalizedThemes[key] = normalizeThemeConfig(theme);
+    }
 
     return {
-        ts: tsTemplate(context),
-        css: cssTemplate(context),
+        ts: tsTemplate({ themes: themesData }),
+        css: cssTemplate({ themes: normalizedThemes }),
     };
 }
 
@@ -110,15 +140,21 @@ function writeIfChanged(filePath: string, content: string) {
 
 function runGeneration() {
     try {
-        const themesPath = path.join(import.meta.dirname, '../src/core/webview/themes.json');
+        const themesPath = path.join(import.meta.dirname, '../src/core/webview/themes.jsonc');
         if (!fs.existsSync(themesPath)) {
-            console.error(`Error: themes.json not found at ${themesPath}`);
+            console.error(`Error: themes.jsonc not found at ${themesPath}`);
             return;
         }
 
-        const themesData: Record<string, ThemeJsonConfig> = JSON.parse(fs.readFileSync(themesPath, 'utf8'));
+        const raw = fs.readFileSync(themesPath, 'utf8');
+        const errors: ParseError[] = [];
+        const themesData: unknown = parse(raw, errors);
+        if (errors.length > 0 || !themesData || typeof themesData !== 'object') {
+            console.error(`Error parsing themes.jsonc: ${errors.map((e) => e.error).join(', ')}`);
+            return;
+        }
 
-        const { ts, css } = generateThemes(themesData);
+        const { ts, css } = generateThemes(themesData as Record<string, ThemeJsonConfig>);
 
         const tsOutputPath = path.join(import.meta.dirname, '../src/core/webview/themes.generated.ts');
         const cssOutputPath = path.join(import.meta.dirname, '../media/themes.generated.css');
@@ -132,7 +168,7 @@ function runGeneration() {
 }
 
 async function watchThemes() {
-    const themesPath = path.join(import.meta.dirname, '../src/core/webview/themes.json');
+    const themesPath = path.join(import.meta.dirname, '../src/core/webview/themes.jsonc');
     const themesDir = path.dirname(themesPath);
     const themesFile = path.basename(themesPath);
 


### PR DESCRIPTION
Fix the semi-transparent orange graph lane caused by VS Code's charts.orange fallback to editor search highlights (#ea5c0055). A build-time --opaque(...) polyfill strips the alpha channel via CSS Relative Color Syntax while preserving custom theme colors. Also migrate themes configuration to JSONC with explanatory comments, reorder default lanes to place red and orange on later branches, and add unit test coverage.