### PR TITLE
commit-details: preserve dirty state across background reloads

### DIFF
--- a/src/core/controllers/commit-details-controller.ts
+++ b/src/core/controllers/commit-details-controller.ts
@@ -84,7 +84,7 @@ export class CommitDetailsController implements Disposable {
         return {
             changeId: this.changeId,
             commitId: this._logEntry.commit_id,
-            description: (this._draftDescription ?? this._logEntry.description ?? '').trim(),
+            description: (this._persistedDescription ?? this._logEntry.description ?? '').trim(),
             files: this._changes ? [...this._changes] : [],
             isImmutable: this._logEntry.is_immutable,
             author: this._logEntry.author,

--- a/src/test/commit-details-controller.test.ts
+++ b/src/test/commit-details-controller.test.ts
@@ -78,6 +78,7 @@ describe('CommitDetailsController Domain Unit Tests', () => {
         await controller.load();
         expect(controller.draftDescription).toBe('in-progress draft editing');
         expect(controller.persistedDescription).toBe('persisted description');
+        expect(controller.getState()?.description).toBe('persisted description');
     });
 
     test('saves commit description to real repository', async () => {


### PR DESCRIPTION
Ensure CommitDetailsController.getState() reports the persisted description rather than the active in-progress draft. This prevents background updates from mistaking draft edits for saved state, avoiding unexpected resets to the dirty indicator and protecting draft messages from being overwritten.