### PR TITLE
fix(commit-details): resolve infinite loading on tab reopen

### DIFF
--- a/src/core/controllers/commit-details-controller.ts
+++ b/src/core/controllers/commit-details-controller.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CoalescingQueue } from '../../utils/coalescing-queue';
 import { toError } from '../../utils/error-utils';
 import type { LoggerChannel } from '../../utils/output-channel';
 import { type Disposable, type Event, EventEmitter } from '../host/events';
@@ -31,7 +32,7 @@ export interface CommitDetailsControllerOptions {
 export class CommitDetailsController implements Disposable {
     private _disposed = false;
     private readonly _disposables: Disposable[] = [];
-    private _loadVersion = 0;
+    private readonly _loadQueue: CoalescingQueue;
     private readonly _logger?: LoggerChannel;
     private readonly _receiver: WebviewRpcReceiver<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>;
 
@@ -59,6 +60,13 @@ export class CommitDetailsController implements Disposable {
     ) {
         this._logger = _options?.logger;
         this._receiver = this._createRpcReceiver();
+        this._loadQueue = new CoalescingQueue(async () => {
+            await this._doLoad();
+        });
+    }
+
+    public get isDisposed(): boolean {
+        return this._disposed;
     }
 
     public get logEntry(): JjLogEntry | undefined {
@@ -130,21 +138,31 @@ export class CommitDetailsController implements Disposable {
             return undefined;
         }
 
-        const currentVersion = ++this._loadVersion;
+        await this._loadQueue.run();
+        return this._logEntry;
+    }
+
+    private async _doLoad(): Promise<void> {
+        if (!this.repo || this._disposed) {
+            return;
+        }
+
         try {
             const logsPromise = this.repo.jj.getLog({ revision: this.changeId });
             const changesPromise = this.repo.jj.getChanges(this.changeId).catch(() => null);
 
             const [logs, rawChanges] = await Promise.all([logsPromise, changesPromise]);
 
-            if (currentVersion !== this._loadVersion || this._disposed) {
-                return undefined;
+            if (this._disposed) {
+                return;
             }
 
             if (logs.length === 0) {
+                this._logEntry = undefined;
+                this._changes = undefined;
                 this._logger?.info?.(`[CommitDetailsController] Commit ${this.changeId} not found/deleted`);
                 this._onDidClose.fire(this.changeId);
-                return undefined;
+                return;
             }
 
             const log = logs[0];
@@ -168,13 +186,11 @@ export class CommitDetailsController implements Disposable {
             if (state) {
                 this._receiver.sender.update(state);
             }
-            return log;
         } catch (err) {
             this._logger?.error(
                 `[CommitDetailsController] Failed to load commit details for ${this.changeId}`,
                 toError(err),
             );
-            return undefined;
         }
     }
 

--- a/src/test/commit-details-controller.test.ts
+++ b/src/test/commit-details-controller.test.ts
@@ -6,9 +6,16 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CodeForgeRegistry } from '../core/code-forge-registry';
 import { CommitDetailsController } from '../core/controllers/commit-details-controller';
+import {
+    type CommitDetailsHostToWebviewMessage,
+    CommitDetailsHostToWebviewMessageSchema,
+    type CommitDetailsToHostMessage,
+    CommitDetailsToHostMessageSchema,
+} from '../core/host/ipc/commit-details-schemas';
 import { JjRepositoryManager } from '../core/jj-repository-manager';
 import { Uri } from '../core/uri-utils';
 import { FakeHostEnvironment } from './fake-host-environment';
+import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { createMockLogOutputChannel } from './test-utils';
 
@@ -17,11 +24,10 @@ describe('CommitDetailsController Domain Unit Tests', () => {
     let repositoryManager: JjRepositoryManager;
     let fakeHost: FakeHostEnvironment;
     let controller: CommitDetailsController;
-    let postedMessages: unknown[];
+    let client: MockWebviewClient<CommitDetailsToHostMessage, CommitDetailsHostToWebviewMessage>;
 
     beforeEach(async () => {
         vi.clearAllMocks();
-        postedMessages = [];
         testRepo = new TestRepo();
         testRepo.init();
 
@@ -40,15 +46,20 @@ describe('CommitDetailsController Domain Unit Tests', () => {
             throw new Error('Failed to register repo in test');
         }
 
-        controller = new CommitDetailsController('@', repo, fakeHost);
-        controller.addMessenger({
-            postMessage: (m) => postedMessages.push(m),
+        client = createMockWebviewClient({
+            toHostSchema: CommitDetailsToHostMessageSchema,
+            hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
         });
+
+        controller = new CommitDetailsController('@', repo, fakeHost);
+        controller.addMessenger(client.webview);
     });
 
     afterEach(async () => {
+        client.dispose();
         controller.dispose();
         await repositoryManager.dispose();
+        testRepo.dispose();
     });
 
     test('loads commit details and changes from real repository', async () => {
@@ -117,35 +128,46 @@ describe('CommitDetailsController Domain Unit Tests', () => {
 
         await controller.load();
 
-        const lateMessages: unknown[] = [];
-        controller.addMessenger({
-            postMessage: (m) => lateMessages.push(m),
+        const lateClient = createMockWebviewClient({
+            toHostSchema: CommitDetailsToHostMessageSchema,
+            hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
+        });
+        controller.addMessenger(lateClient.webview);
+        await Promise.resolve();
+
+        expect(lateClient.receivedMessages).toHaveLength(1);
+        expect(lateClient.receivedMessages[0]).toEqual({
+            type: 'update',
+            payload: expect.objectContaining({
+                description: 'initial commit for replay',
+            }),
         });
 
-        expect(lateMessages).toHaveLength(1);
-        expect(lateMessages[0]).toEqual(
-            expect.objectContaining({
-                type: 'update',
-                payload: expect.objectContaining({
-                    description: 'initial commit for replay',
-                }),
-            }),
-        );
+        lateClient.dispose();
     });
 
     test('fires onDidClose only when the last messenger detaches', async () => {
         const repo = await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo.path));
+        if (!repo) {
+            throw new Error('repo not found');
+        }
         const testController = new CommitDetailsController('@', repo, fakeHost);
         const closeListener = vi.fn();
         testController.onDidClose(closeListener);
 
-        const messenger1 = { postMessage: vi.fn() };
-        const messenger2 = { postMessage: vi.fn() };
+        const client1 = createMockWebviewClient({
+            toHostSchema: CommitDetailsToHostMessageSchema,
+            hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
+        });
+        const client2 = createMockWebviewClient({
+            toHostSchema: CommitDetailsToHostMessageSchema,
+            hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
+        });
 
-        const sub1 = testController.addMessenger(messenger1);
-        const sub2 = testController.addMessenger(messenger2);
+        const sub1 = testController.addMessenger(client1.webview);
+        const sub2 = testController.addMessenger(client2.webview);
 
-        // Disposing first messenger does not fire onDidClose because messenger2 is still attached
+        // Disposing first messenger does not fire onDidClose because client2 is still attached
         sub1.dispose();
         expect(closeListener).not.toHaveBeenCalled();
 
@@ -153,6 +175,83 @@ describe('CommitDetailsController Domain Unit Tests', () => {
         sub2.dispose();
         expect(closeListener).toHaveBeenCalledTimes(1);
 
+        client1.dispose();
+        client2.dispose();
         testController.dispose();
+    });
+
+    test('loads commit details for a conflicted commit', async () => {
+        testRepo.writeFile('file.txt', 'base content\n');
+        testRepo.describe('base');
+
+        testRepo.new(['@'], 'side 1');
+        testRepo.writeFile('file.txt', 'side 1 content\n');
+
+        testRepo.new(['@-'], 'side 2');
+        testRepo.writeFile('file.txt', 'side 2 content\n');
+
+        testRepo.new(['@-+', '@'], 'merge with conflict');
+
+        const repo = await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo.path));
+        if (!repo) {
+            throw new Error('repo not found');
+        }
+        const conflictController = new CommitDetailsController('@', repo, fakeHost);
+        const conflictClient = createMockWebviewClient({
+            toHostSchema: CommitDetailsToHostMessageSchema,
+            hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
+        });
+        conflictController.addMessenger(conflictClient.webview);
+
+        const log = await conflictController.load();
+        expect(log).toBeDefined();
+        expect(conflictController.logEntry?.conflict).toBe(true);
+
+        const state = conflictController.getState();
+        expect(state).toBeDefined();
+        expect(state?.isConflict).toBe(true);
+
+        const updates = conflictClient.receivedMessages.filter((m) => m.type === 'update');
+        expect(updates.length).toBeGreaterThanOrEqual(1);
+        expect(updates[0]).toEqual({
+            type: 'update',
+            payload: expect.objectContaining({
+                isConflict: true,
+            }),
+        });
+
+        conflictClient.dispose();
+        conflictController.dispose();
+    });
+
+    test('loads commit details for a divergent commit', async () => {
+        testRepo.writeFile('file.txt', 'v1\n');
+        testRepo.describe('feature v1');
+        const changeId = testRepo.getChangeId('@');
+        const commitIdV1 = testRepo.getCommitId('@');
+
+        testRepo.describe('feature v2', changeId);
+        testRepo.bookmark('old-version', commitIdV1);
+
+        const repo = await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo.path));
+        if (!repo) {
+            throw new Error('repo not found');
+        }
+
+        const logs = await repo.jj.getLog({ revision: 'all()' });
+        const divergentEntry = logs.find((l) => l.is_divergent);
+        expect(divergentEntry).toBeDefined();
+        if (!divergentEntry) {
+            throw new Error('divergentEntry not found');
+        }
+        expect(divergentEntry.change_id).toContain('/');
+
+        const divergentController = new CommitDetailsController(divergentEntry.change_id, repo, fakeHost);
+        const log = await divergentController.load();
+        expect(log).toBeDefined();
+        expect(divergentController.logEntry?.change_id).toBe(divergentEntry.change_id);
+        expect(divergentController.getState()?.changeId).toBe(divergentEntry.change_id);
+
+        divergentController.dispose();
     });
 });

--- a/src/test/mock-webview-client.ts
+++ b/src/test/mock-webview-client.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { vi } from 'vitest';
+import type * as vscode from 'vscode';
+import type { z } from 'zod';
+import {
+    createWebviewRpcReceiver,
+    createWebviewRpcSender,
+    type DiscriminatedMessage,
+    type RpcReceiverHandlers,
+    type RpcSenderMethods,
+    type WebviewRpcReceiver,
+} from '../core/host/webview-rpc-dispatcher';
+import { createMock } from './test-utils';
+
+export interface MockWebviewClient<
+    TToHost extends DiscriminatedMessage<'type'>,
+    THostToWebview extends DiscriminatedMessage<'type'>,
+> {
+    panel: vscode.WebviewPanel;
+    view: vscode.WebviewView;
+    webview: vscode.Webview;
+    sender: RpcSenderMethods<TToHost, 'type', Promise<unknown>>;
+    receiver: WebviewRpcReceiver<THostToWebview, TToHost, 'type'>;
+    receivedMessages: THostToWebview[];
+    triggerVisibilityChange: (visible: boolean) => void;
+    dispose: () => void;
+}
+
+export interface MockWebviewClientOptions<
+    TToHost extends DiscriminatedMessage<'type'>,
+    THostToWebview extends DiscriminatedMessage<'type'>,
+> {
+    toHostSchema: z.ZodType<TToHost>;
+    hostToWebviewSchema: z.ZodType<THostToWebview>;
+    handlers?: Partial<RpcReceiverHandlers<THostToWebview, 'type'>>;
+}
+
+/**
+ * Creates a type-safe mock webview client connected to a mock WebviewPanel, WebviewView, and Webview.
+ * Automatically wires bi-directional RPC dispatching and validates messages against the provided schemas.
+ */
+export function createMockWebviewClient<
+    TToHost extends DiscriminatedMessage<'type'>,
+    THostToWebview extends DiscriminatedMessage<'type'>,
+>(options: MockWebviewClientOptions<TToHost, THostToWebview>): MockWebviewClient<TToHost, THostToWebview> {
+    let hostMessageListener: ((msg: unknown) => Promise<void> | void) | undefined;
+    let disposeListener: (() => void) | undefined;
+    let visibilityListener: ((e: undefined) => void) | undefined;
+    const receivedMessages: THostToWebview[] = [];
+
+    const handlersProxy = new Proxy({} as RpcReceiverHandlers<THostToWebview, 'type'>, {
+        get(_target, prop: string) {
+            return async (payload: unknown) => {
+                const message = payload !== undefined ? { type: prop, payload } : { type: prop };
+                receivedMessages.push(message as THostToWebview);
+                const customHandler = options.handlers?.[prop as keyof typeof options.handlers];
+                if (typeof customHandler === 'function') {
+                    return (customHandler as (p: unknown) => unknown)(payload);
+                }
+                return undefined;
+            };
+        },
+    });
+
+    const receiver = createWebviewRpcReceiver<THostToWebview, TToHost, 'type'>(
+        options.hostToWebviewSchema,
+        handlersProxy,
+    );
+
+    const webview = createMock<vscode.Webview>({
+        options: {},
+        html: '',
+        cspSource: 'vscode-webview:',
+        asWebviewUri: (uri: vscode.Uri) => uri,
+        onDidReceiveMessage: vi.fn((listener: (msg: unknown) => Promise<void> | void) => {
+            hostMessageListener = listener;
+            return {
+                dispose: () => {
+                    hostMessageListener = undefined;
+                },
+            };
+        }),
+        postMessage: vi.fn(async (msg: unknown) => {
+            await receiver.dispatch(msg);
+            return true;
+        }),
+    });
+
+    const panel = createMock<vscode.WebviewPanel>({
+        webview,
+        onDidDispose: vi.fn((listener: () => void) => {
+            disposeListener = listener;
+            return {
+                dispose: () => {
+                    disposeListener = undefined;
+                },
+            };
+        }),
+        dispose: vi.fn(() => {
+            disposeListener?.();
+        }),
+    });
+
+    const view = createMock<vscode.WebviewView>({
+        webview,
+        visible: true,
+        onDidChangeVisibility: vi.fn((listener: (e: undefined) => void) => {
+            visibilityListener = listener;
+            return {
+                dispose: () => {
+                    visibilityListener = undefined;
+                },
+            };
+        }),
+        onDidDispose: vi.fn((listener: () => void) => {
+            disposeListener = listener;
+            return {
+                dispose: () => {
+                    disposeListener = undefined;
+                },
+            };
+        }),
+        show: vi.fn(),
+    });
+
+    const clientBridge = {
+        postMessage: (msg: unknown) => {
+            if (hostMessageListener) {
+                void hostMessageListener(msg);
+            }
+        },
+    };
+
+    const sender = createWebviewRpcSender<TToHost, 'type'>(clientBridge, options.toHostSchema);
+
+    return {
+        panel,
+        view,
+        webview,
+        sender,
+        receiver,
+        receivedMessages,
+        triggerVisibilityChange: (visible: boolean) => {
+            (view as { visible: boolean }).visible = visible;
+            visibilityListener?.(undefined);
+        },
+        dispose: () => {
+            receiver.dispose();
+            disposeListener?.();
+        },
+    };
+}

--- a/src/test/vscode-commit-details-editor-provider.test.ts
+++ b/src/test/vscode-commit-details-editor-provider.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type * as vscode from 'vscode';
+
+vi.mock('vscode', async () => {
+    const { createVscodeMock } = await import('./vscode-mock');
+    return createVscodeMock();
+});
+
+import { CodeForgeRegistry } from '../core/code-forge-registry';
+import {
+    type CommitDetailsHostToWebviewMessage,
+    CommitDetailsHostToWebviewMessageSchema,
+    type CommitDetailsPayload,
+    CommitDetailsToHostMessageSchema,
+} from '../core/host/ipc/commit-details-schemas';
+import type { RpcReceiverHandlers } from '../core/host/webview-rpc-dispatcher';
+import { JjRepositoryManager } from '../core/jj-repository-manager';
+import { createCommitDetailsUri, Uri } from '../core/uri-utils';
+import {
+    JjCommitDocument,
+    VsCodeCommitDetailsEditorProvider,
+} from '../vscode/providers/vscode-commit-details-editor-provider';
+import { FakeHostEnvironment } from './fake-host-environment';
+import { createMockWebviewClient } from './mock-webview-client';
+import { TestRepo } from './test-repo';
+import { createMock, createMockLogOutputChannel } from './test-utils';
+
+function createCommitDetailsClient(handlers?: Partial<RpcReceiverHandlers<CommitDetailsHostToWebviewMessage, 'type'>>) {
+    const receivedUpdates: CommitDetailsPayload[] = [];
+    const client = createMockWebviewClient({
+        toHostSchema: CommitDetailsToHostMessageSchema,
+        hostToWebviewSchema: CommitDetailsHostToWebviewMessageSchema,
+        handlers: {
+            update: (payload) => {
+                receivedUpdates.push(payload);
+            },
+            ...handlers,
+        },
+    });
+
+    return {
+        ...client,
+        receivedUpdates,
+    };
+}
+
+describe('VsCodeCommitDetailsEditorProvider Unit & Concurrency Tests', () => {
+    let testRepo: TestRepo;
+    let testRepo2: TestRepo | undefined;
+    let repositoryManager: JjRepositoryManager;
+    let fakeHost: FakeHostEnvironment;
+    let provider: VsCodeCommitDetailsEditorProvider;
+    let extensionContext: vscode.ExtensionContext;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        testRepo = new TestRepo();
+        testRepo.init();
+        testRepo.writeFile('file.txt', 'initial content\n');
+        testRepo.describe('initial commit');
+
+        fakeHost = new FakeHostEnvironment();
+        fakeHost.workspace.addFolder(Uri.file(testRepo.path));
+
+        const registry = new CodeForgeRegistry();
+        const outputChannel = createMockLogOutputChannel({
+            appendLine: () => {},
+        });
+
+        repositoryManager = new JjRepositoryManager(registry, outputChannel, fakeHost);
+        await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo.path));
+
+        extensionContext = createMock<vscode.ExtensionContext>({
+            subscriptions: [],
+        });
+
+        provider = new VsCodeCommitDetailsEditorProvider(
+            Uri.file('/extension/path'),
+            repositoryManager,
+            extensionContext,
+        );
+    });
+
+    afterEach(async () => {
+        provider.dispose();
+        await repositoryManager.dispose();
+        testRepo.dispose();
+        testRepo2?.dispose();
+        testRepo2 = undefined;
+    });
+
+    test('switching/reopening tabs preserves controller lifecycle and delivers commit details to new webview', async () => {
+        const changeId = testRepo.getChangeId('@');
+        const repoRoot = Uri.file(testRepo.path);
+        const docUri = createCommitDetailsUri({
+            repoRoot: testRepo.path,
+            changeId,
+            title: `Commit: ${changeId}`,
+        });
+        const document = new JjCommitDocument(docUri, changeId, repoRoot);
+        const cancellationToken = createMock<vscode.CancellationToken>({
+            isCancellationRequested: false,
+        });
+
+        // 1. First tab opens and loads details
+        const client1 = createCommitDetailsClient();
+        await provider.resolveCustomEditor(document, client1.panel, cancellationToken);
+        await client1.sender.webviewLoaded();
+
+        // Verify client1 received the commit update
+        expect(client1.receivedUpdates.length).toBeGreaterThanOrEqual(1);
+
+        // 2. User switches commits or re-opens commit -> second tab opens for the same commit
+        const client2 = createCommitDetailsClient();
+        const resolvePromise = provider.resolveCustomEditor(document, client2.panel, cancellationToken);
+
+        // 3. The first tab is closed (e.g. by closeOtherCommitDetailsTabs or user closing tab)
+        client1.dispose();
+
+        await resolvePromise;
+
+        // 4. Client 2 finishes rendering HTML and sends webviewLoaded
+        await client2.sender.webviewLoaded();
+
+        // 5. Check if client2 receives the commit details payload
+        expect(client2.receivedUpdates.length).toBeGreaterThanOrEqual(1);
+        expect(client2.receivedUpdates[0]).toEqual(
+            expect.objectContaining({
+                changeId,
+            }),
+        );
+    });
+
+    test('concurrent refresh during custom editor resolution does not dispose the webview panel', async () => {
+        const changeId = testRepo.getChangeId('@');
+        const repoRoot = Uri.file(testRepo.path);
+        const docUri = createCommitDetailsUri({
+            repoRoot: testRepo.path,
+            changeId,
+            title: `Commit: ${changeId}`,
+        });
+        const document = new JjCommitDocument(docUri, changeId, repoRoot);
+        const cancellationToken = createMock<vscode.CancellationToken>({
+            isCancellationRequested: false,
+        });
+
+        const client = createCommitDetailsClient();
+        const resolvePromise = provider.resolveCustomEditor(document, client.panel, cancellationToken);
+
+        // Concurrent background refresh occurs while load() is in flight
+        await provider.refresh();
+
+        await resolvePromise;
+
+        // Panel should NOT have been disposed
+        expect(client.panel.dispose).not.toHaveBeenCalled();
+
+        await client.sender.webviewLoaded();
+        expect(client.receivedUpdates.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test('isolates controllers across different repository roots in multi-root workspaces', async () => {
+        testRepo2 = new TestRepo();
+        testRepo2.init();
+        testRepo2.writeFile('file2.txt', 'repo2 content\n');
+        testRepo2.describe('repo2 commit');
+
+        fakeHost.workspace.addFolder(Uri.file(testRepo2.path));
+        await repositoryManager.maybeRegisterRepositoryContainingUri(Uri.file(testRepo2.path));
+
+        const cancellationToken = createMock<vscode.CancellationToken>({
+            isCancellationRequested: false,
+        });
+
+        // Use '@' for both repos
+        const doc1 = new JjCommitDocument(
+            createCommitDetailsUri({ repoRoot: testRepo.path, changeId: '@', title: 'Commit: @' }),
+            '@',
+            Uri.file(testRepo.path),
+        );
+        const doc2 = new JjCommitDocument(
+            createCommitDetailsUri({ repoRoot: testRepo2.path, changeId: '@', title: 'Commit: @' }),
+            '@',
+            Uri.file(testRepo2.path),
+        );
+
+        const client1 = createCommitDetailsClient();
+        const client2 = createCommitDetailsClient();
+
+        await provider.resolveCustomEditor(doc1, client1.panel, cancellationToken);
+        await provider.resolveCustomEditor(doc2, client2.panel, cancellationToken);
+
+        const controller1 = provider.getController('@', Uri.file(testRepo.path));
+        const controller2 = provider.getController('@', Uri.file(testRepo2.path));
+
+        expect(controller1).toBeDefined();
+        expect(controller2).toBeDefined();
+        expect(controller1).not.toBe(controller2);
+        expect(controller1?.repo?.rootUri.fsPath).toBeSameFsPath(testRepo.path);
+        expect(controller2?.repo?.rootUri.fsPath).toBeSameFsPath(testRepo2.path);
+
+        client1.dispose();
+        client2.dispose();
+    });
+
+    test('refresh() reloads all open controllers and pushes updated repository state to webviews', async () => {
+        testRepo.writeFile('file1.txt', 'commit 1 content\n');
+        testRepo.describe('commit 1');
+        const changeId1 = testRepo.getChangeId('@');
+
+        testRepo.new(['@'], 'commit 2');
+        testRepo.writeFile('file2.txt', 'commit 2 content\n');
+        const changeId2 = testRepo.getChangeId('@');
+
+        const repoRoot = Uri.file(testRepo.path);
+        const cancellationToken = createMock<vscode.CancellationToken>({ isCancellationRequested: false });
+
+        const doc1 = new JjCommitDocument(
+            createCommitDetailsUri({ repoRoot: testRepo.path, changeId: changeId1, title: `Commit: ${changeId1}` }),
+            changeId1,
+            repoRoot,
+        );
+        const doc2 = new JjCommitDocument(
+            createCommitDetailsUri({ repoRoot: testRepo.path, changeId: changeId2, title: `Commit: ${changeId2}` }),
+            changeId2,
+            repoRoot,
+        );
+
+        const client1 = createCommitDetailsClient();
+        const client2 = createCommitDetailsClient();
+
+        await provider.resolveCustomEditor(doc1, client1.panel, cancellationToken);
+        await provider.resolveCustomEditor(doc2, client2.panel, cancellationToken);
+
+        // Initial webview handshake via typed RPC sender
+        await client1.sender.webviewLoaded();
+        await client2.sender.webviewLoaded();
+
+        expect(client1.receivedUpdates[0]).toEqual(
+            expect.objectContaining({
+                changeId: changeId1,
+                description: 'commit 1',
+            }),
+        );
+        expect(client2.receivedUpdates[0]).toEqual(
+            expect.objectContaining({
+                changeId: changeId2,
+                description: 'commit 2',
+            }),
+        );
+
+        // 1. Modify both commits externally in Jujutsu
+        testRepo.describe('commit 1 updated description', changeId1);
+        testRepo.describe('commit 2 updated description', changeId2);
+
+        // 2. Trigger provider.refresh()
+        await provider.refresh();
+
+        // 3. Verify both webviews received the updated state via RPC receiver
+        expect(client1.receivedUpdates.length).toBeGreaterThanOrEqual(2);
+        expect(client2.receivedUpdates.length).toBeGreaterThanOrEqual(2);
+
+        const client1Latest = client1.receivedUpdates[client1.receivedUpdates.length - 1];
+        const client2Latest = client2.receivedUpdates[client2.receivedUpdates.length - 1];
+
+        expect(client1Latest).toEqual(
+            expect.objectContaining({
+                changeId: changeId1,
+                description: 'commit 1 updated description',
+            }),
+        );
+        expect(client2Latest).toEqual(
+            expect.objectContaining({
+                changeId: changeId2,
+                description: 'commit 2 updated description',
+            }),
+        );
+
+        client1.dispose();
+        client2.dispose();
+    });
+});

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -214,7 +214,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     e.affectsConfiguration('jj-view.minChangeIdLength') ||
                     e.affectsConfiguration('jj-view.logTheme')
                 ) {
-                    await commitDetailsProvider.refresh('config change');
+                    await commitDetailsProvider.refresh();
                 }
             }),
         );
@@ -458,7 +458,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     // Refresh webview and commit details panel in parallel
                     await Promise.all([
                         logWebviewProvider.controller.refresh(event.reason),
-                        commitDetailsProvider.refresh(event.reason),
+                        commitDetailsProvider.refresh(),
                     ]);
                 }
             });

--- a/src/vscode/providers/vscode-commit-details-editor-provider.ts
+++ b/src/vscode/providers/vscode-commit-details-editor-provider.ts
@@ -39,7 +39,6 @@ export class VsCodeCommitDetailsEditorProvider
     public readonly onDidClosePanel = this._onDidClosePanel.event;
 
     private readonly _controllers = new Map<string, CommitDetailsController>();
-    private readonly _disposables: vscode.Disposable[] = [];
 
     constructor(
         private readonly _extensionUri: Uri,
@@ -47,19 +46,17 @@ export class VsCodeCommitDetailsEditorProvider
         private readonly _context: vscode.ExtensionContext,
     ) {}
 
-    public getController(changeId: string): CommitDetailsController | undefined {
-        return this._controllers.get(changeId);
+    private _getControllerKey(changeId: string, repoRoot?: Uri): string {
+        const rootPath = repoRoot?.fsPath ?? '';
+        return rootPath ? `${rootPath}#${changeId}` : changeId;
     }
 
-    public async refresh(changeId?: string): Promise<void> {
-        if (changeId && this._controllers.has(changeId)) {
-            const controller = this._controllers.get(changeId);
-            if (controller) {
-                await controller.load();
-            }
-            return;
-        }
+    public getController(changeId: string, repoRoot?: Uri): CommitDetailsController | undefined {
+        const key = this._getControllerKey(changeId, repoRoot);
+        return this._controllers.get(key) ?? this._controllers.get(changeId);
+    }
 
+    public async refresh(): Promise<void> {
         for (const controller of this._controllers.values()) {
             await controller.load();
         }
@@ -69,7 +66,8 @@ export class VsCodeCommitDetailsEditorProvider
         document: JjCommitDocument,
         _cancellation: vscode.CancellationToken,
     ): Promise<void> {
-        const controller = this._controllers.get(document.changeId);
+        const key = this._getControllerKey(document.changeId, document.repoRoot);
+        const controller = this._controllers.get(key) ?? this._controllers.get(document.changeId);
         if (controller) {
             await controller.save();
         }
@@ -128,7 +126,13 @@ export class VsCodeCommitDetailsEditorProvider
             context: this._context,
         });
 
-        let controller = this._controllers.get(document.changeId);
+        const controllerKey = this._getControllerKey(document.changeId, document.repoRoot ?? repo.rootUri);
+        let controller = this._controllers.get(controllerKey);
+        if (controller?.isDisposed) {
+            this._controllers.delete(controllerKey);
+            controller = undefined;
+        }
+
         if (!controller) {
             const newController = new CommitDetailsController(document.changeId, repo, host, {
                 logger: this._repositoryManager.outputChannel,
@@ -150,22 +154,14 @@ export class VsCodeCommitDetailsEditorProvider
                     }
                 },
             });
-            this._controllers.set(document.changeId, newController);
+            this._controllers.set(controllerKey, newController);
             controller = newController;
 
             newController.onDidClose(() => {
-                this._controllers.delete(document.changeId);
+                this._controllers.delete(controllerKey);
                 this._onDidClosePanel.fire(document.changeId);
                 newController.dispose();
             });
-        }
-
-        const log = await controller.load();
-        if (!log) {
-            this._controllers.delete(document.changeId);
-            controller.dispose();
-            panel.dispose();
-            return;
         }
 
         panel.webview.options = {
@@ -175,7 +171,14 @@ export class VsCodeCommitDetailsEditorProvider
         };
 
         const messageDisposable = panel.webview.onDidReceiveMessage(async (message: unknown) => {
-            await controller.handleMessage(message);
+            try {
+                await controller.handleMessage(message);
+            } catch (err) {
+                this._repositoryManager.outputChannel.error(
+                    `[VsCodeCommitDetailsEditorProvider] Error handling message for ${document.changeId}:`,
+                    err instanceof Error ? err : new Error(String(err)),
+                );
+            }
         });
         const messengerDisposable = controller.addMessenger(panel.webview);
 
@@ -185,6 +188,12 @@ export class VsCodeCommitDetailsEditorProvider
                 d.dispose();
             }
         });
+
+        const log = await controller.load();
+        if (!log && !controller.isDisposed) {
+            panel.dispose();
+            return;
+        }
 
         panel.webview.html = getWebviewHtml({
             webview: panel.webview,
@@ -199,10 +208,6 @@ export class VsCodeCommitDetailsEditorProvider
             controller.dispose();
         }
         this._controllers.clear();
-        for (const d of this._disposables) {
-            d.dispose();
-        }
-        this._disposables.length = 0;
         this._onDidChangeCustomDocument.dispose();
         this._onDidClosePanel.dispose();
     }


### PR DESCRIPTION
- Attach webview listener and controller messenger before awaiting load() during custom editor resolution.
- Key controllers by compound rootUri#changeId to isolate multi-root workspaces.
- Check controller isDisposed before reusing in resolveCustomEditor.
- Simplify commitDetailsProvider.refresh to a parameterless call that reloads all active controllers.
- Add generic type-safe createMockWebviewClient test helper and comprehensive unit tests.