### PR TITLE
test(webview): migrate webview test suites to createMockWebviewClient

### DIFF
--- a/src/test/mock-webview-client.ts
+++ b/src/test/mock-webview-client.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { vi } from 'vitest';
 import type * as vscode from 'vscode';
 import type { z } from 'zod';
 import {
@@ -17,26 +16,29 @@ import {
 import { createMock } from './test-utils';
 
 export interface MockWebviewClient<
-    TToHost extends DiscriminatedMessage<'type'>,
+    TToHost extends DiscriminatedMessage<KToHost>,
     THostToWebview extends DiscriminatedMessage<'type'>,
+    KToHost extends string = 'type',
 > {
     panel: vscode.WebviewPanel;
     view: vscode.WebviewView;
     webview: vscode.Webview;
-    sender: RpcSenderMethods<TToHost, 'type', Promise<unknown>>;
-    receiver: WebviewRpcReceiver<THostToWebview, TToHost, 'type'>;
+    sender: RpcSenderMethods<TToHost, KToHost, Promise<unknown>>;
+    receiver: WebviewRpcReceiver<THostToWebview, DiscriminatedMessage<'type'>, 'type'>;
     receivedMessages: THostToWebview[];
     triggerVisibilityChange: (visible: boolean) => void;
     dispose: () => void;
 }
 
 export interface MockWebviewClientOptions<
-    TToHost extends DiscriminatedMessage<'type'>,
+    TToHost extends DiscriminatedMessage<KToHost>,
     THostToWebview extends DiscriminatedMessage<'type'>,
+    KToHost extends string = 'type',
 > {
     toHostSchema: z.ZodType<TToHost>;
     hostToWebviewSchema: z.ZodType<THostToWebview>;
     handlers?: Partial<RpcReceiverHandlers<THostToWebview, 'type'>>;
+    toHostDiscriminatorKey?: KToHost;
 }
 
 /**
@@ -44,12 +46,16 @@ export interface MockWebviewClientOptions<
  * Automatically wires bi-directional RPC dispatching and validates messages against the provided schemas.
  */
 export function createMockWebviewClient<
-    TToHost extends DiscriminatedMessage<'type'>,
+    TToHost extends DiscriminatedMessage<KToHost>,
     THostToWebview extends DiscriminatedMessage<'type'>,
->(options: MockWebviewClientOptions<TToHost, THostToWebview>): MockWebviewClient<TToHost, THostToWebview> {
+    KToHost extends string = 'type',
+>(
+    options: MockWebviewClientOptions<TToHost, THostToWebview, KToHost>,
+): MockWebviewClient<TToHost, THostToWebview, KToHost> {
     let hostMessageListener: ((msg: unknown) => Promise<void> | void) | undefined;
     let disposeListener: (() => void) | undefined;
     let visibilityListener: ((e: undefined) => void) | undefined;
+    let isVisible = true;
     const receivedMessages: THostToWebview[] = [];
 
     const handlersProxy = new Proxy({} as RpcReceiverHandlers<THostToWebview, 'type'>, {
@@ -66,7 +72,7 @@ export function createMockWebviewClient<
         },
     });
 
-    const receiver = createWebviewRpcReceiver<THostToWebview, TToHost, 'type'>(
+    const receiver = createWebviewRpcReceiver<THostToWebview, DiscriminatedMessage<'type'>, 'type'>(
         options.hostToWebviewSchema,
         handlersProxy,
     );
@@ -76,66 +82,71 @@ export function createMockWebviewClient<
         html: '',
         cspSource: 'vscode-webview:',
         asWebviewUri: (uri: vscode.Uri) => uri,
-        onDidReceiveMessage: vi.fn((listener: (msg: unknown) => Promise<void> | void) => {
+        onDidReceiveMessage: (listener: (msg: unknown) => Promise<void> | void) => {
             hostMessageListener = listener;
             return {
                 dispose: () => {
                     hostMessageListener = undefined;
                 },
             };
-        }),
-        postMessage: vi.fn(async (msg: unknown) => {
+        },
+        postMessage: async (msg: unknown) => {
             await receiver.dispatch(msg);
             return true;
-        }),
+        },
     });
 
     const panel = createMock<vscode.WebviewPanel>({
         webview,
-        onDidDispose: vi.fn((listener: () => void) => {
+        onDidDispose: (listener: () => void) => {
             disposeListener = listener;
             return {
                 dispose: () => {
                     disposeListener = undefined;
                 },
             };
-        }),
-        dispose: vi.fn(() => {
+        },
+        dispose: () => {
             disposeListener?.();
-        }),
+        },
     });
 
     const view = createMock<vscode.WebviewView>({
         webview,
-        visible: true,
-        onDidChangeVisibility: vi.fn((listener: (e: undefined) => void) => {
+        get visible() {
+            return isVisible;
+        },
+        onDidChangeVisibility: (listener: (e: undefined) => void) => {
             visibilityListener = listener;
             return {
                 dispose: () => {
                     visibilityListener = undefined;
                 },
             };
-        }),
-        onDidDispose: vi.fn((listener: () => void) => {
+        },
+        onDidDispose: (listener: () => void) => {
             disposeListener = listener;
             return {
                 dispose: () => {
                     disposeListener = undefined;
                 },
             };
-        }),
-        show: vi.fn(),
+        },
+        show: () => {},
     });
 
     const clientBridge = {
         postMessage: (msg: unknown) => {
             if (hostMessageListener) {
-                void hostMessageListener(msg);
+                return hostMessageListener(msg);
             }
+            return undefined;
         },
     };
 
-    const sender = createWebviewRpcSender<TToHost, 'type'>(clientBridge, options.toHostSchema);
+    const sender = createWebviewRpcSender<TToHost, KToHost>(clientBridge, options.toHostSchema, {
+        discriminatorKey: options.toHostDiscriminatorKey,
+    });
 
     return {
         panel,
@@ -145,7 +156,7 @@ export function createMockWebviewClient<
         receiver,
         receivedMessages,
         triggerVisibilityChange: (visible: boolean) => {
-            (view as { visible: boolean }).visible = visible;
+            isVisible = visible;
             visibilityListener?.(undefined);
         },
         dispose: () => {

--- a/src/test/process-monitor-controller.test.ts
+++ b/src/test/process-monitor-controller.test.ts
@@ -6,29 +6,40 @@
 import type { ChildProcess } from 'node:child_process';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ProcessMonitorController } from '../core/controllers/process-monitor-controller';
+import {
+    type ProcessMonitorHostToWebviewMessage,
+    ProcessMonitorHostToWebviewMessageSchema,
+    type ProcessMonitorToHostMessage,
+    ProcessMonitorToHostMessageSchema,
+} from '../core/host/ipc/process-monitor-schemas';
 import { JjProcessTracker } from '../core/jj-process-tracker';
 import { FakeHostEnvironment } from './fake-host-environment';
+import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-client';
 import { createMock } from './test-utils';
 
 describe('ProcessMonitorController Domain Unit Tests', () => {
     let tracker: JjProcessTracker;
     let fakeHost: FakeHostEnvironment;
     let controller: ProcessMonitorController;
-    let postedMessages: unknown[];
+    let client: MockWebviewClient<ProcessMonitorToHostMessage, ProcessMonitorHostToWebviewMessage, 'command'>;
 
     beforeEach(() => {
         tracker = new JjProcessTracker();
         fakeHost = new FakeHostEnvironment();
-        postedMessages = [];
+
+        client = createMockWebviewClient({
+            toHostSchema: ProcessMonitorToHostMessageSchema,
+            hostToWebviewSchema: ProcessMonitorHostToWebviewMessageSchema,
+            toHostDiscriminatorKey: 'command',
+        });
 
         controller = new ProcessMonitorController(tracker, fakeHost, {
-            messenger: {
-                postMessage: (m) => postedMessages.push(m),
-            },
+            messenger: client.webview,
         });
     });
 
     afterEach(() => {
+        client.dispose();
         controller.dispose();
     });
 
@@ -79,13 +90,16 @@ describe('ProcessMonitorController Domain Unit Tests', () => {
     });
 
     test('replays initial snapshot on setMessenger and responds to webviewLoaded', async () => {
-        const newMessages: unknown[] = [];
-        controller.setMessenger({
-            postMessage: (m) => newMessages.push(m),
+        const newClient = createMockWebviewClient({
+            toHostSchema: ProcessMonitorToHostMessageSchema,
+            hostToWebviewSchema: ProcessMonitorHostToWebviewMessageSchema,
+            toHostDiscriminatorKey: 'command',
         });
+        controller.setMessenger(newClient.webview);
+        await Promise.resolve();
 
-        expect(newMessages).toHaveLength(1);
-        expect(newMessages[0]).toEqual(
+        expect(newClient.receivedMessages).toHaveLength(1);
+        expect(newClient.receivedMessages[0]).toEqual(
             expect.objectContaining({
                 type: 'update',
                 payload: expect.objectContaining({
@@ -98,6 +112,9 @@ describe('ProcessMonitorController Domain Unit Tests', () => {
 
         const loadedHandled = await controller.handleMessage({ command: 'webviewLoaded' });
         expect(loadedHandled).toBe(true);
-        expect(newMessages).toHaveLength(2);
+        await Promise.resolve();
+        expect(newClient.receivedMessages).toHaveLength(2);
+
+        newClient.dispose();
     });
 });

--- a/src/test/vscode-commit-details-editor-provider.test.ts
+++ b/src/test/vscode-commit-details-editor-provider.test.ts
@@ -150,6 +150,7 @@ describe('VsCodeCommitDetailsEditorProvider Unit & Concurrency Tests', () => {
         });
 
         const client = createCommitDetailsClient();
+        const disposeSpy = vi.spyOn(client.panel, 'dispose');
         const resolvePromise = provider.resolveCustomEditor(document, client.panel, cancellationToken);
 
         // Concurrent background refresh occurs while load() is in flight
@@ -158,7 +159,7 @@ describe('VsCodeCommitDetailsEditorProvider Unit & Concurrency Tests', () => {
         await resolvePromise;
 
         // Panel should NOT have been disposed
-        expect(client.panel.dispose).not.toHaveBeenCalled();
+        expect(disposeSpy).not.toHaveBeenCalled();
 
         await client.sender.webviewLoaded();
         expect(client.receivedUpdates.length).toBeGreaterThanOrEqual(1);

--- a/src/test/webview-commands.integration.test.ts
+++ b/src/test/webview-commands.integration.test.ts
@@ -13,6 +13,12 @@ import { redoCommand } from '../core/commands/redo';
 import { squashRevisionIntoParentCommand } from '../core/commands/squash-revision';
 import { undoCommand } from '../core/commands/undo';
 import type { CommentsManager } from '../core/comments-manager';
+import {
+    type LogViewHostToWebviewMessage,
+    LogViewHostToWebviewMessageSchema,
+    type LogViewToHostMessage,
+    LogViewToHostMessageSchema,
+} from '../core/host/ipc/log-view-schemas';
 import { Uri } from '../core/uri-utils';
 import { createAbandonPayload } from '../vscode/payloads/abandon.payload';
 import { createEditPayload } from '../vscode/payloads/edit.payload';
@@ -25,46 +31,19 @@ import {
     createTestRepositoryContext,
     type TestRepositoryContext,
 } from './integration-test-utils';
+import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { asSinonStub, createMock } from './test-utils';
 
 suite('Webview Commands End-to-End Integration Test', () => {
     let scm: VsCodeScmProvider;
     let provider: VsCodeLogWebviewProvider;
-    let messageHandler: (m: unknown) => Promise<void>;
+    let client: MockWebviewClient<LogViewToHostMessage, LogViewHostToWebviewMessage>;
     let repo: TestRepo;
     let disposables: vscode.Disposable[] = [];
     let executeCommandStub: sinon.SinonStub;
     let outputChannel: vscode.LogOutputChannel;
     let contextHelper: TestRepositoryContext;
-
-    // Mock Webview
-    const mockWebview = createMock<vscode.Webview>({
-        options: {},
-        html: '',
-        onDidReceiveMessage: (handler: (m: unknown) => Promise<void>) => {
-            messageHandler = handler;
-            return { dispose: () => {} };
-        },
-        asWebviewUri: (uri: Uri) => uri,
-        cspSource: '',
-        postMessage: async () => {
-            return true;
-        },
-    });
-
-    const mockWebviewView = createMock<vscode.WebviewView>({
-        webview: mockWebview,
-        viewType: 'jj-view.logView',
-        onDidChangeVisibility: () => {
-            return { dispose: () => {} };
-        },
-        onDidDispose: () => {
-            return { dispose: () => {} };
-        },
-        visible: true,
-    });
-
     let showInfoStub: sinon.SinonStub;
 
     setup(async () => {
@@ -143,15 +122,21 @@ suite('Webview Commands End-to-End Integration Test', () => {
             return asSinonStub(executeCommandStub).wrappedMethod.call(vscode.commands, command, ...args);
         });
 
+        client = createMockWebviewClient({
+            toHostSchema: LogViewToHostMessageSchema,
+            hostToWebviewSchema: LogViewHostToWebviewMessageSchema,
+        });
+
         // Webview Provider
         provider.resolveWebviewView(
-            mockWebviewView,
+            client.view,
             createMock<vscode.WebviewViewResolveContext>({}),
             createMock<vscode.CancellationToken>({}),
         );
     });
 
     teardown(async () => {
+        client.dispose();
         if (showInfoStub) {
             showInfoStub.restore();
         }
@@ -165,8 +150,6 @@ suite('Webview Commands End-to-End Integration Test', () => {
         if (contextHelper) {
             await contextHelper.dispose();
         }
-        if (repo) {
-        }
         if (outputChannel) {
             outputChannel.dispose();
         }
@@ -179,11 +162,8 @@ suite('Webview Commands End-to-End Integration Test', () => {
         const commitToAbandonId = repo.getChangeId('@');
 
         // 2. Simulate Webview Message
-        await messageHandler({
-            type: 'abandon',
-            payload: {
-                changeId: commitToAbandonId,
-            },
+        await client.sender.abandon({
+            changeId: commitToAbandonId,
         });
 
         // After abandon, the working copy should involve a new commit (or parent)
@@ -202,10 +182,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
     test('New command creates a new change', async () => {
         const initialHead = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'new',
-            payload: {},
-        });
+        await client.sender.new();
 
         const newHead = repo.getChangeId('@');
         assert.notStrictEqual(newHead, initialHead, 'Should have a new head');
@@ -218,10 +195,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('Parent Commit');
         const parentId = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'newChild',
-            payload: { changeId: parentId },
-        });
+        await client.sender.newChild({ changeId: parentId });
 
         const childId = repo.getChangeId('@');
         assert.notStrictEqual(childId, parentId);
@@ -245,10 +219,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
         assert.notStrictEqual(currentId, targetId);
 
         // Send Edit
-        await messageHandler({
-            type: 'edit',
-            payload: { changeId: targetId },
-        });
+        await client.sender.edit({ changeId: targetId });
 
         // Verify working copy is now targetId
         const newWcId = repo.getChangeId('@');
@@ -267,18 +238,12 @@ suite('Webview Commands End-to-End Integration Test', () => {
         assert.notStrictEqual(id1, id2);
 
         // Undo
-        await messageHandler({
-            type: 'undo',
-            payload: {},
-        });
+        await client.sender.undo();
 
         assert.strictEqual(repo.getChangeId('@'), id1, 'Should undo back to first commit');
 
         // Redo
-        await messageHandler({
-            type: 'redo',
-            payload: {},
-        });
+        await client.sender.redo();
 
         assert.strictEqual(repo.getChangeId('@'), id2, 'Should redo back to second commit');
     });
@@ -296,10 +261,7 @@ suite('Webview Commands End-to-End Integration Test', () => {
         // Force snapshot of working copy changes
         repo.snapshot();
 
-        await messageHandler({
-            type: 'squash',
-            payload: { changeId: childId },
-        });
+        await client.sender.squash({ changeId: childId });
 
         const parentContent = repo.getFileContent('@-', 'file.txt');
         assert.strictEqual(parentContent, 'changes', 'Parent (@-) should contain squashed changes');
@@ -319,12 +281,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
         let bookmarksA = repo.getBookmarks(commitA);
         assert.ok(bookmarksA.includes('my-bookmark'), 'Bookmark should be on A');
 
-        await messageHandler({
-            type: 'moveBookmark',
-            payload: {
-                bookmark: 'my-bookmark',
-                targetChangeId: commitB,
-            },
+        await client.sender.moveBookmark({
+            bookmark: 'my-bookmark',
+            targetChangeId: commitB,
         });
 
         bookmarksA = repo.getBookmarks(commitA);
@@ -347,13 +306,10 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('B');
         const idB = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'rebaseCommit',
-            payload: {
-                sourceChangeId: idB,
-                targetChangeId: idA,
-                mode: 'source',
-            },
+        await client.sender.rebaseCommit({
+            sourceChangeId: idB,
+            targetChangeId: idA,
+            mode: 'source',
         });
 
         // Verify B's parent is now A
@@ -369,13 +325,10 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('Source B');
         const idB = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'squashCommit',
-            payload: {
-                sourceChangeId: idB,
-                targetChangeId: idA,
-                mode: 'into',
-            },
+        await client.sender.squashCommit({
+            sourceChangeId: idB,
+            targetChangeId: idA,
+            mode: 'into',
         });
 
         const logOutput = repo.log();
@@ -391,13 +344,10 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('Source B');
         const idB = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'squashCommit',
-            payload: {
-                sourceChangeId: idB,
-                targetChangeId: idA,
-                mode: 'onto',
-            },
+        await client.sender.squashCommit({
+            sourceChangeId: idB,
+            targetChangeId: idA,
+            mode: 'onto',
         });
 
         const logOutput = repo.log();
@@ -412,12 +362,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('Source B');
         const idB = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'duplicateCommit',
-            payload: {
-                sourceChangeId: idB,
-                targetChangeId: idA,
-            },
+        await client.sender.duplicateCommit({
+            sourceChangeId: idB,
+            targetChangeId: idA,
         });
 
         const logOutput = repo.log();
@@ -432,12 +379,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
         repo.describe('Parent B');
         const idB = repo.getChangeId('@');
 
-        await messageHandler({
-            type: 'mergeCommit',
-            payload: {
-                sourceChangeId: idB,
-                targetChangeId: idA,
-            },
+        await client.sender.mergeCommit({
+            sourceChangeId: idB,
+            targetChangeId: idA,
         });
 
         const parents = repo.getParents('@');
@@ -451,13 +395,10 @@ suite('Webview Commands End-to-End Integration Test', () => {
         const idA = repo.getChangeId('@');
         const initialLog = repo.log();
 
-        await messageHandler({
-            type: 'squashCommit',
-            payload: {
-                sourceChangeId: idA,
-                targetChangeId: idA,
-                mode: 'into',
-            },
+        await client.sender.squashCommit({
+            sourceChangeId: idA,
+            targetChangeId: idA,
+            mode: 'into',
         });
 
         const finalLog = repo.log();
@@ -473,12 +414,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
         const idA = repo.getChangeId('@');
         const initialLog = repo.log();
 
-        await messageHandler({
-            type: 'duplicateCommit',
-            payload: {
-                sourceChangeId: idA,
-                targetChangeId: idA,
-            },
+        await client.sender.duplicateCommit({
+            sourceChangeId: idA,
+            targetChangeId: idA,
         });
 
         const finalLog = repo.log();
@@ -494,12 +432,9 @@ suite('Webview Commands End-to-End Integration Test', () => {
         const idA = repo.getChangeId('@');
         const initialLog = repo.log();
 
-        await messageHandler({
-            type: 'mergeCommit',
-            payload: {
-                sourceChangeId: '',
-                targetChangeId: idA,
-            },
+        await client.sender.mergeCommit({
+            sourceChangeId: '',
+            targetChangeId: idA,
         });
 
         const finalLog = repo.log();

--- a/src/test/webview-initialization.integration.test.ts
+++ b/src/test/webview-initialization.integration.test.ts
@@ -6,42 +6,14 @@
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 import type { CodeForgeService } from '../core/code-forge-service';
+import { LogViewHostToWebviewMessageSchema, LogViewToHostMessageSchema } from '../core/host/ipc/log-view-schemas';
 import type { JjRepository } from '../core/jj-repository';
 import { Uri } from '../core/uri-utils';
 import { VsCodeLogWebviewProvider } from '../vscode/providers/vscode-log-webview-provider';
 import { createTestRepositoryContext } from './integration-test-utils';
+import { createMockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
-
-function createMockWebviewView() {
-    let visibilityListener!: (e: undefined) => void;
-
-    const mockWebview = createMock<vscode.Webview>({
-        options: {},
-        html: '',
-        onDidReceiveMessage: () => ({ dispose: () => {} }),
-        asWebviewUri: (uri: Uri) => uri,
-        cspSource: '',
-        postMessage: async () => true,
-    });
-
-    const mockWebviewView = createMock<vscode.WebviewView>({
-        webview: mockWebview,
-        viewType: 'jj-view.logView',
-        onDidChangeVisibility: (listener: (e: undefined) => void) => {
-            visibilityListener = listener;
-            return { dispose: () => {} };
-        },
-        onDidDispose: () => ({ dispose: () => {} }),
-        visible: true,
-    });
-
-    return {
-        view: mockWebviewView,
-        webview: mockWebview,
-        triggerVisibilityChange: () => visibilityListener(undefined),
-    };
-}
 
 suite('Webview Initialization Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
@@ -91,18 +63,23 @@ suite('Webview Initialization Integration Test', () => {
         repo.describe('Test Commit 1');
 
         // 1. Initial Resolve & Refresh
-        const { view: initialView, webview: initialWebview } = createMockWebviewView();
+        const client = createMockWebviewClient({
+            toHostSchema: LogViewToHostMessageSchema,
+            hostToWebviewSchema: LogViewHostToWebviewMessageSchema,
+        });
         provider.resolveWebviewView(
-            initialView,
+            client.view,
             createMock<vscode.WebviewViewResolveContext>({}),
             createMock<vscode.CancellationToken>({}),
         );
         await provider.controller.refresh();
 
         // 2. Verify HTML is clean and points to webview bundle
-        const html = initialWebview.html;
+        const html = client.webview.html;
         assert.ok(html.includes('dist/webview/index.js'), 'HTML should reference webview bundle');
         assert.ok(!html.includes('window.vscodeInitialData'), 'HTML should not contain initial data script injection');
+
+        client.dispose();
     });
 
     test('repository getter returns undefined until updateRepository is called', async () => {

--- a/src/test/webview-selection.integration.test.ts
+++ b/src/test/webview-selection.integration.test.ts
@@ -6,51 +6,31 @@
 import * as assert from 'node:assert';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
+import {
+    type LogViewHostToWebviewMessage,
+    LogViewHostToWebviewMessageSchema,
+    type LogViewToHostMessage,
+    LogViewToHostMessageSchema,
+} from '../core/host/ipc/log-view-schemas';
 import { Uri } from '../core/uri-utils';
 import { VsCodeLogWebviewProvider } from '../vscode/providers/vscode-log-webview-provider';
 import { createTestRepositoryContext, type TestRepositoryContext } from './integration-test-utils';
+import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { asSinonStub, createMock, createMockLogOutputChannel } from './test-utils';
 
 suite('Webview Selection Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
-    let messageHandler: (m: unknown) => Promise<void>;
+    let client: MockWebviewClient<LogViewToHostMessage, LogViewHostToWebviewMessage>;
     let executeCommandStub: sinon.SinonStub;
     let repo: TestRepo;
     let contextHelper: TestRepositoryContext;
-
-    // Mock Webview
-    const mockWebview = createMock<vscode.Webview>({
-        options: {},
-        html: '',
-        onDidReceiveMessage: (handler: (m: unknown) => Promise<void>) => {
-            messageHandler = handler;
-            return { dispose: () => {} };
-        },
-        asWebviewUri: (uri: Uri) => uri,
-        cspSource: '',
-        postMessage: async () => {
-            return true;
-        },
-    });
-
-    const mockWebviewView = createMock<vscode.WebviewView>({
-        webview: mockWebview,
-        viewType: 'jj-view.logView',
-        onDidChangeVisibility: () => {
-            return { dispose: () => {} };
-        },
-        onDidDispose: () => {
-            return { dispose: () => {} };
-        },
-        visible: true,
-    });
 
     setup(async () => {
         repo = new TestRepo();
         repo.init();
 
-        const extensionUri = Uri.file(__dirname); // Mock URI
+        const extensionUri = Uri.file(__dirname);
         const outputChannel = createMockLogOutputChannel({
             appendLine: () => {},
         });
@@ -81,15 +61,21 @@ suite('Webview Selection Integration Test', () => {
             return undefined;
         });
 
+        client = createMockWebviewClient({
+            toHostSchema: LogViewToHostMessageSchema,
+            hostToWebviewSchema: LogViewHostToWebviewMessageSchema,
+        });
+
         // Initialize provider
         provider.resolveWebviewView(
-            mockWebviewView,
+            client.view,
             createMock<vscode.WebviewViewResolveContext>({}),
             createMock<vscode.CancellationToken>({}),
         );
     });
 
     teardown(async () => {
+        client.dispose();
         if (executeCommandStub) {
             executeCommandStub.restore();
         }
@@ -101,12 +87,9 @@ suite('Webview Selection Integration Test', () => {
 
     test('Selection Change updates Context Keys', async () => {
         // user selects 1 item, immutable=false
-        await messageHandler({
-            type: 'selectionChange',
-            payload: {
-                commitIds: ['commit-1'],
-                hasImmutableSelection: false,
-            },
+        await client.sender.selectionChange({
+            commitIds: ['commit-1'],
+            hasImmutableSelection: false,
         });
 
         const getContextCalls = (key: string) =>
@@ -121,12 +104,9 @@ suite('Webview Selection Integration Test', () => {
         assert.strictEqual(calls.at(-1)?.args[2], false, 'allowMerge should be false (count=1)');
 
         // Test Multi-Selection (2 items)
-        await messageHandler({
-            type: 'selectionChange',
-            payload: {
-                commitIds: ['commit-1', 'commit-2'],
-                hasImmutableSelection: false,
-            },
+        await client.sender.selectionChange({
+            commitIds: ['commit-1', 'commit-2'],
+            hasImmutableSelection: false,
         });
 
         // Verify jj.selection.allowAbandon -> true
@@ -138,17 +118,11 @@ suite('Webview Selection Integration Test', () => {
         assert.strictEqual(calls.at(-1)?.args[2], true, 'allowMerge should be true (count > 1)');
 
         // Test Immutable Selection
-        await messageHandler({
-            type: 'selectionChange',
-            payload: {
-                commitIds: ['commit-1'],
-                hasImmutableSelection: true,
-            },
+        await client.sender.selectionChange({
+            commitIds: ['commit-1'],
+            hasImmutableSelection: true,
         });
 
-        // Verify jj.selection.allowAbandon -> false
-        calls = getContextCalls('jj.selection.allowAbandon');
-        assert.strictEqual(calls.at(-1)?.args[2], false, 'allowAbandon should be false for immutable selection');
         // Verify jj.selection.allowAbandon -> false
         calls = getContextCalls('jj.selection.allowAbandon');
         assert.strictEqual(calls.at(-1)?.args[2], false, 'allowAbandon should be false for immutable selection');
@@ -160,10 +134,7 @@ suite('Webview Selection Integration Test', () => {
 
     test('Abandon command from webview triggers extension command', async () => {
         const payload = { changeId: 'commit-to-abandon' };
-        await messageHandler({
-            type: 'abandon',
-            payload,
-        });
+        await client.sender.abandon(payload);
 
         // It should call 'jj-view.abandon' with the payload
         const calls = executeCommandStub.getCalls().filter((call) => call.args[0] === 'jj-view.abandon');

--- a/src/test/webview-visibility.integration.test.ts
+++ b/src/test/webview-visibility.integration.test.ts
@@ -5,59 +5,19 @@
 
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
+import {
+    type LogViewHostToWebviewMessage,
+    LogViewHostToWebviewMessageSchema,
+    type LogViewToHostMessage,
+    LogViewToHostMessageSchema,
+} from '../core/host/ipc/log-view-schemas';
 import type { JjLogEntry } from '../core/jj-types';
 import { Uri } from '../core/uri-utils';
 import { VsCodeLogWebviewProvider } from '../vscode/providers/vscode-log-webview-provider';
 import { createTestRepositoryContext, type TestRepositoryContext } from './integration-test-utils';
+import { createMockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
-
-interface UpdateMessage {
-    type: 'update';
-    payload: {
-        commits: JjLogEntry[];
-    };
-}
-
-function createMockWebviewView() {
-    let visibilityListener!: (e: undefined) => void;
-    const sentMessages: UpdateMessage[] = [];
-
-    const mockWebview = createMock<vscode.Webview>({
-        options: {},
-        html: '',
-        onDidReceiveMessage: () => ({ dispose: () => {} }),
-        postMessage: (message: unknown) => {
-            if (typeof message === 'object' && message !== null && 'type' in message) {
-                const msg = message as { type: string };
-                if (msg.type === 'update') {
-                    sentMessages.push(message as UpdateMessage);
-                }
-            }
-            return Promise.resolve(true);
-        },
-        asWebviewUri: (uri: vscode.Uri) => uri,
-        cspSource: 'https://*.vscode-cdn.net',
-    });
-
-    const mockWebviewView = createMock<vscode.WebviewView>({
-        webview: mockWebview,
-        visible: true,
-        onDidChangeVisibility: (listener: (e: undefined) => void) => {
-            visibilityListener = listener;
-            return { dispose: () => {} };
-        },
-        onDidDispose: () => ({ dispose: () => {} }),
-        show: () => {},
-    });
-
-    return {
-        view: mockWebviewView,
-        webview: mockWebview,
-        sentMessages,
-        triggerVisibilityChange: () => visibilityListener(undefined),
-    };
-}
 
 suite('Webview Visibility Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
@@ -105,47 +65,53 @@ suite('Webview Visibility Integration Test', () => {
         // 1. Initial setup with one commit
         repo.describe('Initial Commit');
 
-        const { view, sentMessages, triggerVisibilityChange } = createMockWebviewView();
+        const client = createMockWebviewClient<LogViewToHostMessage, LogViewHostToWebviewMessage>({
+            toHostSchema: LogViewToHostMessageSchema,
+            hostToWebviewSchema: LogViewHostToWebviewMessageSchema,
+        });
+
         provider.resolveWebviewView(
-            view,
+            client.view,
             createMock<vscode.WebviewViewResolveContext>({}),
             createMock<vscode.CancellationToken>({}),
         );
 
         await provider.controller.refresh();
-        assert.ok(sentMessages.length >= 1, 'Should have sent initial update message');
-        const initialCommits = sentMessages[sentMessages.length - 1].payload.commits;
+        const updateMessages = client.receivedMessages.filter((m) => m.type === 'update');
+        assert.ok(updateMessages.length >= 1, 'Should have sent initial update message');
+        const initialCommits = updateMessages[updateMessages.length - 1].payload.commits;
         assert.ok(
             initialCommits.some((c: JjLogEntry) => c.description.includes('Initial Commit')),
             'Should contain initial description',
         );
 
         // 2. Hide the webview
-        Object.defineProperty(view, 'visible', { get: () => false });
-        triggerVisibilityChange();
+        client.triggerVisibilityChange(false);
 
         // 3. Perform a change while hidden
         repo.describe('Updated Commit while hidden');
         await provider.controller.refresh();
 
-        // provider.refresh() calls _renderCommits, so it will postMessage
-        const messagesCountWhileHidden = sentMessages.length;
+        const messagesCountWhileHidden = client.receivedMessages.filter((m) => m.type === 'update').length;
         assert.ok(messagesCountWhileHidden >= 1);
 
         // 4. Show the webview
-        Object.defineProperty(view, 'visible', { get: () => true });
-        triggerVisibilityChange();
+        client.triggerVisibilityChange(true);
+        await new Promise((resolve) => setTimeout(resolve, 50));
 
         // 5. Verify that a new message was sent
+        const messagesAfterVisible = client.receivedMessages.filter((m) => m.type === 'update');
         assert.ok(
-            sentMessages.length > messagesCountWhileHidden,
+            messagesAfterVisible.length > messagesCountWhileHidden,
             'Should have sent an additional message when becoming visible',
         );
-        const lastMessage = sentMessages[sentMessages.length - 1];
+        const lastMessage = messagesAfterVisible[messagesAfterVisible.length - 1];
         assert.strictEqual(lastMessage.type, 'update');
         assert.ok(
             lastMessage.payload.commits.some((c: JjLogEntry) => c.description.includes('Updated Commit while hidden')),
             'Last message should contain updated data',
         );
+
+        client.dispose();
     });
 });


### PR DESCRIPTION
- Update createMockWebviewClient helper to support custom discriminator keys and async host message dispatch without vitest runtime dependencies.
- Migrate process-monitor-controller, webview-commands, webview-initialization, webview-selection, and webview-visibility suites to createMockWebviewClient.
- Validate all tests pass under both Vitest and VS Code Mocha test runners.