### PR TITLE
test(log-webview): rename log webview integration test files for clarity

### DIFF
--- a/src/test/log-webview-commands.integration.test.ts
+++ b/src/test/log-webview-commands.integration.test.ts
@@ -35,7 +35,7 @@ import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-
 import { TestRepo } from './test-repo';
 import { asSinonStub, createMock } from './test-utils';
 
-suite('Webview Commands End-to-End Integration Test', () => {
+suite('Log Webview Commands End-to-End Integration Test', () => {
     let scm: VsCodeScmProvider;
     let provider: VsCodeLogWebviewProvider;
     let client: MockWebviewClient<LogViewToHostMessage, LogViewHostToWebviewMessage>;

--- a/src/test/log-webview-initialization.integration.test.ts
+++ b/src/test/log-webview-initialization.integration.test.ts
@@ -15,7 +15,7 @@ import { createMockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
 
-suite('Webview Initialization Integration Test', () => {
+suite('Log Webview Initialization Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
     let repo: TestRepo;
     let disposables: vscode.Disposable[] = [];

--- a/src/test/log-webview-selection.integration.test.ts
+++ b/src/test/log-webview-selection.integration.test.ts
@@ -19,7 +19,7 @@ import { createMockWebviewClient, type MockWebviewClient } from './mock-webview-
 import { TestRepo } from './test-repo';
 import { asSinonStub, createMock, createMockLogOutputChannel } from './test-utils';
 
-suite('Webview Selection Integration Test', () => {
+suite('Log Webview Selection Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
     let client: MockWebviewClient<LogViewToHostMessage, LogViewHostToWebviewMessage>;
     let executeCommandStub: sinon.SinonStub;

--- a/src/test/log-webview-visibility.integration.test.ts
+++ b/src/test/log-webview-visibility.integration.test.ts
@@ -19,7 +19,7 @@ import { createMockWebviewClient } from './mock-webview-client';
 import { TestRepo } from './test-repo';
 import { createMock, createMockLogOutputChannel } from './test-utils';
 
-suite('Webview Visibility Integration Test', () => {
+suite('Log Webview Visibility Integration Test', () => {
     let provider: VsCodeLogWebviewProvider;
     let repo: TestRepo;
     let disposables: vscode.Disposable[] = [];


### PR DESCRIPTION
- Rename webview-commands.integration.test.ts to log-webview-commands.integration.test.ts
- Rename webview-initialization.integration.test.ts to log-webview-initialization.integration.test.ts
- Rename webview-selection.integration.test.ts to log-webview-selection.integration.test.ts
- Rename webview-visibility.integration.test.ts to log-webview-visibility.integration.test.ts
- Update suite names to match log webview scope.