### PR TITLE
fix(gerrit): target parent comment patchset for replies and resolutions

### DIFF
--- a/src/core/gerrit-provider.ts
+++ b/src/core/gerrit-provider.ts
@@ -75,6 +75,7 @@ interface GerritCommentGql {
     author?: GerritAuthorGql;
     unresolved?: boolean;
     in_reply_to?: string;
+    patch_set?: number;
 }
 
 export type GerritCommentWithDraftStatus = GerritCommentGql & {
@@ -655,7 +656,8 @@ export class GerritProvider implements CodeForgeProvider {
         }
 
         // Post draft comment reply
-        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/drafts`;
+        const revisionId = parentComment.patch_set ?? 'current';
+        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/${revisionId}/drafts`;
         const response = await this.fetchGerrit(draftUrl, {
             method: 'PUT',
             headers: {
@@ -672,7 +674,10 @@ export class GerritProvider implements CodeForgeProvider {
         });
 
         if (!response.ok) {
-            throw new Error(`Failed to post Gerrit draft reply: ${response.statusText}`);
+            const errorBody = (await response.text().catch(() => '')).trim();
+            throw new Error(
+                `Failed to post Gerrit draft reply: ${response.statusText}${errorBody ? ` - ${errorBody}` : ''}`,
+            );
         }
 
         const responseText = await response.text();
@@ -747,7 +752,8 @@ export class GerritProvider implements CodeForgeProvider {
         }
 
         // Post draft resolution reply comment
-        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/current/drafts`;
+        const revisionId = parentComment.patch_set ?? 'current';
+        const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/${revisionId}/drafts`;
         const response = await this.fetchGerrit(draftUrl, {
             method: 'PUT',
             headers: {
@@ -764,7 +770,10 @@ export class GerritProvider implements CodeForgeProvider {
         });
 
         if (!response.ok) {
-            throw new Error(`Failed to resolve Gerrit comment: ${response.statusText}`);
+            const errorBody = (await response.text().catch(() => '')).trim();
+            throw new Error(
+                `Failed to resolve Gerrit comment: ${response.statusText}${errorBody ? ` - ${errorBody}` : ''}`,
+            );
         }
     }
 

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -373,6 +373,110 @@ describe('GerritProvider', () => {
             expect(threads[0].isResolved).toBe(false);
         });
 
+        test('replyToCommentThread posts a reply targeting parent comment patchset', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 2,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            const reply = await provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!');
+            expect(reply.body).toBe('Thanks!');
+            expect(server.requests.some((req) => req.includes('/changes/123/revisions/2/drafts'))).toBe(true);
+        });
+
+        test('replyToCommentThread falls back to current revision when patch_set is missing', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            const reply = await provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!');
+            expect(reply.body).toBe('Thanks!');
+            expect(server.requests.some((req) => req.includes('/changes/123/revisions/current/drafts'))).toBe(true);
+        });
+
+        test('resolveCommentThread posts a resolution targeting parent comment patchset', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 3,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            await provider.resolveCommentThread('I12345', 'comment-1', true);
+            expect(server.requests.some((req) => req.includes('/changes/123/revisions/3/drafts'))).toBe(true);
+        });
+
+        test('surfaces Gerrit error response body on failure in replyToCommentThread', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            server.failDraftsWithStatus = 400;
+            server.failDraftsResponseBody =
+                'Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.\n';
+
+            await expect(provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!')).rejects.toThrow(
+                'Failed to post Gerrit draft reply: Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
+            );
+        });
+
+        test('surfaces Gerrit error response body on failure in resolveCommentThread', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            server.failDraftsWithStatus = 400;
+            server.failDraftsResponseBody =
+                'Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.';
+
+            await expect(provider.resolveCommentThread('I12345', 'comment-1', true)).rejects.toThrow(
+                'Failed to resolve Gerrit comment: Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
+            );
+        });
+
         test('attaches authentication headers and rewrites URL when auth is available', async () => {
             const tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gerrit-auth-test-'));
             const gitRoot = path.join(tempRepoDir, '.git');

--- a/src/test/helpers/fake-gerrit-server.ts
+++ b/src/test/helpers/fake-gerrit-server.ts
@@ -12,6 +12,7 @@ export interface FakeGerritComment {
     updated: string;
     unresolved?: boolean;
     in_reply_to?: string;
+    patch_set?: number;
     author?: {
         name: string;
         username: string;
@@ -27,6 +28,9 @@ export class FakeGerritServer {
     public requests: string[] = [];
     public lastHeaders: http.IncomingHttpHeaders | undefined;
     public failWithStatus: number | undefined;
+    public failResponseBody: string | undefined;
+    public failDraftsWithStatus: number | undefined;
+    public failDraftsResponseBody: string | undefined;
 
     private nextChangeNumber = 1000;
 
@@ -152,7 +156,7 @@ export class FakeGerritServer {
 
             if (this.failWithStatus) {
                 res.writeHead(this.failWithStatus);
-                res.end('Error');
+                res.end(this.failResponseBody ?? 'Error');
                 return;
             }
 
@@ -174,9 +178,15 @@ export class FakeGerritServer {
             }
 
             if (urlStr.includes('/drafts')) {
-                const matchPutDraft = urlStr.match(/\/changes\/(\d+)\/revisions\/current\/drafts/);
+                const matchPutDraft = urlStr.match(/\/changes\/(\d+)\/revisions\/([^/]+)\/drafts/);
                 if (matchPutDraft && (req.method === 'PUT' || req.method === 'POST')) {
+                    if (this.failDraftsWithStatus) {
+                        res.writeHead(this.failDraftsWithStatus);
+                        res.end(this.failDraftsResponseBody ?? 'Error');
+                        return;
+                    }
                     const changeNumber = parseInt(matchPutDraft[1], 10);
+                    const revisionId = matchPutDraft[2];
                     let body = '';
                     req.on('data', (chunk) => {
                         body += chunk;
@@ -194,6 +204,7 @@ export class FakeGerritServer {
                         const filePath = incoming.path;
                         currentDrafts[filePath] = currentDrafts[filePath] || [];
 
+                        const parsedPatchSet = revisionId === 'current' ? undefined : parseInt(revisionId, 10);
                         const newDraft: FakeGerritComment = {
                             id: `draft-${Date.now()}-${Math.random()}`,
                             line: incoming.line,
@@ -201,6 +212,10 @@ export class FakeGerritServer {
                             updated: new Date().toISOString(),
                             unresolved: incoming.unresolved,
                             in_reply_to: incoming.in_reply_to,
+                            patch_set:
+                                parsedPatchSet !== undefined && !Number.isNaN(parsedPatchSet)
+                                    ? parsedPatchSet
+                                    : undefined,
                             author: { name: 'Gerrit User', username: 'gerrit_user' },
                         };
                         currentDrafts[filePath].push(newDraft);


### PR DESCRIPTION
Fix #504: Target parent comment patchset for replies and resolutions

When replying to or resolving a comment created on an earlier patchset after a new revision has been uploaded, Gerrit returned a 400 Bad Request because draft replies were hardcoded to /revisions/current/drafts. Gerrit requires comment replies linked with in_reply_to to be created on the exact patchset of the parent comment.

- Extend GerritCommentGql to include patch_set
- In replyToCommentThread and resolveCommentThread, target the parent comment's patch_set instead of 'current'
- Surface Gerrit's error response body in thrown errors for easier debugging
- Update FakeGerritServer and add unit tests covering patchset targeting and error reporting