### PR TITLE
refactor(comments): pass thread object with metadata and store threads as Map

### DIFF
--- a/src/core/code-forge-provider.ts
+++ b/src/core/code-forge-provider.ts
@@ -63,12 +63,12 @@ export interface CodeForgeProvider {
     /** Reply to a comment thread */
     replyToCommentThread?(
         changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment>;
     /** Resolve/unresolve a comment thread */
-    resolveCommentThread?(changeId: string, threadId: string, resolved: boolean): Promise<void>;
+    resolveCommentThread?(changeId: string, thread: CodeForgeCommentThread, resolved: boolean): Promise<void>;
 }
 
 export interface CodeForgeComment {
@@ -88,6 +88,7 @@ export interface CodeForgeCommentThread {
     filePath?: string;
     line?: number;
     isResolved: boolean;
+    metadata?: Record<string, unknown>;
     comments: CodeForgeComment[];
 }
 

--- a/src/core/comments-manager.ts
+++ b/src/core/comments-manager.ts
@@ -16,7 +16,8 @@ import type { CodeForgeChangeInfo, JjBookmark, JjLogEntry } from './jj-types';
 export * from './comments-types';
 
 export class CommentsManager implements Disposable {
-    private _threads: CodeForgeCommentThread[] = [];
+    private _threads = new Map<string, CodeForgeCommentThread>();
+    private _threadsList: CodeForgeCommentThread[] = [];
     private activeChangeId: string | undefined;
     private activeChangeInfo: CodeForgeChangeInfo | undefined;
     private activeRepoPath: string | undefined;
@@ -50,11 +51,11 @@ export class CommentsManager implements Disposable {
     }
 
     public get threads(): readonly CodeForgeCommentThread[] {
-        return this._threads;
+        return this._threadsList;
     }
 
     public getThreads(): readonly CodeForgeCommentThread[] {
-        return this._threads;
+        return this._threadsList;
     }
 
     public get activeChange(): CodeForgeChangeInfo | undefined {
@@ -308,7 +309,8 @@ export class CommentsManager implements Disposable {
             this.activeChangeId = providerChangeId;
             this.activeChangeInfo = changeInfo;
             this.activeRepoPath = repo.rootUri.fsPath;
-            this._threads = threadsList;
+            this._threadsList = threadsList;
+            this._threads = new Map(threadsList.map((t) => [t.id, t]));
             this._onDidChangeThreads.fire(threadsList);
         } catch {
             // Ignore/log
@@ -344,7 +346,8 @@ export class CommentsManager implements Disposable {
     }
 
     private clearThreads(): void {
-        this._threads = [];
+        this._threadsList = [];
+        this._threads.clear();
         this._onDidChangeThreads.fire([]);
     }
 
@@ -365,6 +368,18 @@ export class CommentsManager implements Disposable {
             return;
         }
 
+        const targetThread = this._threads.get(threadId);
+        if (!targetThread) {
+            await showJjError(
+                this.host.ui,
+                new Error(`Comment thread not found: ${threadId}`),
+                'Failed to send reply',
+                repo?.jj,
+                this.repositoryManager.outputChannel,
+            );
+            return;
+        }
+
         const provider = activeProvider as Required<
             Pick<CodeForgeProvider, 'replyToCommentThread' | 'getCommentThreads'>
         > &
@@ -372,7 +387,7 @@ export class CommentsManager implements Disposable {
 
         const replyText = reply.text ?? '';
         const executeReply = async () => {
-            await provider.replyToCommentThread(changeId, threadId, replyText, resolved);
+            await provider.replyToCommentThread(changeId, targetThread, replyText, resolved);
             await this.refreshActiveChangeComments();
             repo.codeForge.requestRefreshWithBackoffs();
         };
@@ -407,13 +422,25 @@ export class CommentsManager implements Disposable {
             return;
         }
 
+        const targetThread = this._threads.get(threadId);
+        if (!targetThread) {
+            await showJjError(
+                this.host.ui,
+                new Error(`Comment thread not found: ${threadId}`),
+                'Failed to toggle resolve',
+                repo?.jj,
+                this.repositoryManager.outputChannel,
+            );
+            return;
+        }
+
         const provider = activeProvider as Required<
             Pick<CodeForgeProvider, 'resolveCommentThread' | 'getCommentThreads'>
         > &
             CodeForgeProvider;
 
         const executeToggle = async () => {
-            await provider.resolveCommentThread(changeId, threadId, resolved);
+            await provider.resolveCommentThread(changeId, targetThread, resolved);
             await this.refreshActiveChangeComments();
             repo.codeForge.requestRefreshWithBackoffs();
         };
@@ -432,7 +459,7 @@ export class CommentsManager implements Disposable {
     }
 
     public formatUnresolvedComments(workspaceRoot?: string): string | undefined {
-        const unresolvedThreads = this._threads.filter((thread) => !thread.isResolved);
+        const unresolvedThreads = this._threadsList.filter((thread) => !thread.isResolved);
         if (unresolvedThreads.length === 0) {
             return undefined;
         }
@@ -493,7 +520,7 @@ export class CommentsManager implements Disposable {
             return;
         }
 
-        const unresolvedCount = this._threads.filter((t) => !t.isResolved).length;
+        const unresolvedCount = this._threadsList.filter((t) => !t.isResolved).length;
 
         try {
             await this.host.nav.copyToClipboard(text);

--- a/src/core/gerrit-provider.ts
+++ b/src/core/gerrit-provider.ts
@@ -89,7 +89,7 @@ interface FetchGerritOptions extends RequestInit {
 const AUTH_HEADER_TTL_MS = 5 * 60 * 1000;
 
 function parseGerritJsonResponse<T>(text: string): T {
-    const cleanJson = text.replace(/^\)]}'\n/, '').trim();
+    const cleanJson = text.replace(/^\)]}'\r?\n/, '').trim();
     if (!cleanJson) {
         return {} as T;
     }
@@ -380,7 +380,7 @@ export class GerritProvider implements CodeForgeProvider {
     }
 
     private parseBatchResponse(text: string): GerritChange[][] {
-        const jsonStr = text.replace(/^\)]}'\n/, '');
+        const jsonStr = text.replace(/^\)]}'\r?\n/, '');
         let parsed: unknown;
         try {
             parsed = JSON.parse(jsonStr);
@@ -523,7 +523,9 @@ export class GerritProvider implements CodeForgeProvider {
         ]);
 
         if (!commentsResponse?.ok) {
-            throw new Error(`Failed to fetch Gerrit comments: ${commentsResponse?.statusText ?? 'Network error'}`);
+            const status = commentsResponse?.status ? `${commentsResponse.status} ` : '';
+            const statusText = commentsResponse?.statusText || 'Network error';
+            throw new Error(`Failed to fetch Gerrit comments: ${status}${statusText}`.trim());
         }
 
         const commentsText = await commentsResponse.text();
@@ -606,6 +608,9 @@ export class GerritProvider implements CodeForgeProvider {
                     filePath,
                     line: root.line || undefined,
                     isResolved,
+                    metadata: {
+                        patchSet: root.patch_set,
+                    },
                     comments: threadComments.map((c) => ({
                         id: c.id,
                         author: {
@@ -625,7 +630,7 @@ export class GerritProvider implements CodeForgeProvider {
 
     public async replyToCommentThread(
         changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -637,27 +642,21 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Gerrit provider not fully configured');
         }
 
-        const commentsMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
-
-        let parentComment: GerritCommentWithDraftStatus | undefined;
-        let parentFilePath: string | undefined;
-
-        for (const [filePath, comments] of Object.entries(commentsMap)) {
-            const found = comments.find((c) => c.id === threadId);
-            if (found) {
-                parentComment = found;
-                parentFilePath = filePath;
-                break;
-            }
-        }
-
-        if (!parentComment || !parentFilePath) {
-            throw new Error('Parent comment thread not found');
-        }
-
         // Post draft comment reply
-        const revisionId = parentComment.patch_set ?? 'current';
+        const patchSet =
+            typeof thread.metadata?.patchSet === 'number' &&
+            Number.isSafeInteger(thread.metadata.patchSet) &&
+            thread.metadata.patchSet > 0
+                ? thread.metadata.patchSet
+                : undefined;
+        const revisionId = patchSet ?? 'current';
         const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/${revisionId}/drafts`;
+        const filePath = thread.filePath || '/PATCHSET_LEVEL';
+        const line =
+            typeof thread.line === 'number' && Number.isSafeInteger(thread.line) && thread.line > 0
+                ? thread.line
+                : undefined;
+
         const response = await this.fetchGerrit(draftUrl, {
             method: 'PUT',
             headers: {
@@ -665,18 +664,19 @@ export class GerritProvider implements CodeForgeProvider {
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                path: parentFilePath,
-                line: parentComment.line,
+                path: filePath,
+                line,
                 message: body,
-                in_reply_to: threadId,
-                unresolved: resolved !== undefined ? !resolved : (parentComment.unresolved ?? true),
+                in_reply_to: thread.id,
+                unresolved: resolved !== undefined ? !resolved : !thread.isResolved,
             }),
         });
 
         if (!response.ok) {
             const errorBody = (await response.text().catch(() => '')).trim();
+            const statusText = response.statusText ? ` ${response.statusText}` : '';
             throw new Error(
-                `Failed to post Gerrit draft reply: ${response.statusText}${errorBody ? ` - ${errorBody}` : ''}`,
+                `Failed to post Gerrit draft reply: ${response.status}${statusText}${errorBody ? ` - ${errorBody}` : ''}`,
             );
         }
 
@@ -703,8 +703,10 @@ export class GerritProvider implements CodeForgeProvider {
 
         // Re-fetch to retrieve the newly posted draft comment
         const updatedMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
-        const threadComments = updatedMap[parentFilePath] || [];
-        const replies = threadComments.filter((c) => c.in_reply_to === threadId || c.id === threadId);
+        const threadComments = updatedMap[filePath] || [];
+        const replies = threadComments.filter(
+            (c) => c.in_reply_to === thread.id && c.id !== thread.id && Boolean(c.isDraft),
+        );
         replies.sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
         const newest = replies[0];
 
@@ -724,7 +726,11 @@ export class GerritProvider implements CodeForgeProvider {
         };
     }
 
-    public async resolveCommentThread(changeId: string, threadId: string, resolved: boolean): Promise<void> {
+    public async resolveCommentThread(
+        changeId: string,
+        thread: CodeForgeCommentThread,
+        resolved: boolean,
+    ): Promise<void> {
         const changeInfo = Array.from(this.cache.values()).find((info) => info.id === changeId);
         if (!changeInfo) {
             throw new Error('Change not found in cache');
@@ -733,27 +739,21 @@ export class GerritProvider implements CodeForgeProvider {
             throw new Error('Gerrit provider not fully configured');
         }
 
-        const commentsMap = await this.fetchMergedCommentsAndDrafts(changeInfo.number);
-
-        let parentComment: GerritCommentWithDraftStatus | undefined;
-        let parentFilePath: string | undefined;
-
-        for (const [filePath, comments] of Object.entries(commentsMap)) {
-            const found = comments.find((c) => c.id === threadId);
-            if (found) {
-                parentComment = found;
-                parentFilePath = filePath;
-                break;
-            }
-        }
-
-        if (!parentComment || !parentFilePath) {
-            throw new Error('Parent comment thread not found');
-        }
-
         // Post draft resolution reply comment
-        const revisionId = parentComment.patch_set ?? 'current';
+        const patchSet =
+            typeof thread.metadata?.patchSet === 'number' &&
+            Number.isSafeInteger(thread.metadata.patchSet) &&
+            thread.metadata.patchSet > 0
+                ? thread.metadata.patchSet
+                : undefined;
+        const revisionId = patchSet ?? 'current';
         const draftUrl = `${this.gerritHost}/changes/${changeInfo.number}/revisions/${revisionId}/drafts`;
+        const filePath = thread.filePath || '/PATCHSET_LEVEL';
+        const line =
+            typeof thread.line === 'number' && Number.isSafeInteger(thread.line) && thread.line > 0
+                ? thread.line
+                : undefined;
+
         const response = await this.fetchGerrit(draftUrl, {
             method: 'PUT',
             headers: {
@@ -761,18 +761,19 @@ export class GerritProvider implements CodeForgeProvider {
                 'User-Agent': 'jj-view-vscode-extension',
             },
             body: JSON.stringify({
-                path: parentFilePath,
-                line: parentComment.line,
+                path: filePath,
+                line,
                 message: resolved ? 'Resolved' : 'Unresolved',
-                in_reply_to: threadId,
+                in_reply_to: thread.id,
                 unresolved: !resolved,
             }),
         });
 
         if (!response.ok) {
             const errorBody = (await response.text().catch(() => '')).trim();
+            const statusText = response.statusText ? ` ${response.statusText}` : '';
             throw new Error(
-                `Failed to resolve Gerrit comment: ${response.statusText}${errorBody ? ` - ${errorBody}` : ''}`,
+                `Failed to resolve Gerrit comment: ${response.status}${statusText}${errorBody ? ` - ${errorBody}` : ''}`,
             );
         }
     }

--- a/src/core/github-provider.ts
+++ b/src/core/github-provider.ts
@@ -626,7 +626,7 @@ export class GitHubProvider implements CodeForgeProvider {
 
     public async replyToCommentThread(
         _changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -684,7 +684,7 @@ export class GitHubProvider implements CodeForgeProvider {
             },
             body: JSON.stringify({
                 query,
-                variables: { threadId, body },
+                variables: { threadId: thread.id, body },
             }),
         });
 
@@ -714,7 +714,11 @@ export class GitHubProvider implements CodeForgeProvider {
         };
     }
 
-    public async resolveCommentThread(_changeId: string, threadId: string, resolved: boolean): Promise<void> {
+    public async resolveCommentThread(
+        _changeId: string,
+        thread: CodeForgeCommentThread,
+        resolved: boolean,
+    ): Promise<void> {
         const token = await this.getSessionToken();
         if (!token) {
             throw new Error('Not authenticated');
@@ -748,7 +752,7 @@ export class GitHubProvider implements CodeForgeProvider {
             },
             body: JSON.stringify({
                 query,
-                variables: { threadId },
+                variables: { threadId: thread.id },
             }),
         });
 

--- a/src/core/gitlab-provider.ts
+++ b/src/core/gitlab-provider.ts
@@ -791,7 +791,7 @@ export class GitLabProvider implements CodeForgeProvider {
 
     public async replyToCommentThread(
         changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -806,7 +806,7 @@ export class GitLabProvider implements CodeForgeProvider {
         }
 
         const apiBaseUrl = process.env.JJ_VIEW_GITLAB_API_URL || `${this.gitlabHost}/api/v4`;
-        const url = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${changeInfo.number}/discussions/${threadId}/notes`;
+        const url = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${changeInfo.number}/discussions/${thread.id}/notes`;
 
         const response = await fetchWithTimeout(url, 15000, {
             method: 'POST',
@@ -825,7 +825,7 @@ export class GitLabProvider implements CodeForgeProvider {
         const note = (await response.json()) as GitLabNoteGql;
 
         if (resolved !== undefined) {
-            await this.resolveCommentThread(changeId, threadId, resolved);
+            await this.resolveCommentThread(changeId, thread, resolved);
         }
 
         return {
@@ -840,7 +840,11 @@ export class GitLabProvider implements CodeForgeProvider {
         };
     }
 
-    public async resolveCommentThread(changeId: string, threadId: string, resolved: boolean): Promise<void> {
+    public async resolveCommentThread(
+        changeId: string,
+        thread: CodeForgeCommentThread,
+        resolved: boolean,
+    ): Promise<void> {
         const changeInfo = Array.from(this.cache.values()).find((info) => info.id === changeId);
         if (!changeInfo) {
             throw new Error('Change not found in cache');
@@ -852,7 +856,7 @@ export class GitLabProvider implements CodeForgeProvider {
         }
 
         const apiBaseUrl = process.env.JJ_VIEW_GITLAB_API_URL || `${this.gitlabHost}/api/v4`;
-        const url = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${changeInfo.number}/discussions/${threadId}`;
+        const url = `${apiBaseUrl}/projects/${encodeURIComponent(projectPath)}/merge_requests/${changeInfo.number}/discussions/${thread.id}`;
 
         const response = await fetchWithTimeout(`${url}?resolved=${resolved}`, 15000, {
             method: 'PUT',

--- a/src/test/commands/comments.test.ts
+++ b/src/test/commands/comments.test.ts
@@ -75,7 +75,7 @@ class MockForgeProvider implements CodeForgeProvider {
 
     async replyToCommentThread(
         _changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -85,20 +85,20 @@ class MockForgeProvider implements CodeForgeProvider {
             body,
             createdAt: new Date().toISOString(),
         };
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.comments.push(reply);
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.comments.push(reply);
             if (resolved !== undefined) {
-                thread.isResolved = resolved;
+                found.isResolved = resolved;
             }
         }
         return reply;
     }
 
-    async resolveCommentThread(_changeId: string, threadId: string, resolved: boolean): Promise<void> {
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.isResolved = resolved;
+    async resolveCommentThread(_changeId: string, thread: CodeForgeCommentThread, resolved: boolean): Promise<void> {
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.isResolved = resolved;
         }
     }
 

--- a/src/test/comments-manager.test.ts
+++ b/src/test/comments-manager.test.ts
@@ -77,7 +77,7 @@ class MockCommentsProvider implements CodeForgeProvider {
 
     async replyToCommentThread(
         _changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -87,20 +87,20 @@ class MockCommentsProvider implements CodeForgeProvider {
             body,
             createdAt: new Date().toISOString(),
         };
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.comments.push(reply);
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.comments.push(reply);
             if (resolved !== undefined) {
-                thread.isResolved = resolved;
+                found.isResolved = resolved;
             }
         }
         return reply;
     }
 
-    async resolveCommentThread(_changeId: string, threadId: string, resolved: boolean): Promise<void> {
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.isResolved = resolved;
+    async resolveCommentThread(_changeId: string, thread: CodeForgeCommentThread, resolved: boolean): Promise<void> {
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.isResolved = resolved;
         }
     }
 
@@ -265,6 +265,27 @@ describe('CommentsManager Tests', () => {
         expect(threads[0].comments.length).toBe(0);
         expect(threads[1].comments.length).toBe(1);
         expect(threads[1].comments[0].body).toBe('Reply to thread 2');
+    });
+
+    test('replyToThread and toggleResolveThread show error when thread is not found in cache', async () => {
+        provider.setThreads([]);
+        await commentsManager.showCommentsForChange('@');
+
+        const spyError = vi.spyOn(fakeHost.ui, 'showErrorMessage');
+
+        await commentsManager.replyToThread({
+            thread: { id: 'non-existent-thread', uri: Uri.file(path.join(testRepo.path, 'file.txt')) },
+            text: 'Reply to missing thread',
+        });
+
+        expect(spyError).toHaveBeenCalled();
+
+        await commentsManager.toggleResolveThread(
+            { id: 'non-existent-thread', uri: Uri.file(path.join(testRepo.path, 'file.txt')) },
+            true,
+        );
+
+        expect(spyError).toHaveBeenCalledTimes(2);
     });
 
     test('toggleResolveThread should toggle resolved status and refresh', async () => {

--- a/src/test/gerrit-provider.test.ts
+++ b/src/test/gerrit-provider.test.ts
@@ -345,7 +345,8 @@ describe('GerritProvider', () => {
                 ],
             });
 
-            const reply = await provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!');
+            const threads = await provider.getCommentThreads('I12345');
+            const reply = await provider.replyToCommentThread('I12345', threads[0], 'Thanks!');
             expect(reply.body).toBe('Thanks!');
             expect(reply.author.name).toBe('Gerrit User');
         });
@@ -364,13 +365,14 @@ describe('GerritProvider', () => {
                 ],
             });
 
-            await provider.resolveCommentThread('I12345', 'comment-1', true);
-            let threads = await provider.getCommentThreads('I12345');
-            expect(threads[0].isResolved).toBe(true);
+            const threads = await provider.getCommentThreads('I12345');
+            await provider.resolveCommentThread('I12345', threads[0], true);
+            let updatedThreads = await provider.getCommentThreads('I12345');
+            expect(updatedThreads[0].isResolved).toBe(true);
 
-            await provider.resolveCommentThread('I12345', 'comment-1', false);
-            threads = await provider.getCommentThreads('I12345');
-            expect(threads[0].isResolved).toBe(false);
+            await provider.resolveCommentThread('I12345', threads[0], false);
+            updatedThreads = await provider.getCommentThreads('I12345');
+            expect(updatedThreads[0].isResolved).toBe(false);
         });
 
         test('replyToCommentThread posts a reply targeting parent comment patchset', async () => {
@@ -388,7 +390,8 @@ describe('GerritProvider', () => {
                 ],
             });
 
-            const reply = await provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!');
+            const threads = await provider.getCommentThreads('I12345');
+            const reply = await provider.replyToCommentThread('I12345', threads[0], 'Thanks!');
             expect(reply.body).toBe('Thanks!');
             expect(server.requests.some((req) => req.includes('/changes/123/revisions/2/drafts'))).toBe(true);
         });
@@ -407,7 +410,8 @@ describe('GerritProvider', () => {
                 ],
             });
 
-            const reply = await provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!');
+            const threads = await provider.getCommentThreads('I12345');
+            const reply = await provider.replyToCommentThread('I12345', threads[0], 'Thanks!');
             expect(reply.body).toBe('Thanks!');
             expect(server.requests.some((req) => req.includes('/changes/123/revisions/current/drafts'))).toBe(true);
         });
@@ -427,7 +431,8 @@ describe('GerritProvider', () => {
                 ],
             });
 
-            await provider.resolveCommentThread('I12345', 'comment-1', true);
+            const threads = await provider.getCommentThreads('I12345');
+            await provider.resolveCommentThread('I12345', threads[0], true);
             expect(server.requests.some((req) => req.includes('/changes/123/revisions/3/drafts'))).toBe(true);
         });
 
@@ -449,8 +454,9 @@ describe('GerritProvider', () => {
             server.failDraftsResponseBody =
                 'Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.\n';
 
-            await expect(provider.replyToCommentThread('I12345', 'comment-1', 'Thanks!')).rejects.toThrow(
-                'Failed to post Gerrit draft reply: Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
+            const threads = await provider.getCommentThreads('I12345');
+            await expect(provider.replyToCommentThread('I12345', threads[0], 'Thanks!')).rejects.toThrow(
+                'Failed to post Gerrit draft reply: 400 Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
             );
         });
 
@@ -472,9 +478,96 @@ describe('GerritProvider', () => {
             server.failDraftsResponseBody =
                 'Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.';
 
-            await expect(provider.resolveCommentThread('I12345', 'comment-1', true)).rejects.toThrow(
-                'Failed to resolve Gerrit comment: Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
+            const threads = await provider.getCommentThreads('I12345');
+            await expect(provider.resolveCommentThread('I12345', threads[0], true)).rejects.toThrow(
+                'Failed to resolve Gerrit comment: 400 Bad Request - Invalid comment in_reply_to. Comment replies must be submitted on the same patchset as the parent comment.',
             );
+        });
+
+        test('replyToCommentThread and resolveCommentThread use thread metadata without re-fetching comments', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 2,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            const threads = await provider.getCommentThreads('I12345');
+            server.clearRequests();
+
+            await provider.resolveCommentThread('I12345', threads[0], true);
+            expect(server.requests.some((req) => req.includes('/comments'))).toBe(false);
+            expect(server.requests.some((req) => req.includes('/changes/123/revisions/2/drafts'))).toBe(true);
+        });
+
+        test('replyToCommentThread falls back to re-fetching when draft creation response is empty', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 2,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            server.emptyDraftResponseBody = true;
+            const threads = await provider.getCommentThreads('I12345');
+            const reply = await provider.replyToCommentThread('I12345', threads[0], 'Fallback draft reply');
+            expect(reply.body).toBe('Fallback draft reply');
+            expect(reply.isDraft).toBe(true);
+        });
+
+        test('replyToCommentThread defaults missing filePath to /PATCHSET_LEVEL', async () => {
+            server.registerComments(123, {
+                '/PATCHSET_LEVEL': [
+                    {
+                        id: 'comment-cl',
+                        line: 0,
+                        message: 'CL level comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 1,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            const threads = await provider.getCommentThreads('I12345');
+            const threadWithoutPath = { ...threads[0], filePath: undefined };
+            const reply = await provider.replyToCommentThread('I12345', threadWithoutPath, 'Reply to CL comment');
+            expect(reply.body).toBe('Reply to CL comment');
+        });
+
+        test('replyToCommentThread with resolved parameter updates unresolved status', async () => {
+            server.registerComments(123, {
+                'file.txt': [
+                    {
+                        id: 'comment-1',
+                        line: 10,
+                        message: 'First comment',
+                        updated: '2026-06-30T12:00:00Z',
+                        unresolved: true,
+                        patch_set: 1,
+                        author: { name: 'Reviewer A', username: 'rev_a' },
+                    },
+                ],
+            });
+
+            const threads = await provider.getCommentThreads('I12345');
+            const reply = await provider.replyToCommentThread('I12345', threads[0], 'Resolved reply', true);
+            expect(reply.body).toBe('Resolved reply');
         });
 
         test('attaches authentication headers and rewrites URL when auth is available', async () => {

--- a/src/test/github-provider.test.ts
+++ b/src/test/github-provider.test.ts
@@ -839,7 +839,8 @@ describe('GitHubProvider', () => {
                 },
             ]);
 
-            const reply = await provider.replyToCommentThread('pr_node_id_123', 'thread-1', 'Thanks!');
+            const thread = { id: 'thread-1', isResolved: false, comments: [] };
+            const reply = await provider.replyToCommentThread('pr_node_id_123', thread, 'Thanks!');
             expect(reply.body).toBe('Thanks!');
             expect(reply.author.name).toBe('replier-login');
         });
@@ -855,11 +856,12 @@ describe('GitHubProvider', () => {
                 },
             ]);
 
-            await provider.resolveCommentThread('pr_node_id_123', 'thread-1', true);
+            const thread = { id: 'thread-1', isResolved: false, comments: [] };
+            await provider.resolveCommentThread('pr_node_id_123', thread, true);
             let threads = await provider.getCommentThreads('pr_node_id_123');
             expect(threads[0].isResolved).toBe(true);
 
-            await provider.resolveCommentThread('pr_node_id_123', 'thread-1', false);
+            await provider.resolveCommentThread('pr_node_id_123', thread, false);
             threads = await provider.getCommentThreads('pr_node_id_123');
             expect(threads[0].isResolved).toBe(false);
         });

--- a/src/test/gitlab-provider.test.ts
+++ b/src/test/gitlab-provider.test.ts
@@ -643,7 +643,8 @@ describe('GitLabProvider', () => {
                 },
             ]);
 
-            const reply = await provider.replyToCommentThread('101', 'discussion-1', 'Thanks!');
+            const thread = { id: 'discussion-1', isResolved: false, comments: [] };
+            const reply = await provider.replyToCommentThread('101', thread, 'Thanks!');
             expect(reply.body).toBe('Thanks!');
             expect(reply.author.name).toBe('Replier Name');
         });
@@ -668,11 +669,12 @@ describe('GitLabProvider', () => {
                 },
             ]);
 
-            await provider.resolveCommentThread('101', 'discussion-1', true);
+            const thread = { id: 'discussion-1', isResolved: false, comments: [] };
+            await provider.resolveCommentThread('101', thread, true);
             let threads = await provider.getCommentThreads('101');
             expect(threads[0].isResolved).toBe(true);
 
-            await provider.resolveCommentThread('101', 'discussion-1', false);
+            await provider.resolveCommentThread('101', thread, false);
             threads = await provider.getCommentThreads('101');
             expect(threads[0].isResolved).toBe(false);
         });

--- a/src/test/helpers/fake-gerrit-server.ts
+++ b/src/test/helpers/fake-gerrit-server.ts
@@ -31,6 +31,7 @@ export class FakeGerritServer {
     public failResponseBody: string | undefined;
     public failDraftsWithStatus: number | undefined;
     public failDraftsResponseBody: string | undefined;
+    public emptyDraftResponseBody = false;
 
     private nextChangeNumber = 1000;
 
@@ -220,6 +221,12 @@ export class FakeGerritServer {
                         };
                         currentDrafts[filePath].push(newDraft);
                         this.drafts.set(changeNumber, currentDrafts);
+
+                        if (this.emptyDraftResponseBody) {
+                            res.writeHead(200, { 'Content-Type': 'application/json' });
+                            res.end('');
+                            return;
+                        }
 
                         res.writeHead(200, { 'Content-Type': 'application/json' });
                         res.end(`)]}'\n${JSON.stringify(newDraft)}`);

--- a/src/test/vscode-comments-provider.test.ts
+++ b/src/test/vscode-comments-provider.test.ts
@@ -61,7 +61,7 @@ class MockForgeProvider implements CodeForgeProvider {
 
     async replyToCommentThread(
         _changeId: string,
-        threadId: string,
+        thread: CodeForgeCommentThread,
         body: string,
         resolved?: boolean,
     ): Promise<CodeForgeComment> {
@@ -71,20 +71,20 @@ class MockForgeProvider implements CodeForgeProvider {
             body,
             createdAt: new Date().toISOString(),
         };
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.comments.push(reply);
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.comments.push(reply);
             if (resolved !== undefined) {
-                thread.isResolved = resolved;
+                found.isResolved = resolved;
             }
         }
         return reply;
     }
 
-    async resolveCommentThread(_changeId: string, threadId: string, resolved: boolean): Promise<void> {
-        const thread = this.threads.find((t) => t.id === threadId);
-        if (thread) {
-            thread.isResolved = resolved;
+    async resolveCommentThread(_changeId: string, thread: CodeForgeCommentThread, resolved: boolean): Promise<void> {
+        const found = this.threads.find((t) => t.id === thread.id);
+        if (found) {
+            found.isResolved = resolved;
         }
     }
 

--- a/src/vscode/payloads/comments.payload.ts
+++ b/src/vscode/payloads/comments.payload.ts
@@ -85,14 +85,16 @@ function fromVscodeComment(comment: vscode.Comment): Comment {
 }
 
 function extractThreadId(thread: vscode.CommentThread): string | undefined {
+    if (thread.contextValue) {
+        const match = /^(?:resolved|unresolved):(.+)$/.exec(thread.contextValue);
+        if (match) {
+            return match[1];
+        }
+    }
     if ('id' in thread && typeof thread.id === 'string' && thread.id.length > 0) {
         return thread.id;
     }
-    if (!thread.contextValue) {
-        return undefined;
-    }
-    const match = /^(?:resolved|unresolved):(.+)$/.exec(thread.contextValue);
-    return match ? match[1] : undefined;
+    return undefined;
 }
 
 function fromVscodeCommentThread(thread: vscode.CommentThread): CommentThread | undefined {


### PR DESCRIPTION
- Add generic metadata?: Record<string, unknown> to CodeForgeCommentThread
- Update CodeForgeProvider.replyToCommentThread and resolveCommentThread to accept CodeForgeCommentThread instead of threadId string
- In GerritProvider, store patch_set in thread.metadata and eliminate pre-posting network roundtrips when replying and resolving
- In CommentsManager, store _threads as Map<string, CodeForgeCommentThread> with cached _threadsList for zero-allocation O(1) getters
- Throw early if thread is not found in cache instead of synthesizing invalid stubs
- Prioritize contextValue in extractThreadId to reliably obtain forge thread IDs
- Fix Gerrit draft reply filter to exclude root parent comment in re-fetch fallback
- Include HTTP status code in Gerrit error messages and handle CRLF in JSON prefix