### PR TITLE
merge-editor: fix blank 3-way merge and file overwrites

### DIFF
--- a/scripts/conflict-capture.bat
+++ b/scripts/conflict-capture.bat
@@ -17,12 +17,32 @@ set "left=%~2"
 set "right=%~3"
 set "output=%~4"
 
-set "base=%base:/=\%"
-set "left=%left:/=\%"
-set "right=%right:/=\%"
-set "output=%output:/=\%"
+if not defined output exit /B 1
 
-copy "%base%" "%output%\base"
-copy "%left%" "%output%\left"
-copy "%right%" "%output%\right"
+if defined base set "base=%base:/=\%"
+if defined left set "left=%left:/=\%"
+if defined right set "right=%right:/=\%"
+if defined output set "output=%output:/=\%"
+
+call :capture_side "%base%" "%output%\base"
+if errorlevel 1 goto :fail
+
+call :capture_side "%left%" "%output%\left"
+if errorlevel 1 goto :fail
+
+call :capture_side "%right%" "%output%\right"
+if errorlevel 1 goto :fail
+
+echo done > "%output%\.complete" 2>nul
 exit /B 1
+
+:fail
+exit /B 1
+
+:capture_side
+if exist "%~1" (
+    copy /B /Y "%~1" "%~2" >nul || exit /B 1
+) else (
+    type nul > "%~2" || exit /B 1
+)
+exit /B 0

--- a/scripts/conflict-capture.sh
+++ b/scripts/conflict-capture.sh
@@ -18,7 +18,24 @@ left=$2
 right=$3
 output=$4
 
-cp "${base}" "${output}/base"
-cp "${left}" "${output}/left"
-cp "${right}" "${output}/right"
+if [ -z "${output}" ]; then
+    exit 1
+fi
+
+capture_side() {
+    src=$1
+    dest=$2
+    if [ -f "${src}" ]; then
+        cp -- "${src}" "${dest}" || return 1
+    else
+        touch "${dest}" || return 1
+    fi
+}
+
+if capture_side "${base}" "${output}/base" && \
+   capture_side "${left}" "${output}/left" && \
+   capture_side "${right}" "${output}/right"; then
+    touch "${output}/.complete"
+fi
+
 exit 1

--- a/src/core/jj-merge-service.ts
+++ b/src/core/jj-merge-service.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as path from 'node:path';
 import { type Event, EventEmitter } from './host/events';
 import type { JjService } from './jj-service';
 import { getUriParams, type Uri } from './uri-utils';
@@ -13,29 +14,49 @@ export class JjMergeService {
 
     // Cache to avoid re-running jj resolve for same file
     private cache = new Map<string, { base: string; left: string; right: string }>();
+    private inFlight = new Map<string, Promise<{ base: string; left: string; right: string }>>();
 
     constructor(private jjService: JjService) {}
 
     async provideContent(uri: Uri): Promise<string> {
         const query = getUriParams(uri);
-        const fsPath = query.get('path');
+        const rawPath = query.get('path');
         const part = query.get('part'); // 'base', 'left', 'right'
 
-        if (!fsPath || !part) {
-            console.error('JjMergeService: Missing path or part');
+        if (!rawPath || !part) {
+            console.error('JjMergeService: Missing path or part in URI');
             return '';
         }
+
+        const fsPath = path.normalize(rawPath);
 
         try {
             // Check cache first
             let parts = this.cache.get(fsPath);
             if (!parts) {
-                // Get conflict parts from jj resolve
-                parts = await this.jjService.getConflictParts(fsPath);
-                this.cache.set(fsPath, parts);
-
-                // Clear cache after a short delay (file may change)
-                setTimeout(() => this.cache.delete(fsPath), 5000);
+                let promise = this.inFlight.get(fsPath);
+                if (!promise) {
+                    promise = this.jjService
+                        .getConflictParts(fsPath)
+                        .then((result) => {
+                            if (this.inFlight.get(fsPath) === promise) {
+                                this.cache.set(fsPath, result);
+                                setTimeout(() => {
+                                    if (this.cache.get(fsPath) === result) {
+                                        this.cache.delete(fsPath);
+                                    }
+                                }, 5000);
+                            }
+                            return result;
+                        })
+                        .finally(() => {
+                            if (this.inFlight.get(fsPath) === promise) {
+                                this.inFlight.delete(fsPath);
+                            }
+                        });
+                    this.inFlight.set(fsPath, promise);
+                }
+                parts = await promise;
             }
 
             if (part === 'base') {
@@ -48,22 +69,30 @@ export class JjMergeService {
                 return parts.right;
             }
 
-            return '';
+            throw new Error(`JjMergeService: Unknown merge part '${part}'`);
         } catch (e: unknown) {
             console.error(`JjMergeService: Failed to get conflict parts: ${e}`);
-            return `Error loading content: ${e}`;
+            throw e instanceof Error ? e : new Error(String(e));
         }
     }
 
     update(uri: Uri): void {
+        const query = getUriParams(uri);
+        const rawPath = query.get('path');
+        if (rawPath) {
+            this.clearCache(path.normalize(rawPath));
+        }
         this._onDidChange.fire(uri);
     }
 
     clearCache(fsPath?: string): void {
-        if (fsPath) {
-            this.cache.delete(fsPath);
-        } else {
+        if (!fsPath) {
             this.cache.clear();
+            this.inFlight.clear();
+            return;
         }
+        const normalized = path.normalize(fsPath);
+        this.cache.delete(normalized);
+        this.inFlight.delete(normalized);
     }
 }

--- a/src/core/jj-service.ts
+++ b/src/core/jj-service.ts
@@ -233,8 +233,8 @@ export class JjService {
             const escapedScriptPath = normalizedScriptPath.replace(/\//g, '\\\\');
             return [
                 `--config=merge-tools.${toolName}.program="cmd"`,
-                `--config=merge-tools.${toolName}.merge-args=["/c", "${escapedScriptPath}", ${quotedArgs.join(', ')}]`,
-                `--config=merge-tools.${toolName}.edit-args=["/c", "${escapedScriptPath}", ${quotedArgs.join(', ')}]`,
+                `--config=merge-tools.${toolName}.merge-args=["/s", "/c", "${escapedScriptPath}", ${quotedArgs.join(', ')}]`,
+                `--config=merge-tools.${toolName}.edit-args=["/s", "/c", "${escapedScriptPath}", ${quotedArgs.join(', ')}]`,
             ];
         } else {
             return [
@@ -577,6 +577,7 @@ export class JjService {
 
             const normalizedScriptPath = this.getScriptPath('conflict-capture');
 
+            let resolveError: unknown;
             try {
                 const toolName = 'vscode-capture';
                 const toolConfig = this.getToolConfigArgs(toolName, normalizedScriptPath, [
@@ -588,18 +589,43 @@ export class JjService {
 
                 await this.run('resolve', ['--tool', toolName, ...toolConfig, relativePath], {
                     useCachedSnapshot: true,
+                    label: `getConflictParts ${relativePath}`,
                 });
-            } catch {
-                // Expected: jj returns error because our tool exits with 1
+            } catch (err) {
+                resolveError = err;
             }
 
-            const base = await fs.readFile(basePath, 'utf8');
-            const left = await fs.readFile(leftPath, 'utf8');
-            const right = await fs.readFile(rightPath, 'utf8');
+            // Verify that conflict-capture actually ran and wrote the .complete marker
+            const marker = path.join(tempDir, '.complete');
+            const isCompleted = await fs
+                .access(marker)
+                .then(() => true)
+                .catch(() => false);
+            if (!isCompleted) {
+                throw (
+                    resolveError ??
+                    new Error(`Failed to capture conflict parts for ${relativePath}: tool did not complete.`)
+                );
+            }
+
+            const readConflictPart = async (partPath: string): Promise<string> => {
+                try {
+                    return await fs.readFile(partPath, 'utf8');
+                } catch (error: unknown) {
+                    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+                        return '';
+                    }
+                    throw error;
+                }
+            };
+
+            const base = await readConflictPart(basePath);
+            const left = await readConflictPart(leftPath);
+            const right = await readConflictPart(rightPath);
 
             return { base, left, right };
         } finally {
-            await fs.rm(tempDir, { recursive: true }).catch(() => {});
+            await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
         }
     }
 

--- a/src/core/uri-utils.ts
+++ b/src/core/uri-utils.ts
@@ -83,6 +83,10 @@ function normalizePath(p: string): string {
 
 export function getFsPathFromUri(uri: Uri): string {
     const params = getUriParams(uri);
+    const targetPath = params.get('path');
+    if (targetPath) {
+        return path.normalize(targetPath);
+    }
     const root = params.get('root') || params.get('repoRoot');
     if (root) {
         const normPath = path.normalize(uri.fsPath);

--- a/src/test/jj-merge-service.test.ts
+++ b/src/test/jj-merge-service.test.ts
@@ -53,4 +53,101 @@ describe('JjMergeService Unit Tests', () => {
 
         expect(mockJj.getConflictParts).toHaveBeenCalledTimes(2);
     });
+
+    it('deduplicates concurrent in-flight requests for the same path', async () => {
+        let resolveConflict!: (val: { base: string; left: string; right: string }) => void;
+        const deferred = new Promise<{ base: string; left: string; right: string }>((res) => {
+            resolveConflict = res;
+        });
+        mockJj = createMock<JjService>({
+            getConflictParts: vi.fn().mockReturnValue(deferred),
+        });
+        service = new JjMergeService(mockJj);
+
+        const baseUri = Uri.parse('jj-merge:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=base');
+        const leftUri = Uri.parse('jj-merge:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=left');
+        const rightUri = Uri.parse('jj-merge:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=right');
+
+        const [p1, p2, p3] = [
+            service.provideContent(baseUri),
+            service.provideContent(leftUri),
+            service.provideContent(rightUri),
+        ];
+
+        resolveConflict({ base: 'base content', left: 'ours content', right: 'theirs content' });
+
+        expect(await p1).toBe('base content');
+        expect(await p2).toBe('ours content');
+        expect(await p3).toBe('theirs content');
+        expect(mockJj.getConflictParts).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not populate cache with stale result if clearCache was called while request was in-flight', async () => {
+        let resolveFirst!: (val: { base: string; left: string; right: string }) => void;
+        const firstDeferred = new Promise<{ base: string; left: string; right: string }>((res) => {
+            resolveFirst = res;
+        });
+        const getConflictPartsMock = vi.fn().mockReturnValueOnce(firstDeferred).mockResolvedValueOnce({
+            base: 'new base',
+            left: 'new left',
+            right: 'new right',
+        });
+        mockJj = createMock<JjService>({
+            getConflictParts: getConflictPartsMock,
+        });
+        service = new JjMergeService(mockJj);
+
+        const leftUri = Uri.parse('jj-merge:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=left');
+
+        // Start first request
+        const firstPromise = service.provideContent(leftUri);
+
+        // Clear cache while first request is in-flight
+        service.clearCache('/workspace/conflict.txt');
+
+        // Start second request (which should start a new fetch)
+        const secondPromise = service.provideContent(leftUri);
+
+        // Now resolve the first request with stale content
+        resolveFirst({ base: 'stale base', left: 'stale left', right: 'stale right' });
+
+        expect(await firstPromise).toBe('stale left');
+        expect(await secondPromise).toBe('new left');
+        expect(getConflictPartsMock).toHaveBeenCalledTimes(2);
+
+        // Third request should use the cached result from second request, not stale
+        const thirdResult = await service.provideContent(leftUri);
+        expect(thirdResult).toBe('new left');
+        expect(getConflictPartsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws error when getConflictParts fails rather than returning error string', async () => {
+        mockJj = createMock<JjService>({
+            getConflictParts: vi.fn().mockRejectedValue(new Error('Process failed: conflict-capture exited with 1')),
+        });
+        service = new JjMergeService(mockJj);
+        const baseUri = Uri.parse('jj-merge-output:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=base');
+
+        await expect(service.provideContent(baseUri)).rejects.toThrow('Process failed: conflict-capture exited with 1');
+    });
+
+    it('returns empty string when URI is missing path or part', async () => {
+        const invalidUri = Uri.parse('jj-merge-output:///conflict.txt?path=%2Fworkspace%2Fconflict.txt');
+        expect(await service.provideContent(invalidUri)).toBe('');
+    });
+
+    it('clears cached content and fires onDidChange when update is called', async () => {
+        const leftUri = Uri.parse('jj-merge-output:///conflict.txt?path=%2Fworkspace%2Fconflict.txt&part=left');
+        let firedUri: Uri | undefined;
+        service.onDidChange((uri) => {
+            firedUri = uri;
+        });
+
+        await service.provideContent(leftUri);
+        service.update(leftUri);
+
+        expect(firedUri?.toString()).toBe(leftUri.toString());
+        await service.provideContent(leftUri);
+        expect(mockJj.getConflictParts).toHaveBeenCalledTimes(2);
+    });
 });

--- a/src/test/jj-repository-manager.integration.test.ts
+++ b/src/test/jj-repository-manager.integration.test.ts
@@ -240,6 +240,23 @@ suite('JjRepositoryManager Integration Test', () => {
         assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
     });
 
+    test('getRepositoryForUri works for jj-merge-output URIs', async () => {
+        const filePath = path.join(mainRepo.path, 'sub', 'conflict.txt');
+        const fileUri = Uri.file(filePath);
+        await manager.maybeRegisterRepositoryContainingUri(fileUri);
+
+        const mergeUri = Uri.from({
+            scheme: 'jj-merge-output',
+            authority: 'jj-merge',
+            path: '/sub/conflict.txt',
+            fragment: `path=${encodeURIComponent(filePath)}&part=base`,
+        });
+
+        const matched = manager.getRepositoryForUri(mergeUri);
+        assert.ok(matched, 'Should match repo for jj-merge-output URI');
+        assert.strictEqual(matched.rootUri.fsPath, mainRepo.path);
+    });
+
     test('scan discovers a single repository', async () => {
         await manager.scanForRepositories();
 

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1290,6 +1290,59 @@ log = "none()"
         expect(parts.right).toBe('right content\n');
     });
 
+    test('getConflictParts throws when file has no conflict or resolve fails', async () => {
+        await expect(jjService.getConflictParts('nonexistent-conflict.txt')).rejects.toThrow();
+    });
+
+    test('getConflictParts handles conflict where base does not exist', async () => {
+        const fileName = 'add-conflict.txt';
+        await buildGraph(repo, [
+            { label: 'root', description: 'root' },
+            { label: 'left', parents: ['root'], description: 'left', files: { [fileName]: 'left only\n' } },
+            { label: 'right', parents: ['root'], description: 'right', files: { [fileName]: 'right only\n' } },
+            { label: 'merge', parents: ['left', 'right'], description: 'merge', isCurrentWorkingCopy: true },
+        ]);
+
+        const parts = await jjService.getConflictParts(fileName);
+        expect(parts.base).toBe('');
+        expect(parts.left).toBe('left only\n');
+        expect(parts.right).toBe('right only\n');
+    });
+
+    test('getConflictParts handles modify/delete conflict where right side is deleted', async () => {
+        const fileName = 'mod-del-conflict.txt';
+        const ids = await buildGraph(repo, [
+            { label: 'root', description: 'root', files: { [fileName]: 'base content\n' } },
+            { label: 'left', parents: ['root'], description: 'left', files: { [fileName]: 'modified content\n' } },
+        ]);
+        repo.new([ids.root.changeId], 'right');
+        repo.deleteFile(fileName);
+        const rightChangeId = repo.getChangeId('@');
+        repo.new([ids.left.changeId, rightChangeId], 'merge');
+
+        const parts = await jjService.getConflictParts(fileName);
+        expect(parts.base).toBe('base content\n');
+        expect(parts.left).toBe('modified content\n');
+        expect(parts.right).toBe('');
+    });
+
+    test('getConflictParts handles delete/modify conflict where left side is deleted', async () => {
+        const fileName = 'del-mod-conflict.txt';
+        const ids = await buildGraph(repo, [
+            { label: 'root', description: 'root', files: { [fileName]: 'base content\n' } },
+            { label: 'right', parents: ['root'], description: 'right', files: { [fileName]: 'modified content\n' } },
+        ]);
+        repo.new([ids.root.changeId], 'left');
+        repo.deleteFile(fileName);
+        const leftChangeId = repo.getChangeId('@');
+        repo.new([leftChangeId, ids.right.changeId], 'merge');
+
+        const parts = await jjService.getConflictParts(fileName);
+        expect(parts.base).toBe('base content\n');
+        expect(parts.left).toBe('');
+        expect(parts.right).toBe('modified content\n');
+    });
+
     test('getLog returns file changes with statuses', async () => {
         await buildGraph(repo, [
             {

--- a/src/test/uri-utils.test.ts
+++ b/src/test/uri-utils.test.ts
@@ -226,6 +226,19 @@ describe('getFsPathFromUri and toFileUri', () => {
         expect(fileUri.scheme).toBe('file');
         expect(fileUri.fsPath).toBeSameFsPath('/workspace/repo/src/file.ts');
     });
+
+    it('extracts target path from path fragment parameter for jj-merge-output URIs', () => {
+        const filePath = '/workspace/repo/src/conflict.txt';
+        const encodedPath = encodeURIComponent(filePath);
+        const mergeUri = Uri.from({
+            scheme: 'jj-merge-output',
+            authority: 'jj-merge',
+            path: '/src/conflict.txt',
+            fragment: `path=${encodedPath}&part=base`,
+        });
+        const fsPath = getFsPathFromUri(mergeUri);
+        expect(fsPath).toBeSameFsPath(filePath);
+    });
 });
 
 describe('getRevisionFromUri', () => {

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -22,7 +22,6 @@ import { JjMergeService } from '../core/jj-merge-service';
 import { JjProcessTracker } from '../core/jj-process-tracker';
 import { JjRepositoryManager } from '../core/jj-repository-manager';
 import { JjViewFsService } from '../core/jj-view-fs-service';
-import { getUriParams } from '../core/uri-utils';
 import { resolveJjBinary } from '../utils/binary-utils';
 import { toError } from '../utils/error-utils';
 import { type LoggerChannel, OutputChannel } from '../utils/output-channel';
@@ -321,34 +320,27 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     );
 
     // Register ContentProvider for virtual merge output documents
+    const onDidChangeMergeEmitter = new vscode.EventEmitter<vscode.Uri>();
+    const mergeProviders = new Map<string, VsCodeMergeContentProvider>();
     context.subscriptions.push(
+        onDidChangeMergeEmitter,
         vscode.workspace.registerTextDocumentContentProvider('jj-merge-output', {
+            onDidChange: onDidChangeMergeEmitter.event,
             provideTextDocumentContent(uri) {
                 const repo = repositoryManager.getRepositoryForUri(uri);
                 if (!repo) {
-                    return '';
+                    throw new Error(`Repository not found for URI: ${uri.toString()}`);
                 }
-                const mergeService = new JjMergeService(repo.jj);
-                const mergeProvider = new VsCodeMergeContentProvider(mergeService);
-                return mergeProvider.provideTextDocumentContent(uri);
+                const repoKey = repo.rootUri.fsPath;
+                let provider = mergeProviders.get(repoKey);
+                if (!provider) {
+                    const mergeService = new JjMergeService(repo.jj);
+                    provider = new VsCodeMergeContentProvider(mergeService);
+                    provider.onDidChange((e) => onDidChangeMergeEmitter.fire(e));
+                    mergeProviders.set(repoKey, provider);
+                }
+                return provider.provideTextDocumentContent(uri);
             },
-        }),
-    );
-
-    // Handle saving of virtual merge output
-    context.subscriptions.push(
-        vscode.workspace.onDidSaveTextDocument(async (doc) => {
-            if (doc.uri.scheme === 'jj-merge-output') {
-                const query = getUriParams(doc.uri);
-                const fsPath = query.get('path');
-                if (fsPath) {
-                    try {
-                        await fs.writeFile(fsPath, doc.getText());
-                    } catch (e) {
-                        vscode.window.showErrorMessage(`Failed to save merge result: ${e}`);
-                    }
-                }
-            }
         }),
     );
 

--- a/src/vscode/providers/vscode-merge-provider.ts
+++ b/src/vscode/providers/vscode-merge-provider.ts
@@ -18,7 +18,7 @@ export class VsCodeMergeContentProvider implements vscode.TextDocumentContentPro
     constructor(public readonly service: JjMergeService) {
         this._disposables.push(
             this.service.onDidChange((uri) => {
-                this._onDidChange.fire(uri as unknown as vscode.Uri);
+                this._onDidChange.fire(vscode.Uri.parse(uri.toString()));
             }),
         );
     }

--- a/src/vscode/vscode-host-environment.ts
+++ b/src/vscode/vscode-host-environment.ts
@@ -220,6 +220,9 @@ export class VsCodeHostNavigation implements HostNavigation {
     async openMergeEditor(resourceUri: Uri): Promise<void> {
         const fsPath = getFsPathFromUri(resourceUri);
         const encodedPath = encodeURIComponent(fsPath);
+        const params = getUriParams(resourceUri);
+        const root = params.get('root') || params.get('repoRoot');
+        const rootParam = root ? `&root=${encodeURIComponent(root)}` : '';
         const relativePath = vscode.workspace.asRelativePath(toFileUri(resourceUri));
         const virtualPath = path.posix.join('/', relativePath);
 
@@ -227,19 +230,19 @@ export class VsCodeHostNavigation implements HostNavigation {
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            fragment: `path=${encodedPath}&part=base`,
+            fragment: `path=${encodedPath}&part=base${rootParam}`,
         });
         const leftUri = resourceUri.with({
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            fragment: `path=${encodedPath}&part=left`,
+            fragment: `path=${encodedPath}&part=left${rootParam}`,
         });
         const rightUri = resourceUri.with({
             scheme: 'jj-merge-output',
             authority: 'jj-merge',
             path: virtualPath,
-            fragment: `path=${encodedPath}&part=right`,
+            fragment: `path=${encodedPath}&part=right${rootParam}`,
         });
         const outputUri = toFileUri(resourceUri);
         const args = {


### PR DESCRIPTION
The 3-way merge editor was opening completely blank and overwriting conflicted files in the working copy with empty content.

This happened because `jj-merge-output` URIs were not mapped back to their repository, causing the merge content provider to return empty strings for each conflict side. VS Code saw three empty sides, assumed the conflict was clean, and auto-saved empty content over the file. An extraneous save listener also wrote virtual documents directly into the working copy.

Now, merge output URIs resolve to their parent repository so conflict sides load correctly, concurrent capture requests are deduplicated, and virtual merge documents no longer overwrite working copy files.

Fixes #498