### PR TITLE
fix(watcher): auto-recover and reconnect DirectoryWatcher on daemon disconnect

### DIFF
--- a/src/core/change-detection-manager.ts
+++ b/src/core/change-detection-manager.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { BackendType } from '@parcel/watcher';
+import { toError } from '../utils/error-utils';
 import type { LoggerChannel } from '../utils/output-channel';
 import { DirectoryWatcher } from './directory-watcher';
 import type { HostDisposable, HostEnvironment } from './host/host-environment';
@@ -236,9 +237,30 @@ export class ChangeDetectionManager implements HostDisposable {
                         this.triggerRefresh({ forceSnapshot: false, reason: 'jj operation' });
                     },
                     this.outputChannel,
-                    'OpHeads Watcher',
-                    this.watcherBackend,
-                    this.host,
+                    {
+                        name: 'OpHeads Watcher',
+                        backend: this.watcherBackend,
+                        host: this.host,
+                        onReconnect: () => {
+                            if (this._disposed) {
+                                return;
+                            }
+                            const writes = this.hasActiveOrRecentWrites;
+                            if (writes) {
+                                this._scheduleDeferredRefresh();
+                                return;
+                            }
+                            this.triggerRefresh({ forceSnapshot: false, reason: 'op_heads watcher reconnected' });
+                        },
+                        onPermanentFailure: (err) => {
+                            this.outputChannel.error(
+                                '[ChangeDetectionManager] OpHeads watcher permanently failed',
+                                toError(err),
+                            );
+                            void this._opHeadsWatcher?.stop().catch(() => {});
+                            this._opHeadsWatcher = undefined;
+                        },
+                    },
                 );
                 await this._opHeadsWatcher.start();
                 return; // Success
@@ -319,9 +341,33 @@ export class ChangeDetectionManager implements HostDisposable {
                 this.triggerRefresh({ forceSnapshot: true, reason: 'file watcher event' });
             },
             this.outputChannel,
-            'Working Copy Watcher',
-            this.watcherBackend,
-            this.host,
+            {
+                name: 'Working Copy Watcher',
+                backend: this.watcherBackend,
+                host: this.host,
+                onReconnect: () => {
+                    if (this._disposed) {
+                        return;
+                    }
+                    const writes = this.hasActiveOrRecentWrites;
+                    if (writes) {
+                        this._scheduleDeferredRefresh();
+                        return;
+                    }
+                    this.triggerRefresh({ forceSnapshot: true, reason: 'file watcher reconnected' });
+                },
+                onPermanentFailure: (err) => {
+                    this.outputChannel.error(
+                        '[ChangeDetectionManager] Working copy watcher permanently failed',
+                        toError(err),
+                    );
+                    this.outputChannel.info('Falling back to polling mode.');
+                    this._fileWatcherMode = 'polling';
+                    void this._workingCopyWatcher?.stop().catch(() => {});
+                    this._workingCopyWatcher = undefined;
+                    this.updatePollingState();
+                },
+            },
         );
 
         this.outputChannel.info(
@@ -414,7 +460,7 @@ export class ChangeDetectionManager implements HostDisposable {
             this._poller.stop();
 
             if (this._workingCopyWatcher) {
-                await this._workingCopyWatcher.stop();
+                await this._workingCopyWatcher.dispose();
                 this._workingCopyWatcher = undefined;
             }
 

--- a/src/core/directory-watcher.ts
+++ b/src/core/directory-watcher.ts
@@ -12,45 +12,95 @@ import { Uri } from './uri-utils';
 
 export type DirectoryWatcherCallback = (events: Event[]) => void;
 
+export interface ReconnectOptions {
+    /** Initial retry delay in milliseconds (default: 1000) */
+    initialDelayMs?: number;
+    /** Maximum retry delay in milliseconds (default: 30000) */
+    maxDelayMs?: number;
+    /** Optional maximum retries before permanent failure (default: unlimited) */
+    maxRetries?: number;
+}
+
+export interface DirectoryWatcherOptions {
+    name?: string;
+    backend?: BackendType;
+    host?: HostEnvironment;
+    onReconnect?: () => void | Promise<void>;
+    onPermanentFailure?: (err: unknown) => void | Promise<void>;
+    reconnectOptions?: ReconnectOptions;
+}
+
 export class DirectoryWatcher implements HostDisposable {
+    private readonly name: string;
+    private readonly host: HostEnvironment | undefined;
+    private readonly onReconnect: (() => void | Promise<void>) | undefined;
+    private readonly onPermanentFailure: ((err: unknown) => void | Promise<void>) | undefined;
+    private readonly _initialReconnectDelay: number;
+    private readonly _maxReconnectDelay: number;
+    private readonly _maxRetries: number | undefined;
+
     private _subscription: AsyncSubscription | undefined;
     private _startPromise: Promise<void> | undefined;
+    private _stopPromise: Promise<void> | undefined;
+    private _reconnectPromise: Promise<void> | undefined;
+    private _reconnectTimeout: NodeJS.Timeout | undefined;
+    private _isReconnecting = false;
+    private _currentReconnectDelay: number;
+    private _retryCount = 0;
     private _disposed = false;
     private _stopped = false;
     private _backend: Promise<BackendType | undefined>;
+    private _lastIgnores: string[] = [];
 
     constructor(
         private readonly path: string,
         private readonly callback: DirectoryWatcherCallback,
         private readonly outputChannel: LoggerChannel,
-        private readonly name: string = 'DirectoryWatcher',
-        backend?: BackendType,
-        private readonly host?: HostEnvironment,
+        options?: DirectoryWatcherOptions,
     ) {
+        this.name = options?.name ?? 'DirectoryWatcher';
+        this.host = options?.host;
+        this.onReconnect = options?.onReconnect;
+        this.onPermanentFailure = options?.onPermanentFailure;
+        this._initialReconnectDelay = Math.max(1, options?.reconnectOptions?.initialDelayMs ?? 1000);
+        this._maxReconnectDelay = Math.max(this._initialReconnectDelay, options?.reconnectOptions?.maxDelayMs ?? 30000);
+        this._maxRetries = options?.reconnectOptions?.maxRetries;
+        this._currentReconnectDelay = this._initialReconnectDelay;
+
         this._backend = (async () => {
-            if (backend) {
-                return backend;
-            } else if (await isWatchmanAvailable()) {
-                return 'watchman';
-            } else if (process.platform === 'win32') {
-                return 'windows';
-            } else if (process.platform === 'linux') {
-                return 'inotify';
-            } else if (process.platform === 'darwin') {
-                return 'fs-events';
-            } else {
-                return undefined;
+            if (options?.backend) {
+                return options.backend;
             }
+            if (await isWatchmanAvailable()) {
+                return 'watchman';
+            }
+            if (process.platform === 'win32') {
+                return 'windows';
+            }
+            if (process.platform === 'linux') {
+                return 'inotify';
+            }
+            if (process.platform === 'darwin') {
+                return 'fs-events';
+            }
+            return undefined;
         })();
     }
 
     async start(ignores: string[] = []): Promise<void> {
+        this._lastIgnores = ignores;
         this._stopped = false;
+        if (this._reconnectTimeout) {
+            clearTimeout(this._reconnectTimeout);
+            this._reconnectTimeout = undefined;
+        }
         if (this._startPromise) {
             return this._startPromise;
         }
 
-        this._startPromise = this.startInternal(ignores);
+        this._startPromise = this.startInternal(ignores).finally(() => {
+            this._startPromise = undefined;
+        });
         return this._startPromise;
     }
 
@@ -71,6 +121,10 @@ export class DirectoryWatcher implements HostDisposable {
                 (err, events) => {
                     if (err) {
                         this.logError(`[${this.name}] Error`, err);
+                        this.handleSubscriptionError(err);
+                        return;
+                    }
+                    if (this._disposed || this._stopped) {
                         return;
                     }
                     if (events.length > 0) {
@@ -82,30 +136,45 @@ export class DirectoryWatcher implements HostDisposable {
             );
 
             if (this._disposed || this._stopped) {
-                await sub.unsubscribe();
+                try {
+                    await sub.unsubscribe();
+                } catch (err) {
+                    this.logError(`[${this.name}] Failed to unsubscribe`, err);
+                }
                 return;
             }
 
             this._subscription = sub;
+            this._currentReconnectDelay = this._initialReconnectDelay;
+            this._retryCount = 0;
             this.log(`[${this.name}] Started.`);
         } catch (err) {
-            this._startPromise = undefined;
             this.logError(`[${this.name}] Failed to start`, err);
             this.handleInotifyError(err);
             throw err;
         }
     }
 
-    private handleInotifyError(err: unknown): void {
-        if (!this.host) {
-            return;
+    private isInotifyLimitError(err: unknown): boolean {
+        const errObj = typeof err === 'object' && err !== null ? (err as Record<string, unknown>) : undefined;
+        if (typeof errObj?.code === 'string' && errObj.code === 'ENOSPC') {
+            return true;
         }
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        const isInotifyLimit =
+        const errorMessage =
+            typeof errObj?.message === 'string' ? errObj.message : err instanceof Error ? err.message : String(err);
+        const lower = errorMessage.toLowerCase();
+        return (
             errorMessage.includes('inotify_add_watch') ||
             errorMessage.includes('ENOSPC') ||
-            errorMessage.includes('No space left on device');
-        if (!isInotifyLimit) {
+            lower.includes('no space left on device') ||
+            lower.includes('max_user_watches') ||
+            lower.includes('inotify watch limit') ||
+            lower.includes('inotify limit')
+        );
+    }
+
+    private handleInotifyError(err: unknown): void {
+        if (!this.host || !this.isInotifyLimitError(err)) {
             return;
         }
 
@@ -124,20 +193,169 @@ export class DirectoryWatcher implements HostDisposable {
             .catch(() => {});
     }
 
-    async stop() {
+    private notifyPermanentFailure(err: unknown): void {
         this._stopped = true;
+        if (this._reconnectTimeout) {
+            clearTimeout(this._reconnectTimeout);
+            this._reconnectTimeout = undefined;
+        }
+        try {
+            const result = this.onPermanentFailure?.(err);
+            if (result instanceof Promise) {
+                result.catch((cbErr: unknown) => {
+                    this.logError(`[${this.name}] Error in onPermanentFailure callback`, cbErr);
+                });
+            }
+        } catch (cbErr) {
+            this.logError(`[${this.name}] Error in onPermanentFailure callback`, cbErr);
+        }
+    }
+
+    private handleSubscriptionError(err: unknown): void {
+        if (this._disposed || this._stopped) {
+            return;
+        }
+
+        const deadSub = this._subscription;
+        this._subscription = undefined;
+        if (deadSub) {
+            try {
+                deadSub.unsubscribe().catch((unsubErr) => {
+                    this.logError(`[${this.name}] Failed to unsubscribe dead subscription`, unsubErr);
+                });
+            } catch (unsubErr) {
+                this.logError(`[${this.name}] Failed to unsubscribe dead subscription`, unsubErr);
+            }
+        }
+
+        if (this.isInotifyLimitError(err)) {
+            this.handleInotifyError(err);
+            this.notifyPermanentFailure(err);
+            return;
+        }
+
+        this.scheduleReconnect();
+    }
+
+    private scheduleReconnect(): void {
+        if (this._disposed || this._stopped || this._reconnectTimeout !== undefined || this._isReconnecting) {
+            return;
+        }
+
+        if (this._maxRetries !== undefined && this._retryCount >= this._maxRetries) {
+            const maxRetriesError = new Error(
+                `[${this.name}] Maximum reconnection attempts (${this._maxRetries}) exceeded`,
+            );
+            this.logError(maxRetriesError.message, maxRetriesError);
+            this.notifyPermanentFailure(maxRetriesError);
+            return;
+        }
+
+        const delay = this._currentReconnectDelay;
+        const attempt = this._retryCount + 1;
+        this.log(`[${this.name}] Scheduling reconnect in ${delay}ms (attempt ${attempt})`);
+
+        this._reconnectTimeout = setTimeout(() => {
+            this._reconnectTimeout = undefined;
+            this._reconnectPromise = this.attemptReconnect()
+                .catch((err) => {
+                    this.logError(`[${this.name}] Unexpected error during reconnection attempt`, err);
+                })
+                .finally(() => {
+                    this._reconnectPromise = undefined;
+                });
+        }, delay);
+
+        this._currentReconnectDelay = Math.min(this._currentReconnectDelay * 2, this._maxReconnectDelay);
+        this._retryCount++;
+    }
+
+    private async attemptReconnect(): Promise<void> {
+        if (this._disposed || this._stopped) {
+            return;
+        }
+
+        this._isReconnecting = true;
+        this.log(`[${this.name}] Attempting reconnect...`);
+
+        try {
+            if (this._startPromise) {
+                await this._startPromise;
+            } else {
+                this._startPromise = this.startInternal(this._lastIgnores).finally(() => {
+                    this._startPromise = undefined;
+                });
+                await this._startPromise;
+            }
+        } catch (err) {
+            this._isReconnecting = false;
+            if (this._disposed || this._stopped) {
+                return;
+            }
+            this.logError(`[${this.name}] Reconnection attempt failed`, err);
+            if (this.isInotifyLimitError(err)) {
+                this.notifyPermanentFailure(err);
+                return;
+            }
+            this.scheduleReconnect();
+            return;
+        }
+
+        this._isReconnecting = false;
+        if (this._disposed || this._stopped) {
+            return;
+        }
+
+        this.log(`[${this.name}] Reconnected successfully.`);
+        this._currentReconnectDelay = this._initialReconnectDelay;
+        this._retryCount = 0;
+
+        try {
+            await this.onReconnect?.();
+        } catch (err) {
+            this.logError(`[${this.name}] Error in onReconnect callback`, err);
+        }
+    }
+
+    async stop(): Promise<void> {
+        if (this._stopPromise) {
+            return this._stopPromise;
+        }
+        this._stopPromise = this.stopInternal().finally(() => {
+            this._stopPromise = undefined;
+        });
+        return this._stopPromise;
+    }
+
+    private async stopInternal(): Promise<void> {
+        this._stopped = true;
+        if (this._reconnectTimeout) {
+            clearTimeout(this._reconnectTimeout);
+            this._reconnectTimeout = undefined;
+        }
+        this._isReconnecting = false;
+        this._retryCount = 0;
+        this._currentReconnectDelay = this._initialReconnectDelay;
+
+        if (this._reconnectPromise) {
+            await this._reconnectPromise.catch(() => {});
+            this._reconnectPromise = undefined;
+        }
+
         if (this._startPromise) {
             await this._startPromise.catch(() => {});
             this._startPromise = undefined;
         }
 
-        if (this._subscription) {
+        const sub = this._subscription;
+        this._subscription = undefined;
+
+        if (sub) {
             try {
-                await this._subscription.unsubscribe();
+                await sub.unsubscribe();
             } catch (err) {
                 this.logError(`[${this.name}] Failed to unsubscribe`, err);
             }
-            this._subscription = undefined;
         }
     }
 

--- a/src/test/change-detection-manager.test.ts
+++ b/src/test/change-detection-manager.test.ts
@@ -9,11 +9,12 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, type MockInstan
 import { ChangeDetectionManager } from '../core/change-detection-manager';
 import { DirectoryWatcher } from '../core/directory-watcher';
 import { JjService, NO_OP_LOGGER } from '../core/jj-service';
+import type { Poller } from '../core/poller';
 import { Uri } from '../core/uri-utils';
 import type { LoggerChannel } from '../utils/output-channel';
 import { FakeHostEnvironment } from './fake-host-environment';
 import { TestRepo } from './test-repo';
-import { accessPrivate, createMockLogOutputChannel } from './test-utils';
+import { accessPrivate, createMockLogOutputChannel, setPrivate } from './test-utils';
 
 describe('ChangeDetectionManager', () => {
     let repo: TestRepo;
@@ -171,6 +172,129 @@ describe('ChangeDetectionManager', () => {
     describe('Native Watcher Integration (Real Timers)', () => {
         beforeEach(() => {
             vi.useRealTimers();
+        });
+
+        it('triggers refresh with forceSnapshot: true when working copy watcher reconnects without active writes', async () => {
+            host.config.set('fileWatcherMode', 'watch');
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy, host);
+            await waitForLog('Working Copy Watcher] Started');
+            triggerRefreshSpy.mockClear();
+
+            const wcWatcher = accessPrivate<DirectoryWatcher | undefined>(changeManager, '_workingCopyWatcher');
+            expect(wcWatcher).toBeDefined();
+            if (!wcWatcher) {
+                throw new Error('Working copy watcher undefined');
+            }
+            const onReconnect = accessPrivate<(() => void) | undefined>(wcWatcher, 'onReconnect');
+            expect(onReconnect).toBeDefined();
+
+            onReconnect?.();
+
+            await vi.waitFor(() => {
+                expect(triggerRefreshSpy).toHaveBeenCalledWith({
+                    forceSnapshot: true,
+                    reason: 'file watcher reconnected',
+                });
+            });
+        });
+
+        it('triggers refresh with forceSnapshot: false when op_heads watcher reconnects without active writes', async () => {
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy, host);
+            await waitForLog('OpHeads Watcher] Started');
+            triggerRefreshSpy.mockClear();
+
+            const opHeadsWatcher = accessPrivate<DirectoryWatcher | undefined>(changeManager, '_opHeadsWatcher');
+            expect(opHeadsWatcher).toBeDefined();
+            if (!opHeadsWatcher) {
+                throw new Error('OpHeads watcher undefined');
+            }
+            const onReconnect = accessPrivate<(() => void) | undefined>(opHeadsWatcher, 'onReconnect');
+            expect(onReconnect).toBeDefined();
+
+            onReconnect?.();
+
+            await vi.waitFor(() => {
+                expect(triggerRefreshSpy).toHaveBeenCalledWith({
+                    forceSnapshot: false,
+                    reason: 'op_heads watcher reconnected',
+                });
+            });
+        });
+
+        it('defers refresh when working copy watcher reconnects during active writes', async () => {
+            host.config.set('fileWatcherMode', 'watch');
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy, host);
+            await waitForLog('Working Copy Watcher] Started');
+            triggerRefreshSpy.mockClear();
+
+            // Simulate recent write operation
+            setPrivate(changeManager, 'lastExternalOpTime', Date.now());
+
+            const wcWatcher = accessPrivate<DirectoryWatcher | undefined>(changeManager, '_workingCopyWatcher');
+            if (!wcWatcher) {
+                throw new Error('Working copy watcher undefined');
+            }
+            const onReconnect = accessPrivate<(() => void) | undefined>(wcWatcher, 'onReconnect');
+
+            onReconnect?.();
+
+            // Should not trigger immediately
+            expect(triggerRefreshSpy).not.toHaveBeenCalled();
+
+            // Wait for deferred refresh to execute after 500ms
+            await vi.waitFor(
+                () => {
+                    expect(triggerRefreshSpy).toHaveBeenCalledWith({
+                        forceSnapshot: false,
+                        reason: 'deferred watcher event',
+                    });
+                },
+                { timeout: 2000, interval: 50 },
+            );
+        });
+
+        it('falls back to polling mode when working copy watcher reports permanent failure', async () => {
+            host.config.set('fileWatcherMode', 'watch');
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy, host);
+            await waitForLog('Working Copy Watcher] Started');
+
+            const wcWatcher = accessPrivate<DirectoryWatcher | undefined>(changeManager, '_workingCopyWatcher');
+            if (!wcWatcher) {
+                throw new Error('Working copy watcher undefined');
+            }
+            const onPermanentFailure = accessPrivate<((err: unknown) => void) | undefined>(
+                wcWatcher,
+                'onPermanentFailure',
+            );
+            expect(onPermanentFailure).toBeDefined();
+
+            onPermanentFailure?.(new Error('inotify watch limit reached'));
+
+            await waitForLog('Falling back to polling mode');
+            expect(accessPrivate<string>(changeManager, '_fileWatcherMode')).toBe('polling');
+            expect(accessPrivate<DirectoryWatcher | undefined>(changeManager, '_workingCopyWatcher')).toBeUndefined();
+            const poller = accessPrivate<Poller>(changeManager, '_poller');
+            expect(accessPrivate<boolean>(poller, '_isPolling')).toBe(true);
+        });
+
+        it('cleans up op_heads watcher when reporting permanent failure', async () => {
+            changeManager = new ChangeDetectionManager(repo.path, jj, outputChannel, triggerRefreshSpy, host);
+            await waitForLog('OpHeads Watcher] Started');
+
+            const opHeadsWatcher = accessPrivate<DirectoryWatcher | undefined>(changeManager, '_opHeadsWatcher');
+            if (!opHeadsWatcher) {
+                throw new Error('OpHeads watcher undefined');
+            }
+            const onPermanentFailure = accessPrivate<((err: unknown) => void) | undefined>(
+                opHeadsWatcher,
+                'onPermanentFailure',
+            );
+            expect(onPermanentFailure).toBeDefined();
+
+            onPermanentFailure?.(new Error('inotify watch limit reached'));
+
+            await waitForLog('OpHeads watcher permanently failed');
+            expect(accessPrivate<DirectoryWatcher | undefined>(changeManager, '_opHeadsWatcher')).toBeUndefined();
         });
 
         it('switches to watch mode when configured and detects changes', async () => {

--- a/src/test/directory-watcher.test.ts
+++ b/src/test/directory-watcher.test.ts
@@ -33,7 +33,7 @@ describe('DirectoryWatcher (real @parcel/watcher)', { retry: os.platform() === '
         outputChannel = createMockLogOutputChannel();
         host = new FakeHostEnvironment();
         callback = vi.fn();
-        watcher = new DirectoryWatcher(tmpDir, callback, outputChannel, 'DirectoryWatcher', undefined, host);
+        watcher = new DirectoryWatcher(tmpDir, callback, outputChannel, { name: 'DirectoryWatcher', host });
     });
 
     afterEach(async () => {
@@ -224,5 +224,461 @@ describe('DirectoryWatcher (real @parcel/watcher)', { retry: os.platform() === '
         expect(host.nav.externalUrisOpened.map((u) => u.toString())).toContain(
             'https://github.com/brychanrobot/jj-view#file-watcher-mode',
         );
+    });
+});
+
+describe('Auto-recovery and Reconnection (Fake Timers)', () => {
+    let fakeTmpDir: string;
+    let fakeOutputChannel: LoggerChannel;
+    let fakeHost: FakeHostEnvironment;
+    let fakeCallback: Mock;
+    let capturedCallback: ((err: Error | null, events: parcelWatcher.Event[]) => void) | undefined;
+    let mockUnsubscribe: Mock;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        fakeTmpDir = '/fake/tmp/dir';
+        fakeOutputChannel = createMockLogOutputChannel();
+        fakeHost = new FakeHostEnvironment();
+        fakeCallback = vi.fn();
+        mockUnsubscribe = vi.fn().mockResolvedValue(undefined);
+        capturedCallback = undefined;
+
+        vi.mocked(parcelWatcher.subscribe).mockReset();
+        vi.mocked(parcelWatcher.subscribe).mockImplementation(async (_dir, cb) => {
+            capturedCallback = cb;
+            return { unsubscribe: mockUnsubscribe };
+        });
+    });
+
+    afterEach(async () => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        const actual = await vi.importActual<typeof import('@parcel/watcher')>('@parcel/watcher');
+        vi.mocked(parcelWatcher.subscribe).mockImplementation(actual.subscribe);
+    });
+
+    it('reconnects after subscription error and invokes onReconnect', async () => {
+        const onReconnectSpy = vi.fn();
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ReconnectWatcher',
+            host: fakeHost,
+            onReconnect: onReconnectSpy,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // Trigger error in subscriber callback (daemon crash / socket drop)
+        capturedCallback?.(new Error('Watchman daemon disconnected'), []);
+
+        // Old subscription should have been cleaned up
+        expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+
+        // Virtual time 999ms: retry should not have executed yet
+        await vi.advanceTimersByTimeAsync(999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+        expect(onReconnectSpy).not.toHaveBeenCalled();
+
+        // Advance 1ms to reach 1000ms: retry executes
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+        expect(onReconnectSpy).toHaveBeenCalledTimes(1);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('exponentially backs off retry delay and caps at maxDelay', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'BackoffWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // Subsequent reconnect attempts fail
+        vi.mocked(parcelWatcher.subscribe).mockRejectedValue(new Error('Daemon unavailable'));
+
+        // Initial failure
+        capturedCallback?.(new Error('Watchman daemon disconnected'), []);
+
+        // Attempt 1: 1000ms
+        await vi.advanceTimersByTimeAsync(999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // Attempt 2: 2000ms (doubled)
+        await vi.advanceTimersByTimeAsync(1999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+
+        // Attempt 3: 4000ms (doubled to maxDelay)
+        await vi.advanceTimersByTimeAsync(3999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(4);
+
+        // Attempt 4: 4000ms (capped at maxDelay, not 8000ms)
+        await vi.advanceTimersByTimeAsync(3999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(4);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(5);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('resets retry delay to initialDelay after successful reconnection', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ResetDelayWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // First retry attempt fails
+        vi.mocked(parcelWatcher.subscribe).mockRejectedValueOnce(new Error('Temporary fail'));
+
+        capturedCallback?.(new Error('Disconnect 1'), []);
+
+        // Attempt 1 at 1000ms fails
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // Attempt 2 at +2000ms succeeds
+        vi.mocked(parcelWatcher.subscribe).mockImplementationOnce(async (_dir, cb) => {
+            capturedCallback = cb;
+            return { unsubscribe: mockUnsubscribe };
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+
+        // Disconnect again; delay should be reset to 1000ms
+        capturedCallback?.(new Error('Disconnect 2'), []);
+
+        await vi.advanceTimersByTimeAsync(999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(4);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('stops reconnecting when stop() is called while reconnect timer is pending', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'StopWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        await reconnectWatcher.stop();
+
+        // Advance by a large duration; subscribe should not have been called again
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('stops reconnecting when dispose() is called while reconnect timer is pending', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'DisposeWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        await reconnectWatcher.dispose();
+
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('halts cleanly without reconnecting if stopped while subscribe() is in-flight during attemptReconnect', async () => {
+        const onReconnectSpy = vi.fn();
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'InFlightStopWatcher',
+            host: fakeHost,
+            onReconnect: onReconnectSpy,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+
+        let resolveSub!: (val: { unsubscribe: Mock }) => void;
+        vi.mocked(parcelWatcher.subscribe).mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveSub = resolve;
+                }),
+        );
+
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        // Fire timer -> attemptReconnect calls start() which hangs on subscribe
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // Now stop while subscribe is in flight
+        const stopPromise = reconnectWatcher.stop();
+
+        // Now resolve subscribe
+        resolveSub({ unsubscribe: mockUnsubscribe });
+        await stopPromise;
+
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(onReconnectSpy).not.toHaveBeenCalled();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('cancels pending reconnect timer if start() is called manually', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ManualStartWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        // Advance 500ms into the 1000ms delay
+        await vi.advanceTimersByTimeAsync(500);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // Manual start
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // Advance past original 1000ms mark; no extra duplicate subscribe
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('does not schedule duplicate timers if error fires multiple times rapidly', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'RapidErrorWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // Fire multiple errors in rapid succession
+        capturedCallback?.(new Error('Error 1'), []);
+        capturedCallback?.(new Error('Error 2'), []);
+        capturedCallback?.(new Error('Error 3'), []);
+
+        // Only one retry should happen at 1000ms
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('does not re-trigger reconnection if onReconnect callback throws', async () => {
+        const onReconnectSpy = vi.fn().mockRejectedValue(new Error('Queue crashed'));
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ThrowingReconnectWatcher',
+            host: fakeHost,
+            onReconnect: onReconnectSpy,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        // Advance 1000ms; reconnect succeeds but onReconnect throws
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+        expect(onReconnectSpy).toHaveBeenCalledTimes(1);
+
+        // Error is logged and no further reconnect loops happen
+        expect(fakeOutputChannel.error).toHaveBeenCalledWith(
+            expect.stringContaining('Error in onReconnect callback'),
+            expect.any(Error),
+        );
+
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('does not auto-reconnect on ENOSPC inotify limit error and invokes onPermanentFailure', async () => {
+        const onPermanentFailureSpy = vi.fn();
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'InotifyErrorWatcher',
+            host: fakeHost,
+            onPermanentFailure: onPermanentFailureSpy,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        capturedCallback?.(new Error("inotify_add_watch on '/some/path' failed: No space left on device (ENOSPC)"), []);
+
+        expect(fakeHost.ui.warningMessages.some((msg) => msg.includes('inotify watch limit reached'))).toBe(true);
+        expect(onPermanentFailureSpy).toHaveBeenCalledTimes(1);
+
+        // Should not schedule any reconnect
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('calls onPermanentFailure and stops retrying when maxRetries is exceeded', async () => {
+        const onPermanentFailureSpy = vi.fn();
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'MaxRetriesWatcher',
+            host: fakeHost,
+            onPermanentFailure: onPermanentFailureSpy,
+            reconnectOptions: { initialDelayMs: 100, maxDelayMs: 100, maxRetries: 2 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        vi.mocked(parcelWatcher.subscribe).mockRejectedValue(new Error('Permanently dead'));
+
+        capturedCallback?.(new Error('Disconnect'), []);
+
+        // Attempt 1 at 100ms
+        await vi.advanceTimersByTimeAsync(100);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // Attempt 2 at +100ms
+        await vi.advanceTimersByTimeAsync(100);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+
+        // Retry count is now 2 (maxRetries reached). Attempt 3 should fail permanently
+        expect(onPermanentFailureSpy).toHaveBeenCalledTimes(1);
+        expect(onPermanentFailureSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ message: expect.stringContaining('Maximum reconnection attempts') }),
+        );
+
+        await vi.advanceTimersByTimeAsync(60000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('classifies Watchman daemon max_user_watches error as inotify limit and skips reconnect', async () => {
+        const onPermanentFailureSpy = vi.fn();
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'WatchmanLimitWatcher',
+            host: fakeHost,
+            onPermanentFailure: onPermanentFailureSpy,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        const watchmanError = new Error(
+            'The user limit on the total number of inotify watches was reached; increase the fs.inotify.max_user_watches sysctl',
+        );
+        capturedCallback?.(watchmanError, []);
+
+        expect(onPermanentFailureSpy).toHaveBeenCalledWith(watchmanError);
+        expect(fakeHost.ui.warningMessages.some((msg) => msg.includes('inotify watch limit reached'))).toBe(true);
+
+        // Ensure no reconnect is scheduled
+        await vi.advanceTimersByTimeAsync(10000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('handles throwing onPermanentFailure callback without unhandled exception', async () => {
+        const throwingCallback = vi.fn().mockImplementation(() => {
+            throw new Error('Callback boom');
+        });
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ThrowingFailureWatcher',
+            host: fakeHost,
+            onPermanentFailure: throwingCallback,
+            reconnectOptions: { initialDelayMs: 100, maxDelayMs: 100, maxRetries: 1 },
+        });
+
+        await reconnectWatcher.start();
+        capturedCallback?.(new Error('Fatal error: inotify_add_watch failed (ENOSPC)'), []);
+
+        expect(throwingCallback).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(fakeOutputChannel.error)).toHaveBeenCalledWith(
+            expect.stringContaining('Error in onPermanentFailure callback'),
+            expect.anything(),
+        );
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('resets reconnect delay and retry count on manual start()', async () => {
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'ManualStartWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000, maxRetries: 2 },
+        });
+
+        await reconnectWatcher.start();
+
+        // First error: scheduled for 1000ms, backoff delay becomes 2000ms, retryCount becomes 1
+        capturedCallback?.(new Error('Drop 1'), []);
+
+        // Manually restart before reconnect timeout fires
+        await reconnectWatcher.start();
+
+        // Next error should use initial delay (1000ms), not the backed-off 2000ms
+        capturedCallback?.(new Error('Drop 2'), []);
+
+        // At 999ms, it should not have reconnected yet
+        await vi.advanceTimersByTimeAsync(999);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        // At 1000ms, it reconnects!
+        await vi.advanceTimersByTimeAsync(1);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(3);
+
+        await reconnectWatcher.dispose();
+    });
+
+    it('handles synchronous throw from dead subscription unsubscribe() cleanly', async () => {
+        mockUnsubscribe.mockImplementation(() => {
+            throw new Error('Native unsubscribe sync crash');
+        });
+
+        const reconnectWatcher = new DirectoryWatcher(fakeTmpDir, fakeCallback, fakeOutputChannel, {
+            name: 'SyncCrashWatcher',
+            host: fakeHost,
+            reconnectOptions: { initialDelayMs: 1000, maxDelayMs: 4000 },
+        });
+
+        await reconnectWatcher.start();
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(1);
+
+        // Should not crash, and should schedule reconnect as expected
+        capturedCallback?.(new Error('Disconnect with crashing unsubscribe'), []);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(parcelWatcher.subscribe).toHaveBeenCalledTimes(2);
+
+        await reconnectWatcher.dispose();
     });
 });


### PR DESCRIPTION

Implement exponential backoff auto-reconnect logic in DirectoryWatcher when the underlying @parcel/watcher subscription fails (e.g. Watchman daemon restarts or socket drops).

- Reconnect with exponential backoff starting at 1s, doubling up to 30s max
- Reset reconnect delay after a successful subscription
- Avoid reconnecting on fatal inotify watch limit errors (ENOSPC / inotify_add_watch) and notify host UI
- Provide onReconnect and onPermanentFailure hooks in DirectoryWatcherOptions
- Trigger refresh with snapshot forced for working copy watcher and without snapshot forced for op_heads watcher
- Safely clean up in-flight subscriptions, promises, and timeouts during stop() and dispose()
- Fall back to polling mode when file watcher permanently fails

Fixes #510