### PR TITLE
test(e2e): prevent cross-test UI pollution with fixture-level dismissal

### DIFF
--- a/src/test/e2e/e2e-helpers.ts
+++ b/src/test/e2e/e2e-helpers.ts
@@ -13,6 +13,7 @@ export type { ExpectedTreeItem, TestRepo, TreeEntrySpec } from '../test-repo';
 
 import { logPerf } from './perf-logger';
 import {
+    dismissActiveUI,
     type VSCodeContext as FixtureVSCodeContext,
     type VSCodeFixture as FixtureVSCodeFixture,
     isMac as fixtureIsMac,
@@ -856,31 +857,10 @@ export function locateQuickInputItem(page: Page, label: string | RegExp): Locato
 }
 
 /**
- * Dismisses any open QuickInput widget using the closeQuickOpen command or Escape key.
+ * Dismisses any open QuickInput widget or active UI using the Escape key.
  */
-export async function dismissQuickInput(page: Page, vscode?: VSCodeFixture, timeout: number = 2000): Promise<void> {
-    if (vscode) {
-        try {
-            await vscode.executeCommand('workbench.action.closeQuickOpen');
-        } catch {}
-    }
-    const quickInput = locateQuickInputWidget(page).filter({ visible: true });
-    try {
-        await expect(async () => {
-            if (await quickInput.isVisible()) {
-                if (vscode) {
-                    await vscode.executeCommand('workbench.action.closeQuickOpen');
-                } else {
-                    await quickInput
-                        .locator('input.input')
-                        .focus()
-                        .catch(() => {});
-                    await page.keyboard.press('Escape');
-                }
-            }
-            await expect(quickInput).not.toBeVisible({ timeout: 500 });
-        }).toPass({ timeout });
-    } catch {}
+export async function dismissQuickInput(page: Page): Promise<void> {
+    await dismissActiveUI(page);
 }
 
 /**

--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -8,7 +8,6 @@ import { ACK_REPLY_TEXT, DONE_REPLY_TEXT } from '../../core/comments-constants';
 import { FakeGitHubServer } from '../helpers/fake-github-server';
 import { buildGraph, type CommitDefinition, TestRepo } from '../test-repo';
 import {
-    dismissQuickInput,
     expectBadgeLink,
     expectNotificationToast,
     focusJJLog,
@@ -326,7 +325,6 @@ test.describe('GitHub Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        await dismissQuickInput(page, vscode);
     });
 
     test('Detects PR from fork targeting mainline repo', async ({ vscode }) => {

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -7,7 +7,6 @@ import { expect } from '@playwright/test';
 import { FakeGitLabServer } from '../helpers/fake-gitlab-server';
 import { buildGraph, type CommitDefinition, TestRepo } from '../test-repo';
 import {
-    dismissQuickInput,
     expectBadgeLink,
     expectNotificationToast,
     focusJJLog,
@@ -296,7 +295,6 @@ test.describe('GitLab Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
-        await dismissQuickInput(page, vscode);
     });
 
     test('Shows extension-not-found interstitial when signing in via OAuth without GitLab extension', async ({
@@ -320,7 +318,6 @@ test.describe('GitLab Integration E2E', () => {
         );
 
         await focusSCM(page);
-        await dismissQuickInput(page, vscode);
 
         // Click the Manage Auth button in the Source Control title bar
         const manageAuthButton = page.getByRole('button', { name: 'Manage Code Forge Authentication' }).first();

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -618,6 +618,13 @@ export class VSCodeWorker {
         // Ensure IPC socket is ready (in case VS Code window was reloaded by a previous test)
         await waitForIpcReady(context.userDataDir, 5000);
 
+        // Dismiss any active UI left by a previous test before mutating settings/workspace
+        const isClean = await dismissActiveUI(context.page);
+        if (!isClean) {
+            context.needsReset = true;
+            throw new Error('Active UI could not be dismissed during context reuse; forcing new launch');
+        }
+
         // 1. Update the settings first (under the new context/notifications config)
         const startSettings = Date.now();
         await this.updateSettings(context, extraSettings, showNotifications);
@@ -974,6 +981,58 @@ export class VSCodeWorker {
     }
 }
 
+/**
+ * Dismisses any active hovers, quick picks, or context menus to guarantee test isolation.
+ * Returns true if clean, or false if active UI could not be dismissed.
+ */
+export async function dismissActiveUI(page: Page | undefined): Promise<boolean> {
+    if (!page || page.isClosed()) {
+        return true;
+    }
+    try {
+        await page.mouse.move(0, 0);
+        const quickInput = page.locator('.quick-input-widget').filter({ visible: true });
+        let iterations = 0;
+        while ((await quickInput.count()) > 0 && iterations < 5) {
+            iterations++;
+            const first = quickInput.first();
+            const input = first.locator('input.input');
+            if (await input.isVisible()) {
+                await input.focus().catch(() => {});
+                const value = await input.inputValue().catch(() => '');
+                if (value.length > 0) {
+                    await input.fill('').catch(() => {});
+                }
+            } else {
+                const list = first.locator('.monaco-list').first();
+                if (await list.isVisible()) {
+                    await list.focus().catch(() => {});
+                }
+            }
+            await page.keyboard.press('Escape');
+            await quickInput
+                .first()
+                .waitFor({ state: 'hidden', timeout: 500 })
+                .catch(() => {});
+        }
+
+        const contextMenu = page.locator('.context-view.monaco-menu-container').filter({ visible: true });
+        let menuIterations = 0;
+        while ((await contextMenu.count()) > 0 && menuIterations < 5) {
+            menuIterations++;
+            await page.keyboard.press('Escape');
+            await contextMenu
+                .first()
+                .waitFor({ state: 'hidden', timeout: 500 })
+                .catch(() => {});
+        }
+
+        return (await quickInput.count()) === 0 && (await contextMenu.count()) === 0;
+    } catch {
+        return false;
+    }
+}
+
 export class VSCodeFixtureImpl implements VSCodeFixture {
     app?: ElectronApplication;
     page?: Page;
@@ -982,6 +1041,17 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
     private openedRepos: string[] = [];
 
     constructor(private readonly worker: VSCodeWorker) {}
+
+    /**
+     * Dismisses any active hovers, quick picks, or context menus to guarantee test isolation.
+     */
+    private async dismissActiveUI(): Promise<boolean> {
+        const isClean = await dismissActiveUI(this.page);
+        if (!isClean) {
+            this.requestReset();
+        }
+        return isClean;
+    }
 
     async openWorkspace(
         repo: { path: string },
@@ -1001,10 +1071,7 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
         // Dismiss any active hovers, quick picks, or context menus from previous tests
         // before we do any operations for the new workspace
         const dismissStart = Date.now();
-        if (this.page) {
-            await this.page.mouse.move(0, 0);
-            await this.page.keyboard.press('Escape');
-        }
+        await this.dismissActiveUI();
         logPerf('openWorkspace: dismiss UI', dismissStart);
 
         if (skipRepoSync) {
@@ -1157,11 +1224,7 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
             }
             logPerf('cleanupAfterTest: close auxiliary windows', start);
 
-            if (this.page && !this.page.isClosed()) {
-                try {
-                    await this.page.keyboard.press('Escape');
-                } catch {}
-            }
+            await this.dismissActiveUI();
 
             const cleanupEvalStart = Date.now();
             try {
@@ -1169,10 +1232,6 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
                 // We fire this off asynchronously because if it prompts, it will block the promise.
                 const evaluatePromise = this.evaluate(async (vscode, api) => {
                     const evalStart = Date.now();
-
-                    try {
-                        await vscode.commands.executeCommand('workbench.action.closeQuickOpen');
-                    } catch {}
 
                     const hasOpenEditors = vscode.window.tabGroups.all.some((group) => group.tabs.length > 0);
                     if (hasOpenEditors) {


### PR DESCRIPTION
Centralize active UI dismissal into the test fixture's setup and teardown cycles to ensure leftover quick inputs, hovers, and context menus do not leak across test boundaries. Harden dismissal by clearing quick input text before Escape, supporting inputs without text boxes, auto-resetting the worker on dismissal failures, and removing ineffective quick open commands and redundant per-test dismissal calls.