### PR TITLE
fix(upload): support -c change flags and fall back to parent on empty working copy

### DIFF
--- a/src/core/commands/upload.ts
+++ b/src/core/commands/upload.ts
@@ -51,7 +51,14 @@ async function resolveUploadCommand(
     revision?: string,
     customCommand?: string,
 ): Promise<ResolvedUploadCommand> {
-    const rev = revision || '@';
+    let rev = revision || '@';
+    if (rev === '@') {
+        const currentEntries = await repo.jj.getLog({ revision: '@', omitChanges: true, limit: 1 });
+        const current = currentEntries[0];
+        if (current?.is_empty && (!current.bookmarks || current.bookmarks.length === 0)) {
+            rev = '@-';
+        }
+    }
     const trimmedCommand = customCommand?.trim();
     if (trimmedCommand) {
         const [subcommand, ...commandArgs] = trimmedCommand.split(/\s+/);

--- a/tooling/jj/upload.ts
+++ b/tooling/jj/upload.ts
@@ -4,34 +4,71 @@
  */
 import { execFileSync } from 'node:child_process';
 
-async function main() {
-    const args = process.argv.slice(2);
-    let revision = '@';
+function resolveRevision(rev: string): string {
+    if (rev === '@') {
+        try {
+            const template =
+                'empty ++ "\\t" ++ if(description, "true", "false") ++ "\\t" ++ if(bookmarks, "true", "false")';
+            const output = execFileSync('jj', ['log', '-r', '@', '--no-graph', '-T', template], {
+                encoding: 'utf8',
+            }).trim();
+            const [isEmpty, hasDesc, hasBm] = output.split('\t');
+            if (isEmpty === 'true' && hasDesc !== 'true' && hasBm !== 'true') {
+                console.log('Working copy @ is empty and has no description/bookmarks. Targeting parent @- instead.');
+                return '@-';
+            }
+        } catch {
+            // If check fails, return original revision
+        }
+    }
+    return rev;
+}
 
-    for (let i = 0; i < args.length; i++) {
-        if (args[i] === '-r' && args[i + 1]) {
-            revision = args[++i];
+async function main() {
+    const rawArgs = process.argv.slice(2);
+    const pushArgs: string[] = [];
+    const fixTargets: string[] = [];
+
+    // Parse -r, --revision, -c, --change, and other flags
+    for (let i = 0; i < rawArgs.length; i++) {
+        const arg = rawArgs[i];
+        if ((arg === '-r' || arg === '--revision' || arg === '-c' || arg === '--change') && rawArgs[i + 1]) {
+            const target = resolveRevision(rawArgs[++i]);
+            pushArgs.push(arg, target);
+            fixTargets.push(target);
+        } else {
+            pushArgs.push(arg);
         }
     }
 
     try {
-        console.log(`Running jj fix on ${revision}...`);
-        execFileSync('jj', ['fix', '-s', revision], { stdio: 'inherit' });
+        const hasExplicitTarget = fixTargets.length > 0;
+        if (!hasExplicitTarget) {
+            const revision = resolveRevision('@');
+            fixTargets.push(revision);
 
-        const bookmarksOutput = execFileSync('jj', ['log', '-r', revision, '--no-graph', '-T', 'bookmarks'], {
-            encoding: 'utf8',
-        }).trim();
+            const bookmarksOutput = execFileSync('jj', ['log', '-r', revision, '--no-graph', '-T', 'bookmarks'], {
+                encoding: 'utf8',
+            }).trim();
+            const bookmarks = bookmarksOutput.split(/[\s,]+/).filter(Boolean);
 
-        const bookmarks = bookmarksOutput.split(/[\s,]+/).filter(Boolean);
-
-        if (bookmarks.length > 0) {
-            console.log(`Found existing bookmarks: ${bookmarks.join(', ')}`);
-            console.log(`Pushing revision ${revision}...`);
-            execFileSync('jj', ['git', 'push', '-r', revision], { stdio: 'inherit' });
-        } else {
-            console.log(`No bookmark found on ${revision}. Pushing as change...`);
-            execFileSync('jj', ['git', 'push', '-c', revision], { stdio: 'inherit' });
+            if (bookmarks.length > 0) {
+                console.log(`Found existing bookmarks: ${bookmarks.join(', ')}`);
+                pushArgs.unshift('-r', revision);
+            } else {
+                console.log(`No bookmark found on ${revision}. Pushing as change...`);
+                pushArgs.unshift('-c', revision);
+            }
         }
+
+        if (fixTargets.length > 0) {
+            console.log(`Running jj fix on targets: ${fixTargets.join(', ')}...`);
+            const fixArgs = ['fix', ...fixTargets.flatMap((t) => ['-s', t])];
+            execFileSync('jj', fixArgs, { stdio: 'inherit' });
+        }
+
+        console.log(`Pushing with args: ${pushArgs.join(' ')}...`);
+        execFileSync('jj', ['git', 'push', ...pushArgs], { stdio: 'inherit' });
 
         console.log('Upload successful!');
     } catch (error: unknown) {


### PR DESCRIPTION
Parse both -c/--change and -r/--revision flags in tooling/jj/upload.ts so stacked uploads passing change IDs forward correctly to jj git push instead of defaulting to @.
Automatically fall back to @- when @ is an empty, un-described working copy both in tooling/jj/upload.ts and in resolveUploadCommand to prevent push rejection.