### PR TITLE
perf(core): memoize git root resolution

### DIFF
--- a/src/core/jj-service.ts
+++ b/src/core/jj-service.ts
@@ -136,12 +136,27 @@ export class JjService {
         return path.dirname(path.dirname(storePath));
     }
 
+    private _gitRoot?: string | null;
+    private _gitRootPromise?: Promise<string | null>;
     async getGitRoot(): Promise<string | null> {
-        try {
-            return await this.run('git', ['root'], { useCachedSnapshot: true, label: 'getGitRoot' });
-        } catch {
-            return null;
+        if (this._gitRoot !== undefined) {
+            return this._gitRoot;
         }
+        if (this._gitRootPromise) {
+            return this._gitRootPromise;
+        }
+        this._gitRootPromise = (async () => {
+            try {
+                this._gitRoot = await this.run('git', ['root'], { useCachedSnapshot: true, label: 'getGitRoot' });
+                return this._gitRoot;
+            } catch {
+                this._gitRoot = null;
+                return null;
+            } finally {
+                this._gitRootPromise = undefined;
+            }
+        })();
+        return this._gitRootPromise;
     }
 
     get hasActiveWriteOps(): boolean {
@@ -724,6 +739,8 @@ export class JjService {
     }
 
     async clearCache(): Promise<void> {
+        this._gitRoot = undefined;
+        this._gitRootPromise = undefined;
         await Promise.all([this._diffCache.clear(), this._changesCache.clear()]);
     }
 

--- a/src/test/gerrit-credential-utils.test.ts
+++ b/src/test/gerrit-credential-utils.test.ts
@@ -10,6 +10,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
+    clearGitRootCache,
     getGerritAuthHeader,
     getGitCookies,
     getGitCredential,
@@ -23,11 +24,13 @@ describe('Credential Utils', () => {
     let repo: TestRepo | undefined;
 
     beforeEach(async () => {
+        clearGitRootCache();
         repo = undefined;
         tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jj-view-cred-test-'));
     });
 
     afterEach(async () => {
+        clearGitRootCache();
         if (repo) {
             repo.dispose();
         }
@@ -48,9 +51,32 @@ describe('Credential Utils', () => {
             expect(gitRoot).toBeSameFsPath(path.join(repo.path, '.git'));
         });
 
-        test('returns null when not in a jj repo', async () => {
-            const result = await resolveGitRoot(tempDir);
-            expect(result).toBeNull();
+        test('caches resolved git root on subsequent calls', async () => {
+            repo = new TestRepo();
+            repo.init();
+
+            const gitRoot1 = await resolveGitRoot(repo.path);
+            const gitRoot2 = await resolveGitRoot(repo.path);
+            expect(gitRoot1).toBe(gitRoot2);
+            expect(gitRoot1).toBeSameFsPath(path.join(repo.path, '.git'));
+        });
+
+        test('clearGitRootCache clears cached results', async () => {
+            repo = new TestRepo();
+            repo.init();
+
+            const gitRoot1 = await resolveGitRoot(repo.path);
+            clearGitRootCache();
+            const gitRoot2 = await resolveGitRoot(repo.path);
+            expect(gitRoot1).toEqual(gitRoot2);
+        });
+
+        test('returns null when not in a jj repo and caches the negative result', async () => {
+            const result1 = await resolveGitRoot(tempDir);
+            expect(result1).toBeNull();
+
+            const result2 = await resolveGitRoot(tempDir);
+            expect(result2).toBeNull();
         });
     });
 

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -56,10 +56,13 @@ describe('JjService Unit Tests', () => {
         expect(changes.length).toBe(0);
     });
 
-    test('getGitRoot returns valid path for git-backed repo', async () => {
-        const gitRoot = await jjService.getGitRoot();
-        expect(gitRoot).toBeTruthy();
-        expect(gitRoot).toContain('.git');
+    test('getGitRoot returns valid path for git-backed repo and memoizes result', async () => {
+        const gitRoot1 = await jjService.getGitRoot();
+        expect(gitRoot1).toBeTruthy();
+        expect(gitRoot1).toContain('.git');
+
+        const gitRoot2 = await jjService.getGitRoot();
+        expect(gitRoot2).toBe(gitRoot1);
     });
 
     test('getRepoStorePath returns directory for main repo', async () => {

--- a/src/utils/gerrit-credential-utils.ts
+++ b/src/utils/gerrit-credential-utils.ts
@@ -33,15 +33,49 @@ function execFilePromise(
     });
 }
 
+const gitRootCache = new Map<string, string | null>();
+const gitRootPromiseCache = new Map<string, Promise<string | null>>();
+
+/**
+ * Clears the in-memory cache of resolved git roots.
+ */
+export function clearGitRootCache(): void {
+    gitRootCache.clear();
+    gitRootPromiseCache.clear();
+}
+
 /**
  * Resolves the backing git directory of a jj repository using `jj git root`.
  */
 export async function resolveGitRoot(repoRoot: string, binaryPath = 'jj'): Promise<string | null> {
-    const { err, stdout } = await execFilePromise(binaryPath, ['git', 'root'], { cwd: repoRoot, timeout: 10000 });
-    if (err || !stdout) {
-        return null;
+    const normalizedRoot = path.resolve(repoRoot);
+    const cacheKey = `${binaryPath}:${normalizedRoot}`;
+    if (gitRootCache.has(cacheKey)) {
+        return gitRootCache.get(cacheKey) ?? null;
     }
-    return stdout.trim();
+    const pending = gitRootPromiseCache.get(cacheKey);
+    if (pending) {
+        return pending;
+    }
+    const promise = (async () => {
+        try {
+            const { err, stdout } = await execFilePromise(binaryPath, ['git', 'root'], {
+                cwd: normalizedRoot,
+                timeout: 10000,
+            });
+            if (err || !stdout) {
+                gitRootCache.set(cacheKey, null);
+                return null;
+            }
+            const trimmed = stdout.trim();
+            gitRootCache.set(cacheKey, trimmed);
+            return trimmed;
+        } finally {
+            gitRootPromiseCache.delete(cacheKey);
+        }
+    })();
+    gitRootPromiseCache.set(cacheKey, promise);
+    return promise;
 }
 
 /**


### PR DESCRIPTION
Memoize `getGitRoot` in `JjService` so git root is resolved once per service instance.
Add in-memory caching to `resolveGitRoot` in `gerrit-credential-utils` keyed by repo path, and expose `clearGitRootCache` for test cleanup.