### PR TITLE
perf(code-forge): prioritize fast-path remote URL provider detection

### DIFF
--- a/src/core/code-forge-provider.ts
+++ b/src/core/code-forge-provider.ts
@@ -25,6 +25,8 @@ export interface CodeForgeProvider {
     readonly displayName: string;
     /** Terminology used for change units (e.g. 'CL' for Gerrit, 'PR' for GitHub) */
     readonly changeTerm: 'CL' | 'PR' | 'Change';
+    /** Optional priority order for auto-detection (lower values detected first) */
+    readonly priority?: number;
 
     /** Fires when change cache statuses or states are updated */
     readonly onDidUpdate: Event<void>;

--- a/src/core/code-forge-service.ts
+++ b/src/core/code-forge-service.ts
@@ -13,6 +13,16 @@ import type { HostDisposable, HostEnvironment } from './host/host-environment';
 import type { JjService } from './jj-service';
 import type { CodeForgeChangeInfo, CommitParent, JjLogEntry } from './jj-types';
 
+const DEFAULT_PRIORITY_ORDER = ['github', 'gitlab', 'gerrit'];
+
+function getProviderPriority(provider: CodeForgeProvider): number {
+    if (provider.priority !== undefined) {
+        return provider.priority;
+    }
+    const idx = DEFAULT_PRIORITY_ORDER.indexOf(provider.id);
+    return idx === -1 ? 500 : idx;
+}
+
 export class CodeForgeService implements Disposable {
     private poller: NodeJS.Timeout | undefined;
     private activeProviderDisposable: Disposable | undefined;
@@ -233,7 +243,11 @@ export class CodeForgeService implements Disposable {
             }
 
             if (!detectedProvider) {
-                for (const provider of this.providers.values()) {
+                const sortedProviders = Array.from(this.providers.values()).sort(
+                    (a, b) => getProviderPriority(a) - getProviderPriority(b),
+                );
+
+                for (const provider of sortedProviders) {
                     if (await provider.detect(repoRoot, remotes)) {
                         detectedProvider = provider;
                         break;

--- a/src/core/gerrit-provider.ts
+++ b/src/core/gerrit-provider.ts
@@ -100,6 +100,7 @@ export class GerritProvider implements CodeForgeProvider {
     public readonly id = 'gerrit';
     public readonly displayName = 'Gerrit';
     public readonly changeTerm = 'CL' as const;
+    public readonly priority = 100;
 
     private cache = new Map<string, CodeForgeChangeInfo>();
     private gerritHost: string | undefined;

--- a/src/core/github-provider.ts
+++ b/src/core/github-provider.ts
@@ -271,6 +271,7 @@ export class GitHubProvider implements CodeForgeProvider {
     public readonly id = 'github';
     public readonly displayName = 'GitHub';
     public readonly changeTerm = 'PR' as const;
+    public readonly priority = 10;
     public readonly isAuthManageable = true;
 
     private cache = new Map<string, CodeForgeChangeInfo>();

--- a/src/core/gitlab-provider.ts
+++ b/src/core/gitlab-provider.ts
@@ -94,6 +94,7 @@ export class GitLabProvider implements CodeForgeProvider {
     public readonly id = 'gitlab';
     public readonly displayName = 'GitLab';
     public readonly changeTerm = 'PR' as const;
+    public readonly priority = 20;
     public readonly isAuthManageable = true;
 
     private cache = new Map<string, CodeForgeChangeInfo>();

--- a/src/test/code-forge-service.test.ts
+++ b/src/test/code-forge-service.test.ts
@@ -20,6 +20,7 @@ class MockProvider implements CodeForgeProvider {
     private emitter = new EventEmitter<void>();
     readonly onDidUpdate = this.emitter.event;
     public dispose?: () => void;
+    public priority?: number;
 
     constructor(
         public readonly id = 'mock-provider',
@@ -235,6 +236,36 @@ describe('CodeForgeService Tests', () => {
         service.dispose();
     });
 
+    test('prioritizes github and gitlab before gerrit during detection', async () => {
+        const detectionOrder: string[] = [];
+        const createTrackingProvider = (id: string) => {
+            const p = new MockProvider(id, id, true);
+            const origDetect = p.detect.bind(p);
+            p.detect = async (root, remotes) => {
+                detectionOrder.push(id);
+                return origDetect(root, remotes);
+            };
+            return p;
+        };
+
+        const gerrit = createTrackingProvider('gerrit');
+        const gitlab = createTrackingProvider('gitlab');
+        const github = createTrackingProvider('github');
+
+        // Register in arbitrary order (gerrit first)
+        registry.register({ id: 'gerrit', create: () => gerrit });
+        registry.register({ id: 'gitlab', create: () => gitlab });
+        registry.register({ id: 'github', create: () => github });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry, host, NO_OP_LOGGER);
+        await service.awaitReady();
+
+        expect(service.activeProvider).toBe(github);
+        expect(detectionOrder[0]).toBe('github');
+
+        service.dispose();
+    });
+
     test('populateCodeForgeInfo correctly computes sync and needsUpload statuses', async () => {
         const provider = new MockProvider();
         registry.register({ id: 'mock-provider', create: () => provider });
@@ -369,5 +400,20 @@ describe('CodeForgeService Tests', () => {
         expect(() => service.dispose()).not.toThrow();
         expect(deactivateSpy).toHaveBeenCalledTimes(1);
         expect(disposeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('unlisted provider without explicit priority has lower precedence than prioritized providers', async () => {
+        const unlistedProvider = new MockProvider('custom-forge', 'Custom Forge', true);
+        const githubProvider = new MockProvider('github', 'GitHub', true);
+        githubProvider.priority = 10;
+
+        registry.register({ id: 'custom-forge', create: () => unlistedProvider });
+        registry.register({ id: 'github', create: () => githubProvider });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry, host, NO_OP_LOGGER);
+        await service.awaitReady();
+
+        expect(service.activeProvider).toBe(githubProvider);
+        service.dispose();
     });
 });

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -112,12 +112,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
     context.subscriptions.push(
         codeForgeRegistry.register({
-            id: 'gerrit',
-            create: (outputChannel, host) => new GerritProvider(outputChannel, host),
-        }),
-    );
-    context.subscriptions.push(
-        codeForgeRegistry.register({
             id: 'github',
             create: (outputChannel) => new GitHubProvider(authManager, outputChannel),
         }),
@@ -126,6 +120,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         codeForgeRegistry.register({
             id: 'gitlab',
             create: (outputChannel, host) => new GitLabProvider(authManager, outputChannel, host),
+        }),
+    );
+    context.subscriptions.push(
+        codeForgeRegistry.register({
+            id: 'gerrit',
+            create: (outputChannel, host) => new GerritProvider(outputChannel, host),
         }),
     );
 


### PR DESCRIPTION
Prioritize URL-pattern based providers (github, gitlab) ahead of heavier providers (gerrit) in provider registration and detection loops, avoiding unnecessary subprocesses and filesystem probes on standard GitHub/GitLab repositories.