### PR TITLE
perf(code-forge): eliminate double-fetch echo loop in LogViewController

### DIFF
--- a/src/core/code-forge-service.ts
+++ b/src/core/code-forge-service.ts
@@ -32,6 +32,9 @@ export class CodeForgeService implements Disposable {
     private _onDidUpdate = new EventEmitter<void>();
     public readonly onDidUpdate: Event<void> = this._onDidUpdate.event;
 
+    private _onRequestRefresh = new EventEmitter<void>();
+    public readonly onRequestRefresh: Event<void> = this._onRequestRefresh.event;
+
     private _onDidActiveProviderChange = new EventEmitter<CodeForgeProvider | undefined>();
     public readonly onDidActiveProviderChange: Event<CodeForgeProvider | undefined> =
         this._onDidActiveProviderChange.event;
@@ -123,6 +126,7 @@ export class CodeForgeService implements Disposable {
         this.disposables = [];
         this.safeDispose(this._onDidActiveProviderChange, 'active provider change emitter');
         this.safeDispose(this._onDidUpdate, 'update emitter');
+        this.safeDispose(this._onRequestRefresh, 'request refresh emitter');
         this.activeProviderDisposable = undefined;
         this.activeProviderInstance = undefined;
     }
@@ -183,7 +187,7 @@ export class CodeForgeService implements Disposable {
         if (this.activeProviderInstance) {
             this.outputChannel.info(`[CodeForgeService] Force refresh triggered`);
             this.lastRefreshTime = Date.now();
-            this._onDidUpdate.fire();
+            this._onRequestRefresh.fire();
         }
     }
 
@@ -345,9 +349,7 @@ export class CodeForgeService implements Disposable {
                     commit.description,
                     (commit.bookmarks ?? []).filter((b) => !b.remote).map((b) => b.name),
                 );
-                if (info) {
-                    commit.codeForgeChange = info;
-                }
+                commit.codeForgeChange = info ?? undefined;
             }
         }
 

--- a/src/core/controllers/log-view-controller.ts
+++ b/src/core/controllers/log-view-controller.ts
@@ -171,11 +171,22 @@ export class LogViewController implements Disposable {
         }
 
         const cf = repo.codeForge;
-        this._codeForgeDisposable = cf.onDidUpdate(() => {
+        const updateDisposable = cf.onDidUpdate(() => {
+            if (this._commits.length > 0) {
+                this.setCommits(this._commits);
+            }
+        });
+        const refreshDisposable = cf.onRequestRefresh(() => {
             this.refreshCodeForge().catch((e) => {
-                this._logger?.error('[LogViewController] CodeForge update failed', toError(e));
+                this._logger?.error('[LogViewController] CodeForge refresh failed', toError(e));
             });
         });
+        this._codeForgeDisposable = {
+            dispose: () => {
+                updateDisposable.dispose();
+                refreshDisposable.dispose();
+            },
+        };
 
         cf.detectActiveProvider(true).catch((e) => {
             this._logger?.error('Code forge detection failed', toError(e));
@@ -424,7 +435,7 @@ export class LogViewController implements Disposable {
         try {
             cf.startPolling();
             const start = performance.now();
-            const hasChanges = await cf.ensureFreshStatuses(
+            await cf.ensureFreshStatuses(
                 this._commits.map((c) => ({
                     commitId: c.commit_id ?? '',
                     changeId: c.change_id,
@@ -435,11 +446,6 @@ export class LogViewController implements Disposable {
 
             const duration = performance.now() - start;
             this._logger?.info?.(`[LogViewController] CodeForge fetch took ${duration.toFixed(0)}ms`);
-
-            if (hasChanges) {
-                this._logger?.info?.('[LogViewController] CodeForge data changed, re-populating commits');
-                this.setCommits(this._commits);
-            }
         } catch (e) {
             this._logger?.error('[LogViewController] CodeForge refresh failed', toError(e));
         }

--- a/src/test/code-forge-service.test.ts
+++ b/src/test/code-forge-service.test.ts
@@ -382,7 +382,9 @@ describe('CodeForgeService Tests', () => {
         expect(service.activeProvider).toBe(mockProvider);
 
         const updateListener = vi.fn();
+        const refreshListener = vi.fn();
         service.onDidUpdate(updateListener);
+        service.onRequestRefresh(refreshListener);
 
         // First dispose
         service.dispose();
@@ -395,13 +397,13 @@ describe('CodeForgeService Tests', () => {
         // Force refresh after dispose does not fire listeners
         service.forceRefresh();
         expect(updateListener).not.toHaveBeenCalled();
+        expect(refreshListener).not.toHaveBeenCalled();
 
         // Second dispose should be safe and idempotent
         expect(() => service.dispose()).not.toThrow();
         expect(deactivateSpy).toHaveBeenCalledTimes(1);
         expect(disposeSpy).toHaveBeenCalledTimes(1);
     });
-
     test('unlisted provider without explicit priority has lower precedence than prioritized providers', async () => {
         const unlistedProvider = new MockProvider('custom-forge', 'Custom Forge', true);
         const githubProvider = new MockProvider('github', 'GitHub', true);
@@ -414,6 +416,25 @@ describe('CodeForgeService Tests', () => {
         await service.awaitReady();
 
         expect(service.activeProvider).toBe(githubProvider);
+        service.dispose();
+    });
+
+    test('forceRefresh fires onRequestRefresh when active provider is present', async () => {
+        const mockProvider = new MockProvider('mock-refresh', 'Mock Refresh', true);
+        registry.register({
+            id: 'mock-refresh',
+            create: () => mockProvider,
+        });
+
+        const service = new CodeForgeService(repo1.path, jjService1, registry, host, NO_OP_LOGGER);
+        await service.awaitReady();
+
+        const refreshListener = vi.fn();
+        service.onRequestRefresh(refreshListener);
+
+        service.forceRefresh();
+        expect(refreshListener).toHaveBeenCalledTimes(1);
+
         service.dispose();
     });
 });

--- a/src/test/gerrit-service.test.ts
+++ b/src/test/gerrit-service.test.ts
@@ -427,9 +427,9 @@ describe('GerritService Detection', () => {
         // Verify it's cached
         expect(provider.getCachedChangeInfo(undefined, `Change-Id: ${cacheKey}`)).toBeDefined();
 
-        // Track onDidUpdate calls
+        // Track onRequestRefresh calls
         let updateFired = false;
-        const disposable = service.onDidUpdate(() => {
+        const disposable = service.onRequestRefresh(() => {
             updateFired = true;
         });
 
@@ -439,7 +439,7 @@ describe('GerritService Detection', () => {
         // Advance past the polling interval (60 seconds)
         await vi.advanceTimersByTimeAsync(60_000);
 
-        // onDidUpdate should have been fired to notify listeners to re-fetch
+        // onRequestRefresh should have been fired to notify listeners to re-fetch
         expect(updateFired).toBe(true);
         // Verify cache is preserved (not cleared)
         expect(provider.getCachedChangeInfo(undefined, `Change-Id: ${cacheKey}`)).toBeDefined();
@@ -467,9 +467,9 @@ describe('GerritService Detection', () => {
         // Verify it's cached
         expect(provider.getCachedChangeInfo(undefined, `Change-Id: ${cacheKey}`)).toBeDefined();
 
-        // Track onDidUpdate calls
+        // Track onRequestRefresh calls
         let updateFired = false;
-        const disposable = service.onDidUpdate(() => {
+        const disposable = service.onRequestRefresh(() => {
             updateFired = true;
         });
 
@@ -765,9 +765,9 @@ describe('GerritService Detection', () => {
         service = initService();
         await service.awaitReady();
 
-        // Spy on _onDidUpdate.fire to verify refreshes
+        // Spy on _onRequestRefresh.fire to verify refreshes
         let updateCount = 0;
-        const disposable = service.onDidUpdate(() => {
+        const disposable = service.onRequestRefresh(() => {
             updateCount++;
         });
 

--- a/src/test/log-view-controller.test.ts
+++ b/src/test/log-view-controller.test.ts
@@ -4,8 +4,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { CodeForgeProvider } from '../core/code-forge-provider';
 import { CodeForgeRegistry } from '../core/code-forge-registry';
 import { LogViewController } from '../core/controllers/log-view-controller';
+import { EventEmitter } from '../core/host/events';
 import { JjContextKey } from '../core/jj-context-keys';
 import { JjRepositoryManager } from '../core/jj-repository-manager';
 import type { JjLogEntry } from '../core/jj-types';
@@ -18,6 +20,7 @@ describe('LogViewController Domain Unit Tests', () => {
     let testRepo: TestRepo;
     let repositoryManager: JjRepositoryManager;
     let fakeHost: FakeHostEnvironment;
+    let registry: CodeForgeRegistry;
     let controller: LogViewController;
     let postedMessages: unknown[];
 
@@ -27,7 +30,7 @@ describe('LogViewController Domain Unit Tests', () => {
         testRepo = new TestRepo();
         testRepo.init();
 
-        const registry = new CodeForgeRegistry();
+        registry = new CodeForgeRegistry();
         const outputChannel = createMockLogOutputChannel({
             appendLine: () => {},
         });
@@ -180,5 +183,94 @@ describe('LogViewController Domain Unit Tests', () => {
         controller.setSelectedCommits([changeId]);
         controller.setCommits(controller.commits);
         expect(fakeHost.commands.contextKeys.get(JjContextKey.SelectionAllowAbandon)).toBe(true);
+    });
+
+    test('cf.onDidUpdate re-populates commits without re-triggering ensureFreshStatuses', async () => {
+        const repo = repositoryManager.getRepositoryForUri(Uri.file(testRepo.path));
+        expect(repo).toBeDefined();
+        if (!repo) {
+            return;
+        }
+
+        const updateEmitter = new EventEmitter<void>();
+        const mockProvider = createMock<CodeForgeProvider>({
+            id: 'mock-provider',
+            detect: async () => true,
+            onDidUpdate: updateEmitter.event,
+            getCachedChangeInfo: () => undefined,
+            fetchStatuses: async () => false,
+            clearCache: () => {},
+            activate: () => {},
+            deactivate: () => {},
+        });
+        registry.register({ id: 'mock-provider', create: () => mockProvider });
+        await repo.codeForge.detectActiveProvider(true);
+
+        const dummyCommits: JjLogEntry[] = [
+            createMock<JjLogEntry>({
+                change_id: 'test-change-1',
+                commit_id: 'test-commit-1',
+                description: 'test commit',
+                is_immutable: false,
+                is_empty: false,
+                conflict: false,
+                bookmarks: [],
+                tags: [],
+                parents: [],
+            }),
+        ];
+
+        controller.setCommits(dummyCommits);
+        const ensureFreshSpy = vi.spyOn(repo.codeForge, 'ensureFreshStatuses');
+        const setCommitsSpy = vi.spyOn(controller, 'setCommits');
+
+        // Fire onDidUpdate from provider
+        updateEmitter.fire();
+
+        expect(setCommitsSpy).toHaveBeenCalledWith(dummyCommits);
+        expect(ensureFreshSpy).not.toHaveBeenCalled();
+    });
+
+    test('cf.onRequestRefresh triggers refreshCodeForge and ensureFreshStatuses', async () => {
+        const repo = repositoryManager.getRepositoryForUri(Uri.file(testRepo.path));
+        expect(repo).toBeDefined();
+        if (!repo) {
+            return;
+        }
+
+        const mockProvider = createMock<CodeForgeProvider>({
+            id: 'mock-provider-2',
+            detect: async () => true,
+            onDidUpdate: new EventEmitter<void>().event,
+            getCachedChangeInfo: () => undefined,
+            fetchStatuses: vi.fn().mockResolvedValue(false),
+            clearCache: () => {},
+            activate: () => {},
+            deactivate: () => {},
+        });
+        registry.register({ id: 'mock-provider-2', create: () => mockProvider });
+        await repo.codeForge.detectActiveProvider(true);
+
+        const dummyCommits: JjLogEntry[] = [
+            createMock<JjLogEntry>({
+                change_id: 'test-change-2',
+                commit_id: 'test-commit-2',
+                description: 'test commit 2',
+                is_immutable: false,
+                is_empty: false,
+                conflict: false,
+                bookmarks: [],
+                tags: [],
+                parents: [],
+            }),
+        ];
+
+        controller.setCommits(dummyCommits);
+        const ensureFreshSpy = vi.spyOn(repo.codeForge, 'ensureFreshStatuses');
+
+        // Trigger force refresh on codeForge service (simulating post-upload backoff timer or poller)
+        repo.codeForge.forceRefresh();
+
+        expect(ensureFreshSpy).toHaveBeenCalled();
     });
 });

--- a/src/test/log-webview-initialization.integration.test.ts
+++ b/src/test/log-webview-initialization.integration.test.ts
@@ -119,6 +119,7 @@ suite('Log Webview Initialization Integration Test', () => {
             jj: testContext.repository.jj,
             codeForge: createMock<CodeForgeService>({
                 onDidUpdate: () => ({ dispose: () => {} }),
+                onRequestRefresh: () => ({ dispose: () => {} }),
                 detectActiveProvider: () => pendingDetection,
             }),
         });
@@ -164,6 +165,7 @@ suite('Log Webview Initialization Integration Test', () => {
             jj: testContext.repository.jj,
             codeForge: createMock<CodeForgeService>({
                 onDidUpdate: () => ({ dispose: () => {} }),
+                onRequestRefresh: () => ({ dispose: () => {} }),
                 detectActiveProvider: () => Promise.reject(rejectingDetectionError),
             }),
         });


### PR DESCRIPTION
Break the event feedback loop where `cf.onDidUpdate` re-invoked `refreshCodeForge` and triggered redundant network status checks. The controller now directly calls `setCommits` to re-populate existing commits with the latest cached code forge info.