### PR TITLE
perf(code-forge): reuse log changes and memoize git blob hashes in Gerrit sync

### DIFF
--- a/src/core/code-forge-provider.ts
+++ b/src/core/code-forge-provider.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type { Event } from './host/events';
-import type { CodeForgeChangeInfo, CommitParent } from './jj-types';
+import type { CodeForgeChangeInfo, CommitParent, JjStatusEntry } from './jj-types';
 
 export interface GitRemote {
     name: string;
@@ -16,6 +16,7 @@ export interface ChangeStatusRequest {
     description?: string;
     bookmarks?: string[];
     parents?: CommitParent[];
+    changes?: JjStatusEntry[];
 }
 
 export interface CodeForgeProvider {

--- a/src/core/controllers/log-view-controller.ts
+++ b/src/core/controllers/log-view-controller.ts
@@ -441,6 +441,7 @@ export class LogViewController implements Disposable {
                     changeId: c.change_id,
                     description: c.description,
                     bookmarks: c.bookmarks.filter((b) => !b.remote).map((b) => b.name),
+                    changes: c.changes,
                 })),
             );
 

--- a/src/core/gerrit-provider.ts
+++ b/src/core/gerrit-provider.ts
@@ -21,7 +21,7 @@ import type {
 import { type Event, EventEmitter } from './host/events';
 import type { HostEnvironment } from './host/host-environment';
 import type { JjService } from './jj-service';
-import type { CodeForgeChangeInfo } from './jj-types';
+import type { CodeForgeChangeInfo, JjStatusEntry } from './jj-types';
 
 export const GerritFileSchema = z.object({
     status: z.string().optional(),
@@ -103,6 +103,7 @@ export class GerritProvider implements CodeForgeProvider {
     public readonly priority = 100;
 
     private cache = new Map<string, CodeForgeChangeInfo>();
+    private contentSyncCache = new Map<string, boolean>();
     private gerritHost: string | undefined;
     private repoRoot: string | undefined;
     private gitRoot: string | null = null;
@@ -302,7 +303,7 @@ export class GerritProvider implements CodeForgeProvider {
     private async processBatch(
         batchCacheKeys: string[],
         batchIndex: number,
-        changesByCacheKey: Map<string, { commitId: string; description?: string }[]>,
+        changesByCacheKey: Map<string, ChangeStatusRequest[]>,
         jj: JjService,
     ): Promise<boolean> {
         let batchChanged = false;
@@ -326,7 +327,7 @@ export class GerritProvider implements CodeForgeProvider {
                 const changesForCacheKey = changesByCacheKey.get(cacheKey) || [];
                 await Promise.all(
                     changesForCacheKey.map((change) =>
-                        this.verifyContentSync(change.commitId, change.description, info, jj),
+                        this.verifyContentSync(change.commitId, change.description, info, jj, change.changes),
                     ),
                 );
                 this.cache.set(cacheKey, info);
@@ -451,6 +452,7 @@ export class GerritProvider implements CodeForgeProvider {
         description: string | undefined,
         info: CodeForgeChangeInfo,
         jj: JjService,
+        changes?: JjStatusEntry[],
     ): Promise<void> {
         if (info.status !== 'NEW' || !info.files) {
             return;
@@ -461,23 +463,34 @@ export class GerritProvider implements CodeForgeProvider {
             return;
         }
 
+        const syncCacheKey = `${commitId}:${info.currentRevision ?? ''}`;
+        if (this.contentSyncCache.has(syncCacheKey)) {
+            const cached = this.contentSyncCache.get(syncCacheKey);
+            if (cached) {
+                info.contentSynced = true;
+            }
+            return;
+        }
+
         if (
             info.remoteDescription &&
             description &&
             stripGerritTrailers(description) !== stripGerritTrailers(info.remoteDescription)
         ) {
+            this.contentSyncCache.set(syncCacheKey, false);
             return;
         }
 
         const gerritFiles = info.files;
         try {
-            const localChanges = await jj.getChanges(commitId);
+            const localChanges = changes ?? (await jj.getChanges(commitId));
             const localPaths = new Set(localChanges.filter((c) => c.status !== 'deleted').map((c) => c.path));
 
             const gerritPaths = Object.keys(gerritFiles).filter((p) => gerritFiles[p].status !== 'D');
             const gerritPathSet = new Set(gerritPaths);
 
             if (localPaths.difference(gerritPathSet).size > 0 || gerritPathSet.difference(localPaths).size > 0) {
+                this.contentSyncCache.set(syncCacheKey, false);
                 return;
             }
 
@@ -489,12 +502,14 @@ export class GerritProvider implements CodeForgeProvider {
                     const localSha = localHashes.get(file);
 
                     if (!localSha || localSha !== gerritFile.newSha) {
+                        this.contentSyncCache.set(syncCacheKey, false);
                         return;
                     }
                 }
             }
 
             info.contentSynced = true;
+            this.contentSyncCache.set(syncCacheKey, true);
         } catch (e) {
             this.outputChannel?.error(`[GerritProvider] Content sync verification failed for ${commitId}: ${e}`);
         }
@@ -781,6 +796,7 @@ export class GerritProvider implements CodeForgeProvider {
 
     public clearCache(): void {
         this.cache.clear();
+        this.contentSyncCache.clear();
         this.authHeader = undefined;
         this.authChecked = false;
         this.lastAuthTime = 0;

--- a/src/core/jj-service.ts
+++ b/src/core/jj-service.ts
@@ -60,6 +60,27 @@ export interface JjServiceOptions {
     processTracker?: JjProcessTracker;
 }
 
+function unquoteGitPath(rawPath: string): string {
+    if (!rawPath.startsWith('"') || !rawPath.endsWith('"')) {
+        return rawPath;
+    }
+    try {
+        const parsed = JSON.parse(rawPath);
+        if (typeof parsed === 'string') {
+            return parsed;
+        }
+    } catch {
+        // Fallback for Git's C-style octal escape sequences (e.g. \303\251)
+        const unescapedBinary = rawPath
+            .slice(1, -1)
+            .replace(/\\([0-7]{3})/g, (_, oct: string) => String.fromCharCode(parseInt(oct, 8)))
+            .replace(/\\"/g, '"')
+            .replace(/\\\\/g, '\\');
+        return Buffer.from(unescapedBinary, 'latin1').toString('utf8');
+    }
+    return rawPath;
+}
+
 export class JjService {
     public binaryPath: string;
     public processTracker?: JjProcessTracker;
@@ -741,6 +762,7 @@ export class JjService {
     async clearCache(): Promise<void> {
         this._gitRoot = undefined;
         this._gitRootPromise = undefined;
+        this._gitBlobHashCache.clear();
         await Promise.all([this._diffCache.clear(), this._changesCache.clear()]);
     }
 
@@ -1316,9 +1338,35 @@ export class JjService {
         return this.run('absorb', args, { isMutation: true, label: 'absorb' });
     }
 
+    private _gitBlobHashCache = new Map<string, Map<string, string | null>>();
+
     async getGitBlobHashes(commitId: string, filePaths: string[]): Promise<Map<string, string>> {
         if (filePaths.length === 0) {
             return new Map();
+        }
+
+        let commitCache = this._gitBlobHashCache.get(commitId);
+        if (!commitCache) {
+            commitCache = new Map<string, string | null>();
+            this._gitBlobHashCache.set(commitId, commitCache);
+        }
+
+        const missingPaths: string[] = [];
+        const resultMap = new Map<string, string>();
+
+        for (const filePath of filePaths) {
+            const cachedSha = commitCache.get(filePath);
+            if (cachedSha !== undefined) {
+                if (cachedSha !== null) {
+                    resultMap.set(filePath, cachedSha);
+                }
+            } else {
+                missingPaths.push(filePath);
+            }
+        }
+
+        if (missingPaths.length === 0) {
+            return resultMap;
         }
 
         // We use raw git command because jj doesn't expose ls-tree
@@ -1326,7 +1374,7 @@ export class JjService {
             const timeout = 10000; // 10s safety timeout
             cp.execFile(
                 'git',
-                ['--no-pager', '--no-optional-locks', 'ls-tree', commitId, '--', ...filePaths],
+                ['--no-pager', '--no-optional-locks', 'ls-tree', commitId, '--', ...missingPaths],
                 {
                     cwd: this.workspaceRoot,
                     maxBuffer: 10 * 1024 * 1024,
@@ -1337,18 +1385,18 @@ export class JjService {
                 },
                 (err, stdout) => {
                     if (err) {
-                        // If git fails (e.g. not a git repo, or commit not found in git backing), return empty
+                        // If git fails (e.g. not a git repo, or commit not found in git backing), return partial resultMap
                         // This is expected fallback behavior
                         this.logger.warn(`getGitBlobHashes failed: ${err.message}`);
-                        resolve(new Map());
+                        resolve(resultMap);
                         return;
                     }
 
-                    const resultMap = new Map<string, string>();
                     // Output format: <mode> blob <sha> <tab><path>
                     // 100644 blob 3a8500ab7725f03cca3806ee9ebaf7b4b53c3ca6    vitest.config.js
 
                     const lines = stdout.toString().trim().split('\n');
+                    const foundPaths = new Set<string>();
                     for (const line of lines) {
                         if (!line) {
                             continue;
@@ -1360,13 +1408,21 @@ export class JjService {
                         if (parts.length >= 4 && parts[1] === 'blob') {
                             const sha = parts[2];
                             const pathPart = line.substring(line.indexOf('\t') + 1);
-                            // Remove quotes if present (git ls-tree quotes paths with spaces/unusual chars)
-                            const cleanPath =
-                                pathPart.startsWith('"') && pathPart.endsWith('"') ? JSON.parse(pathPart) : pathPart;
+                            const cleanPath = unquoteGitPath(pathPart);
 
+                            commitCache.set(cleanPath, sha);
                             resultMap.set(cleanPath, sha);
+                            foundPaths.add(cleanPath);
                         }
                     }
+
+                    // Negative cache requested paths absent from ls-tree
+                    for (const path of missingPaths) {
+                        if (!foundPaths.has(path)) {
+                            commitCache.set(path, null);
+                        }
+                    }
+
                     resolve(resultMap);
                 },
             );

--- a/src/test/gerrit-sync.test.ts
+++ b/src/test/gerrit-sync.test.ts
@@ -111,6 +111,59 @@ describe('Gerrit Sync Verification', () => {
         expect(result?.contentSynced).toBe(true);
     });
 
+    test('uses pre-fetched changes from request and memoizes content sync outcome', async () => {
+        repo.writeFile('hello.txt', 'hello world');
+        const desc = 'Change-Id: I1111111111111111111111111111111111111111';
+        repo.describe(desc);
+
+        const commitId = repo.getCommitId('@');
+        const blobHashes = await jjService.getGitBlobHashes(commitId, ['hello.txt']);
+        const realHash = blobHashes.get('hello.txt');
+        if (!realHash) {
+            throw new Error('Failed to get blob hash for hello.txt');
+        }
+
+        mockGerritResponse(
+            'I1111111111111111111111111111111111111111',
+            'remote-sha',
+            {
+                'hello.txt': { status: 'M', new_sha: realHash },
+            },
+            '',
+        );
+
+        service = initService();
+        await service.awaitReady();
+
+        await service.ensureFreshStatuses([
+            {
+                commitId,
+                description: desc,
+                parents: [],
+                changes: [{ path: 'hello.txt', status: 'modified' }],
+            },
+        ]);
+        const result1 = provider.getCachedChangeInfo(undefined, desc);
+        expect(result1?.contentSynced).toBe(true);
+
+        // Verify repeated call uses cached contentSynced state
+        await service.ensureFreshStatuses([
+            {
+                commitId,
+                description: desc,
+                parents: [],
+                changes: [{ path: 'hello.txt', status: 'modified' }],
+            },
+        ]);
+        const result2 = provider.getCachedChangeInfo(undefined, desc);
+        expect(result2?.contentSynced).toBe(true);
+
+        // Verify clearCache clears the content sync cache
+        provider.clearCache();
+        const resultAfterClear = provider.getCachedChangeInfo(undefined, desc);
+        expect(resultAfterClear).toBeUndefined();
+    });
+
     test('does not set synced when blob hashes differ', async () => {
         repo.writeFile('hello.txt', 'hello world');
         const desc = 'Change-Id: I2222222222222222222222222222222222222222';

--- a/src/test/jj-service.test.ts
+++ b/src/test/jj-service.test.ts
@@ -1718,6 +1718,32 @@ log = "none()"
 
         expect(hashes.size).toBe(1);
         expect(hashes.get(fileName)).toBe(expectedHash);
+
+        const cachedHashes = await jjService.getGitBlobHashes(commitId, [fileName]);
+        expect(cachedHashes.size).toBe(1);
+        expect(cachedHashes.get(fileName)).toBe(expectedHash);
+    });
+
+    test('getGitBlobHashes negative-caches missing paths and handles unicode filenames', async () => {
+        const unicodeFile = 'café.txt';
+        repo.writeFile(unicodeFile, 'unicode content');
+        repo.describe('unicode test');
+        const commitId = repo.getCommitId('@');
+
+        const expectedHash = cp
+            .execFileSync('git', ['hash-object', path.join(repo.path, unicodeFile)], { cwd: repo.path })
+            .toString()
+            .trim();
+
+        const hashes = await jjService.getGitBlobHashes(commitId, [unicodeFile, 'non-existent.txt']);
+        expect(hashes.size).toBe(1);
+        expect(hashes.get(unicodeFile)).toBe(expectedHash);
+        expect(hashes.has('non-existent.txt')).toBe(false);
+
+        // Repeated query should use cache including negative cache for missing path
+        const cachedHashes = await jjService.getGitBlobHashes(commitId, [unicodeFile, 'non-existent.txt']);
+        expect(cachedHashes.size).toBe(1);
+        expect(cachedHashes.get(unicodeFile)).toBe(expectedHash);
     });
 
     test('getLog detects divergent commits and offsets', async () => {


### PR DESCRIPTION
Pass pre-fetched log changes in ChangeStatusRequest to bypass redundant `jj.getChanges` invocations during Gerrit sync verification. Memoize `git ls-tree` blob hashes by commit and path in `JjService.getGitBlobHashes`, and memoize verified content sync results in `GerritProvider`.