### PR TITLE
perf(upload): reuse resolved stack commits and check bookmarks in memory

### DIFF
--- a/src/core/commands/upload-stack.ts
+++ b/src/core/commands/upload-stack.ts
@@ -96,12 +96,24 @@ export async function resolveStackedUploadCommand(
     repo: JjRepository,
     targetRevision: string,
     customCommand?: string,
+    preResolvedStackCommits?: JjLogEntry[],
 ): Promise<ResolvedStackedUploadCommand> {
     if (repo.codeForge.activeProvider?.id === 'gerrit') {
         throw new Error('Stacked uploads are not supported for Gerrit repositories. Use standard upload instead.');
     }
 
-    const stackCommits = await resolveStackCommits(repo.jj, targetRevision);
+    const matchesTarget = preResolvedStackCommits?.some(
+        (c) =>
+            c.commit_id === targetRevision ||
+            c.change_id === targetRevision ||
+            c.commit_id.startsWith(targetRevision) ||
+            c.change_id.startsWith(targetRevision) ||
+            (targetRevision === '@' && c.is_current_working_copy),
+    );
+    const stackCommits =
+        preResolvedStackCommits && (matchesTarget || targetRevision === '@')
+            ? preResolvedStackCommits
+            : await resolveStackCommits(repo.jj, targetRevision);
     if (stackCommits.length === 0) {
         throw new Error('No mutable commits found in stack to upload.');
     }
@@ -146,7 +158,7 @@ export async function uploadStackCommand(ctx: CommandContext, payload?: UploadPa
 
     let resolved: ResolvedStackedUploadCommand;
     try {
-        resolved = await resolveStackedUploadCommand(repo, revision, customCommand);
+        resolved = await resolveStackedUploadCommand(repo, revision, customCommand, payload?.stackCommits);
         if (!resolved.subcommand) {
             throw new Error('Invalid upload command configuration.');
         }

--- a/src/core/commands/upload.ts
+++ b/src/core/commands/upload.ts
@@ -6,6 +6,7 @@ import type { CommandContext } from '../host/command-context';
 import { showJjError } from '../host/ui-helpers';
 import type { JjRepository } from '../jj-repository';
 import type { JjService } from '../jj-service';
+import type { JjLogEntry } from '../jj-types';
 import {
     buildStackPushArgs,
     isEligibleForAutoStackedUpload,
@@ -29,6 +30,7 @@ export {
 export interface UploadPayload {
     revision?: string;
     mode?: 'auto' | 'single' | 'stack';
+    stackCommits?: JjLogEntry[];
 }
 
 interface ResolvedUploadCommand {
@@ -37,7 +39,30 @@ interface ResolvedUploadCommand {
     uploadRevision?: string;
 }
 
-async function checkHasLocalBookmark(jj: JjService, revision: string): Promise<boolean> {
+async function checkHasLocalBookmark(jj: JjService, revision: string, stackCommits?: JjLogEntry[]): Promise<boolean> {
+    if (stackCommits && stackCommits.length > 0) {
+        let commit = stackCommits.find(
+            (c) =>
+                c.commit_id === revision ||
+                c.change_id === revision ||
+                c.commit_id.startsWith(revision) ||
+                c.change_id.startsWith(revision) ||
+                (revision === '@' && c.is_current_working_copy),
+        );
+        if (!commit && revision === '@-') {
+            const wc = stackCommits.find((c) => c.is_current_working_copy);
+            if (wc && wc.parents.length > 0) {
+                const parent = wc.parents[0];
+                commit = stackCommits.find((c) => c.commit_id === parent.commit_id || c.change_id === parent.change_id);
+            }
+            if (!commit) {
+                commit = stackCommits[stackCommits.length - 1];
+            }
+        }
+        if (commit?.bookmarks) {
+            return commit.bookmarks.some((b) => !b.remote);
+        }
+    }
     try {
         const bookmarks = await jj.getBookmarks({ revision });
         return bookmarks.some((b) => !b.remote);
@@ -50,6 +75,7 @@ async function resolveUploadCommand(
     repo: JjRepository,
     revision?: string,
     customCommand?: string,
+    stackCommits?: JjLogEntry[],
 ): Promise<ResolvedUploadCommand> {
     let rev = revision || '@';
     if (rev === '@') {
@@ -70,7 +96,7 @@ async function resolveUploadCommand(
         return { subcommand: 'git', commandArgs: ['push'], uploadRevision: rev };
     }
 
-    const hasBookmark = await checkHasLocalBookmark(repo.jj, rev);
+    const hasBookmark = await checkHasLocalBookmark(repo.jj, rev, stackCommits);
     const provCommand = activeProvider.getUploadCommand(rev, hasBookmark);
     if (!provCommand) {
         return { subcommand: 'git', commandArgs: ['push'], uploadRevision: rev };
@@ -94,21 +120,30 @@ export async function uploadCommand(ctx: CommandContext, payload?: UploadPayload
     const alwaysUploadStack = !isGerrit && config.get<boolean>('alwaysUploadStack', false);
     const mode = isGerrit ? 'single' : alwaysUploadStack ? 'stack' : (payload?.mode ?? 'auto');
 
+    let stackCommits = payload?.stackCommits;
+
     if (mode === 'stack') {
-        return uploadStackCommand(ctx, { ...payload, mode: 'stack' });
+        return uploadStackCommand(ctx, { ...payload, mode: 'stack', stackCommits });
     }
 
     if (mode === 'auto') {
-        const stackCommits = await resolveStackCommits(repo.jj, revision ?? '@');
+        if (!stackCommits) {
+            stackCommits = await resolveStackCommits(repo.jj, revision ?? '@');
+        }
         if (isEligibleForAutoStackedUpload(stackCommits)) {
-            return uploadStackCommand(ctx, { ...payload, mode: 'stack' });
+            return uploadStackCommand(ctx, { ...payload, mode: 'stack', stackCommits });
         }
     }
 
     const customCommand = config.get<string>('uploadCommand');
     const hasCustomCommand = !!(customCommand && customCommand.trim().length > 0);
     try {
-        const { subcommand, commandArgs, uploadRevision } = await resolveUploadCommand(repo, revision, customCommand);
+        const { subcommand, commandArgs, uploadRevision } = await resolveUploadCommand(
+            repo,
+            revision,
+            customCommand,
+            stackCommits,
+        );
 
         if (!subcommand) {
             throw new Error('Invalid upload command configuration.');

--- a/src/test/commands/upload.test.ts
+++ b/src/test/commands/upload.test.ts
@@ -1043,5 +1043,26 @@ describe('uploadCommand', () => {
                 'Stacked uploads are not supported for Gerrit repositories. Use standard upload instead.',
             );
         });
+
+        test('resolveStackedUploadCommand reuses pre-resolved stack commits', async () => {
+            const dummyCommits: JjLogEntry[] = [
+                createMock<JjLogEntry>({
+                    commit_id: 'commit-1',
+                    change_id: 'change-1',
+                    bookmarks: [{ name: 'bm-1' }],
+                    parents: [],
+                }),
+                createMock<JjLogEntry>({
+                    commit_id: 'commit-2',
+                    change_id: 'change-2',
+                    bookmarks: [{ name: 'bm-2' }],
+                    parents: [{ commit_id: 'commit-1', change_id: 'change-1', is_immutable: false }],
+                }),
+            ];
+
+            const result = await resolveStackedUploadCommand(mockJjRepo, '@', undefined, dummyCommits);
+            expect(result.stackCommits).toBe(dummyCommits);
+            expect(result.commandArgs).toEqual(['push', '-r', 'bm-1', '-r', 'bm-2']);
+        });
     });
 });


### PR DESCRIPTION
Forward pre-resolved stack commits between `uploadCommand` and `uploadStackCommand` to eliminate redundant `resolveStackCommits` invocations (saving multiple `jj log` subprocesses). Check bookmark presence directly from in-memory commits in `checkHasLocalBookmark` when available to bypass `jj bookmark list`.