### PR TITLE
ci: optimize windows runner and add windows-specific test timeouts and retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,13 @@ jobs:
                   name: build-outputs
                   path: .
 
+            - name: Optimize Windows Runner (Disable Defender)
+              if: runner.os == 'Windows'
+              shell: powershell
+              run: |
+                  Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+                  Add-MpPreference -ExclusionPath $env:TEMP, $env:GITHUB_WORKSPACE -ErrorAction SilentlyContinue
+
             - name: Run Unit Tests
               run: pnpm test:unit
 
@@ -200,6 +207,13 @@ jobs:
               with:
                   name: build-outputs
                   path: .
+
+            - name: Optimize Windows Runner (Disable Defender)
+              if: runner.os == 'Windows'
+              shell: powershell
+              run: |
+                  Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+                  Add-MpPreference -ExclusionPath $env:TEMP, $env:GITHUB_WORKSPACE -ErrorAction SilentlyContinue
 
             - name: Run Integration Tests (Linux)
               if: runner.os == 'Linux'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,8 @@
  */
 import { defineConfig } from 'vitest/config';
 
+const isWindows = process.platform === 'win32';
+
 export default defineConfig({
     test: {
         include: ['src/test/**/*.test.{ts,tsx}', 'tooling/**/*.test.ts'],
@@ -11,7 +13,10 @@ export default defineConfig({
         // Temporary global setup to provide vscode mock during host abstraction retrofit
         setupFiles: ['./src/test/vitest-setup.ts'],
         globals: true,
-        testTimeout: 20000,
-        hookTimeout: 20000,
+        testTimeout: isWindows ? 60000 : 20000,
+        hookTimeout: isWindows ? 60000 : 20000,
+        retry: isWindows && process.env.CI ? 1 : 0,
+        maxWorkers: isWindows && process.env.CI ? 2 : undefined,
+        execArgv: ['--max-old-space-size=4096'],
     },
 });


### PR DESCRIPTION
Disable Windows Defender real-time scanning and add exclusions for temp
and workspace directories to reduce disk I/O latency and process creation
overhead on Windows runners. Increase Vitest test and hook timeouts to 60s
on Windows and allow a single retry on Windows CI to prevent transient I/O
congestion from failing the suite.