### PR TITLE
ci: add defender process exclusions and batch test repo operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
               run: |
                   Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
                   Add-MpPreference -ExclusionPath $env:TEMP, $env:GITHUB_WORKSPACE -ErrorAction SilentlyContinue
+                  Add-MpPreference -ExclusionProcess "node.exe", "jj.exe", "git.exe" -ErrorAction SilentlyContinue
 
             - name: Run Unit Tests
               run: pnpm test:unit
@@ -233,6 +234,7 @@ jobs:
               run: |
                   Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
                   Add-MpPreference -ExclusionPath $env:TEMP, $env:GITHUB_WORKSPACE -ErrorAction SilentlyContinue
+                  Add-MpPreference -ExclusionProcess "node.exe", "jj.exe", "git.exe" -ErrorAction SilentlyContinue
 
             - name: Run Integration Tests (Linux)
               if: runner.os == 'Linux'

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -139,22 +139,21 @@ export class TestRepo {
     }
 
     configBatch(configs: Record<string, string>) {
-        if (process.platform !== 'win32') {
-            const commands: string[] = [];
+        const commands: string[] = [];
 
-            for (const [key, val] of Object.entries(configs)) {
-                commands.push(`jj --quiet config set --repo ${key} "${val}"`);
-            }
+        for (const [key, val] of Object.entries(configs)) {
+            commands.push(`jj --quiet config set --repo ${key} "${val}"`);
+        }
 
-            if (commands.length > 0) {
-                const cmd = commands.join(' && ');
-                const env = { ...process.env, JJ_CONFIG: '' };
-                cp.execSync(cmd, { cwd: this.path, env, stdio: 'ignore' });
-            }
-        } else {
-            for (const [key, val] of Object.entries(configs)) {
-                this.config(key, val, true);
-            }
+        if (commands.length > 0) {
+            const cmd = commands.join(' && ');
+            const env = { ...process.env, JJ_CONFIG: '' };
+            cp.execSync(cmd, {
+                cwd: this.path,
+                env,
+                stdio: 'ignore',
+                shell: process.platform === 'win32' ? 'cmd.exe' : undefined,
+            });
         }
     }
 
@@ -178,36 +177,12 @@ export class TestRepo {
             env,
         });
 
-        if (process.platform !== 'win32') {
-            const commands = [
-                `jj --quiet config set --repo user.name "Test User"`,
-                `jj --quiet config set --repo user.email "test@example.com"`,
-                `jj --quiet config set --repo signing.backend "none"`,
-                `jj --quiet config set --repo ui.merge-editor "builtin"`,
-            ];
-            cp.execSync(commands.join(' && '), { cwd: this.path, env, stdio: 'ignore' });
-        } else {
-            cp.execFileSync(jjBinary, ['--quiet', 'config', 'set', '--repo', 'user.name', 'Test User'], {
-                cwd: this.path,
-                env,
-                stdio: 'ignore',
-            });
-            cp.execFileSync(jjBinary, ['--quiet', 'config', 'set', '--repo', 'user.email', 'test@example.com'], {
-                cwd: this.path,
-                env,
-                stdio: 'ignore',
-            });
-            cp.execFileSync(jjBinary, ['--quiet', 'config', 'set', '--repo', 'signing.backend', 'none'], {
-                cwd: this.path,
-                env,
-                stdio: 'ignore',
-            });
-            cp.execFileSync(jjBinary, ['--quiet', 'config', 'set', '--repo', 'ui.merge-editor', 'builtin'], {
-                cwd: this.path,
-                env,
-                stdio: 'ignore',
-            });
-        }
+        this.configBatch({
+            'user.name': 'Test User',
+            'user.email': 'test@example.com',
+            'signing.backend': 'none',
+            'ui.merge-editor': 'builtin',
+        });
 
         cp.execFileSync(jjBinary, ['--quiet', 'metaedit', '--update-author'], {
             cwd: this.path,
@@ -362,6 +337,20 @@ export class TestRepo {
 
     getCommitId(revision: string): string {
         return this.exec(['log', '--ignore-working-copy', '-r', revision, '-T', 'commit_id', '--no-graph']);
+    }
+
+    getChangeAndCommitId(revision: string): { changeId: string; commitId: string } {
+        const output = this.exec([
+            'log',
+            '--ignore-working-copy',
+            '-r',
+            revision,
+            '-T',
+            'change_id ++ " " ++ commit_id',
+            '--no-graph',
+        ]);
+        const [changeId = '', commitId = ''] = output.trim().split(/\s+/);
+        return { changeId, commitId };
     }
 
     diff(relativePath: string, revision?: string): string {
@@ -731,8 +720,7 @@ export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): P
         }
 
         // Capture ID
-        const changeId = repo.getChangeId('@');
-        const commitId = repo.getCommitId('@');
+        const { changeId, commitId } = repo.getChangeAndCommitId('@');
         if (commit.label) {
             labelToId[commit.label] = { changeId, commitId };
         }


### PR DESCRIPTION
Add process exclusions for node.exe, jj.exe, and git.exe to Windows Defender
in CI to bypass file-system filter inspection on subprocess execution.

In TestRepo, batch Windows repo configs into a single chained command to avoid
sequential child process spawns in init and configBatch, and fetch change and
commit IDs in a single jj log call during buildGraph.