### PR TITLE
ci: cache jj binary across workflow jobs

### DIFF
--- a/.github/actions/setup-jj/action.yml
+++ b/.github/actions/setup-jj/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup jj'
+description: 'Restore cached jj binary or install latest jj via taiki-e/install-action'
+
+inputs:
+    version:
+        description: 'Target jj version tag for cache key'
+        required: false
+        default: 'latest'
+
+runs:
+    using: 'composite'
+    steps:
+        - name: Cache jj binary
+          id: cache-jj
+          uses: actions/cache@v4
+          with:
+              path: |
+                  ~/.cargo/bin/jj
+                  ~/.cargo/bin/jj.exe
+              key: jj-cli-${{ runner.os }}-${{ inputs.version }}
+
+        - name: Install jj (Jujutsu)
+          if: steps.cache-jj.outputs.cache-hit != 'true'
+          uses: taiki-e/install-action@v2
+          with:
+              tool: jj-cli

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,21 @@ concurrency:
 jobs:
     prepare:
         runs-on: ubuntu-latest
+        outputs:
+            jj_version: ${{ steps.jj_version.outputs.version }}
         steps:
             - name: Checkout
               uses: actions/checkout@v7
               with:
                   fetch-depth: 0
+
+            - name: Get Latest jj Version
+              id: jj_version
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  TAG=$(gh release view -R jj-vcs/jj --json tagName -q .tagName 2>/dev/null || echo "latest")
+                  echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
             - name: Install pnpm
               uses: pnpm/action-setup@v6
@@ -34,15 +44,17 @@ jobs:
                   node-version: 22
                   cache: 'pnpm'
 
+            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
             - name: Install Go
               uses: actions/setup-go@v6
               with:
                   go-version: '1.21'
+                  cache: false
 
-            - name: Install jj (Jujutsu)
-              uses: taiki-e/install-action@v2
+            - name: Setup jj (Jujutsu)
+              uses: ./.github/actions/setup-jj
               with:
-                  tool: jj-cli
+                  version: ${{ steps.jj_version.outputs.version }}
 
             - name: Verify Environment
               run: |
@@ -136,15 +148,17 @@ jobs:
                   node-version: 22
                   cache: 'pnpm'
 
+            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
             - name: Install Go
               uses: actions/setup-go@v6
               with:
                   go-version: '1.21'
+                  cache: false
 
-            - name: Install jj (Jujutsu)
-              uses: taiki-e/install-action@v2
+            - name: Setup jj (Jujutsu)
+              uses: ./.github/actions/setup-jj
               with:
-                  tool: jj-cli
+                  version: ${{ needs.prepare.outputs.jj_version }}
 
             - name: Verify Environment
               run: |
@@ -202,15 +216,17 @@ jobs:
                   node-version: 22
                   cache: 'pnpm'
 
+            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
             - name: Install Go
               uses: actions/setup-go@v6
               with:
                   go-version: '1.21'
+                  cache: false
 
-            - name: Install jj (Jujutsu)
-              uses: taiki-e/install-action@v2
+            - name: Setup jj (Jujutsu)
+              uses: ./.github/actions/setup-jj
               with:
-                  tool: jj-cli
+                  version: ${{ needs.prepare.outputs.jj_version }}
 
             - name: Verify Environment
               run: |
@@ -264,15 +280,17 @@ jobs:
                   node-version: 22
                   cache: 'pnpm'
 
+            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
             - name: Install Go
               uses: actions/setup-go@v6
               with:
                   go-version: '1.21'
+                  cache: false
 
-            - name: Install jj (Jujutsu)
-              uses: taiki-e/install-action@v2
+            - name: Setup jj (Jujutsu)
+              uses: ./.github/actions/setup-jj
               with:
-                  tool: jj-cli
+                  version: ${{ needs.prepare.outputs.jj_version }}
 
             - name: Verify Environment
               run: |


### PR DESCRIPTION
Downloading and installing jj on every runner takes up to 30 seconds,
creating noticeable latency particularly on Windows. This caches the
binary across workflow jobs keyed by runner OS and the latest release
tag queried dynamically from GitHub, eliminating redundant downloads
while automatically staying up to date with new jj releases.

Also documents the Go setup required by test binary generators and
disables Go module caching to eliminate missing-manifest warnings.