### PR TITLE
ci: optimize pnpm, node, and go setup caching across workflows

### DIFF
--- a/.github/actions/setup-jj/action.yml
+++ b/.github/actions/setup-jj/action.yml
@@ -12,7 +12,7 @@ runs:
     steps:
         - name: Cache jj binary
           id: cache-jj
-          uses: actions/cache@v4
+          uses: actions/cache@v6
           with:
               path: |
                   ~/.cargo/bin/jj

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,16 @@ jobs:
                   echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/setup@v2
               with:
-                  version: 10
+                  version: 11
+                  cache: true
+                  install: false
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
-                  cache: 'pnpm'
-
-            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
-            - name: Install Go
-              uses: actions/setup-go@v6
-              with:
-                  go-version: '1.21'
-                  cache: false
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -58,7 +52,6 @@ jobs:
 
             - name: Verify Environment
               run: |
-                  go version
                   jj --version
                   which jj
                   git config --global init.defaultBranch main
@@ -122,6 +115,7 @@ jobs:
     unit-tests:
         needs: prepare
         strategy:
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
         runs-on: ${{ matrix.os }}
@@ -149,21 +143,22 @@ jobs:
                   fsutil 8dot3name set 1 | Out-Null
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/setup@v2
               with:
-                  version: 10
+                  version: 11
+                  cache: true
+                  install: false
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
-                  cache: 'pnpm'
 
             # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
-            - name: Install Go
+            - name: Setup Go
               uses: actions/setup-go@v6
               with:
-                  go-version: '1.21'
+                  go-version: '1.x'
                   cache: false
 
             - name: Setup jj (Jujutsu)
@@ -193,6 +188,7 @@ jobs:
     integration-tests:
         needs: prepare
         strategy:
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
         runs-on: ${{ matrix.os }}
@@ -220,22 +216,16 @@ jobs:
                   fsutil 8dot3name set 1 | Out-Null
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/setup@v2
               with:
-                  version: 10
+                  version: 11
+                  cache: true
+                  install: false
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
-                  cache: 'pnpm'
-
-            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
-            - name: Install Go
-              uses: actions/setup-go@v6
-              with:
-                  go-version: '1.21'
-                  cache: false
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -244,7 +234,6 @@ jobs:
 
             - name: Verify Environment
               run: |
-                  go version
                   jj --version
                   which jj
                   git config --global init.defaultBranch main
@@ -276,22 +265,16 @@ jobs:
               uses: actions/checkout@v7
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/setup@v2
               with:
-                  version: 10
+                  version: 11
+                  cache: true
+                  install: false
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
-                  cache: 'pnpm'
-
-            # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
-            - name: Install Go
-              uses: actions/setup-go@v6
-              with:
-                  go-version: '1.21'
-                  cache: false
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -300,7 +283,6 @@ jobs:
 
             - name: Verify Environment
               run: |
-                  go version
                   jj --version
                   which jj
                   git config --global init.defaultBranch main

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -13,14 +13,27 @@ concurrency:
 jobs:
     build:
         runs-on: ubuntu-latest
+        env:
+            PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: 'false'
 
         steps:
             - uses: actions/checkout@v7
 
-            - name: Set up Go stable
-              uses: actions/setup-go@v6
+            - name: Install pnpm
+              uses: pnpm/setup@v2
               with:
-                  go-version: stable
+                  version: 11
+                  install: false
 
-            - name: Check
-              run: go run github.com/google/addlicense@v1.1.1 -check -s=only -ignore='node_modules/**' -ignore='dist/**' -ignore='out/**' -ignore='coverage/**' -ignore='.vscode-test/**' -ignore='.jj/**' -ignore='pnpm-lock.yaml' **
+            - name: Cache Go build & modules
+              uses: actions/cache@v6
+              with:
+                  path: |
+                      ~/.cache/go-build
+                      ~/go/pkg/mod
+                  key: go-license-${{ runner.os }}-v1.1.1
+                  restore-keys: |
+                      go-license-${{ runner.os }}-
+
+            - name: Check License
+              run: pnpm check-license

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,20 +15,19 @@ jobs:
                   fetch-depth: 0
 
             - name: Install pnpm
-              uses: pnpm/action-setup@v6
+              uses: pnpm/setup@v2
               with:
-                  version: 10
+                  version: 11
+                  cache: true
+                  install: false
 
             - name: Install Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22
-                  cache: 'pnpm'
 
-            - name: Install jj (Jujutsu)
-              uses: taiki-e/install-action@v2
-              with:
-                  tool: jj-cli
+            - name: Setup jj (Jujutsu)
+              uses: ./.github/actions/setup-jj
 
             - name: Install Dependencies
               run: pnpm install --frozen-lockfile


### PR DESCRIPTION
- Update pnpm/action-setup to version 11 with built-in cache: true to match runner pre-installed pnpm and avoid npm downgrade overhead
- Remove cache: 'pnpm' from actions/setup-node to avoid redundant and slow store tarball uncompress
- Update actions/setup-go to go-version: 'stable' to reuse runner's pre-installed Go cache instead of downloading Go 1.21