### PR TITLE
ci: cache custom icon font build and streamline pnpm and node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,17 +33,20 @@ jobs:
                   TAG=$(gh release view -R jj-vcs/jj --json tagName -q .tagName 2>/dev/null || echo "latest")
                   echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
-            - name: Install pnpm
+            - name: Install pnpm & Node.js
               uses: pnpm/setup@v2
               with:
                   version: 11
+                  runtime: node@22
                   cache: true
                   install: false
 
-            - name: Install Node.js
-              uses: actions/setup-node@v7
+            - name: Cache Custom Icons
+              id: cache-icons
+              uses: actions/cache@v6
               with:
-                  node-version: 22
+                  path: media/custom-icons
+                  key: custom-icons-${{ runner.os }}-${{ hashFiles('media/custom-icons-src/**') }}
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -108,7 +111,8 @@ jobs:
                       dist/
                       out/
                       jj-view.vsix
-                      src/webview/themes.generated.ts
+                      media/custom-icons/
+                      src/core/webview/themes.generated.ts
                       media/themes.generated.css
                   retention-days: 1
 
@@ -142,17 +146,13 @@ jobs:
                   fsutil behavior set disablelastaccess 1 | Out-Null
                   fsutil 8dot3name set 1 | Out-Null
 
-            - name: Install pnpm
+            - name: Install pnpm & Node.js
               uses: pnpm/setup@v2
               with:
                   version: 11
+                  runtime: node@22
                   cache: true
                   install: false
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
 
             # Go is required by tests (e.g., src/test/utils/binary-utils.test.ts) to compile test binaries on the fly
             - name: Setup Go
@@ -173,14 +173,14 @@ jobs:
                   which jj
                   git config --global init.defaultBranch main
 
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
             - name: Download Build Artifacts
               uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile --config.ignore-scripts=true
 
             - name: Run Unit Tests
               run: pnpm test:unit
@@ -215,17 +215,13 @@ jobs:
                   fsutil behavior set disablelastaccess 1 | Out-Null
                   fsutil 8dot3name set 1 | Out-Null
 
-            - name: Install pnpm
+            - name: Install pnpm & Node.js
               uses: pnpm/setup@v2
               with:
                   version: 11
+                  runtime: node@22
                   cache: true
                   install: false
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -238,14 +234,14 @@ jobs:
                   which jj
                   git config --global init.defaultBranch main
 
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
             - name: Download Build Artifacts
               uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile --config.ignore-scripts=true
 
             - name: Run Integration Tests (Linux)
               if: runner.os == 'Linux'
@@ -264,17 +260,13 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v7
 
-            - name: Install pnpm
+            - name: Install pnpm & Node.js
               uses: pnpm/setup@v2
               with:
                   version: 11
+                  runtime: node@22
                   cache: true
                   install: false
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj
@@ -287,14 +279,14 @@ jobs:
                   which jj
                   git config --global init.defaultBranch main
 
-            - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
-
             - name: Download Build Artifacts
               uses: actions/download-artifact@v8
               with:
                   name: build-outputs
                   path: .
+
+            - name: Install Dependencies
+              run: pnpm install --frozen-lockfile --config.ignore-scripts=true
 
             - name: Install Playwright system dependencies
               run: pnpm playwright install-deps chromium

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,17 +14,13 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Install pnpm
+            - name: Install pnpm & Node.js
               uses: pnpm/setup@v2
               with:
                   version: 11
+                  runtime: node@22
                   cache: true
                   install: false
-
-            - name: Install Node.js
-              uses: actions/setup-node@v7
-              with:
-                  node-version: 22
 
             - name: Setup jj (Jujutsu)
               uses: ./.github/actions/setup-jj

--- a/package.json
+++ b/package.json
@@ -1221,7 +1221,7 @@
         "prepare": "pnpm build:themes && pnpm build:icons",
         "vscode:prepublish": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js --production",
         "build": "pnpm prepare && pnpm check-types && pnpm lint && node esbuild.js",
-        "build:icons": "svgtofont -s media/custom-icons-src -o media/custom-icons",
+        "build:icons": "node tooling/build-icons.ts",
         "watch": "npm-run-all -p watch:*",
         "watch:esbuild": "node esbuild.js --watch",
         "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,5 @@ allowBuilds:
   "@parcel/watcher": true
   esbuild: true
   keytar: true
-  ttf2woff2: true
+  ttf2woff2: false
   "@vscode/vsce-sign": true

--- a/tooling/build-icons.test.ts
+++ b/tooling/build-icons.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { areIconsUpToDate, computeIconsSourceHash } from './build-icons';
+
+describe('build-icons', () => {
+    let tmpDir: string;
+    let srcDir: string;
+    let outDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'build-icons-test-'));
+        srcDir = path.join(tmpDir, 'src');
+        outDir = path.join(tmpDir, 'out');
+        fs.mkdirSync(srcDir, { recursive: true });
+        fs.mkdirSync(outDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('computeIconsSourceHash', () => {
+        it('returns empty string if srcDir does not exist', () => {
+            expect(computeIconsSourceHash(path.join(tmpDir, 'nonexistent'))).toBe('');
+        });
+
+        it('computes deterministic hash for files in srcDir', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon1.svg'), '<svg>1</svg>');
+            fs.writeFileSync(path.join(srcDir, 'icon2.svg'), '<svg>2</svg>');
+
+            const hash1 = computeIconsSourceHash(srcDir);
+            const hash2 = computeIconsSourceHash(srcDir);
+
+            expect(hash1).toBeTruthy();
+            expect(hash1).toBe(hash2);
+        });
+
+        it('changes hash when file content changes without renaming', () => {
+            const iconPath = path.join(srcDir, 'icon.svg');
+            fs.writeFileSync(iconPath, '<svg>initial</svg>');
+            const initialHash = computeIconsSourceHash(srcDir);
+
+            fs.writeFileSync(iconPath, '<svg>modified</svg>');
+            const modifiedHash = computeIconsSourceHash(srcDir);
+
+            expect(modifiedHash).not.toBe(initialHash);
+        });
+
+        it('ignores hidden files in srcDir', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon.svg'), '<svg>test</svg>');
+            const baseHash = computeIconsSourceHash(srcDir);
+
+            fs.writeFileSync(path.join(srcDir, '.DS_Store'), 'junk');
+            const withHiddenHash = computeIconsSourceHash(srcDir);
+
+            expect(withHiddenHash).toBe(baseHash);
+        });
+    });
+
+    describe('areIconsUpToDate', () => {
+        it('returns false if outDir does not exist', () => {
+            fs.rmSync(outDir, { recursive: true, force: true });
+            expect(areIconsUpToDate(srcDir, outDir)).toBe(false);
+        });
+
+        it('returns false if required output files are missing', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon.svg'), '<svg>test</svg>');
+            const hash = computeIconsSourceHash(srcDir);
+            fs.writeFileSync(path.join(outDir, 'icons.hash'), hash);
+
+            // Missing .woff, .woff2, .ttf, .css
+            expect(areIconsUpToDate(srcDir, outDir)).toBe(false);
+        });
+
+        it('returns false if hash file is missing', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon.svg'), '<svg>test</svg>');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff2'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.ttf'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.css'), 'dummy');
+
+            expect(areIconsUpToDate(srcDir, outDir)).toBe(false);
+        });
+
+        it('returns false if hash does not match current source', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon.svg'), '<svg>test</svg>');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff2'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.ttf'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.css'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'icons.hash'), 'old-hash');
+
+            expect(areIconsUpToDate(srcDir, outDir)).toBe(false);
+        });
+
+        it('returns true when all required files exist and hash matches', () => {
+            fs.writeFileSync(path.join(srcDir, 'icon.svg'), '<svg>test</svg>');
+            const hash = computeIconsSourceHash(srcDir);
+
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.woff2'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.ttf'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'jj-view-icons.css'), 'dummy');
+            fs.writeFileSync(path.join(outDir, 'icons.hash'), hash);
+
+            expect(areIconsUpToDate(srcDir, outDir)).toBe(true);
+        });
+    });
+});

--- a/tooling/build-icons.ts
+++ b/tooling/build-icons.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import svgtofont from 'svgtofont';
+
+export interface BuildIconsOptions {
+    srcDir?: string;
+    outDir?: string;
+    force?: boolean;
+}
+
+const REQUIRED_OUTPUT_FILES = [
+    'jj-view-icons.woff',
+    'jj-view-icons.woff2',
+    'jj-view-icons.ttf',
+    'jj-view-icons.css',
+] as const;
+
+/**
+ * Computes a deterministic SHA-256 hash of all files in the icon source directory.
+ */
+export function computeIconsSourceHash(srcDir: string): string {
+    if (!fs.existsSync(srcDir)) {
+        return '';
+    }
+
+    const files = fs
+        .readdirSync(srcDir, { withFileTypes: true })
+        .filter((entry) => entry.isFile() && !entry.name.startsWith('.'))
+        .map((entry) => entry.name)
+        .sort();
+
+    const hash = crypto.createHash('sha256');
+    for (const filename of files) {
+        const filePath = path.join(srcDir, filename);
+        const content = fs.readFileSync(filePath);
+        hash.update(`${filename}:${content.length}:`);
+        hash.update(content);
+    }
+
+    return hash.digest('hex');
+}
+
+/**
+ * Checks whether the generated icons are up-to-date with the source directory.
+ */
+export function areIconsUpToDate(srcDir: string, outDir: string): boolean {
+    if (!fs.existsSync(outDir)) {
+        return false;
+    }
+
+    for (const requiredFile of REQUIRED_OUTPUT_FILES) {
+        const filePath = path.join(outDir, requiredFile);
+        if (!fs.existsSync(filePath)) {
+            return false;
+        }
+    }
+
+    const currentHash = computeIconsSourceHash(srcDir);
+    if (!currentHash) {
+        return false;
+    }
+
+    const hashFilePath = path.join(outDir, 'icons.hash');
+    if (!fs.existsSync(hashFilePath)) {
+        return false;
+    }
+
+    const storedHash = fs.readFileSync(hashFilePath, 'utf-8').trim();
+    return storedHash === currentHash;
+}
+
+/**
+ * Builds custom icon fonts using svgtofont if needed.
+ */
+export async function buildIcons(options: BuildIconsOptions = {}): Promise<boolean> {
+    const defaultSrcDir = path.join(import.meta.dirname, '../media/custom-icons-src');
+    const defaultOutDir = path.join(import.meta.dirname, '../media/custom-icons');
+
+    const srcDir = options.srcDir ?? defaultSrcDir;
+    const outDir = options.outDir ?? defaultOutDir;
+    const force = options.force ?? false;
+
+    if (!force && areIconsUpToDate(srcDir, outDir)) {
+        console.log('Custom icons are up to date. Skipping icon generation.');
+        return false;
+    }
+
+    console.log('Building custom icons from SVG sources...');
+    fs.mkdirSync(outDir, { recursive: true });
+
+    process.env.TTF2WOFF2_VERSION = 'wasm';
+    await svgtofont({
+        src: srcDir,
+        dist: outDir,
+    });
+
+    const sourceHash = computeIconsSourceHash(srcDir);
+    fs.writeFileSync(path.join(outDir, 'icons.hash'), sourceHash, 'utf-8');
+    console.log('Custom icons generation complete.');
+
+    return true;
+}
+
+async function main(): Promise<void> {
+    const force = process.argv.includes('--force');
+    try {
+        await buildIcons({ force });
+    } catch (error) {
+        console.error(`Failed to build custom icons: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+    }
+}
+
+if (import.meta.main) {
+    void main();
+}


### PR DESCRIPTION
- Cache media/custom-icons across workflow runs keyed on SVG sources
- Add tooling/build-icons.ts with content hash verification and WASM fallback
- Consolidate pnpm/setup@v2 with runtime: node@22 and remove redundant setup-node
- Disable native ttf2woff2 compilation in pnpm-workspace.yaml allowBuilds
- Include media/custom-icons in prepare build-outputs artifact