### PR TITLE
perf(gerrit): optimize auth routing, avoid unreachable GCE/SSO probes, and parse credential protocols

### DIFF
--- a/package.json
+++ b/package.json
@@ -1277,8 +1277,7 @@
         "sinon": "^21.0.1",
         "svgtofont": "^6.5.1",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.16",
-        "which": "^7.0.0"
+        "vitest": "^4.0.16"
     },
     "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -1294,6 +1293,7 @@
         "renderdag-ts": "git+https://github.com/brychanrobot/renderdag-ts.git",
         "ts-pattern": "^5.9.0",
         "vscode-uri": "^3.1.0",
+        "which": "^7.0.0",
         "zod": "^4.4.3"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       vscode-uri:
         specifier: ^3.1.0
         version: 3.1.0
+      which:
+        specifier: ^7.0.0
+        version: 7.0.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -129,9 +132,6 @@ importers:
       vitest:
         specifier: ^4.0.16
         version: 4.0.16(@types/node@22.19.3)(jiti@2.6.1)(yaml@2.8.2)
-      which:
-        specifier: ^7.0.0
-        version: 7.0.0
 
 packages:
 

--- a/src/test/gerrit-credential-utils.test.ts
+++ b/src/test/gerrit-credential-utils.test.ts
@@ -10,11 +10,16 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import {
+    clearGceEnvironmentCache,
     clearGitRootCache,
     getGerritAuthHeader,
     getGitCookies,
     getGitCredential,
+    isGceEnvironment,
+    isGoogleHost,
+    isLoopbackHost,
     matchCookieDomain,
+    parseGerritHost,
     resolveGitRoot,
 } from '../utils/gerrit-credential-utils';
 import { TestRepo } from './test-repo';
@@ -190,7 +195,7 @@ describe('Credential Utils', () => {
             process.env.LUCI_CONTEXT = '{"some":"context"}';
 
             try {
-                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                const header = await getGerritAuthHeader('https://chromium-review.googlesource.com', null);
                 expect(header).toEqual({ name: 'Authorization', value: 'Bearer fake_luci_token_123' });
             } finally {
                 process.env.PATH = originalPath;
@@ -233,10 +238,36 @@ describe('Credential Utils', () => {
             process.env.PATH = `${tempDir}${path.delimiter}${originalPath}`;
 
             try {
-                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                const header = await getGerritAuthHeader('https://chromium-review.googlesource.com', null);
                 expect(header).toEqual({ name: 'Authorization', value: 'Basic c3NvX3VzZXI6c3NvX3Bhc3M=' });
             } finally {
                 process.env.PATH = originalPath;
+            }
+        });
+
+        test('skips LUCI and Google SSO helper for non-Google hosts', async () => {
+            const isWindows = process.platform === 'win32';
+            const scriptName = isWindows ? 'git-remote-sso.cmd' : 'git-remote-sso';
+            const scriptPath = path.join(tempDir, scriptName);
+
+            if (isWindows) {
+                await fs.writeFile(scriptPath, '@echo off\r\nexit /b 0\r\n');
+            } else {
+                await fs.writeFile(scriptPath, '#!/bin/sh\nexit 0\n');
+                await fs.chmod(scriptPath, 0o755);
+            }
+
+            const originalPath = process.env.PATH;
+            const originalLuciContext = process.env.LUCI_CONTEXT;
+            process.env.PATH = `${tempDir}${path.delimiter}${originalPath}`;
+            process.env.LUCI_CONTEXT = '{"some":"context"}';
+
+            try {
+                const header = await getGerritAuthHeader('https://gerrit.example.com', null);
+                expect(header).toBeUndefined();
+            } finally {
+                process.env.PATH = originalPath;
+                process.env.LUCI_CONTEXT = originalLuciContext;
             }
         });
 
@@ -331,6 +362,150 @@ describe('Credential Utils', () => {
 
             const header = await getGerritAuthHeader('https://gerrit.example.com', gitDir);
             expect(header).toBeUndefined();
+        });
+    });
+
+    describe('parseGerritHost', () => {
+        test('parses https and http URLs with ports', () => {
+            expect(parseGerritHost('https://chromium-review.googlesource.com')).toEqual({
+                protocol: 'https',
+                hostname: 'chromium-review.googlesource.com',
+                port: undefined,
+            });
+            expect(parseGerritHost('http://127.0.0.1:8080/')).toEqual({
+                protocol: 'http',
+                hostname: '127.0.0.1',
+                port: '8080',
+            });
+            expect(parseGerritHost('http://localhost:3000')).toEqual({
+                protocol: 'http',
+                hostname: 'localhost',
+                port: '3000',
+            });
+            expect(parseGerritHost('gerrit.example.com')).toEqual({
+                protocol: 'https',
+                hostname: 'gerrit.example.com',
+                port: undefined,
+            });
+        });
+    });
+
+    describe('isGoogleHost and isLoopbackHost', () => {
+        test('identifies Google hosts correctly', () => {
+            expect(isGoogleHost('chromium-review.googlesource.com')).toBe(true);
+            expect(isGoogleHost('chromium-review.googlesource.com.')).toBe(true);
+            expect(isGoogleHost('android-review.googlesource.com')).toBe(true);
+            expect(isGoogleHost('googlesource.com')).toBe(true);
+            expect(isGoogleHost('gerrit.google.com')).toBe(true);
+            expect(isGoogleHost('foo.googleplex.com')).toBe(true);
+            expect(isGoogleHost('gerrit.example.com')).toBe(false);
+            expect(isGoogleHost('notgooglesource.com')).toBe(false);
+            expect(isGoogleHost('127.0.0.1')).toBe(false);
+        });
+
+        test('identifies loopback hosts correctly', () => {
+            expect(isLoopbackHost('localhost')).toBe(true);
+            expect(isLoopbackHost('localhost.localdomain')).toBe(true);
+            expect(isLoopbackHost('foo.localhost')).toBe(true);
+            expect(isLoopbackHost('127.0.0.1')).toBe(true);
+            expect(isLoopbackHost('127.0.1.1')).toBe(true);
+            expect(isLoopbackHost('127.255.255.255')).toBe(true);
+            expect(isLoopbackHost('127.0.0.999')).toBe(false);
+            expect(isLoopbackHost('::1')).toBe(true);
+            expect(isLoopbackHost('[::1]')).toBe(true);
+            expect(isLoopbackHost('0.0.0.0')).toBe(true);
+            expect(isLoopbackHost('test.local')).toBe(false);
+            expect(isLoopbackHost('gerrit.corp.local')).toBe(false);
+            expect(isLoopbackHost('gerrit.example.com')).toBe(false);
+        });
+    });
+
+    describe('isGceEnvironment', () => {
+        const originalEnv = { ...process.env };
+
+        afterEach(() => {
+            process.env = { ...originalEnv };
+            clearGceEnvironmentCache();
+        });
+
+        test('recognizes GCE container environment variables', () => {
+            clearGceEnvironmentCache();
+            delete process.env.GCE_METADATA_HOST;
+            delete process.env.GCE_METADATA_IP;
+            delete process.env.CLOUD_WORKSTATIONS;
+            delete process.env.GOOGLE_CLOUD_WORKSTATIONS;
+            delete process.env.K_SERVICE;
+            delete process.env.BUILDER_OUTPUT;
+
+            process.env.CLOUD_WORKSTATIONS = 'true';
+            expect(isGceEnvironment()).toBe(true);
+
+            delete process.env.CLOUD_WORKSTATIONS;
+            process.env.GOOGLE_CLOUD_WORKSTATIONS = 'true';
+            expect(isGceEnvironment()).toBe(true);
+
+            delete process.env.GOOGLE_CLOUD_WORKSTATIONS;
+            process.env.K_SERVICE = 'review-service';
+            expect(isGceEnvironment()).toBe(true);
+
+            delete process.env.K_SERVICE;
+            process.env.BUILDER_OUTPUT = '/workspace';
+            expect(isGceEnvironment()).toBe(true);
+
+            delete process.env.BUILDER_OUTPUT;
+            process.env.GCE_METADATA_IP = '169.254.169.254';
+            expect(isGceEnvironment()).toBe(true);
+        });
+    });
+
+    describe('loopback and protocol handling in getGitCredential', () => {
+        test('skips credential helper for loopback host without local helper', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-loopback-nohelper.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+
+            const creds = await getGitCredential(gitDir, '127.0.0.1');
+            expect(creds).toBeNull();
+
+            const credsNullGitDir = await getGitCredential(null, 'localhost');
+            expect(credsNullGitDir).toBeNull();
+        });
+
+        test('invokes credential helper for loopback host when local helper is configured', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-loopback-helper.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            cp.execSync(
+                `git --git-dir="${gitDir}" config credential.helper "!f() { echo username=localuser; echo password=localpass; }; f"`,
+            );
+
+            const creds = await getGitCredential(gitDir, '127.0.0.1', 'http', '8080');
+            expect(creds).toEqual({ username: 'localuser', password: 'localpass' });
+        });
+
+        test('passes host with port embedded into host field for git credential helper', async () => {
+            const gitDir = path.join(tempDir, 'git-repo-port-helper.git');
+            cp.execSync(`git init --bare "${gitDir}"`);
+            const helperScript = path.join(tempDir, 'dump-cred-helper.cjs');
+            await fs.writeFile(
+                helperScript,
+                [
+                    "let input = '';",
+                    "process.stdin.on('data', chunk => { input += chunk; });",
+                    "process.stdin.on('end', () => {",
+                    '    const lines = input.split(/\\r?\\n/);',
+                    "    let host = '';",
+                    '    for (const line of lines) {',
+                    "        if (line.startsWith('host=')) host = line.slice(5);",
+                    '    }',
+                    "    console.log('username=' + host);",
+                    "    console.log('password=pass123');",
+                    '});',
+                ].join('\n'),
+            );
+            const scriptPathEscaped = helperScript.replace(/\\/g, '/');
+            cp.execSync(`git --git-dir="${gitDir}" config credential.helper "!node \\"${scriptPathEscaped}\\""`);
+
+            const creds = await getGitCredential(gitDir, 'gerrit.example.com', 'https', '8443');
+            expect(creds).toEqual({ username: 'gerrit.example.com:8443', password: 'pass123' });
         });
     });
 });

--- a/src/utils/gerrit-credential-utils.ts
+++ b/src/utils/gerrit-credential-utils.ts
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as cp from 'node:child_process';
+import * as fsSync from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import which from 'which';
 import { fetchWithTimeout } from './fetch-utils';
 import type { LoggerChannel } from './output-channel';
 
@@ -25,6 +27,9 @@ function execFilePromise(
             resolve({ err, stdout: outStr });
         });
         if (child.stdin) {
+            child.stdin.on('error', () => {
+                // Ignore EPIPE errors if child process terminates before consuming all stdin
+            });
             if (input) {
                 child.stdin.write(input);
             }
@@ -89,6 +94,145 @@ export function matchCookieDomain(host: string, cookieDomain: string): boolean {
         return h === domainWithoutDot || h.endsWith(cd);
     }
     return h === cd;
+}
+
+export interface ParsedGerritHost {
+    protocol: string;
+    hostname: string;
+    port?: string;
+}
+
+/**
+ * Parses a Gerrit host string or URL into protocol, hostname, and optional port.
+ */
+export function parseGerritHost(gerritHost: string): ParsedGerritHost {
+    const trimmed = gerritHost.trim();
+    if (trimmed.includes('://')) {
+        try {
+            const url = new URL(trimmed);
+            return {
+                protocol: url.protocol.replace(/:$/, ''),
+                hostname: url.hostname,
+                port: url.port || undefined,
+            };
+        } catch {
+            // Fall through if URL parsing fails
+        }
+    }
+
+    try {
+        const url = new URL(`https://${trimmed}`);
+        return {
+            protocol: 'https',
+            hostname: url.hostname,
+            port: url.port || undefined,
+        };
+    } catch {
+        return {
+            protocol: 'https',
+            hostname: trimmed,
+        };
+    }
+}
+
+/**
+ * Checks if a host belongs to Google infrastructure (googlesource.com, google.com, googleplex.com).
+ */
+export function isGoogleHost(hostname: string): boolean {
+    const h = hostname.toLowerCase().replace(/\.+$/, '');
+    return (
+        h === 'google.com' ||
+        h.endsWith('.google.com') ||
+        h === 'googlesource.com' ||
+        h.endsWith('.googlesource.com') ||
+        h === 'googleplex.com' ||
+        h.endsWith('.googleplex.com')
+    );
+}
+
+/**
+ * Checks if a host is a local loopback address (e.g. localhost, 127.0.0.1, ::1).
+ */
+export function isLoopbackHost(hostname: string): boolean {
+    const raw = hostname.toLowerCase().trim();
+    const h = raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw;
+    if (h === 'localhost' || h === 'localhost.localdomain' || h.endsWith('.localhost')) {
+        return true;
+    }
+    if (h === '::1' || h === '0.0.0.0') {
+        return true;
+    }
+    return /^127(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/.test(h);
+}
+
+let cachedIsLinuxGce: boolean | undefined;
+
+/**
+ * Clears the cached GCE environment detection result (for testing).
+ */
+export function clearGceEnvironmentCache(): void {
+    cachedIsLinuxGce = undefined;
+}
+
+/**
+ * Checks if the current execution environment is running on Google Compute Engine (GCE).
+ */
+export function isGceEnvironment(): boolean {
+    if (
+        process.env.GCE_METADATA_HOST ||
+        process.env.GCE_METADATA_IP ||
+        process.env.CLOUD_WORKSTATIONS ||
+        process.env.GOOGLE_CLOUD_WORKSTATIONS ||
+        process.env.K_SERVICE ||
+        process.env.BUILDER_OUTPUT
+    ) {
+        return true;
+    }
+    if (process.platform !== 'linux') {
+        return false;
+    }
+    if (cachedIsLinuxGce !== undefined) {
+        return cachedIsLinuxGce;
+    }
+    const dmiPaths = [
+        '/sys/class/dmi/id/product_name',
+        '/sys/class/dmi/id/sys_vendor',
+        '/sys/class/dmi/id/bios_vendor',
+    ];
+    for (const dmiPath of dmiPaths) {
+        try {
+            if (fsSync.readFileSync(dmiPath, 'utf8').includes('Google')) {
+                cachedIsLinuxGce = true;
+                return true;
+            }
+        } catch {
+            // Ignore missing or unreadable DMI paths
+        }
+    }
+    cachedIsLinuxGce = false;
+    return false;
+}
+
+/**
+ * Checks whether the repository's local git configuration explicitly defines a credential.helper.
+ */
+async function hasLocalCredentialHelper(gitDir: string): Promise<boolean> {
+    try {
+        let actualDir = gitDir;
+        const stat = await fs.stat(gitDir);
+        if (stat.isFile()) {
+            const content = await fs.readFile(gitDir, 'utf8');
+            const match = content.match(/^gitdir:\s*(.+)$/m);
+            if (match) {
+                actualDir = path.resolve(path.dirname(gitDir), match[1].trim());
+            }
+        }
+        const configPath = path.join(actualDir, 'config');
+        const content = await fs.readFile(configPath, 'utf8');
+        return /\[credential(?:\s+[^\]]+)?\][^[]*helper\s*=/s.test(content);
+    } catch {
+        return false;
+    }
 }
 
 /**
@@ -286,17 +430,13 @@ export async function getSsoAuth(
     host: string,
     outputChannel?: LoggerChannel,
 ): Promise<{ name: string; value: string } | null> {
-    const checkCmd = process.platform === 'win32' ? 'where' : 'which';
-    outputChannel?.debug(`[GerritAuth] Checking if git-remote-sso helper exists using ${checkCmd}...`);
-    const { err: checkErr, stdout: checkStdout } = await execFilePromise(checkCmd, ['git-remote-sso'], {
-        shell: process.platform === 'win32',
-    });
-    if (checkErr || !checkStdout) {
+    outputChannel?.debug('[GerritAuth] Checking if git-remote-sso helper exists in PATH...');
+    const ssoBin = which.sync('git-remote-sso', { nothrow: true });
+    if (!ssoBin) {
         outputChannel?.debug('[GerritAuth] git-remote-sso helper not found in PATH');
         return null;
     }
 
-    const ssoBin = checkStdout.trim().split(/\r?\n/)[0];
     outputChannel?.debug(`[GerritAuth] Found git-remote-sso helper: ${ssoBin}. Printing config...`);
     const { err: ssoErr, stdout: ssoStdout } = await execFilePromise(
         ssoBin,
@@ -346,7 +486,11 @@ export async function getSsoAuth(
  */
 export async function getGceAuth(outputChannel?: LoggerChannel): Promise<{ name: string; value: string } | null> {
     try {
-        const metadataHost = process.env.GCE_METADATA_HOST || 'http://metadata.google.internal';
+        let metadataHost = process.env.GCE_METADATA_HOST;
+        if (!metadataHost) {
+            const ip = process.env.GCE_METADATA_IP || '169.254.169.254';
+            metadataHost = ip.startsWith('http://') || ip.startsWith('https://') ? ip : `http://${ip}`;
+        }
         outputChannel?.debug(`[GerritAuth] Probing GCE Metadata server at ${metadataHost}...`);
         const probeResponse = await fetchWithTimeout(metadataHost, 2000, {
             headers: { 'Metadata-Flavor': 'Google' },
@@ -389,15 +533,33 @@ export async function getGceAuth(outputChannel?: LoggerChannel): Promise<{ name:
 export async function getGitCredential(
     gitDir: string | null,
     host: string,
+    protocol = 'https',
+    port?: string,
     outputChannel?: LoggerChannel,
 ): Promise<{ username?: string; password?: string } | null> {
+    if (isLoopbackHost(host)) {
+        const hasLocalHelper = gitDir ? await hasLocalCredentialHelper(gitDir) : false;
+        if (!hasLocalHelper) {
+            outputChannel?.debug(
+                `[GerritAuth] Skipping git credential helper for loopback host ${host} without local repo helper`,
+            );
+            return null;
+        }
+    }
+
     const args = gitDir ? [`--git-dir=${gitDir}`, 'credential', 'fill'] : ['credential', 'fill'];
     const options = {
         cwd: os.homedir(),
         timeout: 15000,
         env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
     };
-    const input = `protocol=https\nhost=${host}\n\n`;
+    const formattedHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+    const hostWithPort = port && !host.includes(`:${port}`) ? `${formattedHost}:${port}` : host;
+    let input = `protocol=${protocol}\nhost=${hostWithPort}\n`;
+    if (port) {
+        input += `port=${port}\n`;
+    }
+    input += '\n';
 
     outputChannel?.debug(`[GerritAuth] Running git credential helper with args: ${args.join(' ')}`);
     const { err, stdout } = await execFilePromise('git', args, options, input);
@@ -437,37 +599,42 @@ export async function getGerritAuthHeader(
     gitDir: string | null,
     outputChannel?: LoggerChannel,
 ): Promise<{ name: string; value: string } | undefined> {
-    let hostname = gerritHost;
-    try {
-        hostname = new URL(gerritHost).hostname;
-    } catch {
-        // Fallback to raw host string if it's not a valid URL
+    const { hostname, protocol, port } = parseGerritHost(gerritHost);
+
+    outputChannel?.debug(
+        `[GerritAuth] Getting auth header for ${hostname} (protocol=${protocol}, port=${port ?? 'default'}, gitDir=${gitDir})`,
+    );
+
+    const googleHost = isGoogleHost(hostname);
+
+    // 1. LUCI Context (only for Google hosts or when explicitly configured)
+    if (googleHost && process.env.LUCI_CONTEXT) {
+        outputChannel?.debug('[GerritAuth] Checking LUCI Context...');
+        const luciToken = await getLuciToken(outputChannel);
+        if (luciToken) {
+            outputChannel?.debug('[GerritAuth] Successfully authenticated using LUCI Context token');
+            return { name: 'Authorization', value: `Bearer ${luciToken}` };
+        }
     }
 
-    outputChannel?.debug(`[GerritAuth] Getting auth header for ${hostname} (gitDir=${gitDir})`);
-
-    // 1. LUCI Context
-    outputChannel?.debug('[GerritAuth] Checking LUCI Context...');
-    const luciToken = await getLuciToken(outputChannel);
-    if (luciToken) {
-        outputChannel?.debug('[GerritAuth] Successfully authenticated using LUCI Context token');
-        return { name: 'Authorization', value: `Bearer ${luciToken}` };
+    // 2. Google SSO (only for Google hosts)
+    if (googleHost) {
+        outputChannel?.debug('[GerritAuth] Checking Google SSO helper...');
+        const ssoAuth = await getSsoAuth(hostname, outputChannel);
+        if (ssoAuth) {
+            outputChannel?.debug('[GerritAuth] Successfully authenticated using Google SSO helper');
+            return ssoAuth;
+        }
     }
 
-    // 2. Google SSO
-    outputChannel?.debug('[GerritAuth] Checking Google SSO helper...');
-    const ssoAuth = await getSsoAuth(hostname, outputChannel);
-    if (ssoAuth) {
-        outputChannel?.debug('[GerritAuth] Successfully authenticated using Google SSO helper');
-        return ssoAuth;
-    }
-
-    // 3. GCE Metadata
-    outputChannel?.debug('[GerritAuth] Checking GCE Metadata...');
-    const gceAuth = await getGceAuth(outputChannel);
-    if (gceAuth) {
-        outputChannel?.debug('[GerritAuth] Successfully authenticated using GCE Metadata');
-        return gceAuth;
+    // 3. GCE Metadata (only if in GCE environment and host is Google, or explicit GCE_METADATA_HOST)
+    if ((googleHost || Boolean(process.env.GCE_METADATA_HOST)) && isGceEnvironment()) {
+        outputChannel?.debug('[GerritAuth] Checking GCE Metadata...');
+        const gceAuth = await getGceAuth(outputChannel);
+        if (gceAuth) {
+            outputChannel?.debug('[GerritAuth] Successfully authenticated using GCE Metadata');
+            return gceAuth;
+        }
     }
 
     // 4. Git Cookies (parsed as Basic/Bearer matching gerrit_util.py)
@@ -484,7 +651,7 @@ export async function getGerritAuthHeader(
 
     // 5. Git Credential Helper (parsed as Basic/Bearer matching gerrit_util.py)
     outputChannel?.debug('[GerritAuth] Checking Git Credential Helper...');
-    const credential = await getGitCredential(gitDir, hostname, outputChannel);
+    const credential = await getGitCredential(gitDir, hostname, protocol, port, outputChannel);
     if (credential?.password) {
         outputChannel?.debug('[GerritAuth] Successfully retrieved credentials from Git Credential Helper');
         const { username, password } = credential;


### PR DESCRIPTION
- Look up git-remote-sso in-process via which.sync instead of spawning CLI processes
- Restrict LUCI Context and Google SSO helper queries to Google-hosted Gerrit infrastructure
- Detect GCE environment before attempting GCE metadata probes to eliminate DNS timeout latency on non-GCE machines
- Parse protocol and port in parseGerritHost and supply them to git credential helper queries
- Skip credential helper invocations for loopback hosts (127.0.0.1, localhost) unless explicitly configured locally in .git/config, preventing Windows Credential Manager stalls