### PR TITLE
test: wait for test repo filesystem deletion in workspace-open test and TestRepo.dispose

### DIFF
--- a/src/test/commands/workspace-open.test.ts
+++ b/src/test/commands/workspace-open.test.ts
@@ -94,7 +94,7 @@ describe('workspace open commands', () => {
     });
 
     test('reports an error when workspace names cannot be resolved', async () => {
-        repo.dispose();
+        await repo.dispose();
 
         await workspaceOpenInCurrentWindowCommand(ctx, {});
 

--- a/src/test/test-repo.ts
+++ b/src/test/test-repo.ts
@@ -145,7 +145,7 @@ export class TestRepo {
         tempDirs.add(this.path);
     }
 
-    dispose() {
+    async dispose(): Promise<void> {
         if (!this.configId) {
             const configIdFile = path.join(this.path, '.jj', 'repo', 'config-id');
             if (fs.existsSync(configIdFile)) {
@@ -156,12 +156,15 @@ export class TestRepo {
         }
 
         const repoPath = this.path;
-        fs.promises
-            .rm(repoPath, { recursive: true, force: true })
-            .catch(() => {})
-            .finally(() => {
-                tempDirs.delete(repoPath);
+        try {
+            await fs.promises.rm(repoPath, {
+                recursive: true,
+                force: true,
+                maxRetries: 5,
+                retryDelay: 50,
             });
+        } catch {}
+        tempDirs.delete(repoPath);
 
         if (this.configId) {
             const userJjDir = getUserJjDir();
@@ -924,8 +927,12 @@ export async function buildGraph(repo: TestRepo, commits: CommitDefinition[]): P
     return labelToId;
 }
 
-export class ScopedTestRepo extends TestRepo implements Disposable {
+export class ScopedTestRepo extends TestRepo implements Disposable, AsyncDisposable {
     [Symbol.dispose]() {
-        this.dispose();
+        this.dispose().catch(() => {});
+    }
+
+    async [Symbol.asyncDispose]() {
+        await this.dispose();
     }
 }


### PR DESCRIPTION
Make TestRepo.dispose() return a Promise awaiting fs.promises.rm() with retries, and await repo.dispose() in workspace-open.test.ts. This ensures the temporary repository directory is completely removed from disk before attempting to resolve workspace names, preventing race conditions that caused failures on Windows CI.