### PR TITLE
feat(commit-details): mark conflicted files and show conflict side count

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -16,6 +16,7 @@ vsc-extension-quickstart.md
 tooling/**
 playwright-report/**
 test-results/**
+test-artifacts/**
 
 # Dev config and tools
 .jj/**

--- a/src/core/jj-schemas.ts
+++ b/src/core/jj-schemas.ts
@@ -51,6 +51,8 @@ export const JjFileChangeSchema = z.object({
     status: z.enum(['modified', 'added', 'renamed', 'copied', 'deleted']),
     /** Whether the file is currently conflicted. */
     conflicted: z.boolean().optional(),
+    /** The number of conflicting sides (e.g. 2 for standard conflict, 3+ for multi-way merge). */
+    conflictSides: z.number().optional(),
 });
 export type JjFileChange = z.infer<typeof JjFileChangeSchema>;
 
@@ -73,9 +75,16 @@ export const DiffStatEntrySchema = z.object({
 });
 export type DiffStatEntry = z.infer<typeof DiffStatEntrySchema>;
 
+export const ConflictedFileEntrySchema = z.object({
+    path: NormalizedPathSchema,
+    conflictSides: z.number().optional(),
+});
+export type ConflictedFileEntry = z.infer<typeof ConflictedFileEntrySchema>;
+
 export const ChangesAndStatsOutputSchema = z.object({
     changes: z.array(JjFileChangeSchema).default([]),
     stats: z.array(DiffStatEntrySchema).default([]),
+    conflicts: z.array(ConflictedFileEntrySchema).default([]),
 });
 export type ChangesAndStatsOutput = z.infer<typeof ChangesAndStatsOutputSchema>;
 

--- a/src/core/jj-service.ts
+++ b/src/core/jj-service.ts
@@ -14,6 +14,7 @@ import { type LoggerChannel, NO_OP_LOGGER } from '../utils/output-channel';
 import type { IJjTrackedProcess, JjProcessTracker } from './jj-process-tracker';
 import {
     ChangesAndStatsOutputSchema,
+    type ConflictedFileEntry,
     type DiffStatEntry,
     JjBookmarkSchema,
     type JjFileChange,
@@ -1175,6 +1176,14 @@ export class JjService {
                     deletions: { type: 'raw', expr: 'item.lines_removed()' },
                 },
             },
+            conflicts: {
+                type: 'array',
+                expr: 'self.conflicted_files()',
+                itemSchema: {
+                    path: { type: 'json', expr: 'item.path().display()' },
+                    conflictSides: { type: 'raw', expr: 'item.conflict_side_count()' },
+                },
+            },
         });
 
         const output = await this.run('log', ['-r', revision, '--no-graph', '-T', combinedTemplate], {
@@ -1192,17 +1201,37 @@ export class JjService {
             );
         }
 
-        const { changes, stats } = entries[0];
+        const { changes, stats, conflicts } = entries[0];
         const statsMap = new Map<string, DiffStatEntry>(stats.map((s) => [s.path, s]));
+        const conflictMap = new Map<string, ConflictedFileEntry>(conflicts.map((c) => [c.path, c]));
 
-        return changes.map((c) => {
+        const results: JjFileChangeWithStats[] = changes.map((c) => {
             const stat = statsMap.get(c.path);
+            const conflict = conflictMap.get(c.path);
+            if (conflict) {
+                conflictMap.delete(c.path);
+            }
             return {
                 ...c,
+                conflicted: c.conflicted || conflict !== undefined,
+                conflictSides: c.conflictSides ?? conflict?.conflictSides,
                 additions: stat?.additions ?? 0,
                 deletions: stat?.deletions ?? 0,
             };
         });
+
+        for (const [path, conflict] of conflictMap) {
+            results.push({
+                path,
+                status: 'modified',
+                conflicted: true,
+                conflictSides: conflict.conflictSides,
+                additions: 0,
+                deletions: 0,
+            });
+        }
+
+        return results;
     }
 
     private async _doGetChangesBetween(fromRevision: string, toRevision: string): Promise<JjFileChange[]> {

--- a/src/core/jj-template-builder.ts
+++ b/src/core/jj-template-builder.ts
@@ -88,6 +88,11 @@ export function buildDiffFileSchema(varName: 'item' | 'self'): Record<string, Jj
             expr: `if(${varName}.status() == "removed", "\\"deleted\\"", json(${varName}.status()))`,
         },
         conflicted: { type: 'raw', expr: `${varName}.target().conflict()` },
+        conflictSides: {
+            type: 'optionalField',
+            where: `${varName}.target().conflict()`,
+            valueExpr: `${varName}.target().conflict_side_count()`,
+        },
     };
 }
 

--- a/src/core/webview/commit-details/CommitDetails.svelte
+++ b/src/core/webview/commit-details/CommitDetails.svelte
@@ -331,7 +331,10 @@ function getFileIcon(status: string): string {
     }
 }
 
-function getFileColor(status: string): string {
+function getFileColor(status: string, conflicted?: boolean): string {
+    if (conflicted) {
+        return 'var(--vscode-gitDecoration-conflictingResourceForeground, #e51400)';
+    }
     switch (status) {
         case 'added':
         case 'copied':
@@ -549,6 +552,7 @@ function getFileColor(status: string): string {
                 {:else}
                     {#each files as file (file.path)}
                         {@const { dir, name } = splitFilePath(file.path)}
+                        {@const conflictLabel = file.conflictSides ? `${file.conflictSides}-way conflict` : 'Conflicted file'}
                         <button
                             type="button"
                             class="file-row"
@@ -562,14 +566,22 @@ function getFileColor(status: string): string {
                         >
                             <span
                                 class="codicon codicon-{getFileIcon(file.status)} file-icon"
-                                style:color={getFileColor(file.status)}
+                                style:color={getFileColor(file.status, file.conflicted)}
                             ></span>
                             <span class="file-path-container" title={file.path}>
                                 {#if dir}
                                     <span class="file-dir">{dir}</span>
                                 {/if}
-                                <span class="file-name">{name}</span>
+                                <span class="file-name" style:color={file.conflicted ? 'var(--vscode-gitDecoration-conflictingResourceForeground, #e51400)' : undefined}>{name}</span>
                             </span>
+                            {#if file.conflicted}
+                                <span
+                                    class="codicon codicon-warning conflict-icon"
+                                    role="img"
+                                    title={conflictLabel}
+                                    aria-label={conflictLabel}
+                                ></span>
+                            {/if}
                             <span class="file-meta-group">
                                 {#if file.additions !== undefined || file.deletions !== undefined}
                                     <span class="file-diff-stats">
@@ -581,7 +593,13 @@ function getFileColor(status: string): string {
                                         {/if}
                                     </span>
                                 {/if}
-                                <span class="file-status-badge status-{file.status}">{file.status}</span>
+                                {#if file.conflicted}
+                                    <span class="file-status-badge status-conflicted" title={conflictLabel}>
+                                        {file.conflictSides ? `${file.conflictSides}-way conflict` : 'conflicted'}
+                                    </span>
+                                {:else}
+                                    <span class="file-status-badge status-{file.status}">{file.status}</span>
+                                {/if}
                                 <span class="diff-hover-icon codicon codicon-git-compare" title="Open diff"></span>
                             </span>
                         </button>
@@ -1070,11 +1088,17 @@ function getFileColor(status: string): string {
 
     .file-icon {
         font-size: 15px;
+        width: 16px;
+        height: 16px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         flex-shrink: 0;
     }
 
     .file-path-container {
-        flex: 1;
+        flex: 0 1 auto;
+        min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -1090,6 +1114,18 @@ function getFileColor(status: string): string {
     .file-name {
         color: var(--vscode-foreground);
         font-weight: 500;
+    }
+
+    .conflict-icon {
+        color: var(--vscode-gitDecoration-conflictingResourceForeground, #e51400);
+        font-size: 14px;
+        width: 16px;
+        height: 16px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        margin-left: 6px;
     }
 
     .file-meta-group {
@@ -1116,6 +1152,11 @@ function getFileColor(status: string): string {
         padding: 1px 6px;
         border-radius: 10px;
         line-height: normal;
+    }
+
+    .file-status-badge.status-conflicted {
+        color: var(--vscode-gitDecoration-conflictingResourceForeground, #e51400);
+        background: color-mix(in srgb, var(--vscode-gitDecoration-conflictingResourceForeground, #e51400) 12%, transparent);
     }
 
     .file-status-badge.status-added,

--- a/src/test/commit-details-controller.test.ts
+++ b/src/test/commit-details-controller.test.ts
@@ -210,6 +210,15 @@ describe('CommitDetailsController Domain Unit Tests', () => {
         const state = conflictController.getState();
         expect(state).toBeDefined();
         expect(state?.isConflict).toBe(true);
+        expect(state?.files).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    path: 'file.txt',
+                    conflicted: true,
+                    conflictSides: 2,
+                }),
+            ]),
+        );
 
         const updates = conflictClient.receivedMessages.filter((m) => m.type === 'update');
         expect(updates.length).toBeGreaterThanOrEqual(1);
@@ -217,6 +226,13 @@ describe('CommitDetailsController Domain Unit Tests', () => {
             type: 'update',
             payload: expect.objectContaining({
                 isConflict: true,
+                files: expect.arrayContaining([
+                    expect.objectContaining({
+                        path: 'file.txt',
+                        conflicted: true,
+                        conflictSides: 2,
+                    }),
+                ]),
             }),
         });
 

--- a/src/test/e2e/commit-details.spec.ts
+++ b/src/test/e2e/commit-details.spec.ts
@@ -114,6 +114,31 @@ test.describe('Commit Details E2E', () => {
             await expect(details.locator('text=Changed Files (2)')).toBeVisible();
         });
 
+        test('Marks the conflicted file in the file list with conflict sides and warning icon', async () => {
+            const conflictedRow = await waitForLogCommitRow(page, 'conflicted commit');
+            await conflictedRow.click();
+
+            const shortId = nodes['conflicted-commit'].changeId.substring(0, 3);
+            await expect(page.getByRole('tab', { name: new RegExp(`^Commit: ${shortId}`) })).toBeVisible({
+                timeout: 15000,
+            });
+
+            const details = await getDetailsWebview(page);
+            const conflictedFileRow = details.locator('.file-row', { hasText: 'f.txt' });
+            await expect(conflictedFileRow).toHaveCount(1);
+            await expect(conflictedFileRow).toBeVisible();
+
+            // Verify the warning icon with tooltip inside the specific file row
+            const conflictIcon = conflictedFileRow.locator('.conflict-icon');
+            await expect(conflictIcon).toBeVisible();
+            await expect(conflictIcon).toHaveAttribute('title', '2-way conflict');
+
+            // Verify the conflicted status badge inside the specific file row
+            const conflictBadge = conflictedFileRow.locator('.file-status-badge.status-conflicted');
+            await expect(conflictBadge).toBeVisible();
+            await expect(conflictBadge).toHaveText('2-way conflict');
+        });
+
         test('Save description via button', async () => {
             const featureRow = await waitForLogCommitRow(page, 'add feature');
 

--- a/src/test/jj-service-diff.test.ts
+++ b/src/test/jj-service-diff.test.ts
@@ -141,6 +141,7 @@ describe('JjService Diff Tests', () => {
                 path: 'conflict.txt',
                 status: 'modified',
                 conflicted: true,
+                conflictSides: 2,
             },
         ]);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
         "scripts",
         "tooling",
         "playwright-report",
-        "test-results"
+        "test-results",
+        "test-artifacts"
     ]
 }


### PR DESCRIPTION
- Include `conflictSides` count via `TreeEntry.conflict_side_count()` in `buildDiffFileSchema`.
- Augment `_doGetChanges` with `self.conflicted_files()` to ensure conflicted files appear accurately across both rebase and multi-parent merge conflicts.
- Render warning icon, conflicting resource coloring, and `<N>-way conflict` badge in `CommitDetails.svelte`.
- Add unit and scoped E2E test coverage verifying conflict indicators.