### PR TITLE
test: deflake E2E tests by dismissing quick picks and retrying inline actions

### DIFF
--- a/src/test/e2e/github.spec.ts
+++ b/src/test/e2e/github.spec.ts
@@ -325,6 +325,8 @@ test.describe('GitHub Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(quickPick).not.toBeVisible();
     });
 
     test('Detects PR from fork targeting mainline repo', async ({ vscode }) => {

--- a/src/test/e2e/gitlab.spec.ts
+++ b/src/test/e2e/gitlab.spec.ts
@@ -295,6 +295,8 @@ test.describe('GitLab Integration E2E', () => {
         }).toPass({ timeout: 15000 });
 
         await expect(locateQuickInputItem(page, 'Clear Personal Access Token (PAT)')).not.toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(quickPick).not.toBeVisible();
     });
 
     test('Shows extension-not-found interstitial when signing in via OAuth without GitLab extension', async ({

--- a/src/test/e2e/scm.spec.ts
+++ b/src/test/e2e/scm.spec.ts
@@ -438,11 +438,14 @@ test.describe('SCM Pane E2E', () => {
 
         // The squashInto action should be visible since there are two mutable ancestors
         const squashIntoIcon = newWcFileRow.getByRole('button', { name: /Squash File\(s\) into Ancestor/ }).first();
-        await hoverAndClick(newWcFileRow, squashIntoIcon);
-
-        // SCM QuickPick should appear for Ancestor selection
         const quickPickInput = page.getByRole('listbox');
-        await expect(quickPickInput).toBeVisible({ timeout: 5000 });
+        await expect(async () => {
+            const isVisible = await quickPickInput.isVisible();
+            if (!isVisible) {
+                await hoverAndClick(newWcFileRow, squashIntoIcon);
+            }
+            await expect(quickPickInput).toBeVisible({ timeout: 2000 });
+        }).toPass({ timeout: 15000 });
 
         const ancestor2Option = page.getByRole('option', { name: /initial/i });
         await ancestor2Option.click();

--- a/src/test/e2e/vscode-fixture.ts
+++ b/src/test/e2e/vscode-fixture.ts
@@ -991,6 +991,16 @@ export async function dismissActiveUI(page: Page | undefined): Promise<boolean> 
     }
     try {
         await page.mouse.move(0, 0);
+
+        // Clear focus from any active iframe/webview to allow top-level keybinding to work.
+        // Blurring activeElement directly doesn't work if focus is trapped inside a webview iframe
+        // within VS Code's shadow DOM. Focusing a top-level tab steals focus back to the main window.
+        await page
+            .getByRole('tab', { name: /Explorer/i })
+            .first()
+            .focus()
+            .catch(() => {});
+
         const quickInput = page.locator('.quick-input-widget').filter({ visible: true });
         let iterations = 0;
         while ((await quickInput.count()) > 0 && iterations < 5) {
@@ -1012,7 +1022,7 @@ export async function dismissActiveUI(page: Page | undefined): Promise<boolean> 
             await page.keyboard.press('Escape');
             await quickInput
                 .first()
-                .waitFor({ state: 'hidden', timeout: 500 })
+                .waitFor({ state: 'hidden', timeout: 1500 })
                 .catch(() => {});
         }
 
@@ -1023,7 +1033,7 @@ export async function dismissActiveUI(page: Page | undefined): Promise<boolean> 
             await page.keyboard.press('Escape');
             await contextMenu
                 .first()
-                .waitFor({ state: 'hidden', timeout: 500 })
+                .waitFor({ state: 'hidden', timeout: 1500 })
                 .catch(() => {});
         }
 
@@ -1071,7 +1081,15 @@ export class VSCodeFixtureImpl implements VSCodeFixture {
         // Dismiss any active hovers, quick picks, or context menus from previous tests
         // before we do any operations for the new workspace
         const dismissStart = Date.now();
-        await this.dismissActiveUI();
+        const isClean = await this.dismissActiveUI();
+        if (!isClean) {
+            this.requestReset();
+            this.activeContext = await this.worker.getContext(repo, extraSettings, extraEnv, showNotifications);
+            this.app = this.activeContext.app;
+            this.page = this.activeContext.page;
+            this.userDataDir = this.activeContext.userDataDir;
+            await this.dismissActiveUI();
+        }
         logPerf('openWorkspace: dismiss UI', dismissStart);
 
         if (skipRepoSync) {


### PR DESCRIPTION
Ensure QuickPick menus in GitHub and GitLab PAT authentication tests are explicitly dismissed before completing each test case to prevent lingering UI elements from obstructing subsequent test interactions. Additionally, harden dismissActiveUI in the E2E fixture to transfer focus away from nested webview iframes before sending Escape key events, force-reset the test workspace context if UI dismissals fail, and wrap inline action clicking in SCM ancestor squash in an expect retry loop.